### PR TITLE
Switch from face to triangle data structure

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "program": "${workspaceFolder}/build/test/manifold_test",
             "args": [
                 "--gtest_break_on_failure",
-                "--gtest_filter=Polygon.Slit"
+                "--gtest_filter=Manifold.Extract"
             ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/build/test",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ OPTION( MANIFOLD_USE_CPP
 set(MAINFOLD_FLAGS -Werror -Wall -Wno-sign-compare)
 set(MANIFOLD_NVCC_FLAGS -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored)
 set(MANIFOLD_NVCC_RELEASE_FLAGS -O3)
+set(MANIFOLD_NVCC_DEBUG_FLAGS -G)
 
 IF(MANIFOLD_USE_OMP)
     message("------------------------- Using OpenMP instead of CUDA.")

--- a/collider/CMakeLists.txt
+++ b/collider/CMakeLists.txt
@@ -16,7 +16,7 @@ target_compile_options(${PROJECT_NAME}
     PRIVATE ${MANIFOLD_NVCC_FLAGS}
 )
 target_compile_options(${PROJECT_NAME} 
-    PRIVATE "$<$<CONFIG:RELEASE>:${MANIFOLD_NVCC_RELEASE_FLAGS}>"
+    PRIVATE "$<$<CONFIG:RELEASE>:${MANIFOLD_NVCC_RELEASE_FLAGS}>" "$<$<CONFIG:DEBUG>:${MANIFOLD_NVCC_DEBUG_FLAGS}>"
 )
 target_compile_features(${PROJECT_NAME} 
     PUBLIC cxx_std_14

--- a/collider/src/collider.cu
+++ b/collider/src/collider.cu
@@ -222,7 +222,7 @@ Collider::Collider(const VecDH<Box>& leafBB,
   nodeParent_.resize(num_nodes, -1);
   internalChildren_.resize(leafBB.size() - 1, thrust::make_pair(-1, -1));
   // organize tree
-  thrust::for_each_n(thrust::make_counting_iterator(0), NumInternal(),
+  thrust::for_each_n(countAt(0), NumInternal(),
                      CreateRadixTree({nodeParent_.ptrD(),
                                       internalChildren_.ptrD(), leafMorton}));
   UpdateBoxes(leafBB);
@@ -244,8 +244,7 @@ SparseIndices Collider::Collisions(const VecDH<T>& querriesIn) const {
     VecDH<int> nOverlapsD(1, 0);
     // calculate Bounding Box overlaps
     thrust::for_each_n(
-        zip(querriesIn.cbeginD(), thrust::make_counting_iterator(0)),
-        querriesIn.size(),
+        zip(querriesIn.cbeginD(), countAt(0)), querriesIn.size(),
         FindCollisions<T>({querryTri.ptrDpq(), nOverlapsD.ptrD(), maxOverlaps,
                            nodeBBox_.ptrD(), internalChildren_.ptrD()}));
     nOverlaps = nOverlapsD.H()[0];
@@ -277,7 +276,7 @@ void Collider::UpdateBoxes(const VecDH<Box>& leafBB) {
   thrust::fill(counter_.beginD(), counter_.endD(), 0);
   // kernel over leaves to save internal Boxs
   thrust::for_each_n(
-      thrust::make_counting_iterator(0), NumLeaves(),
+      countAt(0), NumLeaves(),
       BuildInternalBoxes({nodeBBox_.ptrD(), counter_.ptrD(), nodeParent_.ptrD(),
                           internalChildren_.ptrD()}));
 }

--- a/manifold/CMakeLists.txt
+++ b/manifold/CMakeLists.txt
@@ -16,7 +16,7 @@ target_compile_options(${PROJECT_NAME}
     PRIVATE ${MANIFOLD_NVCC_FLAGS}
 )
 target_compile_options(${PROJECT_NAME} 
-    PRIVATE "$<$<CONFIG:RELEASE>:${MANIFOLD_NVCC_RELEASE_FLAGS}>"
+    PRIVATE "$<$<CONFIG:RELEASE>:${MANIFOLD_NVCC_RELEASE_FLAGS}>" "$<$<CONFIG:DEBUG>:${MANIFOLD_NVCC_DEBUG_FLAGS}>"
 )
 target_compile_features(${PROJECT_NAME} 
     PUBLIC cxx_std_14 

--- a/manifold/include/manifold.h
+++ b/manifold/include/manifold.h
@@ -56,7 +56,7 @@ class Manifold {
   bool IsEmpty() const;
   int NumVert() const;
   int NumEdge() const;
-  int NumFace() const;
+  int NumTri() const;
   Box BoundingBox() const;
   int Genus() const;
   Properties GetProperties() const;

--- a/manifold/include/manifold.h
+++ b/manifold/include/manifold.h
@@ -43,9 +43,6 @@ class Manifold {
   static Manifold Compose(const std::vector<Manifold>&);
   std::vector<Manifold> Decompose() const;
 
-  // Extraction is not const because it triangulates the Manifold.
-  Mesh Extract();
-
   // Defaults for construction
   static void SetMinCircularAngle(float degrees);
   static void SetMinCircularEdgeLength(float length);
@@ -63,6 +60,7 @@ class Manifold {
   Box BoundingBox() const;
   int Genus() const;
   Properties GetProperties() const;
+  Mesh Extract() const;
 
   // Modification
   Manifold& Translate(glm::vec3);

--- a/manifold/src/boolean3.cu
+++ b/manifold/src/boolean3.cu
@@ -166,8 +166,7 @@ struct CopyFaceEdges {
   }
 };
 
-SparseIndices Filter11(const Manifold::Impl &inP, const VecDH<int> &faceSizeP,
-                       const Manifold::Impl &inQ, const VecDH<int> &faceSizeQ,
+SparseIndices Filter11(const Manifold::Impl &inP, const Manifold::Impl &inQ,
                        const SparseIndices &p1q2, const SparseIndices &p2q1) {
   SparseIndices p1q1(3 * p1q2.size() + 3 * p2q1.size());
   thrust::for_each_n(
@@ -957,9 +956,6 @@ Boolean3::Boolean3(const Manifold::Impl &inP, const Manifold::Impl &inQ,
   inP_.Tri2Face();
   inQ_.Tri2Face();
 
-  VecDH<int> faceSizeP = inP_.FaceSize();
-  VecDH<int> faceSizeQ = inQ_.FaceSize();
-
   Time t0 = NOW();
   Time t1;
   // Level 3
@@ -985,7 +981,7 @@ Boolean3::Boolean3(const Manifold::Impl &inP, const Manifold::Impl &inQ,
   if (kVerbose) std::cout << "p2q0 size = " << p2q0.size() << std::endl;
 
   // Find involved edge pairs from Level 3
-  SparseIndices p1q1 = Filter11(inP_, faceSizeP, inQ_, faceSizeQ, p1q2_, p2q1_);
+  SparseIndices p1q1 = Filter11(inP_, inQ_, p1q2_, p2q1_);
   if (kVerbose) std::cout << "p1q1 size = " << p1q1.size() << std::endl;
 
   if (kVerbose) {

--- a/manifold/src/boolean3.cu
+++ b/manifold/src/boolean3.cu
@@ -952,9 +952,6 @@ Boolean3::Boolean3(const Manifold::Impl &inP, const Manifold::Impl &inQ,
   // Union -> expand inP
   // Difference, Intersection -> contract inP
 
-  inP_.Tri2Face();
-  inQ_.Tri2Face();
-
   Time t0 = NOW();
   Time t1;
   // Level 3
@@ -1160,8 +1157,6 @@ Manifold::Impl Boolean3::Result(Manifold::OpType op) const {
   std::tie(faceEdge, facePQ2R) =
       SizeOutput(outR, inP_, inQ_, i03, i30, i12, i21, p1q2_, p2q1_,
                  op == Manifold::OpType::SUBTRACT);
-
-  outR.faceEdge_ = faceEdge;
 
   // This gets incremented for each halfedge that's added to a face so that the
   // next one knows where to slot in.

--- a/manifold/src/boolean3.cu
+++ b/manifold/src/boolean3.cu
@@ -1215,7 +1215,6 @@ Manifold::Impl Boolean3::Result(Manifold::OpType op) const {
 
   // Create the manifold's data structures and verify manifoldness.
   outR.LabelVerts();
-  outR.Finish();
 
   // TODO: Revert Manifold back to only triangles.
   outR.Face2Tri();

--- a/manifold/src/boolean3.cu
+++ b/manifold/src/boolean3.cu
@@ -1186,11 +1186,9 @@ Manifold::Impl Boolean3::Result(Manifold::OpType op) const {
 
   // Level 6
 
-  // Create the manifold's data structures and verify manifoldness.
-  outR.LabelVerts();
-
-  // TODO: Revert Manifold back to only triangles.
+  // Create the manifold's data structures.
   outR.Face2Tri(faceEdge);
+  outR.LabelVerts();
   outR.Finish();
 
   if (kVerbose) {

--- a/manifold/src/boolean3.cu
+++ b/manifold/src/boolean3.cu
@@ -169,13 +169,12 @@ struct CopyFaceEdges {
 SparseIndices Filter11(const Manifold::Impl &inP, const Manifold::Impl &inQ,
                        const SparseIndices &p1q2, const SparseIndices &p2q1) {
   SparseIndices p1q1(3 * p1q2.size() + 3 * p2q1.size());
-  thrust::for_each_n(
-      zip(thrust::make_counting_iterator(0), p1q2.beginD(0), p1q2.beginD(1)),
-      p1q2.size(), CopyFaceEdges({p1q1.ptrDpq(), inQ.halfedge_.cptrD()}));
+  thrust::for_each_n(zip(countAt(0), p1q2.beginD(0), p1q2.beginD(1)),
+                     p1q2.size(),
+                     CopyFaceEdges({p1q1.ptrDpq(), inQ.halfedge_.cptrD()}));
 
   p1q1.SwapPQ();
-  thrust::for_each_n(zip(thrust::make_counting_iterator(p1q2.size()),
-                         p2q1.beginD(1), p2q1.beginD(0)),
+  thrust::for_each_n(zip(countAt(p1q2.size()), p2q1.beginD(1), p2q1.beginD(0)),
                      p2q1.size(),
                      CopyFaceEdges({p1q1.ptrDpq(), inP.halfedge_.cptrD()}));
   p1q1.SwapPQ();

--- a/manifold/src/connected_components.cu
+++ b/manifold/src/connected_components.cu
@@ -65,7 +65,7 @@ using namespace manifold;
 //   VecDH<int> source(numHalfedge);
 //   sink.resize(numHalfedge);
 //   thrust::for_each_n(
-//       zip(thrust::make_counting_iterator(0), halfedges.cbeginD()),
+//       zip(countAt(0), halfedges.cbeginD()),
 //       numHalfedge, DuplicateEdges({source.ptrD(), sink.ptrD()}));
 //   // Build symmetric CSR adjacency matrix
 //   VecDH<int> degree(numVert, 0);
@@ -73,7 +73,7 @@ using namespace manifold;
 //   VecDH<int> temp(numVert);
 //   if (keep.size() > 0) {
 //     edgeMask.resize(numHalfedge);
-//     thrust::for_each_n(zip(thrust::make_counting_iterator(0), keep.cbeginD(),
+//     thrust::for_each_n(zip(countAt(0), keep.cbeginD(),
 //                            halfedges.cbeginD()),
 //                        numHalfedge, DuplicateKeep({edgeMask.ptrD()}));
 //     thrust::sort_by_key(zip(source.beginD(), sink.beginD()),

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -404,29 +404,8 @@ std::vector<Manifold> Manifold::Decompose() const {
     return meshes;
   }
 
-  VecDH<Halfedge> edges = pImpl_->halfedge_;
-
-  VecH<Halfedge>& edgesH = edges.H();
-  const VecH<int>& faceEdgeH = pImpl_->faceEdge_.H();
-
-  for (int face = 0; face < NumFace(); ++face) {
-    const int firstEdge = faceEdgeH[face];
-    const int lastEdge = faceEdgeH[face + 1];
-    if (lastEdge - firstEdge > 5) {
-      // With 6 edges or more, the face could be made of multiple polygons. Add
-      // a star graph of edges to ensure the face's verts are connected.
-      const int startVert = edgesH[firstEdge].startVert;
-      for (int i = firstEdge + 1; i < lastEdge; ++i) {
-        Halfedge edge = {startVert, edgesH[i].startVert};
-        // ConnectedComponents only uses forward halfedges.
-        if (!edge.IsForward()) std::swap(edge.startVert, edge.endVert);
-        edgesH.push_back(edge);
-      }
-    }
-  }
-
   VecDH<int> vertLabel;
-  int numLabel = ConnectedComponents(vertLabel, NumVert(), edges);
+  int numLabel = ConnectedComponents(vertLabel, NumVert(), pImpl_->halfedge_);
 
   std::vector<Manifold> meshes(numLabel);
   for (int i = 0; i < numLabel; ++i) {

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -342,11 +342,11 @@ Manifold Manifold::Revolve(const Polygons& crossSection, int circularSegments) {
 Manifold Manifold::Compose(const std::vector<Manifold>& manifolds) {
   int numVert = 0;
   int numEdge = 0;
-  int numFace = 0;
+  int NumTri = 0;
   for (const Manifold& manifold : manifolds) {
     numVert += manifold.NumVert();
     numEdge += manifold.NumEdge();
-    numFace += manifold.NumFace();
+    NumTri += manifold.NumTri();
   }
 
   Manifold out;
@@ -354,7 +354,7 @@ Manifold Manifold::Compose(const std::vector<Manifold>& manifolds) {
   combined.vertPos_.resize(numVert);
   combined.halfedge_.resize(2 * numEdge);
   combined.vertLabel_.resize(numVert);
-  combined.faceNormal_.resize(numFace);
+  combined.faceNormal_.resize(NumTri);
 
   int nextVert = 0;
   int nextEdge = 0;
@@ -376,7 +376,7 @@ Manifold Manifold::Compose(const std::vector<Manifold>& manifolds) {
 
     nextVert += manifold.NumVert();
     nextEdge += 2 * manifold.NumEdge();
-    nextFace += manifold.NumFace();
+    nextFace += manifold.NumTri();
     nextLabel += impl.numLabel_;
   }
 
@@ -410,7 +410,7 @@ std::vector<Manifold> Manifold::Decompose() const {
         zip(meshes[i].pImpl_->vertPos_.beginD(), countAt(0));
     meshes[i].pImpl_->vertPos_.resize(nVert);
 
-    VecDH<int> faceNew2Old(NumFace());
+    VecDH<int> faceNew2Old(NumTri());
     thrust::sequence(faceNew2Old.beginD(), faceNew2Old.endD());
 
     int nFace = thrust::remove_if(faceNew2Old.beginD(), faceNew2Old.endD(),
@@ -439,8 +439,8 @@ Mesh Manifold::Extract() const {
   result.vertPos.insert(result.vertPos.end(), pImpl_->vertPos_.begin(),
                         pImpl_->vertPos_.end());
 
-  result.triVerts.resize(NumFace());
-  thrust::for_each_n(zip(result.triVerts.begin(), countAt(0)), NumFace(),
+  result.triVerts.resize(NumTri());
+  thrust::for_each_n(zip(result.triVerts.begin(), countAt(0)), NumTri(),
                      MakeTri({pImpl_->halfedge_.cptrH()}));
 
   return result;
@@ -485,7 +485,7 @@ int Manifold::GetCircularSegments(float radius) {
 bool Manifold::IsEmpty() const { return NumVert() == 0; }
 int Manifold::NumVert() const { return pImpl_->NumVert(); }
 int Manifold::NumEdge() const { return pImpl_->NumEdge(); }
-int Manifold::NumFace() const { return pImpl_->NumFace(); }
+int Manifold::NumTri() const { return pImpl_->NumTri(); }
 
 Box Manifold::BoundingBox() const {
   return pImpl_->bBox_.Transform(pImpl_->transform_);
@@ -497,7 +497,7 @@ Box Manifold::BoundingBox() const {
  * mesh, so it is best to call Decompose() first.
  */
 int Manifold::Genus() const {
-  int chi = NumVert() - NumEdge() + NumFace();
+  int chi = NumVert() - NumEdge() + NumTri();
   return 1 - chi / 2;
 }
 

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -129,44 +129,7 @@ Manifold Manifold::Octahedron() {
  */
 Manifold Manifold::Cube(glm::vec3 size, bool center) {
   Manifold cube;
-  std::vector<glm::vec3> vertPos = {{0.0f, 0.0f, 0.0f},  //
-                                    {1.0f, 0.0f, 0.0f},  //
-                                    {1.0f, 1.0f, 0.0f},  //
-                                    {0.0f, 1.0f, 0.0f},  //
-                                    {0.0f, 0.0f, 1.0f},  //
-                                    {1.0f, 0.0f, 1.0f},  //
-                                    {1.0f, 1.0f, 1.0f},  //
-                                    {0.0f, 1.0f, 1.0f}};
-  std::vector<Halfedge> halfedge = {{0, 3, 20, 0},  //
-                                    {3, 2, 16, 0},  //
-                                    {2, 1, 12, 0},  //
-                                    {1, 0, 8, 0},   //
-                                    {4, 5, 10, 1},  //
-                                    {5, 6, 14, 1},  //
-                                    {6, 7, 18, 1},  //
-                                    {7, 4, 22, 1},  //
-                                    {0, 1, 3, 2},   //
-                                    {1, 5, 15, 2},  //
-                                    {5, 4, 4, 2},   //
-                                    {4, 0, 21, 2},  //
-                                    {1, 2, 2, 3},   //
-                                    {2, 6, 19, 3},  //
-                                    {6, 5, 5, 3},   //
-                                    {5, 1, 9, 3},   //
-                                    {2, 3, 1, 4},   //
-                                    {3, 7, 23, 4},  //
-                                    {7, 6, 6, 4},   //
-                                    {6, 2, 13, 4},  //
-                                    {3, 0, 0, 5},   //
-                                    {0, 4, 11, 5},  //
-                                    {4, 7, 7, 5},   //
-                                    {7, 3, 17, 5}};
-  std::vector<int> faceEdge = {0, 4, 8, 12, 16, 20, 24};
-  cube.pImpl_->vertPos_ = vertPos;
-  cube.pImpl_->halfedge_ = halfedge;
-  cube.pImpl_->faceEdge_ = faceEdge;
-  cube.pImpl_->Finish();
-
+  cube.pImpl_ = std::make_unique<Impl>(Impl::Shape::CUBE);
   cube.Scale(size);
   if (center) cube.Translate(-size / 2.0f);
   return cube;
@@ -516,8 +479,6 @@ std::vector<Manifold> Manifold::Decompose() const {
  */
 Mesh Manifold::Extract() {
   pImpl_->ApplyTransform();
-  pImpl_->Face2Tri();
-  pImpl_->Finish();
 
   Mesh result;
   result.vertPos.insert(result.vertPos.end(), pImpl_->vertPos_.begin(),

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -434,14 +434,12 @@ std::vector<Manifold> Manifold::Decompose() const {
     VecDH<int> vertNew2Old(NumVert());
     int nVert =
         thrust::copy_if(
-            zip(pImpl_->vertPos_.beginD(), thrust::make_counting_iterator(0)),
-            zip(pImpl_->vertPos_.endD(),
-                thrust::make_counting_iterator(NumVert())),
+            zip(pImpl_->vertPos_.beginD(), countAt(0)),
+            zip(pImpl_->vertPos_.endD(), countAt(NumVert())),
             vertLabel.beginD(),
             zip(meshes[i].pImpl_->vertPos_.beginD(), vertNew2Old.beginD()),
             Equals({i})) -
-        zip(meshes[i].pImpl_->vertPos_.beginD(),
-            thrust::make_counting_iterator(0));
+        zip(meshes[i].pImpl_->vertPos_.beginD(), countAt(0));
     meshes[i].pImpl_->vertPos_.resize(nVert);
 
     VecDH<int> faceNew2Old(NumFace());
@@ -477,9 +475,8 @@ Mesh Manifold::Extract() {
                         pImpl_->vertPos_.end());
 
   result.triVerts.resize(NumFace());
-  thrust::for_each_n(
-      zip(result.triVerts.begin(), thrust::make_counting_iterator(0)),
-      NumFace(), MakeTri({pImpl_->halfedge_.cptrH()}));
+  thrust::for_each_n(zip(result.triVerts.begin(), countAt(0)), NumFace(),
+                     MakeTri({pImpl_->halfedge_.cptrH()}));
 
   return result;
 }

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -353,7 +353,6 @@ Manifold Manifold::Compose(const std::vector<Manifold>& manifolds) {
   Impl& combined = *(out.pImpl_);
   combined.vertPos_.resize(numVert);
   combined.halfedge_.resize(2 * numEdge);
-  combined.faceEdge_.resize(numFace + 1);
   combined.vertLabel_.resize(numVert);
   combined.faceNormal_.resize(numFace);
 
@@ -369,8 +368,6 @@ Manifold Manifold::Compose(const std::vector<Manifold>& manifolds) {
                  combined.vertPos_.beginD() + nextVert);
     thrust::copy(impl.faceNormal_.beginD(), impl.faceNormal_.endD(),
                  combined.faceNormal_.beginD() + nextFace);
-    thrust::transform(impl.faceEdge_.beginD(), impl.faceEdge_.endD(),
-                      combined.faceEdge_.beginD() + nextFace, _1 + nextEdge);
     thrust::transform(impl.vertLabel_.beginD(), impl.vertLabel_.endD(),
                       combined.vertLabel_.beginD() + nextVert, _1 + nextLabel);
     thrust::transform(impl.halfedge_.beginD(), impl.halfedge_.endD(),
@@ -432,7 +429,6 @@ std::vector<Manifold> Manifold::Decompose() const {
     faceNew2Old.resize(nFace);
 
     meshes[i].pImpl_->GatherFaces(pImpl_->halfedge_, faceNew2Old);
-    meshes[i].pImpl_->Tri2Face();
     meshes[i].pImpl_->ReindexVerts(vertNew2Old, pImpl_->NumVert());
 
     meshes[i].pImpl_->Finish();

--- a/manifold/src/manifold_impl.cu
+++ b/manifold/src/manifold_impl.cu
@@ -515,8 +515,8 @@ struct NoDuplicates {
   const Halfedge* halfedges;
 
   __host__ __device__ bool operator()(int edge) {
-    return halfedges[2 * edge].startVert != halfedges[2 * edge + 1].startVert ||
-           halfedges[2 * edge].endVert != halfedges[2 * edge + 1].endVert;
+    return halfedges[edge].startVert != halfedges[edge + 1].startVert ||
+           halfedges[edge].endVert != halfedges[edge + 1].endVert;
   }
 };
 
@@ -892,9 +892,10 @@ bool Manifold::Impl::IsManifold() const {
 
   VecDH<Halfedge> halfedge(halfedge_);
   thrust::sort(halfedge.beginD(), halfedge.endD());
-  isManifold &= thrust::all_of(thrust::make_counting_iterator(0),
-                               thrust::make_counting_iterator(NumEdge()),
-                               NoDuplicates({halfedge.cptrD()}));
+  isManifold &=
+      thrust::all_of(thrust::make_counting_iterator(0),
+                     thrust::make_counting_iterator(2 * NumEdge() - 1),
+                     NoDuplicates({halfedge.cptrD()}));
   return isManifold;
 }
 

--- a/manifold/src/manifold_impl.cu
+++ b/manifold/src/manifold_impl.cu
@@ -809,15 +809,15 @@ bool Manifold::Impl::Tri2Face() {
  * Triangulates the faces. It is possible, but rare, that this function can
  * also add vertices. This never happens for geometrically valid manifolds.
  */
-bool Manifold::Impl::Face2Tri() {
-  if (faceEdge_.size() == 0 && halfedge_.size() % 3 == 0) return false;
+bool Manifold::Impl::Face2Tri(const VecDH<int>& faceEdge) {
+  if (faceEdge.size() == 0 && halfedge_.size() % 3 == 0) return false;
   VecDH<glm::ivec3> triVertsOut;
   VecDH<glm::vec3> triNormalOut;
 
   VecH<glm::ivec3>& triVerts = triVertsOut.H();
   VecH<glm::vec3>& triNormal = triNormalOut.H();
   VecH<glm::vec3>& vertPos = vertPos_.H();
-  const VecH<int>& face = faceEdge_.H();
+  const VecH<int>& face = faceEdge.H();
   const VecH<Halfedge>& halfedge = halfedge_.H();
   const VecH<glm::vec3>& faceNormal = faceNormal_.H();
   const VecH<int> nextHalfedge = AssembleFaces();

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -27,7 +27,6 @@ struct Manifold::Impl {
   VecDH<int> vertLabel_;
   int numLabel_ = 1;
   VecDH<Halfedge> halfedge_;
-  VecDH<int> faceEdge_;
 
   VecDH<glm::vec3> vertNormal_;
   VecDH<glm::vec3> faceNormal_;
@@ -46,15 +45,13 @@ struct Manifold::Impl {
   void ApplyTransform() const;
   void ApplyTransform();
   VecH<int> AssembleFaces(const VecH<int>& faceEdge) const;
-  bool Tri2Face() const;
-  bool Tri2Face();
   bool Face2Tri(const VecDH<int>& faceEdge);
   void Refine(int n);
   bool IsManifold() const;
 
   int NumVert() const { return vertPos_.size(); }
   int NumEdge() const { return halfedge_.size() / 2; }
-  int NumFace() const { return faceEdge_.size() - 1; }
+  int NumFace() const { return halfedge_.size() / 3; }
   Properties GetProperties() const;
   void CalculateBBox();
 

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -27,7 +27,6 @@ struct Manifold::Impl {
   VecDH<int> vertLabel_;
   int numLabel_ = 1;
   VecDH<Halfedge> halfedge_;
-  VecDH<int> nextHalfedge_;
   VecDH<int> faceEdge_;
 
   VecDH<glm::vec3> vertNormal_;
@@ -46,8 +45,7 @@ struct Manifold::Impl {
   void Update();
   void ApplyTransform() const;
   void ApplyTransform();
-  void AssembleFaces() const;
-  void AssembleFaces();
+  VecH<int> AssembleFaces() const;
   bool Tri2Face() const;
   bool Tri2Face();
   bool Face2Tri();
@@ -72,6 +70,7 @@ struct Manifold::Impl {
   SparseIndices VertexCollisionsZ(const VecDH<glm::vec3>& vertsIn) const;
   VecDH<int> FaceSize() const;
   void GetFaceBoxMorton(VecDH<Box>& faceBox, VecDH<uint32_t>& faceMorton) const;
-  Polygons Face2Polygons(int face, glm::mat3x2 projection) const;
+  Polygons Face2Polygons(int face, glm::mat3x2 projection,
+                         const VecH<int>& nextHalfedge) const;
 };
 }  // namespace manifold

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -47,7 +47,7 @@ struct Manifold::Impl {
 
   int NumVert() const { return vertPos_.size(); }
   int NumEdge() const { return halfedge_.size() / 2; }
-  int NumFace() const { return halfedge_.size() / 3; }
+  int NumTri() const { return halfedge_.size() / 3; }
   Properties GetProperties() const;
   void CalculateBBox();
   bool IsManifold() const;

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -27,7 +27,6 @@ struct Manifold::Impl {
   VecDH<int> vertLabel_;
   int numLabel_ = 1;
   VecDH<Halfedge> halfedge_;
-
   VecDH<glm::vec3> vertNormal_;
   VecDH<glm::vec3> faceNormal_;
   Collider collider_;
@@ -44,16 +43,14 @@ struct Manifold::Impl {
   void Update();
   void ApplyTransform() const;
   void ApplyTransform();
-  VecH<int> AssembleFaces(const VecH<int>& faceEdge) const;
-  bool Face2Tri(const VecDH<int>& faceEdge);
   void Refine(int n);
-  bool IsManifold() const;
 
   int NumVert() const { return vertPos_.size(); }
   int NumEdge() const { return halfedge_.size() / 2; }
   int NumFace() const { return halfedge_.size() / 3; }
   Properties GetProperties() const;
   void CalculateBBox();
+  bool IsManifold() const;
 
   void SortVerts();
   void ReindexVerts(const VecDH<int>& vertNew2Old, int numOldVert);
@@ -61,10 +58,12 @@ struct Manifold::Impl {
   void GatherFaces(const VecDH<Halfedge>& oldHalfedge,
                    const VecDH<int>& faceNew2Old);
   void CalculateNormals();
+  void Face2Tri(const VecDH<int>& faceEdge);
 
   SparseIndices EdgeCollisions(const Impl& B) const;
   SparseIndices VertexCollisionsZ(const VecDH<glm::vec3>& vertsIn) const;
   void GetFaceBoxMorton(VecDH<Box>& faceBox, VecDH<uint32_t>& faceMorton) const;
+  VecH<int> AssembleFaces(const VecH<int>& faceEdge) const;
   Polygons Face2Polygons(int face, glm::mat3x2 projection,
                          const VecH<int>& faceEdge,
                          const VecH<int>& nextHalfedge) const;

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -62,13 +62,11 @@ struct Manifold::Impl {
   void ReindexVerts(const VecDH<int>& vertNew2Old, int numOldVert);
   void SortFaces(VecDH<Box>& faceBox, VecDH<uint32_t>& faceMorton);
   void GatherFaces(const VecDH<Halfedge>& oldHalfedge,
-                   const VecDH<int>& oldFaceEdge, const VecDH<int>& faceNew2Old,
-                   const VecDH<int>& faceSize);
+                   const VecDH<int>& faceNew2Old);
   void CalculateNormals();
 
   SparseIndices EdgeCollisions(const Impl& B) const;
   SparseIndices VertexCollisionsZ(const VecDH<glm::vec3>& vertsIn) const;
-  VecDH<int> FaceSize() const;
   void GetFaceBoxMorton(VecDH<Box>& faceBox, VecDH<uint32_t>& faceMorton) const;
   Polygons Face2Polygons(int face, glm::mat3x2 projection,
                          const VecH<int>& faceEdge,

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -45,7 +45,7 @@ struct Manifold::Impl {
   void Update();
   void ApplyTransform() const;
   void ApplyTransform();
-  VecH<int> AssembleFaces() const;
+  VecH<int> AssembleFaces(const VecH<int>& faceEdge) const;
   bool Tri2Face() const;
   bool Tri2Face();
   bool Face2Tri(const VecDH<int>& faceEdge);
@@ -71,6 +71,7 @@ struct Manifold::Impl {
   VecDH<int> FaceSize() const;
   void GetFaceBoxMorton(VecDH<Box>& faceBox, VecDH<uint32_t>& faceMorton) const;
   Polygons Face2Polygons(int face, glm::mat3x2 projection,
+                         const VecH<int>& faceEdge,
                          const VecH<int>& nextHalfedge) const;
 };
 }  // namespace manifold

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -48,7 +48,7 @@ struct Manifold::Impl {
   VecH<int> AssembleFaces() const;
   bool Tri2Face() const;
   bool Tri2Face();
-  bool Face2Tri();
+  bool Face2Tri(const VecDH<int>& faceEdge);
   void Refine(int n);
   bool IsManifold() const;
 

--- a/polygon/src/polygon.cpp
+++ b/polygon/src/polygon.cpp
@@ -405,29 +405,9 @@ class Monotones {
   bool IsHole(VertItr vert) {
     VertItr left = vert->left;
     VertItr right = vert->right;
-    int isHole = CCW(right->pos, vert->pos, left->pos);
-    if (isHole != 0) return isHole > 0;
-
-    while (left != right && !left->IsPast(vert)) {
-      left = left->left;
-    }
-    while (right != left && !right->IsPast(vert)) {
-      right = right->right;
-    }
-    if (left == right) return false;  // degenerate
-
-    left = left->right;
-    right = right->left;
-    const float xLeft = left->pos.x;
-    const float xRight = right->pos.x;
-    isHole = xRight > xLeft + params.kTolerance
-                 ? -1
-                 : xRight < xLeft - params.kTolerance ? 1 : 0;
-    if (isHole != 0) return isHole > 0;
-
     // TODO: if left or right is Processed(), determine from east/west
     while (left != right || left == vert) {
-      isHole = CCW(right->pos, vert->pos, left->pos);
+      int isHole = CCW(right->pos, vert->pos, left->pos);
       if (isHole != 0) return isHole > 0;
 
       if (left->pos.y < right->pos.y) {

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -44,12 +44,12 @@ void ExpectMeshes(Manifold& manifold,
   std::sort(meshes.begin(), meshes.end(),
             [](const Manifold& a, const Manifold& b) {
               return a.NumVert() != b.NumVert() ? a.NumVert() > b.NumVert()
-                                                : a.NumFace() > b.NumFace();
+                                                : a.NumTri() > b.NumTri();
             });
   for (int i = 0; i < meshes.size(); ++i) {
     EXPECT_TRUE(meshes[i].IsManifold());
     EXPECT_EQ(meshes[i].NumVert(), numVertTri[i].first);
-    EXPECT_EQ(meshes[i].NumFace(), numVertTri[i].second);
+    EXPECT_EQ(meshes[i].NumTri(), numVertTri[i].second);
   }
 }
 
@@ -127,7 +127,7 @@ TEST(Manifold, Sphere) {
   int n = 25;
   Manifold sphere = Manifold::Sphere(1.0f, 4 * n);
   ASSERT_TRUE(sphere.IsManifold());
-  EXPECT_EQ(sphere.NumFace(), n * n * 8);
+  EXPECT_EQ(sphere.NumTri(), n * n * 8);
 }
 
 TEST(Manifold, Extrude) {

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -246,13 +246,10 @@ TEST(Manifold, MultiCoplanar) {
   Manifold first = cube - cube2.Translate({0.3f, 0.3f, 0.0f});
   cube.Translate({-0.3f, -0.3f, 0.0f});
   Manifold out = first - cube;
-  first.Extract();  // Force triangulation and compare results
-  Manifold out2 = first - cube;
   EXPECT_EQ(out.Genus(), -1);
   auto prop = out.GetProperties();
-  auto prop2 = out2.GetProperties();
-  EXPECT_NEAR(prop.volume, prop2.volume, 1e-5);
-  EXPECT_NEAR(prop.surfaceArea, prop2.surfaceArea, 1e-5);
+  EXPECT_NEAR(prop.volume, 0.18, 1e-5);
+  EXPECT_NEAR(prop.surfaceArea, 2.76, 1e-5);
 }
 
 /**

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -39,7 +39,6 @@ void Identical(Mesh& mesh1, Mesh& mesh2) {
 void ExpectMeshes(Manifold& manifold,
                   const std::vector<std::pair<int, int>>& numVertTri) {
   ASSERT_TRUE(manifold.IsManifold());
-  manifold.Extract();
   std::vector<Manifold> meshes = manifold.Decompose();
   ASSERT_EQ(meshes.size(), numVertTri.size());
   std::sort(meshes.begin(), meshes.end(),

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -25,7 +25,7 @@ using namespace manifold;
 TEST(Samples, Knot13) {
   Manifold knot13 = TorusKnot(1, 3, 25, 10, 3.75);
   //   ExportMesh("knot13.stl", knot13.Extract());
-  ASSERT_TRUE(knot13.IsManifold());
+  EXPECT_TRUE(knot13.IsManifold());
   EXPECT_EQ(knot13.Genus(), 1);
   auto prop = knot13.GetProperties();
   EXPECT_NEAR(prop.volume, 20786, 1);
@@ -36,7 +36,7 @@ TEST(Samples, Knot13) {
 TEST(Samples, Knot42) {
   Manifold knot42 = TorusKnot(4, 2, 15, 6, 5);
   //   ExportMesh("knot42.stl", knot42.Extract());
-  ASSERT_TRUE(knot42.IsManifold());
+  EXPECT_TRUE(knot42.IsManifold());
   std::vector<Manifold> knots = knot42.Decompose();
   ASSERT_EQ(knots.size(), 2);
   EXPECT_EQ(knots[0].Genus(), 1);
@@ -51,18 +51,21 @@ TEST(Samples, Knot42) {
 // that are not in general position, e.g. coplanar faces.
 TEST(Samples, Bracelet) {
   Manifold bracelet = StretchyBracelet();
-  Mesh triangulated = bracelet.Extract();
+  EXPECT_TRUE(bracelet.IsManifold());
   EXPECT_EQ(bracelet.Genus(), 1);
-  // ExportMesh("bracelet.ply", triangulated);
+  // ExportMesh("bracelet.ply", bracelet.Extract());
 }
 
 // A fractal with many degenerate intersections, which also tests exact 90
 // degree rotations.
 TEST(Samples, Sponge) {
   Manifold sponge = MengerSponge(4);
+  EXPECT_TRUE(sponge.IsManifold());
   EXPECT_EQ(sponge.Genus(), 26433);
   std::pair<Manifold, Manifold> cutSponge = sponge.SplitByPlane({1, 1, 1}, 0);
+  EXPECT_TRUE(cutSponge.first.IsManifold());
   EXPECT_EQ(cutSponge.first.Genus(), 13394);
+  EXPECT_TRUE(cutSponge.second.IsManifold());
   EXPECT_EQ(cutSponge.second.Genus(), 13394);
   // ExportMesh("mengerSponge.ply", cutSponge.first.Extract());
 }

--- a/tools/perf_test.cpp
+++ b/tools/perf_test.cpp
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <iostream>
+
 #include "manifold.h"
 
 using namespace manifold;
@@ -29,7 +30,7 @@ int main(int argc, char **argv) {
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> elapsed = end - start;
     times.push_back(elapsed.count());
-    std::cout << "nTri = " << sphere.NumFace() << ", time = " << elapsed.count()
+    std::cout << "nTri = " << sphere.NumTri() << ", time = " << elapsed.count()
               << " sec" << std::endl;
   }
 }

--- a/utilities/include/structs.h
+++ b/utilities/include/structs.h
@@ -84,7 +84,7 @@ inline float cosd(float x) { return sind(x + 90.0f); }
 #endif
 
 struct ExecutionParams {
-  float kTolerance = 1e-4;
+  float kTolerance = 2e-5;
   bool intermediateChecks = false;
   bool verbose = false;
   bool suppressErrors = false;

--- a/utilities/include/utils.cuh
+++ b/utilities/include/utils.cuh
@@ -19,6 +19,7 @@
 #include <thrust/iterator/permutation_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/tuple.h>
+
 #include <iostream>
 
 namespace manifold {
@@ -47,6 +48,11 @@ thrust::zip_iterator<thrust::tuple<Iters...>> zip(Iters... iters) {
 template <typename A, typename B>
 thrust::permutation_iterator<A, B> perm(A a, B b) {
   return thrust::make_permutation_iterator(a, b);
+}
+
+template <typename T>
+thrust::counting_iterator<T> countAt(T i) {
+  return thrust::make_counting_iterator(i);
 }
 
 // Copied from


### PR DESCRIPTION
Reverting to the triangle data structure, though using a halfedge vector that forms triangles implicitly by consecutive sets of three. General faces turned out to be a disaster, largely because they are not just polygons, but polygons with holes, which complicates a lot of logic (even things like connectivity). But the real reason was that the Boolean could intersect co-planar edges in such a way as to slice in between a polygon and its hole, resulting in geometrically invalid polygon output (not marginal).