### PR TITLE
Add CGAL corefinement perf test

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get -y update
-        DEBIAN_FRONTEND=noninteractive apt install -y cmake libglm-dev libassimp-dev libboost-graph-dev
+        DEBIAN_FRONTEND=noninteractive apt install -y cmake libglm-dev libassimp-dev libboost-graph-dev libcgal-dev
     - name: Build CUDA
       run: |
         mkdir buildCUDA

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get -y update && apt-get -y install \
     cmake \
     libglm-dev \
     libassimp-dev \
-    libboost-graph-dev
+    libboost-graph-dev \
+    libcgal-dev
 # RUN DEBIAN_FRONTEND=noninteractive apt-get -y install cuda-drivers
 COPY . /usr/src
 WORKDIR /usr/src

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -15,6 +15,12 @@ target_compile_features(perfTest PUBLIC cxx_std_14)
 add_executable(perfTestCGAL perf_test_cgal.cpp)
 find_package(CGAL REQUIRED COMPONENTS Core)
 target_compile_definitions(perfTestCGAL PRIVATE CGAL_USE_GMPXX)
+# target_compile_definitions(perfTestCGAL PRIVATE CGAL_DEBUG)
+target_link_libraries(perfTestCGAL manifold CGAL::CGAL CGAL::CGAL_Core)
+
+target_compile_options(perfTestCGAL PRIVATE ${MANIFOLD_FLAGS})
+target_compile_features(perfTestCGAL PUBLIC cxx_std_14)
+
 # add_executable(playground playground.cpp)
 # target_link_libraries(playground manifold meshIO samples)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -12,6 +12,9 @@ target_link_libraries(perfTest manifold)
 target_compile_options(perfTest PRIVATE ${MANIFOLD_FLAGS})
 target_compile_features(perfTest PUBLIC cxx_std_14)
 
+add_executable(perfTestCGAL perf_test_cgal.cpp)
+find_package(CGAL REQUIRED COMPONENTS Core)
+target_compile_definitions(perfTestCGAL PRIVATE CGAL_USE_GMPXX)
 # add_executable(playground playground.cpp)
 # target_link_libraries(playground manifold meshIO samples)
 

--- a/tools/perf_test_cgal.cpp
+++ b/tools/perf_test_cgal.cpp
@@ -1,0 +1,80 @@
+// Copyright 2020 Emmett Lalish & contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/corefinement.h>
+#include <CGAL/Surface_mesh.h>
+
+#include <chrono>
+#include <fstream>
+#include <iostream>
+
+#include "manifold.h"
+
+using namespace manifold;
+
+// Epick = Exact predicates Inexact constructions. Seems fair to use to compare
+// to Manifold, which seems to store double coordinates.
+typedef CGAL::Epick Kernel;
+
+// Epeck = Exact predicates Exact constructions. What OpenSCAD uses to guarantee
+// geometry ends up where it should even after many operations. typedef
+// CGAL::Epeck Kernel;
+
+typedef CGAL::Point_3<Kernel> Point;
+typedef CGAL::Surface_mesh<Point> TriangleMesh;
+
+void manifoldToCGALSurfaceMesh(Manifold &manifold, TriangleMesh &cgalMesh) {
+  typedef boost::graph_traits<TriangleMesh> GT;
+  typedef typename GT::vertex_descriptor vertex_descriptor;
+
+  auto maniMesh = manifold.GetMesh();
+
+  std::unordered_map<size_t, vertex_descriptor> vertices;
+  for (size_t i = 0, n = maniMesh.vertPos.size(); i < n; i++) {
+    auto &vert = maniMesh.vertPos[i];
+    vertices[i] = cgalMesh.add_vertex(Point(vert.x, vert.y, vert.z));
+  }
+
+  for (auto &triVert : maniMesh.triVerts) {
+    std::vector<vertex_descriptor> polygon{
+        vertices[triVert[0]], vertices[triVert[1]], vertices[triVert[2]]};
+    cgalMesh.add_face(polygon);
+  }
+}
+
+int main(int argc, char **argv) {
+  for (int i = 0; i < 8; ++i) {
+    Manifold sphere = Manifold::Sphere(1, (8 << i) * 4);
+    Manifold sphere2 = sphere;
+    sphere2.Translate(glm::vec3(0.5));
+
+    TriangleMesh cgalSphere, cgalSphere2, cgalOut;
+    manifoldToCGALSurfaceMesh(sphere, cgalSphere);
+    manifoldToCGALSurfaceMesh(sphere2, cgalSphere2);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    auto result =
+        CGAL::Polygon_mesh_processing::corefine_and_compute_difference(
+            // CGAL::Polygon_mesh_processing::corefine_and_compute_union(
+            // CGAL::Polygon_mesh_processing::corefine_and_compute_intersection(
+            cgalSphere, cgalSphere2, cgalSphere);
+
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = end - start;
+    std::cout << "nTri = " << sphere.NumTri() << ", time = " << elapsed.count()
+              << " sec" << std::endl;
+  }
+}


### PR DESCRIPTION
First off: amazing work, I'm super excited about Manifold and hope we can use it in OpenSCAD and beyond!

I've ported perf_test to use CGAL's corefinement after reading [your post](https://elalish.blogspot.com/2022/03/manifold-performance.html),
which I believe tests OpenSCAD more than it does CGAL itself.

I haven't had a chance to test with CUDA hardware or with OpenMP (which I expect are gonna leave CGAL in the dust, since I don't think corefinement is one of their parallelizable operations), but thought it worth doing a mono-threaded comparison as fairly as possible.

To that effect I've used the `CGAL::Epick` [kernel](https://doc.cgal.org/latest/Kernel_d/group__PkgKernelDKernels.html) (rather than the exact, [GMP](https://gmplib.org/) rationals-based `CGAL::Epeck` we use in OpenSCAD). `Epick` is only marginally faster than `Epeck` here anyway, but note that both provide exact predicates, `Epick` is only "inexact" in that it's built from double values (much like Manifold, AFAICT).

Haven't tested all the operations but hopefully you can vary the test cases using this PR as a starting point.

Some take-aways from only testing union and difference (again, only CPU-monothreaded)
- Manifold's union is up to 2.3x faster than corefinement for meshes >32k faces, but...
- Corefinement union 2-3x faster for small meshes <=2k faces
- Corefinement difference is faster at all mesh sizes I've tested

(see [raw results here](https://docs.google.com/spreadsheets/d/13ze7G1JTXOtgKhyWsBr890G-kdcGM-aG-fp6QcWManw/edit#gid=0), took best of 3 runs)

Tested with:

```bash
git clone https://github.com/ochafik/manifold.git --single-branch -b perf_test_cgal
cd manifold
docker run -v $PWD:/src:z -it nvidia/cuda:11.1-devel-ubuntu20.04 

# Then:
apt-get -y update
DEBIAN_FRONTEND=noninteractive apt install -y cmake libglm-dev libassimp-dev libboost-graph-dev libcgal-dev

cd /src
mkdir -p buildCPP && cd buildCPP
cmake -DCMAKE_BUILD_TYPE=Release -DMANIFOLD_USE_CPP=ON .. && make
tools/perfTest
tools/perfTestCGAL
```

@sloriot FYI more microbenchmarking action :-)