### PR TITLE
build script update

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -35,7 +35,7 @@ jobs:
         patch third_party/assimp/code/CMakeLists.txt < assimp.diff
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} -DMANIFOLD_USE_CUDA=${{matrix.cuda_support}} -DCODE_COVERAGE=ON .. && make
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} -DMANIFOLD_USE_CUDA=${{matrix.cuda_support}} .. && make
     - name: Test ${{matrix.parallel_backend}} with CUDA ${{matrix.cuda_support}}
       # note that the test for CUDA backend does not really test CUDA, as we
       # don't have CUDA GPU on GitHub Action
@@ -45,9 +45,20 @@ jobs:
         ./manifold_test
         cd ../../
         python3 test/python/run_all.py
+    - name: Coverage Report
+      # only do code coverage for default sequential backend, it seems that TBB
+      # backend will cause failure
+      # perhaps issue related to invalid memory access?
+      if: matrix.parallel_backend == 'NONE'
+      run: |
         cd build
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} -DMANIFOLD_USE_CUDA=${{matrix.cuda_support}} -DCODE_COVERAGE=ON .. && make
+        cd test
+        ./manifold_test
+        cd ../
         lcov --directory ./manifold --directory collider --directory polygon --directory utilities --capture --output-file ./code_coverage.info -rc lcov_branch_coverage=1
     - uses: codecov/codecov-action@v2
+      if: matrix.parallel_backend == 'NONE'
       with:
         files: build/code_coverage.info
         fail_ci_if_error: true

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -49,11 +49,9 @@ jobs:
         lcov --directory ./manifold --directory collider --directory polygon --directory utilities --capture --output-file ./code_coverage.info -rc lcov_branch_coverage=1
     - uses: codecov/codecov-action@v2
       with:
-        dry_run: true
         files: build/code_coverage.info
         fail_ci_if_error: true
         name: ${{matrix.parallel_backend}}-${{matrix.cuda_support}}
-        verbose: true
 
   build_wasm:
     runs-on: ubuntu-20.04

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get -y update
-        DEBIAN_FRONTEND=noninteractive apt install -y libomp-dev git libtbb-dev pkg-config libpython3-dev python3 python3-distutils
+        DEBIAN_FRONTEND=noninteractive apt install -y libomp-dev git libtbb-dev pkg-config libpython3-dev python3 python3-distutils lcov
     - uses: actions/checkout@v3
       with:
         submodules: true
@@ -35,7 +35,7 @@ jobs:
         patch third_party/assimp/code/CMakeLists.txt < assimp.diff
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} -DMANIFOLD_USE_CUDA=${{matrix.cuda_support}} .. && make
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} -DMANIFOLD_USE_CUDA=${{matrix.cuda_support}} -DCODE_COVERAGE=ON .. && make
     - name: Test ${{matrix.parallel_backend}} with CUDA ${{matrix.cuda_support}}
       # note that the test for CUDA backend does not really test CUDA, as we
       # don't have CUDA GPU on GitHub Action
@@ -45,6 +45,15 @@ jobs:
         ./manifold_test
         cd ../../
         python3 test/python/run_all.py
+        cd build
+        lcov --directory ./manifold --directory collider --directory polygon --directory utilities --capture --output-file ./code_coverage.info -rc lcov_branch_coverage=1
+    - uses: codecov/codecov-action@v2
+      with:
+        dry_run: true
+        files: build/code_coverage.info
+        fail_ci_if_error: true
+        name: ${{matrix.parallel_backend}}-${{matrix.cuda_support}}
+        verbose: true
 
   build_wasm:
     runs-on: ubuntu-20.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,6 @@ cmake_minimum_required(VERSION 3.18)
 project(manifold LANGUAGES CXX)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
-# OPTION(DEBUG_CMAKE_TARGETS "enable debug output for cmake target properties" OFF)
-# if(DEBUG_CMAKE_TARGETS)
-#     set(CMAKE_DEBUG_TARGET_PROPERTIES
-#             INCLUDE_DIRECTORIES
-#         )
-# endif()
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(MANIFOLD_USE_CUDA on)
@@ -43,49 +36,33 @@ if(ASSIMP_FAST_BUILD)
     endforeach()
 endif()
 
