### PR TITLE
universal vector

### DIFF
--- a/collider/src/collider.cpp
+++ b/collider/src/collider.cpp
@@ -274,7 +274,7 @@ SparseIndices Collider::Collisions(const VecDH<T>& querriesIn) const {
     VecDH<int> nOverlapsD(1, 0);
     // calculate Bounding Box overlaps
     thrust::for_each_n(
-        thrust::device, zip(querriesIn.cbeginD(), countAt(0)), querriesIn.size(),
+        thrust::device, zip(querriesIn.cbegin(), countAt(0)), querriesIn.size(),
         FindCollisions<T>({querryTri.ptrDpq(), nOverlapsD.ptrD(), maxOverlaps,
                            nodeBBox_.ptrD(), internalChildren_.ptrD()}));
     nOverlaps = nOverlapsD[0];
@@ -303,12 +303,12 @@ void Collider::UpdateBoxes(const VecDH<Box>& leafBB) {
   ALWAYS_ASSERT(leafBB.size() == NumLeaves(), userErr,
                 "must have the same number of updated boxes as original");
   // copy in leaf node Boxs
-  strided_range<VecDH<Box>::IterD> leaves(nodeBBox_.beginD(), nodeBBox_.endD(),
+  strided_range<VecDH<Box>::Iter> leaves(nodeBBox_.begin(), nodeBBox_.end(),
                                           2);
-  thrust::copy(thrust::device, leafBB.cbeginD(), leafBB.cendD(), leaves.begin());
+  thrust::copy(thrust::device, leafBB.cbegin(), leafBB.cend(), leaves.begin());
   // create global counters
   VecDH<int> counter(NumInternal());
-  thrust::fill(thrust::device, counter.beginD(), counter.endD(), 0);
+  thrust::fill(thrust::device, counter.begin(), counter.end(), 0);
   // kernel over leaves to save internal Boxs
   thrust::for_each_n(
       thrust::device, countAt(0), NumLeaves(),
@@ -330,7 +330,7 @@ bool Collider::Transform(glm::mat4x3 transform) {
     if (count != 2) axisAligned = false;
   }
   if (axisAligned) {
-    thrust::for_each(thrust::device, nodeBBox_.beginD(), nodeBBox_.endD(),
+    thrust::for_each(thrust::device, nodeBBox_.begin(), nodeBBox_.end(),
                      TransformBox({transform}));
   }
   return axisAligned;

--- a/manifold/src/boolean3.cpp
+++ b/manifold/src/boolean3.cpp
@@ -14,7 +14,6 @@
 
 #include "boolean3.h"
 #include <limits>
-#include <thrust/execution_policy.h>
 
 // TODO: make this runtime configurable for quicker debug
 constexpr bool kVerbose = false;
@@ -86,12 +85,12 @@ struct CopyFaceEdges {
 SparseIndices Filter11(const Manifold::Impl &inP, const Manifold::Impl &inQ,
                        const SparseIndices &p1q2, const SparseIndices &p2q1) {
   SparseIndices p1q1(3 * p1q2.size() + 3 * p2q1.size());
-  thrust::for_each_n(thrust::device, zip(countAt(0), p1q2.beginD(0), p1q2.beginD(1)),
+  thrust::for_each_n(thrust::device, zip(countAt(0), p1q2.begin(0), p1q2.begin(1)),
                      p1q2.size(),
                      CopyFaceEdges({p1q1.ptrDpq(), inQ.halfedge_.cptrD()}));
 
   p1q1.SwapPQ();
-  thrust::for_each_n(thrust::device, zip(countAt(p1q2.size()), p2q1.beginD(1), p2q1.beginD(0)),
+  thrust::for_each_n(thrust::device, zip(countAt(p1q2.size()), p2q1.begin(1), p2q1.begin(0)),
                      p2q1.size(),
                      CopyFaceEdges({p1q1.ptrDpq(), inP.halfedge_.cptrD()}));
   p1q1.SwapPQ();
@@ -247,7 +246,7 @@ std::tuple<VecDH<int>, VecDH<glm::vec4>> Shadow11(SparseIndices &p1q1,
   VecDH<glm::vec4> xyzz11(p1q1.size());
 
   thrust::for_each_n(
-      thrust::device, zip(xyzz11.beginD(), s11.beginD(), p1q1.beginD(0), p1q1.beginD(1)),
+      thrust::device, zip(xyzz11.begin(), s11.begin(), p1q1.begin(0), p1q1.begin(1)),
       p1q1.size(),
       Kernel11({inP.vertPos_.cptrD(), inQ.vertPos_.cptrD(),
                 inP.halfedge_.cptrD(), inQ.halfedge_.cptrD(), expandP,
@@ -344,8 +343,8 @@ std::tuple<VecDH<int>, VecDH<float>> Shadow02(const Manifold::Impl &inP,
   auto vertNormalP =
       forward ? inP.vertNormal_.cptrD() : inQ.vertNormal_.cptrD();
   thrust::for_each_n(
-      thrust::device, zip(s02.beginD(), z02.beginD(), p0q2.beginD(!forward),
-          p0q2.beginD(forward)),
+      thrust::device, zip(s02.begin(), z02.begin(), p0q2.begin(!forward),
+          p0q2.begin(forward)),
       p0q2.size(),
       Kernel02({inP.vertPos_.cptrD(), inQ.halfedge_.cptrD(),
                 inQ.vertPos_.cptrD(), forward, expandP, vertNormalP}));
@@ -454,8 +453,8 @@ std::tuple<VecDH<int>, VecDH<glm::vec3>> Intersect12(
   VecDH<glm::vec3> v12(p1q2.size());
 
   thrust::for_each_n(
-      thrust::device, zip(x12.beginD(), v12.beginD(), p1q2.beginD(!forward),
-          p1q2.beginD(forward)),
+      thrust::device, zip(x12.begin(), v12.begin(), p1q2.begin(!forward),
+          p1q2.begin(forward)),
       p1q2.size(),
       Kernel12({p0q2.ptrDpq(), s02.ptrD(), z02.cptrD(), p0q2.size(),
                 p1q1.ptrDpq(), s11.ptrD(), xyzz11.cptrD(), p1q1.size(),
@@ -472,19 +471,19 @@ VecDH<int> Winding03(const Manifold::Impl &inP, SparseIndices &p0q2,
   // verts that are not shadowed (not in p0q2) have winding number zero.
   VecDH<int> w03(inP.NumVert(), 0);
 
-  if (!thrust::is_sorted(thrust::device, p0q2.beginD(reverse), p0q2.endD(reverse)))
-    thrust::sort_by_key(thrust::device, p0q2.beginD(reverse), p0q2.endD(reverse), s02.beginD());
+  if (!thrust::is_sorted(thrust::device, p0q2.begin(reverse), p0q2.end(reverse)))
+    thrust::sort_by_key(thrust::device, p0q2.begin(reverse), p0q2.end(reverse), s02.begin());
   VecDH<int> w03val(w03.size());
   VecDH<int> w03vert(w03.size());
   // sum known s02 values into w03 (winding number)
   auto endPair =
-      thrust::reduce_by_key(thrust::device, p0q2.beginD(reverse), p0q2.endD(reverse),
-                            s02.beginD(), w03vert.beginD(), w03val.beginD());
-  thrust::scatter(thrust::device, w03val.beginD(), endPair.second, w03vert.beginD(),
-                  w03.beginD());
+      thrust::reduce_by_key(thrust::device, p0q2.begin(reverse), p0q2.end(reverse),
+                            s02.begin(), w03vert.begin(), w03val.begin());
+  thrust::scatter(thrust::device, w03val.begin(), endPair.second, w03vert.begin(),
+                  w03.begin());
 
   if (reverse)
-    thrust::transform(thrust::device, w03.beginD(), w03.endD(), w03.beginD(),
+    thrust::transform(thrust::device, w03.begin(), w03.end(), w03.begin(),
                       thrust::negate<int>());
   return w03;
 };

--- a/manifold/src/edge_op.cpp
+++ b/manifold/src/edge_op.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "impl.h"
-#include <thrust/execution_policy.h>
 
 namespace {
 using namespace manifold;
@@ -122,9 +121,9 @@ void Manifold::Impl::SimplifyTopology() {
   VecDH<int> flaggedEdges(halfedge_.size());
   int numFlagged =
       thrust::copy_if(
-          thrust::device, countAt(0), countAt(halfedge_.size()), flaggedEdges.beginD(),
+          thrust::device, countAt(0), countAt(halfedge_.size()), flaggedEdges.begin(),
           ShortEdge({halfedge_.cptrD(), vertPos_.cptrD(), precision_})) -
-      flaggedEdges.beginD();
+      flaggedEdges.begin();
   flaggedEdges.resize(numFlagged);
 
   for (const int edge : flaggedEdges) CollapseEdge(edge);
@@ -132,19 +131,19 @@ void Manifold::Impl::SimplifyTopology() {
   flaggedEdges.resize(halfedge_.size());
   numFlagged =
       thrust::copy_if(
-          thrust::device, countAt(0), countAt(halfedge_.size()), flaggedEdges.beginD(),
+          thrust::device, countAt(0), countAt(halfedge_.size()), flaggedEdges.begin(),
           FlagEdge({halfedge_.cptrD(), meshRelation_.triBary.cptrD()})) -
-      flaggedEdges.beginD();
+      flaggedEdges.begin();
   flaggedEdges.resize(numFlagged);
 
   for (const int edge : flaggedEdges) CollapseEdge(edge);
 
   flaggedEdges.resize(halfedge_.size());
   numFlagged = thrust::copy_if(
-                   thrust::device, countAt(0), countAt(halfedge_.size()), flaggedEdges.beginD(),
+                   thrust::device, countAt(0), countAt(halfedge_.size()), flaggedEdges.begin(),
                    SwappableEdge({halfedge_.cptrD(), vertPos_.cptrD(),
                                   faceNormal_.cptrD(), precision_})) -
-               flaggedEdges.beginD();
+               flaggedEdges.begin();
   flaggedEdges.resize(numFlagged);
 
   for (const int edge : flaggedEdges) {
@@ -215,42 +214,39 @@ void Manifold::Impl::RemoveIfFolded(int edge) {
 }
 
 void Manifold::Impl::CollapseEdge(const int edge) {
-  VecDH<Halfedge>& halfedge = halfedge_;
-  VecDH<glm::vec3>& vertPos = vertPos_;
-  VecDH<glm::vec3>& triNormal = faceNormal_;
   VecDH<BaryRef>& triBary = meshRelation_.triBary;
 
-  const Halfedge toRemove = halfedge[edge];
+  const Halfedge toRemove = halfedge_[edge];
   if (toRemove.pairedHalfedge < 0) return;
 
   const int endVert = toRemove.endVert;
   const glm::ivec3 tri0edge = TriOf(edge);
   const glm::ivec3 tri1edge = TriOf(toRemove.pairedHalfedge);
 
-  const glm::vec3 pNew = vertPos[endVert];
-  const glm::vec3 pOld = vertPos[toRemove.startVert];
+  const glm::vec3 pNew = vertPos_[endVert];
+  const glm::vec3 pOld = vertPos_[toRemove.startVert];
   const glm::vec3 delta = pNew - pOld;
   const bool shortEdge = glm::dot(delta, delta) < precision_ * precision_;
 
   std::vector<int> edges;
   // Orbit endVert
-  int current = halfedge[tri0edge[1]].pairedHalfedge;
+  int current = halfedge_[tri0edge[1]].pairedHalfedge;
   while (current != tri1edge[2]) {
     current = NextHalfedge(current);
     edges.push_back(current);
-    current = halfedge[current].pairedHalfedge;
+    current = halfedge_[current].pairedHalfedge;
   }
 
   // Orbit startVert
-  int start = halfedge[tri1edge[1]].pairedHalfedge;
+  int start = halfedge_[tri1edge[1]].pairedHalfedge;
   const BaryRef ref0 = triBary[edge / 3];
   const BaryRef ref1 = triBary[toRemove.pairedHalfedge / 3];
   if (!shortEdge) {
     current = start;
-    glm::vec3 pLast = vertPos[halfedge[tri1edge[1]].endVert];
+    glm::vec3 pLast = vertPos_[halfedge_[tri1edge[1]].endVert];
     while (current != tri0edge[2]) {
       current = NextHalfedge(current);
-      glm::vec3 pNext = vertPos[halfedge[current].endVert];
+      glm::vec3 pNext = vertPos_[halfedge_[current].endVert];
       const int tri = current / 3;
       const BaryRef ref = triBary[tri];
       // Don't collapse if the edge is not redundant (this may have changed due
@@ -260,18 +256,18 @@ void Manifold::Impl::CollapseEdge(const int edge) {
         return;
 
       // Don't collapse edge if it would cause a triangle to invert.
-      const glm::mat3x2 projection = GetAxisAlignedProjection(triNormal[tri]);
+      const glm::mat3x2 projection = GetAxisAlignedProjection(faceNormal_[tri]);
       if (CCW(projection * pNext, projection * pLast, projection * pNew,
               precision_) < 0)
         return;
 
       pLast = pNext;
-      current = halfedge[current].pairedHalfedge;
+      current = halfedge_[current].pairedHalfedge;
     }
   }
 
   // Remove toRemove.startVert and replace with endVert.
-  vertPos[toRemove.startVert] = glm::vec3(NAN);
+  vertPos_[toRemove.startVert] = glm::vec3(NAN);
   CollapseTri(tri1edge);
 
   // Orbit startVert
@@ -289,10 +285,10 @@ void Manifold::Impl::CollapseEdge(const int edge) {
               : ref1.vertBary[toRemove.pairedHalfedge % 3];
     }
 
-    const int vert = halfedge[current].endVert;
-    const int next = halfedge[current].pairedHalfedge;
+    const int vert = halfedge_[current].endVert;
+    const int next = halfedge_[current].pairedHalfedge;
     for (int i = 0; i < edges.size(); ++i) {
-      if (vert == halfedge[edges[i]].endVert) {
+      if (vert == halfedge_[edges[i]].endVert) {
         FormLoop(edges[i], current);
         start = next;
         edges.resize(i);
@@ -308,48 +304,45 @@ void Manifold::Impl::CollapseEdge(const int edge) {
 }
 
 void Manifold::Impl::RecursiveEdgeSwap(const int edge) {
-  const VecDH<glm::vec3>& vertPos = vertPos_;
-  VecDH<Halfedge>& halfedge = halfedge_;
-  VecDH<glm::vec3>& triNormal = faceNormal_;
   VecDH<BaryRef>& triBary = meshRelation_.triBary;
 
-  if (halfedge[edge].pairedHalfedge < 0) return;
+  if (halfedge_[edge].pairedHalfedge < 0) return;
 
-  const int pair = halfedge[edge].pairedHalfedge;
+  const int pair = halfedge_[edge].pairedHalfedge;
   const glm::ivec3 tri0edge = TriOf(edge);
   const glm::ivec3 tri1edge = TriOf(pair);
   const glm::ivec3 perm0 = TriOf(edge % 3);
   const glm::ivec3 perm1 = TriOf(pair % 3);
 
-  glm::mat3x2 projection = GetAxisAlignedProjection(triNormal[edge / 3]);
+  glm::mat3x2 projection = GetAxisAlignedProjection(faceNormal_[edge / 3]);
   glm::vec2 v[4];
   for (int i : {0, 1, 2})
-    v[i] = projection * vertPos[halfedge[tri0edge[i]].startVert];
+    v[i] = projection * vertPos_[halfedge_[tri0edge[i]].startVert];
   // Only operate on the long edge of a degenerate triangle.
   if (CCW(v[0], v[1], v[2], precision_) > 0 || !Is01Longest(v[0], v[1], v[2]))
     return;
 
   // Switch to neighbor's projection.
-  projection = GetAxisAlignedProjection(triNormal[halfedge[pair].face]);
+  projection = GetAxisAlignedProjection(faceNormal_[halfedge_[pair].face]);
   for (int i : {0, 1, 2})
-    v[i] = projection * vertPos[halfedge[tri0edge[i]].startVert];
-  v[3] = projection * vertPos[halfedge[tri1edge[2]].startVert];
+    v[i] = projection * vertPos_[halfedge_[tri0edge[i]].startVert];
+  v[3] = projection * vertPos_[halfedge_[tri1edge[2]].startVert];
 
   auto SwapEdge = [&]() {
     // The 0-verts are swapped to the opposite 2-verts.
-    const int v0 = halfedge[tri0edge[2]].startVert;
-    const int v1 = halfedge[tri1edge[2]].startVert;
-    halfedge[tri0edge[0]].startVert = v1;
-    halfedge[tri0edge[2]].endVert = v1;
-    halfedge[tri1edge[0]].startVert = v0;
-    halfedge[tri1edge[2]].endVert = v0;
-    PairUp(tri0edge[0], halfedge[tri1edge[2]].pairedHalfedge);
-    PairUp(tri1edge[0], halfedge[tri0edge[2]].pairedHalfedge);
+    const int v0 = halfedge_[tri0edge[2]].startVert;
+    const int v1 = halfedge_[tri1edge[2]].startVert;
+    halfedge_[tri0edge[0]].startVert = v1;
+    halfedge_[tri0edge[2]].endVert = v1;
+    halfedge_[tri1edge[0]].startVert = v0;
+    halfedge_[tri1edge[2]].endVert = v0;
+    PairUp(tri0edge[0], halfedge_[tri1edge[2]].pairedHalfedge);
+    PairUp(tri1edge[0], halfedge_[tri0edge[2]].pairedHalfedge);
     PairUp(tri0edge[2], tri1edge[2]);
     // Both triangles are now subsets of the neighboring triangle.
-    const int tri0 = halfedge[tri0edge[0]].face;
-    const int tri1 = halfedge[tri1edge[0]].face;
-    triNormal[tri0] = triNormal[tri1];
+    const int tri0 = halfedge_[tri0edge[0]].face;
+    const int tri1 = halfedge_[tri1edge[0]].face;
+    faceNormal_[tri0] = faceNormal_[tri1];
     triBary[tri0] = triBary[tri1];
     triBary[tri0].vertBary[perm0[1]] = triBary[tri1].vertBary[perm1[0]];
     triBary[tri0].vertBary[perm0[0]] = triBary[tri1].vertBary[perm1[2]];
@@ -369,16 +362,16 @@ void Manifold::Impl::RecursiveEdgeSwap(const int edge) {
     triBary[tri0].vertBary[perm0[2]] = newBary;
 
     // if the new edge already exists, duplicate the verts and split the mesh.
-    int current = halfedge[tri1edge[0]].pairedHalfedge;
-    const int endVert = halfedge[tri1edge[1]].endVert;
+    int current = halfedge_[tri1edge[0]].pairedHalfedge;
+    const int endVert = halfedge_[tri1edge[1]].endVert;
     while (current != tri0edge[1]) {
       current = NextHalfedge(current);
-      if (halfedge[current].endVert == endVert) {
+      if (halfedge_[current].endVert == endVert) {
         FormLoop(tri0edge[2], current);
         RemoveIfFolded(tri0edge[2]);
         return;
       }
-      current = halfedge[current].pairedHalfedge;
+      current = halfedge_[current].pairedHalfedge;
     }
   };
 
@@ -403,7 +396,7 @@ void Manifold::Impl::RecursiveEdgeSwap(const int edge) {
   }
   // Normal path
   SwapEdge();
-  RecursiveEdgeSwap(halfedge[tri0edge[1]].pairedHalfedge);
-  RecursiveEdgeSwap(halfedge[tri1edge[0]].pairedHalfedge);
+  RecursiveEdgeSwap(halfedge_[tri0edge[1]].pairedHalfedge);
+  RecursiveEdgeSwap(halfedge_[tri1edge[0]].pairedHalfedge);
 }
 }  // namespace manifold

--- a/manifold/src/face_op.cpp
+++ b/manifold/src/face_op.cpp
@@ -40,21 +40,12 @@ void Manifold::Impl::Face2Tri(const VecDH<int>& faceEdge,
   triNormal.reserve(faceEdge.size());
   triBary.reserve(faceEdge.size()*3);
 
-  const VecDH<glm::vec3>& vertPos = vertPos_;
-  const VecDH<int>& faceEdgeH = faceEdge;
-  const VecDH<Halfedge>& halfedge = halfedge_;
-  const VecDH<glm::vec3>& faceNormal = faceNormal_;
-  // meshRelation_.triBary.resize(0);
-  // std::vector<glm::ivec3> triVerts;
-  // std::vector<glm::vec3> triNormal;
-  // std::vector<BaryRef> triBary;
-
-  for (int face = 0; face < faceEdgeH.size() - 1; ++face) {
-    const int firstEdge = faceEdgeH[face];
-    const int lastEdge = faceEdgeH[face + 1];
+  for (int face = 0; face < faceEdge.size() - 1; ++face) {
+    const int firstEdge = faceEdge[face];
+    const int lastEdge = faceEdge[face + 1];
     const int numEdge = lastEdge - firstEdge;
     ALWAYS_ASSERT(numEdge >= 3, topologyErr, "face has less than three edges.");
-    const glm::vec3 normal = faceNormal[face];
+    const glm::vec3 normal = faceNormal_[face];
 
     auto linearSearch = [](const int* mapping, int value) {
       int i = 0;
@@ -64,15 +55,15 @@ void Manifold::Impl::Face2Tri(const VecDH<int>& faceEdge,
     };
 
     if (numEdge == 3) {  // Single triangle
-      int mapping[3] = {halfedge[firstEdge].startVert,
-                        halfedge[firstEdge + 1].startVert,
-                        halfedge[firstEdge + 2].startVert};
-      glm::ivec3 tri(halfedge[firstEdge].startVert,
-                     halfedge[firstEdge + 1].startVert,
-                     halfedge[firstEdge + 2].startVert);
-      glm::ivec3 ends(halfedge[firstEdge].endVert,
-                      halfedge[firstEdge + 1].endVert,
-                      halfedge[firstEdge + 2].endVert);
+      int mapping[3] = {halfedge_[firstEdge].startVert,
+                        halfedge_[firstEdge + 1].startVert,
+                        halfedge_[firstEdge + 2].startVert};
+      glm::ivec3 tri(halfedge_[firstEdge].startVert,
+                     halfedge_[firstEdge + 1].startVert,
+                     halfedge_[firstEdge + 2].startVert);
+      glm::ivec3 ends(halfedge_[firstEdge].endVert,
+                      halfedge_[firstEdge + 1].endVert,
+                      halfedge_[firstEdge + 2].endVert);
       if (ends[0] == tri[2]) {
         std::swap(tri[1], tri[2]);
         std::swap(ends[1], ends[2]);
@@ -88,26 +79,26 @@ void Manifold::Impl::Face2Tri(const VecDH<int>& faceEdge,
         triBary.back().vertBary[k] = halfedgeBary[firstEdge + index];
       }
     } else if (numEdge == 4) {  // Pair of triangles
-      int mapping[4] = {halfedge[firstEdge].startVert,
-                        halfedge[firstEdge + 1].startVert,
-                        halfedge[firstEdge + 2].startVert,
-                        halfedge[firstEdge + 3].startVert};
+      int mapping[4] = {halfedge_[firstEdge].startVert,
+                        halfedge_[firstEdge + 1].startVert,
+                        halfedge_[firstEdge + 2].startVert,
+                        halfedge_[firstEdge + 3].startVert};
       const glm::mat3x2 projection = GetAxisAlignedProjection(normal);
-      auto triCCW = [&projection, &vertPos, this](const glm::ivec3 tri) {
-        return CCW(projection * vertPos[tri[0]], projection * vertPos[tri[1]],
-                   projection * vertPos[tri[2]], precision_) >= 0;
+      auto triCCW = [&projection, this](const glm::ivec3 tri) {
+        return CCW(projection * this->vertPos_[tri[0]], projection * this->vertPos_[tri[1]],
+                   projection * this->vertPos_[tri[2]], precision_) >= 0;
       };
 
-      glm::ivec3 tri0(halfedge[firstEdge].startVert,
-                      halfedge[firstEdge].endVert, -1);
+      glm::ivec3 tri0(halfedge_[firstEdge].startVert,
+                      halfedge_[firstEdge].endVert, -1);
       glm::ivec3 tri1(-1, -1, tri0[0]);
       for (const int i : {1, 2, 3}) {
-        if (halfedge[firstEdge + i].startVert == tri0[1]) {
-          tri0[2] = halfedge[firstEdge + i].endVert;
+        if (halfedge_[firstEdge + i].startVert == tri0[1]) {
+          tri0[2] = halfedge_[firstEdge + i].endVert;
           tri1[0] = tri0[2];
         }
-        if (halfedge[firstEdge + i].endVert == tri0[0]) {
-          tri1[1] = halfedge[firstEdge + i].startVert;
+        if (halfedge_[firstEdge + i].endVert == tri0[0]) {
+          tri1[1] = halfedge_[firstEdge + i].startVert;
         }
       }
       ALWAYS_ASSERT(glm::all(glm::greaterThanEqual(tri0, glm::ivec3(0))) &&
@@ -122,8 +113,8 @@ void Manifold::Impl::Face2Tri(const VecDH<int>& faceEdge,
         tri0[2] = tri1[0];
         tri1[2] = tri0[0];
       } else if (firstValid) {
-        glm::vec3 firstCross = vertPos[tri0[0]] - vertPos[tri1[0]];
-        glm::vec3 secondCross = vertPos[tri0[1]] - vertPos[tri1[1]];
+        glm::vec3 firstCross = vertPos_[tri0[0]] - vertPos_[tri1[0]];
+        glm::vec3 secondCross = vertPos_[tri0[1]] - vertPos_[tri1[1]];
         if (glm::dot(firstCross, firstCross) <
             glm::dot(secondCross, secondCross)) {
           tri0[2] = tri1[0];
@@ -145,15 +136,15 @@ void Manifold::Impl::Face2Tri(const VecDH<int>& faceEdge,
 
       std::map<int, int> vertBary;
       for (int j = firstEdge; j < lastEdge; ++j)
-        vertBary[halfedge[j].startVert] = halfedgeBary[j];
+        vertBary[halfedge_[j].startVert] = halfedgeBary[j];
 
       Polygons polys;
       try {
-        polys = Face2Polygons(face, projection, faceEdgeH);
+        polys = Face2Polygons(face, projection, faceEdge);
       } catch (const std::exception& e) {
         std::cout << e.what() << std::endl;
-        for (int edge = faceEdgeH[face]; edge < faceEdgeH[face + 1]; ++edge)
-          std::cout << "halfedge: " << edge << ", " << halfedge[edge]
+        for (int edge = faceEdge[face]; edge < faceEdge[face + 1]; ++edge)
+          std::cout << "halfedge: " << edge << ", " << halfedge_[edge]
                     << std::endl;
         throw;
       }
@@ -181,15 +172,13 @@ void Manifold::Impl::Face2Tri(const VecDH<int>& faceEdge,
  */
 Polygons Manifold::Impl::Face2Polygons(int face, glm::mat3x2 projection,
                                        const VecDH<int>& faceEdge) const {
-  const VecDH<glm::vec3>& vertPos = vertPos_;
-  const VecDH<Halfedge>& halfedge = halfedge_;
   const int firstEdge = faceEdge[face];
   const int lastEdge = faceEdge[face + 1];
 
   std::map<int, int> vert_edge;
   for (int edge = firstEdge; edge < lastEdge; ++edge) {
     ALWAYS_ASSERT(
-        vert_edge.emplace(std::make_pair(halfedge[edge].startVert, edge))
+        vert_edge.emplace(std::make_pair(halfedge_[edge].startVert, edge))
             .second,
         topologyErr, "face has duplicate vertices.");
   }
@@ -204,9 +193,9 @@ Polygons Manifold::Impl::Face2Polygons(int face, glm::mat3x2 projection,
       thisEdge = startEdge;
       polys.push_back({});
     }
-    int vert = halfedge[thisEdge].startVert;
-    polys.back().push_back({projection * vertPos[vert], vert});
-    const auto result = vert_edge.find(halfedge[thisEdge].endVert);
+    int vert = halfedge_[thisEdge].startVert;
+    polys.back().push_back({projection * vertPos_[vert], vert});
+    const auto result = vert_edge.find(halfedge_[thisEdge].endVert);
     ALWAYS_ASSERT(result != vert_edge.end(), topologyErr, "nonmanifold edge");
     thisEdge = result->second;
     vert_edge.erase(result);

--- a/manifold/src/impl.cpp
+++ b/manifold/src/impl.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <thrust/execution_policy.h>
 #include <thrust/logical.h>
 
 #include <algorithm>
@@ -374,7 +373,7 @@ void Manifold::Impl::DuplicateMeshIDs() {
 }
 
 void Manifold::Impl::ReinitializeReference(int meshID) {
-  thrust::for_each_n(thrust::device, zip(meshRelation_.triBary.beginD(), countAt(0)), NumTri(),
+  thrust::for_each_n(thrust::device, zip(meshRelation_.triBary.begin(), countAt(0)), NumTri(),
                      InitializeBaryRef({meshID, halfedge_.cptrD()}));
 }
 
@@ -402,7 +401,7 @@ int Manifold::Impl::InitializeNewReference(
                   "propertyTolerance.");
 
     const int numSets = properties.size() / numProps;
-    ALWAYS_ASSERT(thrust::all_of(thrust::device, triPropertiesD.beginD(), triPropertiesD.endD(),
+    ALWAYS_ASSERT(thrust::all_of(thrust::device, triPropertiesD.begin(), triPropertiesD.end(),
                                  CheckProperties({numSets})),
                   userErr,
                   "triProperties value is outside the properties range.");
@@ -411,7 +410,7 @@ int Manifold::Impl::InitializeNewReference(
   VecDH<thrust::pair<int, int>> face2face(halfedge_.size(), {-1, -1});
   VecDH<float> triArea(NumTri());
   thrust::for_each_n(
-      thrust::device, zip(face2face.beginD(), countAt(0)), halfedge_.size(),
+      thrust::device, zip(face2face.begin(), countAt(0)), halfedge_.size(),
       CoplanarEdge({triArea.ptrD(), halfedge_.cptrD(), vertPos_.cptrD(),
                     triPropertiesD.cptrD(), propertiesD.cptrD(),
                     propertyToleranceD.cptrD(), numProps, precision_}));
@@ -493,9 +492,9 @@ void Manifold::Impl::CreateHalfedges(const VecDH<glm::ivec3>& triVerts) {
   const int numTri = triVerts.size();
   halfedge_.resize(3 * numTri);
   VecDH<TmpEdge> edge(3 * numTri);
-  thrust::for_each_n(thrust::device, zip(countAt(0), triVerts.beginD()), numTri,
+  thrust::for_each_n(thrust::device, zip(countAt(0), triVerts.begin()), numTri,
                      Tri2Halfedges({halfedge_.ptrD(), edge.ptrD()}));
-  thrust::sort(thrust::device, edge.beginD(), edge.endD());
+  thrust::sort(thrust::device, edge.begin(), edge.end());
   thrust::for_each_n(thrust::device, countAt(0), halfedge_.size() / 2,
                      LinkHalfedges({halfedge_.ptrD(), edge.cptrD()}));
 }
@@ -511,7 +510,7 @@ void Manifold::Impl::CreateAndFixHalfedges(const VecDH<glm::ivec3>& triVerts) {
   halfedge_.resize(0);
   halfedge_.resize(3 * numTri);
   VecDH<TmpEdge> edge(3 * numTri);
-  thrust::for_each_n(thrust::device, zip(countAt(0), triVerts.beginD()), numTri,
+  thrust::for_each_n(thrust::device, zip(countAt(0), triVerts.begin()), numTri,
                      Tri2Halfedges({halfedge_.ptrD(), edge.ptrD()}));
   // Stable sort is required here so that halfedges from the same face are
   // paired together (the triangles were created in face order). In some
@@ -519,7 +518,7 @@ void Manifold::Impl::CreateAndFixHalfedges(const VecDH<glm::ivec3>& triVerts) {
   // two different faces, causing this edge to not be 2-manifold. We detect this
   // and fix it by swapping one of the identical edges, so it is important that
   // we have the edges paired according to their face.
-  thrust::stable_sort(thrust::device, edge.beginD(), edge.endD());
+  thrust::stable_sort(thrust::device, edge.begin(), edge.end());
   thrust::for_each_n(thrust::host, countAt(0), halfedge_.size() / 2,
                      LinkHalfedges({halfedge_.ptrH(), edge.cptrH()}));
   thrust::for_each(thrust::host, countAt(1), countAt(halfedge_.size() / 2),
@@ -551,14 +550,14 @@ void Manifold::Impl::ApplyTransform() const {
  */
 void Manifold::Impl::ApplyTransform() {
   if (transform_ == glm::mat4x3(1.0f)) return;
-  thrust::for_each(thrust::device, vertPos_.beginD(), vertPos_.endD(),
+  thrust::for_each(thrust::device, vertPos_.begin(), vertPos_.end(),
                    Transform4x3({transform_}));
 
   glm::mat3 normalTransform =
       glm::inverse(glm::transpose(glm::mat3(transform_)));
-  thrust::for_each(thrust::device, faceNormal_.beginD(), faceNormal_.endD(),
+  thrust::for_each(thrust::device, faceNormal_.begin(), faceNormal_.end(),
                    TransformNormals({normalTransform}));
-  thrust::for_each(thrust::device, vertNormal_.beginD(), vertNormal_.endD(),
+  thrust::for_each(thrust::device, vertNormal_.begin(), vertNormal_.end(),
                    TransformNormals({normalTransform}));
   // This optimization does a cheap collider update if the transform is
   // axis-aligned.
@@ -601,17 +600,17 @@ void Manifold::Impl::SetPrecision(float minPrecision) {
  */
 void Manifold::Impl::CalculateNormals() {
   vertNormal_.resize(NumVert());
-  thrust::fill(thrust::device, vertNormal_.beginD(), vertNormal_.endD(), glm::vec3(0));
+  thrust::fill(thrust::device, vertNormal_.begin(), vertNormal_.end(), glm::vec3(0));
   bool calculateTriNormal = false;
   if (faceNormal_.size() != NumTri()) {
     faceNormal_.resize(NumTri());
     calculateTriNormal = true;
   }
   thrust::for_each_n(
-      thrust::device, zip(faceNormal_.beginD(), countAt(0)), NumTri(),
+      thrust::device, zip(faceNormal_.begin(), countAt(0)), NumTri(),
       AssignNormals({vertNormal_.ptrD(), vertPos_.cptrD(), halfedge_.cptrD(),
                      precision_, calculateTriNormal}));
-  thrust::for_each(thrust::device, vertNormal_.beginD(), vertNormal_.endD(), Normalize());
+  thrust::for_each(thrust::device, vertNormal_.begin(), vertNormal_.end(), Normalize());
 }
 
 /**
@@ -623,12 +622,12 @@ SparseIndices Manifold::Impl::EdgeCollisions(const Impl& Q) const {
   VecDH<TmpEdge> edges = CreateTmpEdges(Q.halfedge_);
   const int numEdge = edges.size();
   VecDH<Box> QedgeBB(numEdge);
-  thrust::for_each_n(thrust::device, zip(QedgeBB.beginD(), edges.cbeginD()), numEdge,
+  thrust::for_each_n(thrust::device, zip(QedgeBB.begin(), edges.cbegin()), numEdge,
                      EdgeBox({Q.vertPos_.cptrD()}));
 
   SparseIndices q1p2 = collider_.Collisions(QedgeBB);
 
-  thrust::for_each(thrust::device, q1p2.beginD(0), q1p2.endD(0), ReindexEdge({edges.cptrD()}));
+  thrust::for_each(thrust::device, q1p2.begin(0), q1p2.end(0), ReindexEdge({edges.cptrD()}));
   return q1p2;
 }
 

--- a/manifold/src/impl.h
+++ b/manifold/src/impl.h
@@ -94,7 +94,7 @@ struct Manifold::Impl {
   void Face2Tri(const VecDH<int>& faceEdge, const VecDH<BaryRef>& faceRef,
                 const VecDH<int>& halfedgeBary);
   Polygons Face2Polygons(int face, glm::mat3x2 projection,
-                         const VecH<int>& faceEdge) const;
+                         const VecDH<int>& faceEdge) const;
 
   // edge_op.cu
   void SimplifyTopology();

--- a/manifold/src/manifold.cpp
+++ b/manifold/src/manifold.cpp
@@ -14,6 +14,7 @@
 
 #include "boolean3.h"
 #include "impl.h"
+#include <thrust/execution_policy.h>
 
 namespace {
 using namespace manifold;
@@ -124,7 +125,7 @@ Mesh Manifold::GetMesh() const {
                                 pImpl_->halfedgeTangent_.end());
 
   result.triVerts.resize(NumTri());
-  thrust::for_each_n(zip(result.triVerts.begin(), countAt(0)), NumTri(),
+  thrust::for_each_n(thrust::host, zip(result.triVerts.begin(), countAt(0)), NumTri(),
                      MakeTri({pImpl_->halfedge_.cptrH()}));
 
   return result;
@@ -288,11 +289,11 @@ MeshRelation Manifold::GetMeshRelation() const {
 std::vector<int> Manifold::GetMeshIDs() const {
   VecDH<int> meshIDs(NumTri());
   thrust::for_each_n(
-      zip(meshIDs.beginD(), pImpl_->meshRelation_.triBary.beginD()), NumTri(),
+      thrust::device, zip(meshIDs.beginD(), pImpl_->meshRelation_.triBary.beginD()), NumTri(),
       GetMeshID());
 
-  thrust::sort(meshIDs.beginD(), meshIDs.endD());
-  int n = thrust::unique(meshIDs.beginD(), meshIDs.endD()) - meshIDs.beginD();
+  thrust::sort(thrust::device, meshIDs.beginD(), meshIDs.endD());
+  int n = thrust::unique(thrust::device, meshIDs.beginD(), meshIDs.endD()) - meshIDs.beginD();
   meshIDs.resize(n);
 
   std::vector<int> out;
@@ -439,7 +440,7 @@ Manifold& Manifold::Transform(const glm::mat4x3& m) {
  */
 Manifold& Manifold::Warp(std::function<void(glm::vec3&)> warpFunc) {
   pImpl_->ApplyTransform();
-  thrust::for_each_n(pImpl_->vertPos_.begin(), NumVert(), warpFunc);
+  thrust::for_each_n(thrust::host, pImpl_->vertPos_.begin(), NumVert(), warpFunc);
   pImpl_->Update();
   pImpl_->faceNormal_.resize(0);  // force recalculation of triNormal
   pImpl_->CalculateNormals();

--- a/manifold/src/manifold.cpp
+++ b/manifold/src/manifold.cpp
@@ -14,7 +14,6 @@
 
 #include "boolean3.h"
 #include "impl.h"
-#include <thrust/execution_policy.h>
 
 namespace {
 using namespace manifold;
@@ -289,11 +288,11 @@ MeshRelation Manifold::GetMeshRelation() const {
 std::vector<int> Manifold::GetMeshIDs() const {
   VecDH<int> meshIDs(NumTri());
   thrust::for_each_n(
-      thrust::device, zip(meshIDs.beginD(), pImpl_->meshRelation_.triBary.beginD()), NumTri(),
+      thrust::device, zip(meshIDs.begin(), pImpl_->meshRelation_.triBary.begin()), NumTri(),
       GetMeshID());
 
-  thrust::sort(thrust::device, meshIDs.beginD(), meshIDs.endD());
-  int n = thrust::unique(thrust::device, meshIDs.beginD(), meshIDs.endD()) - meshIDs.beginD();
+  thrust::sort(thrust::device, meshIDs.begin(), meshIDs.end());
+  int n = thrust::unique(thrust::device, meshIDs.begin(), meshIDs.end()) - meshIDs.begin();
   meshIDs.resize(n);
 
   std::vector<int> out;

--- a/manifold/src/properties.cpp
+++ b/manifold/src/properties.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <thrust/count.h>
-#include <thrust/execution_policy.h>
 #include <thrust/logical.h>
 #include <thrust/transform_reduce.h>
 #include <limits>
@@ -219,7 +218,7 @@ bool Manifold::Impl::IsManifold() const {
                                    CheckManifold({halfedge_.cptrD()}));
 
   VecDH<Halfedge> halfedge(halfedge_);
-  thrust::sort(thrust::device, halfedge.beginD(), halfedge.endD());
+  thrust::sort(thrust::device, halfedge.begin(), halfedge.end());
   isManifold &= thrust::all_of(thrust::device, countAt(0), countAt(2 * NumEdge() - 1),
                                NoDuplicates({halfedge.cptrD()}));
   return isManifold;
@@ -269,20 +268,20 @@ Curvature Manifold::Impl::GetCurvature() const {
                        vertArea.ptrD(), degree.ptrD(), halfedge_.cptrD(),
                        vertPos_.cptrD(), faceNormal_.cptrD()}));
   thrust::for_each_n(
-      thrust::device, zip(vertMeanCurvature.beginD(), vertGaussianCurvature.beginD(),
-          vertArea.beginD(), degree.beginD()),
+      thrust::device, zip(vertMeanCurvature.begin(), vertGaussianCurvature.begin(),
+          vertArea.begin(), degree.begin()),
       NumVert(), NormalizeCurvature());
   result.minMeanCurvature =
-      thrust::reduce(thrust::device, vertMeanCurvature.beginD(), vertMeanCurvature.endD(),
+      thrust::reduce(thrust::device, vertMeanCurvature.begin(), vertMeanCurvature.end(),
                      std::numeric_limits<float>::infinity(), thrust::minimum<float>());
   result.maxMeanCurvature =
-      thrust::reduce(thrust::device, vertMeanCurvature.beginD(), vertMeanCurvature.endD(),
+      thrust::reduce(thrust::device, vertMeanCurvature.begin(), vertMeanCurvature.end(),
                      -std::numeric_limits<float>::infinity(), thrust::maximum<float>());
   result.minGaussianCurvature = thrust::reduce(
-      thrust::device, vertGaussianCurvature.beginD(), vertGaussianCurvature.endD(), std::numeric_limits<float>::infinity(),
+      thrust::device, vertGaussianCurvature.begin(), vertGaussianCurvature.end(), std::numeric_limits<float>::infinity(),
       thrust::minimum<float>());
   result.maxGaussianCurvature = thrust::reduce(
-      thrust::device, vertGaussianCurvature.beginD(), vertGaussianCurvature.endD(),
+      thrust::device, vertGaussianCurvature.begin(), vertGaussianCurvature.end(),
       -std::numeric_limits<float>::infinity(), thrust::maximum<float>());
   result.vertMeanCurvature.insert(result.vertMeanCurvature.end(),
                                   vertMeanCurvature.begin(),
@@ -299,9 +298,9 @@ Curvature Manifold::Impl::GetCurvature() const {
  * range for Morton code calculation.
  */
 void Manifold::Impl::CalculateBBox() {
-  bBox_.min = thrust::reduce(thrust::device, vertPos_.beginD(), vertPos_.endD(),
+  bBox_.min = thrust::reduce(thrust::device, vertPos_.begin(), vertPos_.end(),
                              glm::vec3(std::numeric_limits<float>::infinity()), PosMin());
-  bBox_.max = thrust::reduce(thrust::device, vertPos_.beginD(), vertPos_.endD(),
+  bBox_.max = thrust::reduce(thrust::device, vertPos_.begin(), vertPos_.end(),
                              glm::vec3(-std::numeric_limits<float>::infinity()), PosMax());
 }
 }  // namespace manifold

--- a/manifold/src/shared.h
+++ b/manifold/src/shared.h
@@ -146,9 +146,9 @@ struct TmpInvalid {
 
 VecDH<TmpEdge> inline CreateTmpEdges(const VecDH<Halfedge>& halfedge) {
   VecDH<TmpEdge> edges(halfedge.size());
-  thrust::for_each_n(zip(edges.beginD(), halfedge.beginD(), countAt(0)),
+  thrust::for_each_n(thrust::device, zip(edges.beginD(), halfedge.beginD(), countAt(0)),
                      edges.size(), Halfedge2Tmp());
-  int numEdge = thrust::remove_if(edges.beginD(), edges.endD(), TmpInvalid()) -
+  int numEdge = thrust::remove_if(thrust::device, edges.beginD(), edges.endD(), TmpInvalid()) -
                 edges.beginD();
   ALWAYS_ASSERT(numEdge == halfedge.size() / 2, topologyErr, "Not oriented!");
   edges.resize(numEdge);

--- a/manifold/src/shared.h
+++ b/manifold/src/shared.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <thrust/remove.h>
+#include <glm/gtx/compatibility.hpp>
+#include "utils.h"
 #include "vec_dh.h"
 
 namespace manifold {
@@ -23,7 +26,7 @@ namespace manifold {
  */
 __host__ __device__ inline glm::vec3 SafeNormalize(glm::vec3 v) {
   v = glm::normalize(v);
-  return isfinite(v.x) ? v : glm::vec3(0);
+  return glm::isfinite(v.x) ? v : glm::vec3(0);
 }
 
 __host__ __device__ inline int NextHalfedge(int current) {
@@ -146,10 +149,10 @@ struct TmpInvalid {
 
 VecDH<TmpEdge> inline CreateTmpEdges(const VecDH<Halfedge>& halfedge) {
   VecDH<TmpEdge> edges(halfedge.size());
-  thrust::for_each_n(thrust::device, zip(edges.beginD(), halfedge.beginD(), countAt(0)),
+  thrust::for_each_n(thrust::device, zip(edges.begin(), halfedge.begin(), countAt(0)),
                      edges.size(), Halfedge2Tmp());
-  int numEdge = thrust::remove_if(thrust::device, edges.beginD(), edges.endD(), TmpInvalid()) -
-                edges.beginD();
+  int numEdge = thrust::remove_if(thrust::device, edges.begin(), edges.end(), TmpInvalid()) -
+                edges.begin();
   ALWAYS_ASSERT(numEdge == halfedge.size() / 2, topologyErr, "Not oriented!");
   edges.resize(numEdge);
   return edges;

--- a/manifold/src/sort.cpp
+++ b/manifold/src/sort.cpp
@@ -122,8 +122,8 @@ template <typename T>
 void Permute(VecDH<T>& inOut, const VecDH<int>& new2Old) {
   VecDH<T> tmp(inOut);
   inOut.resize(new2Old.size());
-  thrust::gather(new2Old.beginD(), new2Old.endD(), tmp.beginD(),
-                 inOut.beginD());
+  thrust::gather(new2Old.begin(), new2Old.end(), tmp.begin(),
+                 inOut.begin());
 }
 
 template void Permute<BaryRef>(VecDH<BaryRef>&, const VecDH<int>&);
@@ -187,7 +187,7 @@ void Manifold::Impl::Finish() {
                 "Not an even number of faces after sorting faces!");
   Halfedge extrema = {0, 0, 0, 0};
   extrema =
-      thrust::reduce(thrust::device, halfedge_.beginD(), halfedge_.endD(), extrema, Extrema());
+      thrust::reduce(thrust::device, halfedge_.begin(), halfedge_.end(), extrema, Extrema());
 
   ALWAYS_ASSERT(extrema.startVert >= 0, topologyErr,
                 "Vertex index is negative!");
@@ -210,21 +210,21 @@ void Manifold::Impl::Finish() {
  */
 void Manifold::Impl::SortVerts() {
   VecDH<uint32_t> vertMorton(NumVert());
-  thrust::for_each_n(thrust::device, zip(vertMorton.beginD(), vertPos_.cbeginD()), NumVert(),
+  thrust::for_each_n(thrust::device, zip(vertMorton.begin(), vertPos_.cbegin()), NumVert(),
                      Morton({bBox_}));
 
   VecDH<int> vertNew2Old(NumVert());
-  thrust::sequence(thrust::device, vertNew2Old.beginD(), vertNew2Old.endD());
-  thrust::sort_by_key(thrust::device, vertMorton.beginD(), vertMorton.endD(),
-                      zip(vertPos_.beginD(), vertNew2Old.beginD()));
+  thrust::sequence(thrust::device, vertNew2Old.begin(), vertNew2Old.end());
+  thrust::sort_by_key(thrust::device, vertMorton.begin(), vertMorton.end(),
+                      zip(vertPos_.begin(), vertNew2Old.begin()));
 
   ReindexVerts(vertNew2Old, NumVert());
 
   // Verts were flagged for removal with NaNs and assigned kNoCode to sort them
   // to the end, which allows them to be removed.
   const int newNumVert =
-      thrust::find(thrust::device, vertMorton.beginD(), vertMorton.endD(), kNoCode) -
-      vertMorton.beginD();
+      thrust::find(thrust::device, vertMorton.begin(), vertMorton.end(), kNoCode) -
+      vertMorton.begin();
   vertPos_.resize(newNumVert);
 }
 
@@ -236,9 +236,9 @@ void Manifold::Impl::SortVerts() {
 void Manifold::Impl::ReindexVerts(const VecDH<int>& vertNew2Old,
                                   int oldNumVert) {
   VecDH<int> vertOld2New(oldNumVert);
-  thrust::scatter(thrust::device, countAt(0), countAt(NumVert()), vertNew2Old.beginD(),
-                  vertOld2New.beginD());
-  thrust::for_each(thrust::device, halfedge_.beginD(), halfedge_.endD(),
+  thrust::scatter(thrust::device, countAt(0), countAt(NumVert()), vertNew2Old.begin(),
+                  vertOld2New.begin());
+  thrust::for_each(thrust::device, halfedge_.begin(), halfedge_.end(),
                    Reindex({vertOld2New.cptrD()}));
 }
 
@@ -252,7 +252,7 @@ void Manifold::Impl::GetFaceBoxMorton(VecDH<Box>& faceBox,
   faceBox.resize(NumTri());
   faceMorton.resize(NumTri());
   thrust::for_each_n(
-      thrust::device, zip(faceMorton.beginD(), faceBox.beginD(), countAt(0)), NumTri(),
+      thrust::device, zip(faceMorton.begin(), faceBox.begin(), countAt(0)), NumTri(),
       FaceMortonBox({halfedge_.cptrD(), vertPos_.cptrD(), bBox_}));
 }
 
@@ -263,16 +263,16 @@ void Manifold::Impl::GetFaceBoxMorton(VecDH<Box>& faceBox,
 void Manifold::Impl::SortFaces(VecDH<Box>& faceBox,
                                VecDH<uint32_t>& faceMorton) {
   VecDH<int> faceNew2Old(NumTri());
-  thrust::sequence(thrust::device, faceNew2Old.beginD(), faceNew2Old.endD());
+  thrust::sequence(thrust::device, faceNew2Old.begin(), faceNew2Old.end());
 
-  thrust::sort_by_key(thrust::device, faceMorton.beginD(), faceMorton.endD(),
-                      zip(faceBox.beginD(), faceNew2Old.beginD()));
+  thrust::sort_by_key(thrust::device, faceMorton.begin(), faceMorton.end(),
+                      zip(faceBox.begin(), faceNew2Old.begin()));
 
   // Tris were flagged for removal with pairedHalfedge = -1 and assigned kNoCode
   // to sort them to the end, which allows them to be removed.
   const int newNumTri =
-      thrust::find(thrust::device, faceMorton.beginD(), faceMorton.endD(), kNoCode) -
-      faceMorton.beginD();
+      thrust::find(thrust::device, faceMorton.begin(), faceMorton.end(), kNoCode) -
+      faceMorton.begin();
   faceBox.resize(newNumTri);
   faceMorton.resize(newNumTri);
   faceNew2Old.resize(newNumTri);
@@ -295,8 +295,8 @@ void Manifold::Impl::GatherFaces(const VecDH<int>& faceNew2Old) {
   VecDH<Halfedge> oldHalfedge(std::move(halfedge_));
   VecDH<glm::vec4> oldHalfedgeTangent(std::move(halfedgeTangent_));
   VecDH<int> faceOld2New(oldHalfedge.size() / 3);
-  thrust::scatter(thrust::device, countAt(0), countAt(numTri), faceNew2Old.beginD(),
-                  faceOld2New.beginD());
+  thrust::scatter(thrust::device, countAt(0), countAt(numTri), faceNew2Old.begin(),
+                  faceOld2New.begin());
 
   halfedge_.resize(3 * numTri);
   if (oldHalfedgeTangent.size() != 0) halfedgeTangent_.resize(3 * numTri);
@@ -311,21 +311,21 @@ void Manifold::Impl::GatherFaces(const Impl& old,
                                  const VecDH<int>& faceNew2Old) {
   const int numTri = faceNew2Old.size();
   meshRelation_.triBary.resize(numTri);
-  thrust::gather(thrust::device, faceNew2Old.beginD(), faceNew2Old.endD(),
-                 old.meshRelation_.triBary.beginD(),
-                 meshRelation_.triBary.beginD());
+  thrust::gather(thrust::device, faceNew2Old.begin(), faceNew2Old.end(),
+                 old.meshRelation_.triBary.begin(),
+                 meshRelation_.triBary.begin());
   meshRelation_.barycentric = old.meshRelation_.barycentric;
   DuplicateMeshIDs();
 
   if (old.faceNormal_.size() == old.NumTri()) {
     faceNormal_.resize(numTri);
-    thrust::gather(thrust::device, faceNew2Old.beginD(), faceNew2Old.endD(),
-                   old.faceNormal_.beginD(), faceNormal_.beginD());
+    thrust::gather(thrust::device, faceNew2Old.begin(), faceNew2Old.end(),
+                   old.faceNormal_.begin(), faceNormal_.begin());
   }
 
   VecDH<int> faceOld2New(old.NumTri());
-  thrust::scatter(thrust::device, countAt(0), countAt(numTri), faceNew2Old.beginD(),
-                  faceOld2New.beginD());
+  thrust::scatter(thrust::device, countAt(0), countAt(numTri), faceNew2Old.begin(),
+                  faceOld2New.begin());
 
   halfedge_.resize(3 * numTri);
   if (old.halfedgeTangent_.size() != 0) halfedgeTangent_.resize(3 * numTri);

--- a/utilities/include/structs.h
+++ b/utilities/include/structs.h
@@ -414,17 +414,17 @@ struct Box {
   }
 };
 
-/**
- * Print the contents of this vector to standard output.
- */
-template <typename T>
-void Dump(const std::vector<T>& vec) {
-  std::cout << "Vec = " << std::endl;
-  for (int i = 0; i < vec.size(); ++i) {
-    std::cout << i << ", " << vec[i] << ", " << std::endl;
-  }
-  std::cout << std::endl;
-}
+// /**
+//  * Print the contents of this vector to standard output.
+//  */
+// template <typename T>
+// void Dump(const std::vector<T>& vec) {
+//   std::cout << "Vec = " << std::endl;
+//   for (int i = 0; i < vec.size(); ++i) {
+//     std::cout << i << ", " << vec[i] << ", " << std::endl;
+//   }
+//   std::cout << std::endl;
+// }
 
 inline std::ostream& operator<<(std::ostream& stream, const Box& box) {
   return stream << "min: " << box.min.x << ", " << box.min.y << ", "

--- a/utilities/include/structs.h
+++ b/utilities/include/structs.h
@@ -414,17 +414,17 @@ struct Box {
   }
 };
 
-// /**
-//  * Print the contents of this vector to standard output.
-//  */
-// template <typename T>
-// void Dump(const std::vector<T>& vec) {
-//   std::cout << "Vec = " << std::endl;
-//   for (int i = 0; i < vec.size(); ++i) {
-//     std::cout << i << ", " << vec[i] << ", " << std::endl;
-//   }
-//   std::cout << std::endl;
-// }
+/**
+ * Print the contents of this vector to standard output.
+ */
+template <typename T>
+void Dump(const std::vector<T>& vec) {
+  std::cout << "Vec = " << std::endl;
+  for (int i = 0; i < vec.size(); ++i) {
+    std::cout << i << ", " << vec[i] << ", " << std::endl;
+  }
+  std::cout << std::endl;
+}
 
 inline std::ostream& operator<<(std::ostream& stream, const Box& box) {
   return stream << "min: " << box.min.x << ", " << box.min.y << ", "

--- a/utilities/include/vec_dh.h
+++ b/utilities/include/vec_dh.h
@@ -15,20 +15,10 @@
 #pragma once
 #include <iostream>
 #include <thrust/universal_vector.h>
+#include <thrust/execution_policy.h>
+#include "structs.h"
 
 namespace manifold {
-
-/** @addtogroup Private
- *  @{
- */
-template <typename T>
-void Dump(const std::vector<T>& vec) {
-  std::cout << "Vec = " << std::endl;
-  for (int i = 0; i < vec.size(); ++i) {
-    std::cout << i << ", " << vec[i] << ", " << std::endl;
-  }
-  std::cout << std::endl;
-}
 
 /*
  * Host and device vector implementation. This uses `thrust::universal_vector` for
@@ -162,60 +152,33 @@ class VecDH {
     }
   }
 
-  using IterD = typename thrust::universal_vector<T>::iterator;
-  using IterH = typename thrust::universal_vector<T>::iterator;
-  using IterDc = typename thrust::universal_vector<T>::const_iterator;
-  using IterHc = typename thrust::universal_vector<T>::const_iterator;
+  using Iter = typename thrust::universal_vector<T>::iterator;
+  using IterC = typename thrust::universal_vector<T>::const_iterator;
 
-  IterH begin() {
+  Iter begin() {
     syncImpl();
     implModified = true;
     return impl_.begin();
   }
 
-  IterH end() {
+  Iter end() {
     syncImpl();
     implModified = true;
     return impl_.end();
   }
 
-  IterHc cbegin() const {
+  IterC cbegin() const {
     syncImpl();
     return impl_.cbegin();
   }
 
-  IterHc cend() const {
+  IterC cend() const {
     syncImpl();
     return impl_.cend();
   }
 
-  IterHc begin() const { return cbegin(); }
-  IterHc end() const { return cend(); }
-
-  IterD beginD() {
-    syncImpl();
-    implModified = true;
-    return impl_.begin();
-  }
-
-  IterD endD() {
-    syncImpl();
-    implModified = true;
-    return impl_.end();
-  }
-
-  IterDc cbeginD() const {
-    syncImpl();
-    return impl_.cbegin();
-  }
-
-  IterDc cendD() const {
-    syncImpl();
-    return impl_.cend();
-  }
-
-  IterDc beginD() const { return cbeginD(); }
-  IterDc endD() const { return cendD(); }
+  IterC begin() const { return cbegin(); }
+  IterC end() const { return cend(); }
 
   T* ptrD() {
     if (size() == 0) return nullptr;

--- a/utilities/include/vec_dh.h
+++ b/utilities/include/vec_dh.h
@@ -284,7 +284,7 @@ class VecDH {
   }
 
   void syncCache() const {
-    if (implModified) {
+    if (implModified || cache.empty()) {
       cache = std::vector<T>(impl_.begin(), impl_.end());
     }
     implModified = false;


### PR DESCRIPTION
Use universal vector to implement `VecDH`. Closes #120. Gives some performance improvement, reduced memory overhead and allows GPU to do demand-paging, i.e. will not OOM when the GPU memory is insufficient.

Note:
1. `thrust::universal_vector<T>::push_back` is very slow, already filed an issue to the upstream. I workaround this problem by implementing a cache that is only used when we push elements to a vector or reserve memory.
2. This requires a sufficiently recent CUDA toolkit (11.4) for the `universal_vector` header. I haven't yet tried compiling using the thrust in submodule  with an older version of CUDA, not sure if that is gonna work.
3. We now have to manually annotate the thrust functions for executor. This might be a feature because we might be able to choose the backend depending on the workload?

Benchmark (note that my computer only has 8GB of RAM, and the `nTri=8388608` was using swap and very slow for previous version, so the improvement is not actually that high):
<details>

```
====== CPP, Host Device Vector =======

nTri = 512, time = 0.00166264 sec
nTri = 2048, time = 0.00448657 sec
nTri = 8192, time = 0.0138731 sec
nTri = 32768, time = 0.0546407 sec
nTri = 131072, time = 0.219077 sec
nTri = 524288, time = 0.898074 sec
nTri = 2097152, time = 3.75272 sec
nTri = 8388608, time = 29.3012 sec
	Command being timed: "./perfTest"
	User time (seconds): 25.34
	System time (seconds): 7.71
	Percent of CPU this job got: 79%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:41.75
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 6927824
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 7640
	Minor (reclaiming a frame) page faults: 6355521
	Voluntary context switches: 8696
	Involuntary context switches: 2278
	Swaps: 0
	File system inputs: 464256
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0

====== CPP, Unified Memory =======

nTri = 512, time = 0.00234139 sec
nTri = 2048, time = 0.00402178 sec
nTri = 8192, time = 0.0129426 sec
nTri = 32768, time = 0.0496874 sec
nTri = 131072, time = 0.201387 sec
nTri = 524288, time = 0.824124 sec
nTri = 2097152, time = 3.29724 sec
nTri = 8388608, time = 14.9187 sec
	Command being timed: "./perfTest"
	User time (seconds): 22.84
	System time (seconds): 3.47
	Percent of CPU this job got: 99%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.31
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 5378220
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 2
	Minor (reclaiming a frame) page faults: 4284852
	Voluntary context switches: 2
	Involuntary context switches: 79
	Swaps: 0
	File system inputs: 136
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0



====== OMP, Host Device Vector =======
nTri = 512, time = 0.00135095 sec
nTri = 2048, time = 0.00298485 sec
nTri = 8192, time = 0.00762013 sec
nTri = 32768, time = 0.0314378 sec
nTri = 131072, time = 0.134311 sec
nTri = 524288, time = 0.606134 sec
nTri = 2097152, time = 2.51857 sec
nTri = 8388608, time = 23.9099 sec
	Command being timed: "./perfTest"
	User time (seconds): 141.85
	System time (seconds): 16.85
	Percent of CPU this job got: 483%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:32.84
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 7058568
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 18459
	Minor (reclaiming a frame) page faults: 7395832
	Voluntary context switches: 20115
	Involuntary context switches: 10690
	Swaps: 0
	File system inputs: 966904
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0

====== OMP, Unified Memory =======
nTri = 512, time = 0.00122855 sec
nTri = 2048, time = 0.00253237 sec
nTri = 8192, time = 0.00616688 sec
nTri = 32768, time = 0.0220143 sec
nTri = 131072, time = 0.0980233 sec
nTri = 524288, time = 0.463016 sec
nTri = 2097152, time = 1.98967 sec
nTri = 8388608, time = 8.25589 sec
	Command being timed: "./perfTest"
	User time (seconds): 106.40
	System time (seconds): 11.07
	Percent of CPU this job got: 765%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:15.34
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 5657400
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 15
	Minor (reclaiming a frame) page faults: 5149280
	Voluntary context switches: 232
	Involuntary context switches: 1642
	Swaps: 0
	File system inputs: 0
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0



====== CUDA, Host Device Vector =======
nTri = 512, time = 0.00396219 sec
nTri = 2048, time = 0.00530954 sec
nTri = 8192, time = 0.00963976 sec
nTri = 32768, time = 0.0254835 sec
nTri = 131072, time = 0.0854017 sec
nTri = 524288, time = 0.319703 sec
nTri = 2097152, time = 1.2162 sec
(OOMed)
	Command being timed: "./perfTest"
	User time (seconds): 2.95
	System time (seconds): 0.87
	Percent of CPU this job got: 99%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:03.83
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 1379072
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 1
	Minor (reclaiming a frame) page faults: 854796
	Voluntary context switches: 82
	Involuntary context switches: 9
	Swaps: 0
	File system inputs: 0
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0

====== CUDA, Unified Memory =======
nTri = 512, time = 0.0123526 sec
nTri = 2048, time = 0.0141026 sec
nTri = 8192, time = 0.0195818 sec
nTri = 32768, time = 0.0374303 sec
nTri = 131072, time = 0.120768 sec
nTri = 524288, time = 0.266435 sec
nTri = 2097152, time = 0.924646 sec
nTri = 8388608, time = 4.01982 sec
	Command being timed: "./perfTest"
	User time (seconds): 5.78
	System time (seconds): 1.68
	Percent of CPU this job got: 99%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:07.48
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 1744420
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 12576
	Minor (reclaiming a frame) page faults: 216926
	Voluntary context switches: 133
	Involuntary context switches: 49
	Swaps: 0
	File system inputs: 0
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```
</details>