### PR TITLE
Precision calculation

### DIFF
--- a/manifold/src/impl.cpp
+++ b/manifold/src/impl.cpp
@@ -506,12 +506,12 @@ Manifold::Impl Manifold::Impl::Transform(const glm::mat4x3& transform_) const {
   // axis-aligned.
   if (!result.collider_.Transform(transform_)) result.Update();
 
-  const float oldScale = result.bBox_.Scale();
   result.CalculateBBox();
-
-  const float newScale = result.bBox_.Scale();
-  result.precision_ *= glm::max(1.0f, newScale / oldScale);
-
+  float scale = 0;
+  for (int i : {0, 1, 2})
+    scale =
+        glm::max(scale, transform_[0][i] + transform_[1][i] + transform_[2][i]);
+  result.precision_ *= scale;
   // Maximum of inherited precision loss and translational precision loss.
   result.SetPrecision(result.precision_);
   return result;

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -395,6 +395,12 @@ TEST(Manifold, Precision) {
   EXPECT_FLOAT_EQ(cube.Precision(), 100 * kTolerance);
 }
 
+TEST(Manifold, Precision2) {
+  Manifold cube = Manifold::Cube();
+  cube = cube.Translate({-0.5, 0, 0}).Scale({2, 1, 1});
+  EXPECT_FLOAT_EQ(cube.Precision(), 2 * kTolerance);
+}
+
 /**
  * Curvature is the inverse of the radius of curvature, and signed such that
  * positive is convex and negative is concave. There are two orthogonal


### PR DESCRIPTION
Modified precision calculation. Instead of scaling the precision using change in max coordinate, we scale the precision according to the transformation matrix, taking the max along three axis.