-set(MANIFOLD_NVCC_FLAGS -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --extended-lambda)
-set(MANIFOLD_NVCC_RELEASE_FLAGS -O3)
-set(MANIFOLD_NVCC_DEBUG_FLAGS -G)
-
 set(THRUST_INC_DIR ${PROJECT_SOURCE_DIR}/third_party/thrust)
-
-message("CUDA Support: ${MANIFOLD_USE_CUDA}")
-message("Parallel Backend: ${MANIFOLD_PAR}")
-
-if (MANIFOLD_PAR STREQUAL "OMP")
-    find_package(OpenMP REQUIRED)
-    set(MANIFOLD_INCLUDE OpenMP::OpenMP_CXX)
-    set(MANIFOLD_FLAGS ${MANIFOLD_FLAGS} -fopenmp -DMANIFOLD_PAR='O')
-elseif (MANIFOLD_PAR STREQUAL "TBB")
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(TBB REQUIRED tbb)
-    set(MANIFOLD_INCLUDE ${TBB_LINK_LIBRARIES})
-    set(MANIFOLD_FLAGS ${MANIFOLD_FLAGS} -DMANIFOLD_PAR='T')
-elseif (MANIFOLD_PAR STREQUAL "NONE")
-    set(MANIFOLD_FLAGS ${MANIFOLD_FLAGS})
-    set(MANIFOLD_PAR "CPP")
-else ()
-    message(FATAL_ERROR "Invalid value for MANIFOLD_PAR: ${MANIFOLD_PAR}. "
-    "Should be one of \"TBB\", \"OMP\", \"CPP\"")
-endif()
 
 if (MANIFOLD_USE_CUDA)
     enable_language(CUDA)
-    find_package(CUDA  REQUIRED)
+    find_package(CUDA REQUIRED)
     # we cannot set THRUST_INC_DIR when building with CUDA, otherwise the
     # compiler will not use the system CUDA headers which causes incompatibility
     # clear THRUST_INC_DIR, we use the one from nvcc
     set(THRUST_INC_DIR "")
-    set(MANIFOLD_FLAGS ${MANIFOLD_FLAGS} -DMANIFOLD_USE_CUDA)
-    set(MANIFOLD_NVCC_FLAGS ${MANIFOLD_NVCC_FLAGS} ${MANIFOLD_FLAGS})
-else ()
-    set(MANIFOLD_FLAGS ${MANIFOLD_FLAGS} -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_${MANIFOLD_PAR})
+    set(MANIFOLD_NVCC_RELEASE_FLAGS -O3 -lineinfo)
+    set(MANIFOLD_NVCC_DEBUG_FLAGS -G)
+    set(MANIFOLD_NVCC_FLAGS -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --extended-lambda
+            "$<$<CONFIG:RELEASE>:${MANIFOLD_NVCC_RELEASE_FLAGS}>"
+            "$<$<CONFIG:DEBUG>:${MANIFOLD_NVCC_DEBUG_FLAGS}>")
 endif()
 
-if(MSVC)
-    set(MANIFOLD_FLAGS ${MANIFOLD_FLAGS})
-else()
-    set(MANIFOLD_FLAGS ${MANIFOLD_FLAGS} -Werror -Wall -Wno-sign-compare -Wno-unused)
+if(NOT MSVC)
+    set(WARNING_FLAGS -Werror -Wall -Wno-sign-compare -Wno-unused)
+    add_compile_options(
+        "$<$<COMPILE_LANGUAGE:CXX>:${WARNING_FLAGS}>"
+        "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${WARNING_FLAGS}>")
+endif()
+if(CODE_COVERAGE AND NOT MSVC)
+    add_compile_options(
+        "$<$<COMPILE_LANGUAGE:CXX>:-coverage>"
+        "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-coverage>")
+    add_link_options("-coverage")
 endif()
 
 add_subdirectory(utilities)

--- a/collider/CMakeLists.txt
+++ b/collider/CMakeLists.txt
@@ -1,29 +1,15 @@
 project (collider)
 
-add_library(${PROJECT_NAME} src/collider.cpp)
+file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
+add_library(${PROJECT_NAME} ${SOURCE_FILES})
 
 if(MANIFOLD_USE_CUDA)
-    set_source_files_properties(src/collider.cpp PROPERTIES LANGUAGE CUDA)
+    set_source_files_properties(${SOURCE_FILES} PROPERTIES LANGUAGE CUDA)
     set_property(TARGET ${PROJECT_NAME} PROPERTY CUDA_ARCHITECTURES 61)
