### PR TITLE
Calculate curvature

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -92,7 +92,7 @@
     "C_Cpp.clang_format_fallbackStyle": "google",
     "editor.formatOnSave": true,
     "cmake.configureArgs": [
-        "-DMANIFOLD_USE_CPP=OFF",
+        "-DMANIFOLD_USE_CPP=ON",
         // "-DMANIFOLD_USE_OMP=ON"
     ],
 }

--- a/manifold/include/manifold.h
+++ b/manifold/include/manifold.h
@@ -59,6 +59,7 @@ class Manifold {
   float Precision() const;
   int Genus() const;
   Properties GetProperties() const;
+  Curvature GetCurvature() const;
   MeshRelation GetMeshRelation() const;
 
   // Modification

--- a/manifold/include/manifold.h
+++ b/manifold/include/manifold.h
@@ -25,10 +25,6 @@ class Manifold {
   // Creation
   Manifold();
   Manifold(const Mesh&);
-  struct Smoothness {
-    int halfedge;
-    float smoothness;
-  };
   static Manifold Smooth(const Mesh&,
                          const std::vector<Smoothness>& sharpenedEdges = {});
   static Manifold Tetrahedron();
@@ -62,9 +58,6 @@ class Manifold {
   Box BoundingBox() const;
   float Precision() const;
   int Genus() const;
-  struct Properties {
-    float surfaceArea, volume;
-  };
   Properties GetProperties() const;
   MeshRelation GetMeshRelation() const;
 

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -548,6 +548,8 @@ int Manifold::Genus() const {
 
 Properties Manifold::GetProperties() const { return pImpl_->GetProperties(); }
 
+Curvature Manifold::GetCurvature() const { return pImpl_->GetCurvature(); }
+
 /**
  * Gets the relationship to the previous mesh, for the purpose of assinging
  * properties like texture coordinates. The triBary vector is the same length as

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -546,9 +546,7 @@ int Manifold::Genus() const {
   return 1 - chi / 2;
 }
 
-Manifold::Properties Manifold::GetProperties() const {
-  return pImpl_->GetProperties();
-}
+Properties Manifold::GetProperties() const { return pImpl_->GetProperties(); }
 
 /**
  * Gets the relationship to the previous mesh, for the purpose of assinging

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -546,8 +546,22 @@ int Manifold::Genus() const {
   return 1 - chi / 2;
 }
 
+/**
+ * Returns the surface area and volume of the manifold in a Properties
+ * structure. These properties are clamped to zero for a given face if they are
+ * within rounding tolerance. This means degenerate manifolds can by identified
+ * by testing these properties as == 0.
+ */
 Properties Manifold::GetProperties() const { return pImpl_->GetProperties(); }
 
+/**
+ * Curvature is the inverse of the radius of curvature, and signed such that
+ * positive is convex and negative is concave. There are two orthogonal
+ * principal curvatures at any point on a manifold, with one maximum and the
+ * other minimum. Gaussian curvature is their product, while mean
+ * curvature is their sum. This approximates them for every vertex (returned as
+ * vectors in the structure) and also returns their minimum and maximum values.
+ */
 Curvature Manifold::GetCurvature() const { return pImpl_->GetCurvature(); }
 
 /**

--- a/manifold/src/manifold_impl.cu
+++ b/manifold/src/manifold_impl.cu
@@ -95,6 +95,11 @@ __host__ __device__ glm::mat3x2 GetAxisAlignedProjection(glm::vec3 normal) {
   return glm::transpose(projection);
 }
 
+struct Barycentric {
+  int tri;
+  glm::vec3 uvw;
+};
+
 struct Normalize {
   __host__ __device__ void operator()(glm::vec3& v) {
     v = glm::normalize(v);
@@ -1571,7 +1576,7 @@ bool Manifold::Impl::MatchesTriNormals() const {
  * within rounding tolerance. This means degenerate manifolds can by identified
  * by testing these properties as == 0.
  */
-Manifold::Properties Manifold::Impl::GetProperties() const {
+Properties Manifold::Impl::GetProperties() const {
   if (halfedge_.size() == 0) return {0, 0};
   ApplyTransform();
   thrust::pair<float, float> areaVolume = thrust::transform_reduce(

--- a/manifold/src/manifold_impl.cu
+++ b/manifold/src/manifold_impl.cu
@@ -1626,12 +1626,6 @@ bool Manifold::Impl::MatchesTriNormals() const {
                                   faceNormal_.cptrD(), precision_}));
 }
 
-/**
- * Returns the surface area and volume of the manifold in a Properties
- * structure. These properties are clamped to zero for a given face if they are
- * within rounding tolerance. This means degenerate manifolds can by identified
- * by testing these properties as == 0.
- */
 Properties Manifold::Impl::GetProperties() const {
   if (IsEmpty()) return {0, 0};
   ApplyTransform();

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -59,6 +59,7 @@ struct Manifold::Impl {
   int NumEdge() const { return halfedge_.size() / 2; }
   int NumTri() const { return halfedge_.size() / 3; }
   Properties GetProperties() const;
+  Curvature GetCurvature() const;
   void CalculateBBox();
   void SetPrecision(float minPrecision = -1);
   bool IsManifold() const;

--- a/samples/src/scallop.cpp
+++ b/samples/src/scallop.cpp
@@ -24,7 +24,7 @@ Manifold Scallop() {
   constexpr float sharpness = 0.8;
 
   Mesh scallop;
-  std::vector<Manifold::Smoothness> sharpenedEdges;
+  std::vector<Smoothness> sharpenedEdges;
   scallop.vertPos = {{-offset, 0, height}, {-offset, 0, -height}};
 
   const float delta = glm::pi<float>() / wiggles;

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -306,6 +306,14 @@ TEST(Manifold, Precision) {
   EXPECT_FLOAT_EQ(cube.Precision(), 100 * kTolerance);
 }
 
+TEST(Manifold, GetCurvature) {
+  for (int n = 4; n < 100; n *= 2) {
+    Manifold sphere = Manifold::Sphere(1, n);
+    Curvature curvature = sphere.GetCurvature();
+    EXPECT_NEAR(curvature.minMeanCurvature, 1, 1);
+  }
+}
+
 /**
  * Testing more advanced Manifold operations.
  */

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -306,11 +306,31 @@ TEST(Manifold, Precision) {
   EXPECT_FLOAT_EQ(cube.Precision(), 100 * kTolerance);
 }
 
+/**
+ * Curvature is the inverse of the radius of curvature, and signed such that
+ * positive is convex and negative is concave. There are two orthogonal
+ * principal curvatures at any point on a manifold, with one maximum and the
+ * other minimum. Gaussian curvature is their product, while mean
+ * curvature is their sum. Here we check our discrete appoximations calculated
+ * at each vertex against the constant expected values of spheres of different
+ * radii and at different mesh resolutions.
+ */
 TEST(Manifold, GetCurvature) {
+  const float precision = 0.015;
   for (int n = 4; n < 100; n *= 2) {
-    Manifold sphere = Manifold::Sphere(1, n);
+    Manifold sphere = Manifold::Sphere(1, 64);
     Curvature curvature = sphere.GetCurvature();
-    EXPECT_NEAR(curvature.minMeanCurvature, 1, 1);
+    EXPECT_NEAR(curvature.minMeanCurvature, 2, 2 * precision);
+    EXPECT_NEAR(curvature.maxMeanCurvature, 2, 2 * precision);
+    EXPECT_NEAR(curvature.minGaussianCurvature, 1, precision);
+    EXPECT_NEAR(curvature.maxGaussianCurvature, 1, precision);
+
+    sphere.Scale(glm::vec3(2.0f));
+    curvature = sphere.GetCurvature();
+    EXPECT_NEAR(curvature.minMeanCurvature, 1, precision);
+    EXPECT_NEAR(curvature.maxMeanCurvature, 1, precision);
+    EXPECT_NEAR(curvature.minGaussianCurvature, 0.25, 0.25 * precision);
+    EXPECT_NEAR(curvature.maxGaussianCurvature, 0.25, 0.25 * precision);
   }
 }
 

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -59,7 +59,13 @@ TEST(Samples, Scallop) {
   // ExportOptions options;
   // options.faceted = false;
   // options.mat.roughness = 0.1;
-  // options.mat.color = {0, 0, 1, 1};
+  // const glm::vec4 blue(0, 0, 1, 1);
+  // const glm::vec4 red(1, 0, 0, 1);
+  // const float limit = 15;
+  // for (float curvature : scallop.GetCurvature().vertMeanCurvature) {
+  //   options.mat.vertColor.push_back(
+  //       glm::mix(blue, red, glm::smoothstep(-limit, limit, curvature)));
+  // }
   // ExportMesh("scallop.gltf", out, options);
 }
 

--- a/utilities/include/structs.h
+++ b/utilities/include/structs.h
@@ -144,6 +144,12 @@ struct Properties {
   float surfaceArea, volume;
 };
 
+struct Curvature {
+  float maxMeanCurvature, minMeanCurvature;
+  float maxGaussianCurvature, minGaussianCurvature;
+  std::vector<float> vertMeanCurvature, vertGaussianCurvature;
+};
+
 struct BaryRef {
   int tri;
   glm::ivec3 vertBary;

--- a/utilities/include/structs.h
+++ b/utilities/include/structs.h
@@ -135,9 +135,13 @@ struct Mesh {
   std::vector<glm::vec4> halfedgeTangent;
 };
 
-struct Barycentric {
-  int tri;
-  glm::vec3 uvw;
+struct Smoothness {
+  int halfedge;
+  float smoothness;
+};
+
+struct Properties {
+  float surfaceArea, volume;
 };
 
 struct BaryRef {
@@ -287,11 +291,6 @@ inline std::ostream& operator<<(std::ostream& stream, const glm::mat4x3& mat) {
 inline std::ostream& operator<<(std::ostream& stream, const BaryRef& ref) {
   return stream << "tri = " << ref.tri << ", uvw idx = " << ref.vertBary;
 }
-
-inline std::ostream& operator<<(std::ostream& stream, const Barycentric& bary) {
-  return stream << "tri = " << bary.tri << ", uvw idx = " << bary.uvw;
-}
-
 }  // namespace manifold
 
 #undef HOST_DEVICE


### PR DESCRIPTION
Added per-vertex calculations of mean and Gaussian curvature. Nice for coloring meshes, and also useful since my stated goal of smooth interpolation is to minimize the maximum magnitude of mean curvature. This allows for a quantitative measure of improvement (though the choice of test meshes will always be an area that arbitrary choices creep in). I'm personally quite impressed that the per-vertex calculations are uniformly within 1.5% of the ideal spherical values, even at such low resolution as an octahedron. 