### PR TITLE
WIP: lazy union

### DIFF
--- a/manifold/CMakeLists.txt
+++ b/manifold/CMakeLists.txt
@@ -1,6 +1,6 @@
 project (manifold)
 
-add_library(${PROJECT_NAME} src/manifold.cu src/constructors.cu src/impl.cu src/properties.cu src/sort.cu src/edge_op.cu src/face_op.cu src/smoothing.cu src/boolean3.cu src/boolean_result.cu)
+add_library(${PROJECT_NAME} src/manifold.cu src/constructors.cu src/impl.cu src/properties.cu src/sort.cu src/edge_op.cu src/face_op.cu src/smoothing.cu src/boolean3.cu src/boolean_result.cu src/manifold_set.cu)
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CUDA_ARCHITECTURES 61)
 

--- a/manifold/include/manifold_set.h
+++ b/manifold/include/manifold_set.h
@@ -9,8 +9,6 @@ public:
   ManifoldSet(const std::vector<manifold::Manifold> &manifolds);
   ManifoldSet(const manifold::Manifold &manifold);
 
-  ManifoldSet(const ManifoldSet &other);
-
   ManifoldSet operator+(const ManifoldSet &other) const;
 
   ManifoldSet &operator+=(const ManifoldSet &other);

--- a/manifold/include/manifold_set.h
+++ b/manifold/include/manifold_set.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "manifold.h"
+
+namespace manifold {
+class ManifoldSet {
+public:
+  ManifoldSet();
+  ManifoldSet(const std::vector<manifold::Manifold> &manifolds);
+  ManifoldSet(const manifold::Manifold &manifold);
+
+  ManifoldSet(const ManifoldSet &other);
+
+  ManifoldSet operator+(const ManifoldSet &other) const;
+
+  ManifoldSet &operator+=(const ManifoldSet &other);
+
+  ManifoldSet operator-(ManifoldSet &other);
+
+  ManifoldSet &operator-=(ManifoldSet &other);
+
+  ManifoldSet operator^(ManifoldSet &other);
+
+  ManifoldSet &operator^=(ManifoldSet &other);
+
+  ManifoldSet Transform(const glm::mat4x3 &transform) const;
+
+  manifold::Manifold ToManifold();
+
+private:
+  std::shared_ptr<std::vector<manifold::Manifold>> manifolds;
+  glm::mat4x3 transform_ = glm::mat4x3(1.0f);
+};
+} // namespace manifold

--- a/manifold/src/manifold_set.cu
+++ b/manifold/src/manifold_set.cu
@@ -2,6 +2,7 @@
 #include <thrust/execution_policy.h>
 #include "manifold_set.h"
 #include "utils.cuh"