-    target_compile_options(${PROJECT_NAME} 
-        PRIVATE ${MANIFOLD_NVCC_FLAGS}
-    )
-    target_compile_options(${PROJECT_NAME} 
-        PRIVATE "$<$<CONFIG:RELEASE>:${MANIFOLD_NVCC_RELEASE_FLAGS}>" "$<$<CONFIG:DEBUG>:${MANIFOLD_NVCC_DEBUG_FLAGS}>"
-    )
-else()
-    target_compile_options(${PROJECT_NAME} 
-        PRIVATE ${MANIFOLD_FLAGS}
-    )
 endif()
 
-target_include_directories( ${PROJECT_NAME}
-    PUBLIC ${PROJECT_SOURCE_DIR}/include
-)
-target_link_libraries( ${PROJECT_NAME}
-    PUBLIC utilities
-    PRIVATE ${MANIFOLD_INCLUDE}
-)
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_link_libraries(${PROJECT_NAME} PUBLIC utilities)
 
 target_compile_features(${PROJECT_NAME} 
     PUBLIC cxx_std_14

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,7 @@
               clang_13
               emscripten
               tbb
+              lcov
             ] ++ additional;
           };
         in
@@ -116,7 +117,7 @@
               '';
             };
           };
-          devShell = devShell { };
+          devShell = devShell { additional = [ pkgs.cudatoolkit_11_4 ]; };
           devShells.cuda = devShell {
             additional = [ pkgs.cudatoolkit_11_5 ];
           };

--- a/manifold/CMakeLists.txt
+++ b/manifold/CMakeLists.txt
@@ -1,34 +1,15 @@
 project (manifold)
 
-add_library(${PROJECT_NAME} src/manifold.cpp src/constructors.cpp src/impl.cpp
-    src/properties.cpp src/sort.cpp src/edge_op.cpp src/face_op.cpp
-    src/smoothing.cpp src/boolean3.cpp src/boolean_result.cpp src/csg_tree.cpp
-)
+file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
+add_library(${PROJECT_NAME} ${SOURCE_FILES})
 
 if(MANIFOLD_USE_CUDA)
-    set_source_files_properties(
-        src/manifold.cpp src/constructors.cpp src/impl.cpp
-        src/properties.cpp src/sort.cpp src/edge_op.cpp src/face_op.cpp
-        src/smoothing.cpp src/boolean3.cpp src/boolean_result.cpp
-        src/manifold_set.cpp src/csg_tree.cpp
-
-        PROPERTIES LANGUAGE CUDA
-    )
+    set_source_files_properties( ${SOURCE_FILES} PROPERTIES LANGUAGE CUDA)
     set_property(TARGET ${PROJECT_NAME} PROPERTY CUDA_ARCHITECTURES 61)
-    target_compile_options(${PROJECT_NAME} 
-        PRIVATE ${MANIFOLD_NVCC_FLAGS}
-    )
-    target_compile_options(${PROJECT_NAME} 
-        PRIVATE "$<$<CONFIG:RELEASE>:${MANIFOLD_NVCC_RELEASE_FLAGS}>" "$<$<CONFIG:DEBUG>:${MANIFOLD_NVCC_DEBUG_FLAGS}>"
-    )
-else()
-    target_compile_options(${PROJECT_NAME} 
-        PRIVATE ${MANIFOLD_FLAGS}
-    )
 endif()
 
-target_include_directories( ${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include )
-target_link_libraries( ${PROJECT_NAME}
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include )
+target_link_libraries(${PROJECT_NAME}
     PUBLIC utilities
     PRIVATE collider polygon ${MANIFOLD_INCLUDE} graphlite
 )

--- a/polygon/CMakeLists.txt
+++ b/polygon/CMakeLists.txt
@@ -1,8 +1,9 @@
 project (polygon)
 
-add_library(${PROJECT_NAME} src/polygon.cpp)
+file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
+add_library(${PROJECT_NAME} ${SOURCE_FILES})
 
-target_include_directories( ${PROJECT_NAME}
+target_include_directories(${PROJECT_NAME}
     PUBLIC ${PROJECT_SOURCE_DIR}/include
 )
 target_link_libraries( ${PROJECT_NAME}

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,6 +1,7 @@
 project (samples)
 
-add_library(${PROJECT_NAME} src/knot.cpp src/bracelet.cpp src/menger_sponge.cpp src/rounded_frame.cpp src/tet_puzzle.cpp src/scallop.cpp)
+file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
+add_library(${PROJECT_NAME} ${SOURCE_FILES})
 
 target_include_directories( ${PROJECT_NAME}
     PUBLIC ${PROJECT_SOURCE_DIR}/include

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,8 @@ project (manifold_test)
 
 enable_testing()
 
-add_executable(${PROJECT_NAME} test_main.cpp polygon_test.cpp mesh_test.cpp samples_test.cpp)
+file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} polygon GTest::GTest manifold meshIO samples)
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})

