### PR TITLE
glTF export and degenerate removal

### DIFF
--- a/manifold/include/manifold.h
+++ b/manifold/include/manifold.h
@@ -59,7 +59,7 @@ class Manifold {
   Box BoundingBox() const;
   int Genus() const;
   Properties GetProperties() const;
-  Mesh Extract() const;
+  Mesh Extract(bool includeNormals = false) const;
 
   // Modification
   Manifold& Translate(glm::vec3);

--- a/manifold/include/manifold.h
+++ b/manifold/include/manifold.h
@@ -87,6 +87,7 @@ class Manifold {
 
   // Testing hooks
   bool IsManifold() const;
+  bool MatchesTriNormals() const;
   int NumOverlaps(const Manifold& second) const;
 
   ~Manifold();

--- a/manifold/src/boolean3.cu
+++ b/manifold/src/boolean3.cu
@@ -1141,6 +1141,8 @@ Manifold::Impl Boolean3::Result(Manifold::OpType op) const {
 
   // outR.SplitNonmanifoldVerts();
 
+  outR.CollapseDegenerates();
+
   triangulate.Stop();
   Timer finish;
   finish.Start();

--- a/manifold/src/boolean3.cu
+++ b/manifold/src/boolean3.cu
@@ -845,8 +845,9 @@ void AppendNewEdges(
     }
     const glm::vec3 size = bbox.Size();
     // Order the points along their longest dimension.
-    const int i =
-        (size.x > size.y && size.x > size.z) ? 0 : size.y > size.z ? 1 : 2;
+    const int i = (size.x > size.y && size.x > size.z) ? 0
+                  : size.y > size.z                    ? 1
+                                                       : 2;
     for (auto &edge : edgePos) {
       edge.edgePos = vertPosR[edge.vert][i];
     }

--- a/manifold/src/boolean3.cu
+++ b/manifold/src/boolean3.cu
@@ -1136,6 +1136,11 @@ Manifold::Impl Boolean3::Result(Manifold::OpType op) const {
   // Create the manifold's data structures.
   outR.Face2Tri(faceEdge);
 
+  // int chi = outR.NumVert() - outR.NumEdge() + outR.NumTri();
+  // std::cout << "triangle Genus = " << 1 - chi / 2 << std::endl;
+
+  // outR.SplitNonmanifoldVerts();
+
   triangulate.Stop();
   Timer finish;
   finish.Start();

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -506,6 +506,8 @@ Manifold::Properties Manifold::GetProperties() const {
 
 bool Manifold::IsManifold() const { return pImpl_->IsManifold(); }
 
+bool Manifold::MatchesTriNormals() const { return pImpl_->MatchesTriNormals(); }
+
 Manifold& Manifold::Translate(glm::vec3 v) {
   pImpl_->transform_[3] += v;
   return *this;

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -426,14 +426,17 @@ std::vector<Manifold> Manifold::Decompose() const {
  * This returns a Mesh of simple vectors of vertices and triangles suitable for
  * saving or other operations outside of the context of this library.
  */
-Mesh Manifold::Extract() const {
+Mesh Manifold::Extract(bool includeNormals) const {
   pImpl_->ApplyTransform();
 
   Mesh result;
   result.vertPos.insert(result.vertPos.end(), pImpl_->vertPos_.begin(),
                         pImpl_->vertPos_.end());
-  result.vertNormal.insert(result.vertNormal.end(), pImpl_->vertNormal_.begin(),
-                           pImpl_->vertNormal_.end());
+  if (includeNormals) {
+    result.vertNormal.insert(result.vertNormal.end(),
+                             pImpl_->vertNormal_.begin(),
+                             pImpl_->vertNormal_.end());
+  }
 
   result.triVerts.resize(NumTri());
   thrust::for_each_n(zip(result.triVerts.begin(), countAt(0)), NumTri(),

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -432,6 +432,8 @@ Mesh Manifold::Extract() const {
   Mesh result;
   result.vertPos.insert(result.vertPos.end(), pImpl_->vertPos_.begin(),
                         pImpl_->vertPos_.end());
+  result.vertNormal.insert(result.vertNormal.end(), pImpl_->vertNormal_.begin(),
+                           pImpl_->vertNormal_.end());
 
   result.triVerts.resize(NumTri());
   thrust::for_each_n(zip(result.triVerts.begin(), countAt(0)), NumTri(),

--- a/manifold/src/manifold_impl.cu
+++ b/manifold/src/manifold_impl.cu
@@ -472,7 +472,8 @@ struct AssignNormals {
 
     const bool isDegenerate = glm::length(crossP) <= perimeter * kTolerance;
 
-    if (calculateTriNormal) {
+    if (calculateTriNormal ||
+        (triNormal.x == 0 && triNormal.y == 0 && triNormal.z == 0)) {
       triNormal = isDegenerate ? glm::vec3(0)
                                : glm::normalize(glm::cross(edge[0], edge[1]));
     }

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -37,6 +37,7 @@ struct Manifold::Impl {
 
   void CreateHalfedges(const VecDH<glm::ivec3>& triVerts);
   void CreateAndFixHalfedges(const VecDH<glm::ivec3>& triVerts);
+  void SplitNonmanifoldVerts();
   void Finish();
   void Update();
   void ApplyTransform() const;

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -52,6 +52,7 @@ struct Manifold::Impl {
   Properties GetProperties() const;
   void CalculateBBox();
   bool IsManifold() const;
+  bool MatchesTriNormals() const;
 
   void SortVerts();
   void ReindexVerts(const VecDH<int>& vertNew2Old, int numOldVert);

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -38,6 +38,7 @@ struct Manifold::Impl {
   void CreateHalfedges(const VecDH<glm::ivec3>& triVerts);
   void CreateAndFixHalfedges(const VecDH<glm::ivec3>& triVerts);
   void SplitNonmanifoldVerts();
+  void CollapseDegenerates();
   void Finish();
   void Update();
   void ApplyTransform() const;

--- a/meshIO/src/meshIO.cpp
+++ b/meshIO/src/meshIO.cpp
@@ -91,13 +91,20 @@ void ExportMesh(const std::string& filename, const Mesh& manifold) {
   scene->mRootNode->mMeshes[0] = 0;
 
   aiMesh* mesh_out = scene->mMeshes[0];
+  mesh_out->mPrimitiveTypes = aiPrimitiveType_TRIANGLE;
 
   mesh_out->mNumVertices = manifold.vertPos.size();
   mesh_out->mVertices = new aiVector3D[mesh_out->mNumVertices];
+  const bool hasNormals = manifold.vertNormal.size() == manifold.vertPos.size();
+  if (hasNormals) mesh_out->mNormals = new aiVector3D[mesh_out->mNumVertices];
 
   for (int i = 0; i < mesh_out->mNumVertices; ++i) {
     const glm::vec3& v = manifold.vertPos[i];
     mesh_out->mVertices[i] = aiVector3D(v.x, v.y, v.z);
+    if (hasNormals) {
+      const glm::vec3& n = manifold.vertNormal[i];
+      mesh_out->mNormals[i] = aiVector3D(n.x, n.y, n.z);
+    }
   }
 
   mesh_out->mNumFaces = manifold.triVerts.size();
@@ -111,8 +118,19 @@ void ExportMesh(const std::string& filename, const Mesh& manifold) {
   }
 
   Assimp::Exporter exporter;
-  auto result = exporter.Export(
-      scene, filename.substr(filename.find_last_of(".") + 1), filename);
+
+  // int n = exporter.GetExportFormatCount();
+  // for (int i = 0; i < n; ++i) {
+  //   auto desc = exporter.GetExportFormatDescription(i);
+  //   std::cout << i << ", id = " << desc->id << ", " << desc->description
+  //             << std::endl;
+  // }
+
+  std::string ext = filename.substr(filename.find_last_of(".") + 1);
+  if (ext == "glb") ext = "glb2";
+  if (ext == "gltf") ext = "gltf2";
+
+  auto result = exporter.Export(scene, ext, filename);
 
   delete scene;
 

--- a/polygon/include/polygon.h
+++ b/polygon/include/polygon.h
@@ -19,7 +19,6 @@
 
 namespace manifold {
 
-int CCW(glm::vec2 p0, glm::vec2 p1, glm::vec2 p2);
 bool Coincident(glm::vec2 p0, glm::vec2 p1);
 std::vector<glm::ivec3> Triangulate(const Polygons &polys);
 

--- a/polygon/src/polygon.cpp
+++ b/polygon/src/polygon.cpp
@@ -375,7 +375,7 @@ class Monotones {
    * of using geometry.
    */
   void RemovePair(PairItr pair) {
-    if (pair == activePairs_.end()) throw logicErr("No pair to remove!");
+    ALWAYS_ASSERT(pair != activePairs_.end(), logicErr, "No pair to remove!");
     pair->nextPair = std::next(pair);
     inactivePairs_.splice(inactivePairs_.end(), activePairs_, pair);
   }
@@ -467,8 +467,8 @@ class Monotones {
    */
   bool ShiftEast(const VertItr vert, const PairItr inputPair,
                  const bool isHole) {
-    if (inputPair == activePairs_.end())
-      throw logicErr("input pair is not defined!");
+    ALWAYS_ASSERT(inputPair != activePairs_.end(), logicErr,
+                  "input pair is not defined!");
 
     if (inputPair->eastCertain) return false;
 
@@ -486,8 +486,6 @@ class Monotones {
       }
 
       const int outside = potentialPair->WestOf(vert);
-      if (outside < 0 && !isHole) return true;
-
       if (outside <= 0 && isHole) {  // certainly a hole
         SwapHole(potentialPair, inputPair);
         return false;
@@ -506,8 +504,8 @@ class Monotones {
    */
   bool ShiftWest(const VertItr vert, const PairItr inputPair,
                  const bool isHole) {
-    if (inputPair == activePairs_.end())
-      throw logicErr("input pair is not defined!");
+    ALWAYS_ASSERT(inputPair != activePairs_.end(), logicErr,
+                  "input pair is not defined!");
 
     if (inputPair->westCertain) return false;
 
@@ -525,8 +523,6 @@ class Monotones {
       }
 
       const int outside = potentialPair->EastOf(vert);
-      if (outside < 0 && !isHole) return true;
-
       if (outside <= 0 && isHole) {  // certainly a hole
         SwapHole(potentialPair, inputPair);
         return false;

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -268,26 +268,24 @@ TEST(Manifold, MultiCoplanar) {
 
 TEST(Manifold, EdgeUnion) {
   Manifold cubes = Manifold::Cube();
-  auto propIn = cubes.GetProperties();
   Manifold cube2 = cubes;
   cubes += cube2.Translate({1, 1, 0});
-  EXPECT_TRUE(cubes.IsManifold());
-  EXPECT_EQ(cubes.Genus(), 0);
-  auto prop = cubes.GetProperties();
-  EXPECT_FLOAT_EQ(prop.volume, 2 * propIn.volume);
-  EXPECT_FLOAT_EQ(prop.surfaceArea, 2 * propIn.surfaceArea);
+  ExpectMeshes(cubes, {{8, 12}, {8, 12}});
+}
+
+TEST(Manifold, EdgeUnion2) {
+  Manifold tets = Manifold::Tetrahedron();
+  Manifold cube2 = tets;
+  tets.Translate({0, 0, -1});
+  tets += cube2.Translate({0, 0, 1}).Rotate(0, 0, 90);
+  ExpectMeshes(tets, {{4, 4}, {4, 4}});
 }
 
 TEST(Manifold, CornerUnion) {
   Manifold cubes = Manifold::Cube();
-  auto propIn = cubes.GetProperties();
   Manifold cube2 = cubes;
   cubes += cube2.Translate({1, 1, 1});
-  EXPECT_TRUE(cubes.IsManifold());
-  EXPECT_EQ(cubes.Genus(), 0);
-  auto prop = cubes.GetProperties();
-  EXPECT_FLOAT_EQ(prop.volume, 2 * propIn.volume);
-  EXPECT_FLOAT_EQ(prop.surfaceArea, 2 * propIn.surfaceArea);
+  ExpectMeshes(cubes, {{8, 12}, {8, 12}});
 }
 
 /**

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -418,5 +418,10 @@ TEST(Manifold, Boolean3) {
   Manifold result = gyroid + gyroid2;
   ExportMesh("gyroidUnion.gltf", result.Extract());
 
-  ExpectMeshes(result, {{29683, 59506}});
+  EXPECT_TRUE(result.IsManifold());
+  EXPECT_TRUE(result.MatchesTriNormals());
+  EXPECT_EQ(result.Decompose().size(), 1);
+  auto prop = result.GetProperties();
+  EXPECT_NEAR(prop.volume, 7692, 1);
+  EXPECT_NEAR(prop.surfaceArea, 9642, 1);
 }

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -130,6 +130,18 @@ TEST(Manifold, Sphere) {
   EXPECT_EQ(sphere.NumTri(), n * n * 8);
 }
 
+TEST(Manifold, Normals) {
+  Mesh cube = Manifold::Cube(glm::vec3(1), true).Extract();
+  const int nVert = cube.vertPos.size();
+  for (int i = 0; i < nVert; ++i) {
+    glm::vec3 v = glm::normalize(cube.vertPos[i]);
+    glm::vec3& n = cube.vertNormal[i];
+    EXPECT_FLOAT_EQ(v.x, n.x);
+    EXPECT_FLOAT_EQ(v.y, n.y);
+    EXPECT_FLOAT_EQ(v.z, n.z);
+  }
+}
+
 TEST(Manifold, Extrude) {
   Polygons polys = SquareHole();
   Manifold donut = Manifold::Extrude(polys, 1.0f, 3);
@@ -203,6 +215,7 @@ TEST(Manifold, BooleanTetra) {
  */
 TEST(Manifold, SelfSubtract) {
   Manifold cube = Manifold::Cube();
+  ExportMesh("cube.gltf", cube.Extract());
   Manifold empty = cube - cube;
   EXPECT_TRUE(empty.IsManifold());
   EXPECT_TRUE(empty.IsEmpty());

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -235,7 +235,7 @@ TEST(Manifold, Perturb) {
   Manifold corner(tmp);
   Manifold empty = corner - corner;
   EXPECT_TRUE(empty.IsManifold());
-  // EXPECT_TRUE(empty.IsEmpty());
+  EXPECT_TRUE(empty.IsEmpty());
 
   auto prop = empty.GetProperties();
   // ExportMesh("perturb.ply", empty.Extract());

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -249,7 +249,7 @@ TEST(Manifold, Coplanar) {
   Manifold out = cube - cube2.Scale({0.5f, 0.5f, 1.0f})
                             .Rotate(0, 0, 15)
                             .Translate({0.25f, 0.25f, 0.0f});
-  ExpectMeshes(out, {{60, 120}});
+  ExpectMeshes(out, {{42, 84}});
   EXPECT_EQ(out.Genus(), 1);
 }
 
@@ -368,11 +368,7 @@ TEST(Manifold, BooleanWinding) {
   Manifold doubled = Manifold::Compose(cubes);
 
   Manifold cube = Manifold::Cube(glm::vec3(1.0f), true);
-  PolygonParams().suppressErrors = true;
-  // The geometry error is expected due to triangulating a doubly-wound
-  // manifold, but we're checking that there was not first a topology error.
-  EXPECT_THROW(cube ^= doubled, geometryErr);
-  PolygonParams().suppressErrors = false;
+  EXPECT_TRUE((cube ^= doubled).IsManifold());
 }
 
 TEST(Manifold, BooleanNonIntersecting) {
@@ -408,5 +404,5 @@ TEST(Manifold, Boolean3) {
   gyroid2.Translate(glm::vec3(5.0f));
   Manifold result = gyroid + gyroid2;
 
-  ExpectMeshes(result, {{31733, 63606}});
+  ExpectMeshes(result, {{31526, 63192}});
 }

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -131,7 +131,7 @@ TEST(Manifold, Sphere) {
 }
 
 TEST(Manifold, Normals) {
-  Mesh cube = Manifold::Cube(glm::vec3(1), true).Extract();
+  Mesh cube = Manifold::Cube(glm::vec3(1), true).Extract(true);
   const int nVert = cube.vertPos.size();
   for (int i = 0; i < nVert; ++i) {
     glm::vec3 v = glm::normalize(cube.vertPos[i]);
@@ -249,8 +249,9 @@ TEST(Manifold, Coplanar) {
   Manifold out = cube - cube2.Scale({0.5f, 0.5f, 1.0f})
                             .Rotate(0, 0, 15)
                             .Translate({0.25f, 0.25f, 0.0f});
-  ExpectMeshes(out, {{42, 84}});
+  ExpectMeshes(out, {{32, 64}});
   EXPECT_EQ(out.Genus(), 1);
+  ExportMesh("coplanar.gltf", out.Extract());
 }
 
 TEST(Manifold, MultiCoplanar) {
@@ -264,6 +265,18 @@ TEST(Manifold, MultiCoplanar) {
   auto prop = out.GetProperties();
   EXPECT_NEAR(prop.volume, 0.18, 1e-5);
   EXPECT_NEAR(prop.surfaceArea, 2.76, 1e-5);
+}
+
+TEST(Manifold, FaceUnion) {
+  Manifold cubes = Manifold::Cube();
+  Manifold cube2 = cubes;
+  cubes += cube2.Translate({1, 0, 0});
+  EXPECT_EQ(cubes.Genus(), 0);
+  ExpectMeshes(cubes, {{8, 12}});
+  auto prop = cubes.GetProperties();
+  EXPECT_NEAR(prop.volume, 2, 1e-5);
+  EXPECT_NEAR(prop.surfaceArea, 10, 1e-5);
+  ExportMesh("faceUnion.gltf", cubes.Extract());
 }
 
 TEST(Manifold, EdgeUnion) {
@@ -402,5 +415,5 @@ TEST(Manifold, Boolean3) {
   gyroid2.Translate(glm::vec3(5.0f));
   Manifold result = gyroid + gyroid2;
 
-  ExpectMeshes(result, {{31526, 63192}});
+  ExpectMeshes(result, {{29602, 59344}});
 }

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -39,6 +39,7 @@ void Identical(Mesh& mesh1, Mesh& mesh2) {
 void ExpectMeshes(Manifold& manifold,
                   const std::vector<std::pair<int, int>>& numVertTri) {
   EXPECT_TRUE(manifold.IsManifold());
+  EXPECT_TRUE(manifold.MatchesTriNormals());
   std::vector<Manifold> meshes = manifold.Decompose();
   ASSERT_EQ(meshes.size(), numVertTri.size());
   std::sort(meshes.begin(), meshes.end(),
@@ -90,7 +91,7 @@ TEST(Manifold, Regression) {
   Manifold mesh1 = manifold;
   mesh1.Translate(glm::vec3(5.0f));
   int num_overlaps = manifold.NumOverlaps(mesh1);
-  ASSERT_EQ(num_overlaps, 237472);
+  ASSERT_EQ(num_overlaps, 237125);
 
   Mesh mesh_out = manifold.Extract();
   Manifold mesh2(mesh_out);
@@ -410,10 +411,12 @@ TEST(Manifold, BooleanSphere) {
 TEST(Manifold, Boolean3) {
   Manifold gyroid(ImportMesh("data/gyroidpuzzle.ply"));
   EXPECT_TRUE(gyroid.IsManifold());
+  EXPECT_TRUE(gyroid.MatchesTriNormals());
 
   Manifold gyroid2 = gyroid;
   gyroid2.Translate(glm::vec3(5.0f));
   Manifold result = gyroid + gyroid2;
+  ExportMesh("gyroidUnion.gltf", result.Extract());
 
-  ExpectMeshes(result, {{29602, 59344}});
+  ExpectMeshes(result, {{29683, 59506}});
 }

--- a/test/polygon_test.cpp
+++ b/test/polygon_test.cpp
@@ -373,6 +373,39 @@ TEST(Polygon, Sliver3) {
   TestPoly(polys, 4);
 }
 
+TEST(Polygon, Sliver4) {
+  Polygons polys;
+  polys.push_back({
+      {glm::vec2(-0.375669807, 8.90489388), 7474},  //
+      {glm::vec2(0, 8.39722729), 7459},             //
+      {glm::vec2(0, 8.9723053), 7468},              //
+      {glm::vec2(0, 8.9723053), 7469},              //
+      {glm::vec2(0, 8.96719646), 7467},             //
+      {glm::vec2(0, 8.89326191), 7466},             //
+      {glm::vec2(0, 8.78047276), 7465},             //
+      {glm::vec2(-0.330551624, 8.8897438), 7473},   //
+  });
+  TestPoly(polys, 6);
+}
+
+TEST(Polygon, Sliver5) {
+  Polygons polys;
+  polys.push_back({
+      {glm::vec2(-60, 0), 19},               //
+      {glm::vec2(-50, 0), 21},               //
+      {glm::vec2(-50, 0), 38},               //
+      {glm::vec2(-60, 4.37113897e-07), 24},  //
+      {glm::vec2(-60, 4.37113897e-07), 37},  //
+  });
+  polys.push_back({
+      {glm::vec2(-60, 100), 20},             //
+      {glm::vec2(-60, 4.37113897e-07), 44},  //
+      {glm::vec2(-60, 4.37113897e-07), 28},  //
+      {glm::vec2(-50, 0), 45},               //
+  });
+  TestPoly(polys, 5);
+}
+
 TEST(Polygon, Colinear2) {
   Polygons polys;
   polys.push_back({
@@ -413,21 +446,6 @@ TEST(Polygon, Duplicates) {
       {glm::vec2(-15, -8.10255623), 1922},         //
   });
   TestPoly(polys, 4);
-}
-
-TEST(Polygon, Sliver4) {
-  Polygons polys;
-  polys.push_back({
-      {glm::vec2(-0.375669807, 8.90489388), 7474},  //
-      {glm::vec2(0, 8.39722729), 7459},             //
-      {glm::vec2(0, 8.9723053), 7468},              //
-      {glm::vec2(0, 8.9723053), 7469},              //
-      {glm::vec2(0, 8.96719646), 7467},             //
-      {glm::vec2(0, 8.89326191), 7466},             //
-      {glm::vec2(0, 8.78047276), 7465},             //
-      {glm::vec2(-0.330551624, 8.8897438), 7473},   //
-  });
-  TestPoly(polys, 6);
 }
 
 TEST(Polygon, Simple1) {

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -82,6 +82,9 @@ TEST(Samples, FrameReduced) {
   EXPECT_TRUE(frame.IsManifold());
   Manifold::SetCircularSegments(0);
   EXPECT_EQ(frame.Genus(), 5);
+  auto prop = frame.GetProperties();
+  EXPECT_NEAR(prop.volume, 227333, 10);
+  EXPECT_NEAR(prop.surfaceArea, 62635, 1);
   ExportMesh("roundedFrameReduced.gltf", frame.Extract());
 }
 

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -61,7 +61,9 @@ TEST(Samples, Bracelet) {
 TEST(Samples, Sponge) {
   Manifold sponge = MengerSponge(4);
   EXPECT_TRUE(sponge.IsManifold());
+  EXPECT_TRUE(sponge.MatchesTriNormals());
   EXPECT_EQ(sponge.Genus(), 26433);  // should be 1:5, 2:81, 3:737, 4:7713
+  ExportMesh("mengerSponge.gltf", sponge.Extract());
   std::pair<Manifold, Manifold> cutSponge = sponge.SplitByPlane({1, 1, 1}, 0);
   EXPECT_TRUE(cutSponge.first.IsManifold());
   EXPECT_EQ(cutSponge.first.Genus(), 13394);
@@ -73,7 +75,9 @@ TEST(Samples, Sponge) {
 TEST(Samples, Sponge1) {
   Manifold sponge = MengerSponge(1);
   EXPECT_TRUE(sponge.IsManifold());
+  EXPECT_TRUE(sponge.MatchesTriNormals());
   EXPECT_EQ(sponge.Genus(), 5);
+  // ExportMesh("mengerSponge1.gltf", sponge.Extract());
 }
 
 TEST(Samples, FrameReduced) {

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -61,7 +61,7 @@ TEST(Samples, Bracelet) {
 TEST(Samples, Sponge) {
   Manifold sponge = MengerSponge(4);
   EXPECT_TRUE(sponge.IsManifold());
-  EXPECT_EQ(sponge.Genus(), 26433);
+  EXPECT_EQ(sponge.Genus(), 26433);  // should be 1:5, 2:81, 3:737, 4:7713
   std::pair<Manifold, Manifold> cutSponge = sponge.SplitByPlane({1, 1, 1}, 0);
   EXPECT_TRUE(cutSponge.first.IsManifold());
   EXPECT_EQ(cutSponge.first.Genus(), 13394);
@@ -70,17 +70,24 @@ TEST(Samples, Sponge) {
   // ExportMesh("mengerSponge.ply", cutSponge.first.Extract());
 }
 
+TEST(Samples, Sponge1) {
+  Manifold sponge = MengerSponge(1);
+  EXPECT_TRUE(sponge.IsManifold());
+  EXPECT_EQ(sponge.Genus(), 5);
+}
+
 TEST(Samples, FrameReduced) {
-  Manifold::SetCircularSegments(6);
+  Manifold::SetCircularSegments(4);
   Manifold frame = RoundedFrame(100, 10);
   EXPECT_TRUE(frame.IsManifold());
   Manifold::SetCircularSegments(0);
-  // EXPECT_EQ(frame.Genus(), 13);
+  EXPECT_EQ(frame.Genus(), 5);
+  ExportMesh("roundedFrameReduced.gltf", frame.Extract());
 }
 
 TEST(Samples, Frame) {
   Manifold frame = RoundedFrame(100, 10);
   EXPECT_TRUE(frame.IsManifold());
-  // EXPECT_EQ(frame.Genus(), 13);
+  EXPECT_EQ(frame.Genus(), 5);
   // ExportMesh("roundedFrame.ply", frame.Extract());
 }

--- a/utilities/include/structs.h
+++ b/utilities/include/structs.h
@@ -108,6 +108,7 @@ using Polygons = std::vector<SimplePolygon>;
 
 struct Mesh {
   std::vector<glm::vec3> vertPos;
+  std::vector<glm::vec3> vertNormal;
   std::vector<glm::ivec3> triVerts;
 };
 

--- a/utilities/include/structs.h
+++ b/utilities/include/structs.h
@@ -47,11 +47,20 @@ void AlwaysAssert(bool condition, const char* file, int line,
   }
 }
 
-inline int Signum(float val) { return (val > 0) - (val < 0); }
+#define ALWAYS_ASSERT(condition, EX, msg) \
+  AlwaysAssert<EX>(condition, __FILE__, __LINE__, #condition, msg);
+
+#ifdef __CUDACC__
+#define HOST_DEVICE __host__ __device__
+#else
+#define HOST_DEVICE
+#endif
+
+inline HOST_DEVICE int Signum(float val) { return (val > 0) - (val < 0); }
 
 // Use sind and cosd for inputs in degrees so that multiples of 90 degrees come
 // out exact.
-inline float sind(float x) {
+inline HOST_DEVICE float sind(float x) {
   if (!std::isfinite(x)) return sin(x);
   if (x < 0.0f) return -sind(-x);
   int quo;
@@ -69,16 +78,19 @@ inline float sind(float x) {
   return 0.0f;
 }
 
-inline float cosd(float x) { return sind(x + 90.0f); }
+inline HOST_DEVICE float cosd(float x) { return sind(x + 90.0f); }
 
-#define ALWAYS_ASSERT(condition, EX, msg) \
-  AlwaysAssert<EX>(condition, __FILE__, __LINE__, #condition, msg);
-
-#ifdef __CUDACC__
-#define HOST_DEVICE __host__ __device__
-#else
-#define HOST_DEVICE
-#endif
+inline HOST_DEVICE int CCW(glm::vec2 p0, glm::vec2 p1, glm::vec2 p2,
+                           float tol) {
+  glm::vec2 v1 = p1 - p0;
+  glm::vec2 v2 = p2 - p0;
+  float area = v1.x * v2.y - v1.y * v2.x;
+  float base2 = glm::max(glm::dot(v1, v1), glm::dot(v2, v2));
+  if (area * area <= base2 * tol * tol)
+    return 0;
+  else
+    return area > 0 ? 1 : -1;
+}
 
 struct ExecutionParams {
   float kTolerance = 2e-5;

--- a/utilities/include/vec_dh.cuh
+++ b/utilities/include/vec_dh.cuh
@@ -22,6 +22,15 @@ template <typename T>
 using VecH = thrust::host_vector<T>;
 
 template <typename T>
+void Dump(const VecH<T>& vec) {
+  std::cout << "VecDH = " << std::endl;
+  for (int i = 0; i < vec.size(); ++i) {
+    std::cout << i << ", " << vec[i] << ", " << std::endl;
+  }
+  std::cout << std::endl;
+}
+
+template <typename T>
 class VecDH {
  public:
   VecDH() {}
@@ -149,14 +158,7 @@ class VecDH {
     return host_;
   }
 
-  void Dump() const {
-    RefreshHost();
-    std::cout << "VecDH = " << std::endl;
-    for (int i = 0; i < size(); ++i) {
-      std::cout << i << ", " << host_[i] << ", " << std::endl;
-    }
-    std::cout << std::endl;
-  }
+  void Dump() const { manifold::Dump(H()); }
 
  private:
   mutable bool host_valid_ = true;


### PR DESCRIPTION
Exporting glTF is now supported using the new version of Assimp, with or without vertex normals. Also added CollapseDegenerates() which removes many, but not all degenerate triangles and extra verts. It is able to split the mesh topologically, thus increasing Euler characteristic (decreasing genus), meaning it either separates objects or removes handles. Several tests were added or strengthened to demonstrate this, including a new method MatchesTriNormals(), which verifies that the collapses have not inverted triangles, since the triNormals are maintained instead of recalculated. 