+#include "vec_dh.cuh"
 
 namespace manifold {
 
@@ -16,6 +17,12 @@ ManifoldSet::ManifoldSet(const Manifold &manifold)
           std::vector<Manifold>({manifold}))) {}
 
 ManifoldSet ManifoldSet::operator+(const ManifoldSet &other) const {
+  if (manifolds == other.manifolds && transform_ == other.transform_) {
+    return *this;
+  }
+  if (manifolds->empty()) {
+    return other;
+  }
   ManifoldSet result;
   result.manifolds->reserve(manifolds->size() + other.manifolds->size());
   result.manifolds->insert(result.manifolds->end(), manifolds->begin(),
@@ -34,6 +41,14 @@ ManifoldSet ManifoldSet::operator+(const ManifoldSet &other) const {
 }
 
 ManifoldSet &ManifoldSet::operator+=(const ManifoldSet &other) {
+  if (manifolds == other.manifolds && transform_ == other.transform_) {
+      return *this;
+  }
+  if (manifolds->empty()) {
+    manifolds = other.manifolds;
+    transform_ = other.transform_;
+    return *this;
+  }
   if (manifolds.use_count() != 1) {
     auto old = manifolds;
     manifolds = std::make_shared<std::vector<Manifold>>();
@@ -87,12 +102,25 @@ Manifold ManifoldSet::ToManifold() {
   if (manifolds->size() == 0) {
     return Manifold();
   }
+
+  // sort the manifolds by their distance to a point, hopefully
+  // the combined bounding box of the first few manifolds will be
+  // smaller, so we can compose more manifolds together cheaply
+  glm::vec3 min_pt(0);
+  for (auto &m : *manifolds) {
+    Box b = m.BoundingBox();
+    min_pt = glm::min(min_pt, b.min);
+  }
+
+  std::sort(manifolds->begin(), manifolds->end(), 
+          [&min_pt](const Manifold &a, const Manifold &b) {
+            return glm::distance(min_pt, a.BoundingBox().min) < glm::distance(min_pt, b.BoundingBox().min);
+          });
+
   std::vector<std::pair<std::vector<size_t>, Box>> disjointSets;
   for (size_t i = 0; i < manifolds->size(); i++) {
-    manifolds->at(i).GetMesh(); // why?
     Box box = manifolds->at(i).BoundingBox();
-    auto it =
-        std::find_if(disjointSets.begin(), disjointSets.end(),
+    auto it = std::find_if(disjointSets.begin(), disjointSets.end(),
                      [&box](const std::pair<std::vector<size_t>, Box> &p) {
                        return !p.second.DoesOverlap(box);
                      });
@@ -103,11 +131,12 @@ Manifold ManifoldSet::ToManifold() {
       it->second = it->second.Union(box);
     }
   }
-  std::vector<Manifold> results(disjointSets.size());
+
+  std::vector<std::unique_ptr<Manifold>> results(disjointSets.size());
   thrust::for_each_n(thrust::host, countAt(0), disjointSets.size(),
                      [&](size_t i) {
                        if (disjointSets[i].first.size() == 1) {
-                         results[i] = manifolds->at(disjointSets[i].first[0]);
+                         results[i] = std::make_unique<Manifold>(manifolds->at(disjointSets[i].first[0]));
                          return;
                        }
                        std::vector<Manifold> buffer;
@@ -115,19 +144,31 @@ Manifold ManifoldSet::ToManifold() {
                        for (auto &i : disjointSets[i].first) {
                          buffer.push_back(std::move(manifolds->at(i)));
                        }
-                       results[i] = Manifold::Compose(buffer);
+                       results[i] = std::make_unique<Manifold>(Manifold::Compose(buffer));
                      });
-  Manifold result;
-  for (auto &m : results) {
-    result += m;
+
+  auto cmp_fn = [](const std::unique_ptr<Manifold> &a, const std::unique_ptr<Manifold> &b) {
+                  // invert the order because we want a min heap
+                  return a->NumVert() > b->NumVert();
+                };
+
+  // union smaller manifolds first to avoid copying large manifolds repeatedly
+  std::make_heap(results.begin(), results.end(), cmp_fn);
+  while (results.size() > 1) {
+    std::pop_heap(results.begin(), results.end(), cmp_fn);
+    auto a = std::move(results.back());
+    results.pop_back();
+    std::pop_heap(results.begin(), results.end(), cmp_fn);
+    *results.back() += *a;
+    std::push_heap(results.begin(), results.end(), cmp_fn);
   }
 
   manifolds->clear();
-  manifolds->push_back(result);
+  manifolds->push_back(*results.back());
 
   if (transform_ != glm::mat4x3(1.0f)) {
     manifolds = std::make_shared<std::vector<Manifold>>();
-    manifolds->push_back(result);
+    manifolds->push_back(*results.back());
     manifolds->back().Transform(transform_);
     transform_ = glm::mat4x3(1.0f);
   }

--- a/manifold/src/manifold_set.cu
+++ b/manifold/src/manifold_set.cu
@@ -1,0 +1,141 @@
+#include "manifold_set.h"
+#include <algorithm>
+#include "utils.cuh"
+#include <thrust/execution_policy.h>
+
+namespace manifold {
+
+ManifoldSet::ManifoldSet()
+    : manifolds(std::make_shared<std::vector<Manifold>>()) {}
+
+ManifoldSet::ManifoldSet(const std::vector<Manifold> &manifolds)
+    : manifolds(std::make_shared<std::vector<Manifold>>(manifolds)) {}
+
+ManifoldSet::ManifoldSet(const Manifold &manifold)
+    : manifolds(std::make_shared<std::vector<Manifold>>(
+          std::vector<Manifold>({manifold}))) {}
+
+ManifoldSet::ManifoldSet(const ManifoldSet &other)
+    : transform_(other.transform_), manifolds(other.manifolds) {}
+
+ManifoldSet ManifoldSet::operator+(const ManifoldSet &other) const {
+  ManifoldSet result;
+  result.manifolds->reserve(manifolds->size() + other.manifolds->size());
+  result.manifolds->insert(result.manifolds->end(), manifolds->begin(),
+                           manifolds->end());
+  if (transform_ != glm::mat4x3(1.0f))
+    for (auto &m : *result.manifolds) {
+      m.Transform(transform_);
+    }
+  int index = result.manifolds->size();
+  result.manifolds->insert(result.manifolds->end(), other.manifolds->begin(),
+                           other.manifolds->end());
+  for (int i = index; i < result.manifolds->size(); i++) {
+    result.manifolds->at(i).Transform(other.transform_);
+  }
+  return result;
+}
+
+ManifoldSet &ManifoldSet::operator+=(const ManifoldSet &other) {
+  if (manifolds.use_count() != 1) {
+    auto old = manifolds;
+    manifolds = std::make_shared<std::vector<Manifold>>(old->size());
+    manifolds->insert(manifolds->end(), old->begin(), old->end());
+  }
+  if (transform_ != glm::mat4x3(1.0f))
+    for (auto &m : *manifolds)
+      m.Transform(transform_);
+  transform_ = glm::mat4x3(1.0f);
+
+  manifolds->reserve(other.manifolds->size());
+  int index = manifolds->size();
+  manifolds->insert(manifolds->end(), other.manifolds->begin(),
+                    other.manifolds->end());
+  for (int i = index; i < manifolds->size(); i++) {
+    manifolds->at(i).Transform(other.transform_);
+  }
+  return *this;
+}
+
+ManifoldSet ManifoldSet::operator-(ManifoldSet &other) {
+  return ManifoldSet({this->ToManifold() - other.ToManifold()});
+}
+
+ManifoldSet &ManifoldSet::operator-=(ManifoldSet &other) {
+  auto result = this->ToManifold() - other.ToManifold();
+  transform_ = glm::mat4x3(1.0f);
+  manifolds = std::make_shared<std::vector<Manifold>>(1);
+  manifolds->push_back(result);
+  return *this;
+}
+
+ManifoldSet ManifoldSet::operator^(ManifoldSet &other) {
+  return ManifoldSet({this->ToManifold() ^ other.ToManifold()});
+}
+
+ManifoldSet &ManifoldSet::operator^=(ManifoldSet &other) {
+  auto result = this->ToManifold() ^ other.ToManifold();
+  transform_ = glm::mat4x3(1.0f);
+  manifolds = std::make_shared<std::vector<Manifold>>(1);
+  manifolds->push_back(result);
+  return *this;
+}
+
+ManifoldSet ManifoldSet::Transform(const glm::mat4x3 &transform) const {
+  ManifoldSet result;
+  result.manifolds = manifolds;
+  result.transform_ = transform * glm::mat4(transform_);
+  return result;
+}
+
+Manifold ManifoldSet::ToManifold() {
+  if (manifolds->size() == 0) {
+    return Manifold();
+  }
+  std::vector<std::pair<std::vector<size_t>, Box>> disjointSets;
+  for (size_t i = 0; i < manifolds->size(); i++) {
+    Box box = manifolds->at(i).BoundingBox();
+    auto it =
+        std::find_if(disjointSets.begin(), disjointSets.end(),
+                     [&box](const std::pair<std::vector<size_t>, Box> &p) {
+                       return !p.second.DoesOverlap(box);
+                     });
+    if (it == disjointSets.end()) {
+      disjointSets.push_back(std::make_pair(std::vector<size_t>{i}, box));
+    } else {
+      it->first.push_back(i);
+      it->second = it->second.Union(box);
+    }
+  }
+  std::vector<Manifold> results(disjointSets.size());
+  thrust::for_each_n(thrust::host, countAt(0), disjointSets.size(),
+                     [&](size_t i) {
+                       if (disjointSets[i].first.size() == 1) {
+                         results[i] = manifolds->at(disjointSets[i].first[0]);
+                         return;
+                       }
+                       std::vector<Manifold> buffer;
+                       buffer.reserve(disjointSets[i].first.size());
+                       for (auto &i : disjointSets[i].first) {
+                         buffer.push_back(std::move(manifolds->at(i)));
+                       }
+                       results[i] = Manifold::Compose(buffer);
+                     });
+  Manifold result;
+  for (auto &m : results) {
+    result += m;
+  }
+
+  manifolds->clear();
+  manifolds->push_back(result);
+
+  if (transform_ != glm::mat4x3(1.0f)) {
+    manifolds = std::make_shared<std::vector<Manifold>>();
+    manifolds->push_back(result);
+    manifolds->back().Transform(transform_);
+    transform_ = glm::mat4x3(1.0f);
+  }
+  return manifolds->back();
+}
+
+} // namespace manifold

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -9,6 +9,9 @@ target_compile_features(loadMesh PUBLIC cxx_std_14)
 add_executable(perfTest perf_test.cpp)
 target_link_libraries(perfTest manifold)
 
+add_executable(unionPerfTest union_perf.cpp)
+target_link_libraries(unionPerfTest manifold)
+
 target_compile_options(perfTest PRIVATE ${MANIFOLD_FLAGS})
 target_compile_features(perfTest PUBLIC cxx_std_14)
 

--- a/tools/union_perf.cpp
+++ b/tools/union_perf.cpp
@@ -1,0 +1,42 @@
+#include <chrono>
+#include <iostream>
+
+#include "manifold.h"
+#include "manifold_set.h"
+
+using namespace manifold;
+
+int main(int argc, char **argv) {
+  const Manifold m = Manifold::Sphere(2.5f, 60);
+  for (int separation = 0; separation < 10; separation++) {
+    std::cout << "Separation: " << separation << std::endl;
+    {
+      auto start = std::chrono::high_resolution_clock::now();
+      Manifold result;
+      for (int i = 0; i < 100; i++) {
+        Manifold tmp = m;
+        result += tmp.Translate(glm::vec3(separation*(i/10), separation*(i%10), 0));
+      }
+      auto end = std::chrono::high_resolution_clock::now();
+      std::chrono::duration<double> elapsed = end - start;
+      std::cout << "Union:        took " << elapsed.count() << " seconds" << std::endl;
+    }
+
+    {
+      ManifoldSet mset(m);
+      auto start = std::chrono::high_resolution_clock::now();
+      ManifoldSet resultSet;
+      for (int i = 0; i < 100; i++) {
+        glm::mat4x3 t(1.0f);
+        t[3] = glm::vec3(separation*(i/10), separation*(i%10), 0);
+        resultSet += mset.Transform(t);
+      }
+      Manifold result = resultSet.ToManifold();
+      auto end = std::chrono::high_resolution_clock::now();
+      std::chrono::duration<double> elapsed = end - start;
+      std::cout << "Manifold Set: took " << elapsed.count() << " seconds" << std::endl;
+    }
+    std::cout << "----------------------" << std::endl;
+  }
+}
+


### PR DESCRIPTION
Implemented `ManifoldSet`, which is a set of manifolds that are unioned together.

This allows users to union manifolds lazily, and use compose as much as possible for faster union. This reduces the time required to union a large set of manifolds significantly when each of them only intersect with a small number of neighbors. Most importantly, this allows users to incrementally compose manifolds together and only pay for the `Manifold::Impl::Finish` once, which is expensive. A simple cache is implemented using `std::shared_ptr` to allow multiple `ManifoldSet` to share the same set of manifolds if they only differ in transformation (this cache is not thread safe, but this can be changed if needed). 

A simple union benchmark is implemented. It will union 100 spheres (with circularSegments=60 to simulate complex objects) with radius 2.5 with different distances.

Benchmark results:

<details>

CUDA:
```
Separation: 0
Union:        took 1.07531 seconds
Manifold Set: took 1.08462 seconds
----------------------
Separation: 1
Union:        took 1.41711 seconds
Manifold Set: took 0.968532 seconds
----------------------
Separation: 2
Union:        took 2.20316 seconds
Manifold Set: took 0.926535 seconds
----------------------
Separation: 3
Union:        took 3.278 seconds
Manifold Set: took 0.984004 seconds
----------------------
Separation: 4
Union:        took 4.69098 seconds
Manifold Set: took 1.34924 seconds
----------------------
Separation: 5
Union:        took 5.90308 seconds
Manifold Set: took 1.65334 seconds
----------------------
Separation: 6
Union:        took 5.49614 seconds
Manifold Set: took 0.832142 seconds
----------------------
Separation: 7
Union:        took 5.50061 seconds
Manifold Set: took 0.844545 seconds
----------------------
Separation: 8
Union:        took 5.47394 seconds
Manifold Set: took 0.835328 seconds
----------------------
Separation: 9
Union:        took 5.48175 seconds
Manifold Set: took 0.836789 seconds
```

OpenMP:
```
Separation: 0
Union:        took 1.51363 seconds
Manifold Set: took 1.55817 seconds
----------------------
Separation: 1
Union:        took 1.3737 seconds
Manifold Set: took 0.95533 seconds
----------------------
Separation: 2
Union:        took 2.34161 seconds
Manifold Set: took 1.02168 seconds
----------------------
Separation: 3
Union:        took 3.63707 seconds
Manifold Set: took 1.13614 seconds
----------------------
Separation: 4
Union:        took 5.41142 seconds
Manifold Set: took 1.59267 seconds
----------------------
Separation: 5
Union:        took 7.04236 seconds
Manifold Set: took 1.96182 seconds
----------------------
Separation: 6
Union:        took 6.76521 seconds
Manifold Set: took 1.02406 seconds
----------------------
Separation: 7
Union:        took 6.73354 seconds
Manifold Set: took 1.01433 seconds
----------------------
Separation: 8
Union:        took 6.72667 seconds
Manifold Set: took 1.02749 seconds
----------------------
Separation: 9
Union:        took 6.71657 seconds
Manifold Set: took 1.02329 seconds
```

</details>