--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -1,20 +1,43 @@
 project (utilities)
 
-add_library(${PROJECT_NAME} src/detect_cuda.cpp)
+file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
+add_library(${PROJECT_NAME} ${SOURCE_FILES})
+
+message("CUDA Support: ${MANIFOLD_USE_CUDA}")
+message("Parallel Backend: ${MANIFOLD_PAR}")
+
+target_include_directories(${PROJECT_NAME} INTERFACE ${PROJECT_SOURCE_DIR}/include)
+
+if (MANIFOLD_PAR STREQUAL "OMP")
+    find_package(OpenMP REQUIRED)
+    target_include_directories(${PROJECT_NAME} PUBLIC OpenMP::OpenMP_CXX)
+    target_compile_options(${PROJECT_NAME} PUBLIC -DMANIFOLD_PAR='O' -fopenmp)
+    target_link_options(${PROJECT_NAME} PUBLIC -fopenmp)
+elseif (MANIFOLD_PAR STREQUAL "TBB")
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(TBB REQUIRED tbb)
+    target_include_directories(${PROJECT_NAME} PUBLIC ${TBB_INCLUDE_DIRS})
+    target_compile_options(${PROJECT_NAME} PUBLIC -DMANIFOLD_PAR='T')
+    target_link_libraries(${PROJECT_NAME} PUBLIC ${TBB_LINK_LIBRARIES})
+elseif (MANIFOLD_PAR STREQUAL "NONE")
+    set(MANIFOLD_PAR "CPP")
+else ()
+    message(FATAL_ERROR "Invalid value for MANIFOLD_PAR: ${MANIFOLD_PAR}. "
+        "Should be one of \"TBB\", \"OMP\", \"NONE\"")
+endif()
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${THRUST_INC_DIR} ${GLM_INC_DIR})
 if(MANIFOLD_USE_CUDA)
-    set_source_files_properties(src/detect_cuda.cpp PROPERTIES LANGUAGE CUDA)
+    set_source_files_properties(${SOURCE_FILES} PROPERTIES LANGUAGE CUDA)
     set_property(TARGET ${PROJECT_NAME} PROPERTY CUDA_ARCHITECTURES 61)
     target_compile_options(${PROJECT_NAME} 
-        PRIVATE ${MANIFOLD_NVCC_FLAGS}
-    )
-    target_compile_options(${PROJECT_NAME} 
-        PRIVATE "$<$<CONFIG:RELEASE>:${MANIFOLD_NVCC_RELEASE_FLAGS}>" "$<$<CONFIG:DEBUG>:${MANIFOLD_NVCC_DEBUG_FLAGS}>"
+        PUBLIC ${MANIFOLD_FLAGS} -DMANIFOLD_USE_CUDA
+        "$<$<COMPILE_LANGUAGE:CUDA>:${MANIFOLD_NVCC_FLAGS}>"
     )
 else()
     target_compile_options(${PROJECT_NAME} 
-        PRIVATE ${MANIFOLD_FLAGS}
+        PUBLIC ${MANIFOLD_FLAGS}
+        -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_${MANIFOLD_PAR}
     )
 endif()
-target_include_directories(${PROJECT_NAME} INTERFACE ${PROJECT_SOURCE_DIR}/include)
+


### PR DESCRIPTION
- Simplified build script by exposing compiler options as public in utilities, so we don't have to repeat them in collider/manifold.
- Use file glob instead of adding source files one by one, so we don't have to change the cmake script to add more source files later.
- Added code coverage report.

Note that you can use `build/compile_commands.json` instead of fiddling with vscode settings :). 