### PR TITLE
meshRelation to input meshes

### DIFF
--- a/manifold/include/manifold.h
+++ b/manifold/include/manifold.h
@@ -61,6 +61,8 @@ class Manifold {
   Properties GetProperties() const;
   Curvature GetCurvature() const;
   MeshRelation GetMeshRelation() const;
+  std::vector<int> MeshIDs() const;
+  static std::vector<int> MeshID2Original();
 
   // Modification
   Manifold& Translate(glm::vec3);
@@ -102,8 +104,8 @@ class Manifold {
 
  private:
   std::unique_ptr<Impl> pImpl_;
-  static int circularSegments;
-  static float circularAngle;
-  static float circularEdgeLength;
+  static int circularSegments_;
+  static float circularAngle_;
+  static float circularEdgeLength_;
 };
 }  // namespace manifold

--- a/manifold/include/manifold.h
+++ b/manifold/include/manifold.h
@@ -63,6 +63,7 @@ class Manifold {
   MeshRelation GetMeshRelation() const;
   std::vector<int> MeshIDs() const;
   static std::vector<int> MeshID2Original();
+  static void SetAsOriginal(int meshID);
 
   // Modification
   Manifold& Translate(glm::vec3);

--- a/manifold/include/manifold.h
+++ b/manifold/include/manifold.h
@@ -62,8 +62,8 @@ class Manifold {
   Curvature GetCurvature() const;
   MeshRelation GetMeshRelation() const;
   std::vector<int> MeshIDs() const;
+  int SetAsOriginal();
   static std::vector<int> MeshID2Original();
-  static void SetAsOriginal(int meshID);
 
   // Modification
   Manifold& Translate(glm::vec3);

--- a/manifold/src/boolean3.cu
+++ b/manifold/src/boolean3.cu
@@ -872,10 +872,14 @@ struct DuplicateHalfedges {
     halfedge.face = faceP2R[faceLeftP];
     const int faceRightP = halfedgesP[halfedge.pairedHalfedge].face;
     const int faceRight = faceP2R[faceRightP];
+    // Negative inclusion means the halfedges are reversed, which means our
+    // reference is now to the endVert instead of the startVert, which is one
+    // position advanced CCW.
     const Ref forwardRef = {forward ? 0 : 1, faceLeftP,
-                            edgeP - 3 * faceLeftP - 3};
-    const Ref backwardRef = {forward ? 0 : 1, faceRightP,
-                             halfedge.pairedHalfedge - 3 * faceRightP - 3};
+                            ((edgeP + (inclusion < 0 ? 1 : 0)) % 3) - 3};
+    const Ref backwardRef = {
+        forward ? 0 : 1, faceRightP,
+        ((halfedge.pairedHalfedge + (inclusion < 0 ? 1 : 0)) % 3) - 3};
 
     for (int i = 0; i < glm::abs(inclusion); ++i) {
       int forwardEdge = AtomicAdd(facePtr[halfedge.face], 1);

--- a/manifold/src/boolean3.cu
+++ b/manifold/src/boolean3.cu
@@ -1239,12 +1239,9 @@ Manifold::Impl Boolean3::Result(Manifold::OpType op) const {
   // Create the manifold's data structures.
   outR.precision_ = glm::max(inP_.precision_, inQ_.precision_);
 
-  // TODO: pass in halfedgeRef and use this to create meshRelation_.triBary.
-  // Skip initialization in CreateAndFixHalfedges().
   outR.Face2Tri(faceEdge, halfedgeRef);
 
-  // TODO: pass meshRelation_ through this function. Only remove long edges with
-  // consistent meshID/tri.
+  // TODO: Only remove long edges with consistent meshID/tri.
   outR.CollapseDegenerates();
 
   triangulate.Stop();

--- a/manifold/src/boolean3.cu
+++ b/manifold/src/boolean3.cu
@@ -737,6 +737,7 @@ void AppendPartialEdges(Manifold::Impl &outR, VecH<bool> &wholeHalfedgeP,
     }
 
     int inclusion = i03[vStart];
+    bool reversed = inclusion < 0;
     EdgePos edgePos = {vP2R[vStart],
                        glm::dot(outR.vertPos_.H()[vP2R[vStart]], edgeVec),
                        inclusion > 0};
@@ -746,6 +747,7 @@ void AppendPartialEdges(Manifold::Impl &outR, VecH<bool> &wholeHalfedgeP,
     }
 
     inclusion = i03[vEnd];
+    reversed |= inclusion < 0;
     edgePos = {vP2R[vEnd], glm::dot(outR.vertPos_.H()[vP2R[vEnd]], edgeVec),
                inclusion < 0};
     for (int j = 0; j < glm::abs(inclusion); ++j) {
@@ -761,10 +763,15 @@ void AppendPartialEdges(Manifold::Impl &outR, VecH<bool> &wholeHalfedgeP,
     const int faceLeft = faceP2R[faceLeftP];
     const int faceRightP = halfedgeP[halfedge.pairedHalfedge].face;
     const int faceRight = faceP2R[faceRightP];
+    // Negative inclusion means the halfedges are reversed, which means our
+    // reference is now to the endVert instead of the startVert, which is one
+    // position advanced CCW.
     const Ref forwardRef = {forward ? 0 : 1, faceLeftP,
-                            edgeP - 3 * faceLeftP - 3};
-    const Ref backwardRef = {forward ? 0 : 1, faceRightP,
-                             halfedge.pairedHalfedge - 3 * faceRightP - 3};
+                            ((edgeP + (reversed ? 1 : 0)) % 3) - 3};
+    const Ref backwardRef = {
+        forward ? 0 : 1, faceRightP,
+        ((halfedge.pairedHalfedge + (reversed ? 1 : 0)) % 3) - 3};
+
     for (Halfedge e : edges) {
       const int forwardEdge = facePtrR[faceLeft]++;
       const int backwardEdge = facePtrR[faceRight]++;

--- a/manifold/src/boolean3.cu
+++ b/manifold/src/boolean3.cu
@@ -57,10 +57,11 @@
 // TODO: make this runtime configurable for quicker debug
 constexpr bool kVerbose = false;
 
+using namespace manifold;
 using namespace thrust::placeholders;
+using Ref = Manifold::Impl::Ref;
 
 namespace {
-using namespace manifold;
 
 // These two functions (Interpolate and Intersect) are the only places where
 // floating-point operations take place in the whole Boolean function. These are
@@ -703,15 +704,6 @@ std::vector<Halfedge> PairUp(std::vector<EdgePos> &edgePos) {
   return edges;
 }
 
-struct Ref {
-  int meshID, tri, bary;
-};
-
-std::ostream &operator<<(std::ostream &stream, const Ref &ref) {
-  return stream << "meshID = " << ref.meshID << ", tri = " << ref.tri
-                << ", bary = " << ref.bary;
-}
-
 void AppendPartialEdges(Manifold::Impl &outR, VecH<bool> &wholeHalfedgeP,
                         VecH<int> &facePtrR,
                         std::map<int, std::vector<EdgePos>> &edgesP,
@@ -1249,7 +1241,7 @@ Manifold::Impl Boolean3::Result(Manifold::OpType op) const {
 
   // TODO: pass in halfedgeRef and use this to create meshRelation_.triBary.
   // Skip initialization in CreateAndFixHalfedges().
-  outR.Face2Tri(faceEdge);
+  outR.Face2Tri(faceEdge, halfedgeRef);
 
   // TODO: pass meshRelation_ through this function. Only remove long edges with
   // consistent meshID/tri.

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -615,6 +615,19 @@ std::vector<int> Manifold::MeshID2Original() {
   return Manifold::Impl::meshID2Original_;
 }
 
+/**
+ * If you copy a manifold, but you want this new copy to have new properties
+ * (e.g. a different UV mapping), you can set this meshID as an original,
+ * meaning it will now be referenced by its descendents instead of the mesh it
+ * was copied from, allowing you to differentiate the copies when applying your
+ * properties to the final result.
+ */
+void Manifold::SetAsOriginal(int meshID) {
+  ALWAYS_ASSERT(meshID < Manifold::Impl::meshID2Original_.size(), userErr,
+                "This meshID has not been defined yet!");
+  Manifold::Impl::meshID2Original_[meshID] = meshID;
+}
+
 bool Manifold::IsManifold() const { return pImpl_->IsManifold(); }
 
 bool Manifold::MatchesTriNormals() const { return pImpl_->MatchesTriNormals(); }

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -590,6 +590,27 @@ MeshRelation Manifold::GetMeshRelation() const {
   return out;
 }
 
+std::vector<int> Manifold::MeshIDs() const {
+  VecDH<int> meshIDs(NumTri());
+  thrust::for_each_n(
+      zip(meshIDs.beginD(), pImpl_->meshRelation_.triBary.beginD()), NumTri(),
+      [](thrust::tuple<int&, BaryRef> inOut) {
+        thrust::get<0>(inOut) = thrust::get<1>(inOut).meshID;
+      });
+
+  thrust::sort(meshIDs.beginD(), meshIDs.endD());
+  int n = thrust::unique(meshIDs.beginD(), meshIDs.endD()) - meshIDs.beginD();
+  meshIDs.resize(n);
+
+  std::vector<int> out;
+  out.insert(out.end(), meshIDs.begin(), meshIDs.end());
+  return out;
+}
+
+// std::vector<int> Manifold::MeshID2Original() {
+//   return Manifold::Impl::meshID2Original_;
+// }
+
 bool Manifold::IsManifold() const { return pImpl_->IsManifold(); }
 
 bool Manifold::MatchesTriNormals() const { return pImpl_->MatchesTriNormals(); }

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -96,11 +96,14 @@ Manifold::~Manifold() = default;
 Manifold::Manifold(Manifold&&) noexcept = default;
 Manifold& Manifold::operator=(Manifold&&) noexcept = default;
 
-Manifold::Manifold(const Manifold& other) : pImpl_(new Impl(*other.pImpl_)) {}
+Manifold::Manifold(const Manifold& other) : pImpl_(new Impl(*other.pImpl_)) {
+  pImpl_->DuplicateMeshIDs();
+}
 
 Manifold& Manifold::operator=(const Manifold& other) {
   if (this != &other) {
     pImpl_.reset(new Impl(*other.pImpl_));
+    pImpl_->DuplicateMeshIDs();
   }
   return *this;
 }
@@ -493,30 +496,30 @@ Mesh Manifold::Extract() const {
  * edge length and angle, rounded up to the nearest multiple of four. To get
  * numbers not divisible by four, circularSegements must be specified.
  */
-int Manifold::circularSegments = 0;
-float Manifold::circularAngle = 10.0f;
-float Manifold::circularEdgeLength = 1.0f;
+int Manifold::circularSegments_ = 0;
+float Manifold::circularAngle_ = 10.0f;
+float Manifold::circularEdgeLength_ = 1.0f;
 
 void Manifold::SetMinCircularAngle(float angle) {
   ALWAYS_ASSERT(angle > 0.0f, userErr, "angle must be positive!");
-  Manifold::circularAngle = angle;
+  Manifold::circularAngle_ = angle;
 }
 
 void Manifold::SetMinCircularEdgeLength(float length) {
   ALWAYS_ASSERT(length > 0.0f, userErr, "length must be positive!");
-  Manifold::circularEdgeLength = length;
+  Manifold::circularEdgeLength_ = length;
 }
 
 void Manifold::SetCircularSegments(int number) {
   ALWAYS_ASSERT(number > 2 || number == 0, userErr,
                 "must have at least three segments in circle!");
-  Manifold::circularSegments = number;
+  Manifold::circularSegments_ = number;
 }
 
 int Manifold::GetCircularSegments(float radius) {
-  if (Manifold::circularSegments > 0) return Manifold::circularSegments;
-  int nSegA = 360.0f / Manifold::circularAngle;
-  int nSegL = 2.0f * radius * glm::pi<float>() / Manifold::circularEdgeLength;
+  if (Manifold::circularSegments_ > 0) return Manifold::circularSegments_;
+  int nSegA = 360.0f / Manifold::circularAngle_;
+  int nSegL = 2.0f * radius * glm::pi<float>() / Manifold::circularEdgeLength_;
   int nSeg = min(nSegA, nSegL) + 3;
   nSeg -= nSeg % 4;
   return nSeg;

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -607,9 +607,9 @@ std::vector<int> Manifold::MeshIDs() const {
   return out;
 }
 
-// std::vector<int> Manifold::MeshID2Original() {
-//   return Manifold::Impl::meshID2Original_;
-// }
+std::vector<int> Manifold::MeshID2Original() {
+  return Manifold::Impl::meshID2Original_;
+}
 
 bool Manifold::IsManifold() const { return pImpl_->IsManifold(); }
 

--- a/manifold/src/manifold.cu
+++ b/manifold/src/manifold.cu
@@ -75,6 +75,12 @@ struct MakeTri {
   }
 };
 
+struct GetMeshID {
+  __host__ __device__ void operator()(thrust::tuple<int&, BaryRef> inOut) {
+    thrust::get<0>(inOut) = thrust::get<1>(inOut).meshID;
+  }
+};
+
 Manifold Halfspace(Box bBox, glm::vec3 normal, float originOffset) {
   normal = glm::normalize(normal);
   Manifold cutter =
@@ -594,9 +600,7 @@ std::vector<int> Manifold::MeshIDs() const {
   VecDH<int> meshIDs(NumTri());
   thrust::for_each_n(
       zip(meshIDs.beginD(), pImpl_->meshRelation_.triBary.beginD()), NumTri(),
-      [](thrust::tuple<int&, BaryRef> inOut) {
-        thrust::get<0>(inOut) = thrust::get<1>(inOut).meshID;
-      });
+      GetMeshID());
 
   thrust::sort(meshIDs.beginD(), meshIDs.endD());
   int n = thrust::unique(meshIDs.beginD(), meshIDs.endD()) - meshIDs.beginD();

--- a/manifold/src/manifold_impl.cu
+++ b/manifold/src/manifold_impl.cu
@@ -1867,6 +1867,8 @@ void Manifold::Impl::GatherFaces(const Impl& old,
   thrust::gather(faceNew2Old.beginD(), faceNew2Old.endD(),
                  old.meshRelation_.triBary.beginD(),
                  meshRelation_.triBary.beginD());
+  meshRelation_.barycentric = old.meshRelation_.barycentric;
+  DuplicateMeshIDs();
 
   if (old.faceNormal_.size() == old.NumTri()) {
     faceNormal_.resize(numTri);

--- a/manifold/src/manifold_impl.cu
+++ b/manifold/src/manifold_impl.cu
@@ -205,8 +205,12 @@ struct InteriorVerts {
   __host__ __device__ void operator()(thrust::tuple<int, BaryRef> in) {
     const int tri = thrust::get<0>(in);
     const BaryRef baryOld = thrust::get<1>(in);
-    glm::mat3 uvwOldTri;
-    for (int i : {0, 1, 2}) uvwOldTri[i] = uvwOld[baryOld.vertBary[i]];
+
+    // When vertBary == -1, it is an original vert and the initial value of the
+    // column from the identity matrix is already correct.
+    glm::mat3 uvwOldTri(1.0f);
+    for (int i : {0, 1, 2})
+      if (baryOld.vertBary[i] >= 0) uvwOldTri[i] = uvwOld[baryOld.vertBary[i]];
 
     const float invTotal = 1.0f / n;
     int posTri = tri * n * n;

--- a/manifold/src/manifold_impl.cu
+++ b/manifold/src/manifold_impl.cu
@@ -44,12 +44,6 @@ __host__ __device__ glm::vec3 OrthogonalTo(glm::vec3 in, glm::vec3 ref) {
   return in;
 }
 
-__host__ __device__ int NextHalfedge(int current) {
-  ++current;
-  if (current % 3 == 0) current -= 3;
-  return current;
-}
-
 /**
  * The total number of verts if a triangle is subdivided naturally such that
  * each edge has edgeVerts verts along it (edgeVerts >= -1).

--- a/manifold/src/manifold_impl.cu
+++ b/manifold/src/manifold_impl.cu
@@ -219,16 +219,16 @@ struct InteriorVerts {
         ++posBary;
         if (j == n - i) continue;
 
-        // The three retained verts are denoted -1. uvw entries are added for
-        // them out of laziness of indexing only.
-        const int a = (k == n) ? -1 : first;
+        // The three retained verts are denoted by their index - 3. uvw entries
+        // are added for them out of laziness of indexing only.
+        const int a = (k == n) ? -2 : first;
         const int b = (i == n - 1) ? -1 : first + n - i + 1;
-        const int c = (j == n - 1) ? -1 : first + 1;
+        const int c = (j == n - 1) ? -3 : first + 1;
         glm::ivec3 vertBary(c, a, b);
         triBary[posTri] = {-1, tri, vertBary};
         triBaryNew[posTri++] = {baryOld.meshID, baryOld.tri, vertBary};
         if (j < n - 1 - i) {
-          int d = b + 1;
+          int d = b + 1;  // d cannot be a retained vert
           vertBary = {b, d, c};
           triBary[posTri] = {-1, tri, vertBary};
           triBaryNew[posTri++] = {baryOld.meshID, baryOld.tri, vertBary};
@@ -1391,6 +1391,7 @@ void Manifold::Impl::Face2Tri(const VecDH<int>& faceEdge,
   const VecH<int>& face = faceEdge.H();
   const VecH<Halfedge>& halfedge = halfedge_.H();
   const VecH<glm::vec3>& faceNormal = faceNormal_.H();
+  meshRelation_.triBary.resize(0);
 
   for (int i = 0; i < face.size() - 1; ++i) {
     const int edge = face[i];
@@ -1402,7 +1403,6 @@ void Manifold::Impl::Face2Tri(const VecDH<int>& faceEdge,
     std::map<int, Ref> vertRef;
     for (int j = edge; j < lastEdge; ++j)
       vertRef[halfedge[j].startVert] = halfedgeRef.H()[j];
-    meshRelation_.triBary.resize(0);
     const int startTri = triVerts.size();
 
     if (numEdge == 3) {  // Single triangle

--- a/manifold/src/manifold_impl.cu
+++ b/manifold/src/manifold_impl.cu
@@ -195,11 +195,19 @@ struct InteriorVerts {
   glm::vec3* vertPos;
   glm::vec3* uvw;
   BaryRef* triBary;
+  glm::vec3* uvwNew;
+  BaryRef* triBaryNew;
+  const glm::vec3* uvwOld;
   const int startIdx;
   const int n;
   const Halfedge* halfedge;
 
-  __host__ __device__ void operator()(int tri) {
+  __host__ __device__ void operator()(thrust::tuple<int, BaryRef> in) {
+    const int tri = thrust::get<0>(in);
+    const BaryRef baryOld = thrust::get<1>(in);
+    glm::mat3 uvwOldTri;
+    for (int i : {0, 1, 2}) uvwOldTri[i] = uvwOld[baryOld.vertBary[i]];
+
     const float invTotal = 1.0f / n;
     int posTri = tri * n * n;
     int posBary = tri * VertsPerTri(n + 1);
@@ -211,7 +219,9 @@ struct InteriorVerts {
         const float v = invTotal * k;
         const float w = invTotal * i;
         const int first = posBary;
-        uvw[posBary++] = {u, v, w};
+        uvw[posBary] = {u, v, w};
+        uvwNew[posBary] = uvwOldTri * uvw[posBary];
+        ++posBary;
         if (j == n - i) continue;
 
         // The three retained verts are denoted -1. uvw entries are added for
@@ -219,10 +229,14 @@ struct InteriorVerts {
         const int a = (k == n) ? -1 : first;
         const int b = (i == n - 1) ? -1 : first + n - i + 1;
         const int c = (j == n - 1) ? -1 : first + 1;
-        triBary[posTri++] = {tri, {c, a, b}};
+        glm::ivec3 vertBary(c, a, b);
+        triBary[posTri] = {-1, tri, vertBary};
+        triBaryNew[posTri++] = {baryOld.meshID, baryOld.tri, vertBary};
         if (j < n - 1 - i) {
           int d = b + 1;
-          triBary[posTri++] = {tri, {b, d, c}};
+          vertBary = {b, d, c};
+          triBary[posTri] = {-1, tri, vertBary};
+          triBaryNew[posTri++] = {baryOld.meshID, baryOld.tri, vertBary};
         }
 
         if (i == 0 || j == 0 || k == 0) continue;
@@ -830,10 +844,13 @@ struct SwapHalfedges {
 };
 
 struct InitializeBaryRef {
+  const int meshID;
+
   __host__ __device__ void operator()(thrust::tuple<BaryRef&, int> inOut) {
     BaryRef& baryRef = thrust::get<0>(inOut);
     int tri = thrust::get<1>(inOut);
 
+    baryRef.meshID = meshID;
     baryRef.tri = tri;
     baryRef.vertBary = {-1, -1, -1};
   }
@@ -1083,6 +1100,8 @@ struct CheckCCW {
 
 namespace manifold {
 
+int Manifold::Impl::nextMeshID_ = 0;
+
 /**
  * Create a manifold from an input triangle Mesh. Will throw if the Mesh is not
  * manifold. TODO: update halfedgeTangent during CollapseDegenerates.
@@ -1149,6 +1168,8 @@ Manifold::Impl::Impl(Shape shape) {
   Finish();
 }
 
+void Manifold::Impl::DuplicateMeshIDs() {}
+
 /**
  * Create the halfedge_ data structure from an input triVerts array like Mesh.
  */
@@ -1164,7 +1185,7 @@ void Manifold::Impl::CreateHalfedges(const VecDH<glm::ivec3>& triVerts) {
   if (meshRelation_.triBary.size() != numTri) {
     meshRelation_.triBary.resize(numTri);
     thrust::for_each_n(zip(meshRelation_.triBary.beginD(), countAt(0)), numTri,
-                       InitializeBaryRef());
+                       InitializeBaryRef({Manifold::Impl::nextMeshID_++}));
   }
 }
 
@@ -1192,7 +1213,7 @@ void Manifold::Impl::CreateAndFixHalfedges(const VecDH<glm::ivec3>& triVerts) {
                    SwapHalfedges({halfedge_.ptrH(), edge.cptrH()}));
   meshRelation_.triBary.resize(numTri);
   thrust::for_each_n(zip(meshRelation_.triBary.begin(), countAt(0)), numTri,
-                     InitializeBaryRef());
+                     InitializeBaryRef({Manifold::Impl::nextMeshID_++}));
 }
 
 /**
@@ -1445,6 +1466,15 @@ void Manifold::Impl::Face2Tri(const VecDH<int>& faceEdge) {
   CreateAndFixHalfedges(triVertsOut);
 }
 
+/**
+ * Calculates halfedgeTangent_, allowing the manifold to be refined and
+ * smoothed. The tangents form weighted cubic Beziers along each edge. This
+ * function creates circular arcs where possible (minimizing maximum curvature),
+ * constrained to the vertex normals. Where sharpenedEdges are specified, the
+ * tangents are shortened that intersect the sharpened edge, concentrating the
+ * curvature there, while the tangents of the sharp edges themselves are aligned
+ * for continuity.
+ */
 void Manifold::Impl::CreateTangents(
     const std::vector<Smoothness>& sharpenedEdges) {
   const int numHalfedge = halfedge_.size();
@@ -1459,6 +1489,9 @@ void Manifold::Impl::CreateTangents(
     const VecH<Halfedge>& halfedge = halfedge_.H();
     const VecH<BaryRef>& triBary = meshRelation_.triBary.H();
 
+    // sharpenedEdges are referenced to the input Mesh, but the triangles have
+    // been sorted in creating the Manifold, so the indices are converted using
+    // meshRelation_.
     std::vector<int> oldHalfedge2New(halfedge.size());
     for (int tri = 0; tri < NumTri(); ++tri) {
       int oldTri = triBary[tri].tri;
@@ -1548,7 +1581,7 @@ void Manifold::Impl::CreateTangents(
  * run after the new vertices have moved, which is a likely scenario after
  * refinement (smoothing).
  */
-void Manifold::Impl::Subdivide(int n) {
+Manifold::Impl::MeshRelationD Manifold::Impl::Subdivide(int n) {
   int numVert = NumVert();
   int numEdge = NumEdge();
   int numTri = NumTri();
@@ -1556,8 +1589,14 @@ void Manifold::Impl::Subdivide(int n) {
   int vertsPerEdge = n - 1;
   int triVertStart = numVert + numEdge * vertsPerEdge;
   vertPos_.resize(triVertStart + numTri * VertsPerTri(n - 2));
-  meshRelation_.barycentric.resize(numTri * VertsPerTri(n + 1));
-  meshRelation_.triBary.resize(n * n * numTri);
+
+  MeshRelationD relation;
+  relation.barycentric.resize(numTri * VertsPerTri(n + 1));
+  relation.triBary.resize(n * n * numTri);
+  MeshRelationD oldMeshRelation = meshRelation_;
+  meshRelation_.barycentric.resize(relation.barycentric.size());
+  meshRelation_.triBary.resize(relation.triBary.size());
+
   VecDH<TmpEdge> edges = CreateTmpEdges(halfedge_);
   VecDH<int> half2Edge(2 * numEdge);
   thrust::for_each_n(zip(countAt(0), edges.beginD()), numEdge,
@@ -1565,9 +1604,11 @@ void Manifold::Impl::Subdivide(int n) {
   thrust::for_each_n(zip(countAt(0), edges.beginD()), numEdge,
                      EdgeVerts({vertPos_.ptrD(), numVert, n}));
   thrust::for_each_n(
-      countAt(0), numTri,
-      InteriorVerts({vertPos_.ptrD(), meshRelation_.barycentric.ptrD(),
-                     meshRelation_.triBary.ptrD(), triVertStart, n,
+      zip(countAt(0), oldMeshRelation.triBary.beginD()), numTri,
+      InteriorVerts({vertPos_.ptrD(), relation.barycentric.ptrD(),
+                     relation.triBary.ptrD(), meshRelation_.barycentric.ptrD(),
+                     meshRelation_.triBary.ptrD(),
+                     oldMeshRelation.barycentric.cptrD(), triVertStart, n,
                      halfedge_.ptrD()}));
   // Create subtriangles
   VecDH<glm::ivec3> triVerts(n * n * numTri);
@@ -1575,19 +1616,20 @@ void Manifold::Impl::Subdivide(int n) {
                      SplitTris({triVerts.ptrD(), halfedge_.cptrD(),
                                 half2Edge.cptrD(), numVert, triVertStart, n}));
   CreateHalfedges(triVerts);
+  return relation;
 }
 
 void Manifold::Impl::Refine(int n) {
   Manifold::Impl old = *this;
-  Subdivide(n);
+  MeshRelationD relation = Subdivide(n);
 
   if (old.halfedgeTangent_.size() == old.halfedge_.size()) {
     VecDH<Barycentric> vertBary(NumVert());
     VecDH<int> lock(NumVert(), 0);
     thrust::for_each_n(
-        zip(meshRelation_.triBary.beginD(), countAt(0)), NumTri(),
+        zip(relation.triBary.beginD(), countAt(0)), NumTri(),
         TriBary2Vert({vertBary.ptrD(), lock.ptrD(),
-                      meshRelation_.barycentric.cptrD(), halfedge_.cptrD()}));
+                      relation.barycentric.cptrD(), halfedge_.cptrD()}));
 
     thrust::for_each_n(
         zip(vertPos_.beginD(), vertBary.beginD()), NumVert(),

--- a/manifold/src/manifold_impl.cu
+++ b/manifold/src/manifold_impl.cu
@@ -1222,11 +1222,13 @@ void Manifold::Impl::CreateAndFixHalfedges(const VecDH<glm::ivec3>& triVerts) {
                      LinkHalfedges({halfedge_.ptrH(), edge.cptrH()}));
   thrust::for_each(thrust::host, countAt(1), countAt(halfedge_.size() / 2),
                    SwapHalfedges({halfedge_.ptrH(), edge.cptrH()}));
-  meshRelation_.triBary.resize(numTri);
-  const int nextMeshID = meshID2Original_.size();
-  meshID2Original_.push_back(nextMeshID);
-  thrust::for_each_n(zip(meshRelation_.triBary.begin(), countAt(0)), numTri,
-                     InitializeBaryRef({nextMeshID}));
+  if (meshRelation_.triBary.size() != numTri) {
+    meshRelation_.triBary.resize(numTri);
+    const int nextMeshID = meshID2Original_.size();
+    meshID2Original_.push_back(nextMeshID);
+    thrust::for_each_n(zip(meshRelation_.triBary.begin(), countAt(0)), numTri,
+                       InitializeBaryRef({nextMeshID}));
+  }
 }
 
 /**

--- a/manifold/src/manifold_impl.cu
+++ b/manifold/src/manifold_impl.cu
@@ -206,11 +206,8 @@ struct InteriorVerts {
     const int tri = thrust::get<0>(in);
     const BaryRef baryOld = thrust::get<1>(in);
 
-    // When vertBary == -1, it is an original vert and the initial value of the
-    // column from the identity matrix is already correct.
-    glm::mat3 uvwOldTri(1.0f);
-    for (int i : {0, 1, 2})
-      if (baryOld.vertBary[i] >= 0) uvwOldTri[i] = uvwOld[baryOld.vertBary[i]];
+    glm::mat3 uvwOldTri;
+    for (int i : {0, 1, 2}) uvwOldTri[i] = UVW(baryOld.vertBary[i], uvwOld);
 
     const float invTotal = 1.0f / n;
     int posTri = tri * n * n;
@@ -856,7 +853,7 @@ struct InitializeBaryRef {
 
     baryRef.meshID = meshID;
     baryRef.tri = tri;
-    baryRef.vertBary = {-1, -1, -1};
+    baryRef.vertBary = {-3, -2, -1};
   }
 };
 

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -49,6 +49,8 @@ struct Manifold::Impl {
   Impl(Shape);
 
   void DuplicateMeshIDs();
+  void ReinitializeReference(int meshID = -1);
+  int InitializeNewReference();
   void CreateHalfedges(const VecDH<glm::ivec3>& triVerts);
   void CreateAndFixHalfedges(const VecDH<glm::ivec3>& triVerts);
   void CollapseDegenerates();

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -26,6 +26,9 @@ struct Manifold::Impl {
     VecDH<glm::vec3> barycentric;
     VecDH<BaryRef> triBary;
   };
+  struct Ref {
+    int meshID, tri, bary;
+  };
 
   Box bBox_;
   float precision_ = -1;
@@ -74,7 +77,7 @@ struct Manifold::Impl {
   void GatherFaces(const VecDH<int>& faceNew2Old);
   void GatherFaces(const Impl& old, const VecDH<int>& faceNew2Old);
   void CalculateNormals();
-  void Face2Tri(const VecDH<int>& faceEdge);
+  void Face2Tri(const VecDH<int>& faceEdge, const VecDH<Ref>& halfedgeRef);
 
   SparseIndices EdgeCollisions(const Impl& B) const;
   SparseIndices VertexCollisionsZ(const VecDH<glm::vec3>& vertsIn) const;
@@ -82,4 +85,10 @@ struct Manifold::Impl {
   Polygons Face2Polygons(int face, glm::mat3x2 projection,
                          const VecH<int>& faceEdge) const;
 };
+
+inline std::ostream& operator<<(std::ostream& stream,
+                                const Manifold::Impl::Ref& ref) {
+  return stream << "meshID = " << ref.meshID << ", tri = " << ref.tri
+                << ", bary = " << ref.bary;
+}
 }  // namespace manifold

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -38,11 +38,15 @@ struct Manifold::Impl {
   Collider collider_;
   glm::mat4x3 transform_ = glm::mat4x3(1.0f);
 
+  static int nextMeshID_;
+  static std::vector<int> meshID2Original_;
+
   Impl() {}
   Impl(const Mesh&);
   enum class Shape { TETRAHEDRON, CUBE, OCTAHEDRON };
   Impl(Shape);
 
+  void DuplicateMeshIDs();
   void CreateHalfedges(const VecDH<glm::ivec3>& triVerts);
   void CreateAndFixHalfedges(const VecDH<glm::ivec3>& triVerts);
   void CollapseDegenerates();
@@ -51,7 +55,7 @@ struct Manifold::Impl {
   void ApplyTransform() const;
   void ApplyTransform();
   void CreateTangents(const std::vector<Smoothness>&);
-  void Subdivide(int n);
+  MeshRelationD Subdivide(int n);
   void Refine(int n);
 
   bool IsEmpty() const { return NumVert() == 0; }

--- a/manifold/src/manifold_impl.cuh
+++ b/manifold/src/manifold_impl.cuh
@@ -38,7 +38,6 @@ struct Manifold::Impl {
   Collider collider_;
   glm::mat4x3 transform_ = glm::mat4x3(1.0f);
 
-  static int nextMeshID_;
   static std::vector<int> meshID2Original_;
 
   Impl() {}

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -387,9 +387,8 @@ TEST(Manifold, MeshRelation) {
   Mesh input = ImportMesh("data/Csaszar.ply");
   Manifold csaszar(input);
   Related(csaszar, input);
-  Mesh sortedInput = csaszar.Extract();
   csaszar.Refine(4);
-  Related(csaszar, sortedInput);
+  Related(csaszar, input);
 }
 
 /**

--- a/utilities/include/structs.h
+++ b/utilities/include/structs.h
@@ -151,7 +151,7 @@ struct Curvature {
 };
 
 struct BaryRef {
-  int tri;
+  int meshID, tri;
   glm::ivec3 vertBary;
 };
 

--- a/utilities/include/structs.h
+++ b/utilities/include/structs.h
@@ -158,6 +158,18 @@ struct BaryRef {
 struct MeshRelation {
   std::vector<glm::vec3> barycentric;
   std::vector<BaryRef> triBary;
+
+  inline glm::vec3 UVW(int tri, int vert) {
+    int idx = triBary[tri].vertBary[vert];
+    glm::vec3 uvw(0.0f);
+    if (idx < 0) {
+      idx += 3;
+      uvw[idx] = 1;
+    } else {
+      uvw = barycentric[idx];
+    }
+    return uvw;
+  }
 };
 
 struct Box {

--- a/utilities/include/structs.h
+++ b/utilities/include/structs.h
@@ -307,7 +307,8 @@ inline std::ostream& operator<<(std::ostream& stream, const glm::mat4x3& mat) {
 }
 
 inline std::ostream& operator<<(std::ostream& stream, const BaryRef& ref) {
-  return stream << "tri = " << ref.tri << ", uvw idx = " << ref.vertBary;
+  return stream << "meshID: " << ref.meshID << ", tri: " << ref.tri
+                << ", uvw idx: " << ref.vertBary;
 }
 }  // namespace manifold
 

--- a/utilities/include/utils.cuh
+++ b/utilities/include/utils.cuh
@@ -112,6 +112,18 @@ __host__ __device__ T AtomicAdd(T& target, T add) {
 #endif
 }
 
+__host__ __device__ inline glm::vec3 UVW(int vertBary,
+                                         const glm::vec3* barycentric) {
+  glm::vec3 uvw(0.0f);
+  if (vertBary < 0) {
+    vertBary += 3;
+    uvw[vertBary] = 1;
+  } else {
+    uvw = barycentric[vertBary];
+  }
+  return uvw;
+}
+
 // Copied from
 // https://github.com/thrust/thrust/blob/master/examples/strided_range.cu
 template <typename Iterator>

--- a/utilities/include/utils.cuh
+++ b/utilities/include/utils.cuh
@@ -112,6 +112,12 @@ __host__ __device__ T AtomicAdd(T& target, T add) {
 #endif
 }
 
+__host__ __device__ inline int NextHalfedge(int current) {
+  ++current;
+  if (current % 3 == 0) current -= 3;
+  return current;
+}
+
 __host__ __device__ inline glm::vec3 UVW(int vertBary,
                                          const glm::vec3* barycentric) {
   glm::vec3 uvw(0.0f);


### PR DESCRIPTION
Making meshRelations able to target multiple meshes and implementing this for Boolean and Compose operations. Now general mesh properties like textures and UV coordinates can reapplied after a long series of operations. A unique meshID is created for each copy made so they can be tracked individually if they are moved and recombined, but a static mapping to the originals is also kept to easily apply original properties to all copies as desired. A meshID can also be reset to become an original if for instance this is the step at which a UV mapping was created. 