### PR TITLE
implemented sweep

### DIFF
--- a/manifold/include/manifold.h
+++ b/manifold/include/manifold.h
@@ -56,6 +56,8 @@ class Manifold {
                           glm::vec2 scaleTop = glm::vec2(1.0f));
   static Manifold Revolve(const Polygons& crossSection,
                           int circularSegments = 0);
+  static Manifold Sweep(Polygons crossSection, int steps,
+                        std::function<glm::mat4x3(int)> &transform, bool closed = false);
   ///@}
 
   /** @name Topological


### PR DESCRIPTION
Implemented a generic sweep operation on polygon cross section to create manifolds. Users can specify the sweeping path with a function that returns the 3D transformation matrix on the cross section (with z = 0). Users can specify the sweeping path to be closed by setting `isClosed = true`, so the first plane (step = 0) and the last plane (step = n - 1) will be connected together.

Example:
```c++
#include "manifold.h"
#include "glm/vec3.hpp"

using namespace manifold;

int main() {
    std::vector<manifold::PolyVert> vertices;
    for (int i = 0; i < 60; i++)
        vertices.push_back({glm::vec2(sind(-i*6) + 10, cosd(-i*6) + 10), i});

    Polygons polygons({vertices});
    std::function<glm::mat4x3(int)> f = [](int s) {
        glm::mat4x3 mat(1.0f);
        mat[0][0] = cosd(6*s);
        mat[2][0] = -sind(6*s);
        mat[0][2] = -mat[2][0];
        mat[2][2] = mat[0][0];
        mat[3][1] = 5*s/60.0;
        return mat;
    };
    // creates a spring
    Manifold m = Manifold::Sweep(polygons, 1000, f);
    return 0;
}
```