### PR TITLE
misc changes for thrust

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -33,6 +33,7 @@ jobs:
       run: |
         # patch assimp
         patch third_party/assimp/code/CMakeLists.txt < assimp.diff
+        git apply thrust.diff
         mkdir build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} -DMANIFOLD_USE_CUDA=${{matrix.cuda_support}} .. && make
@@ -91,6 +92,7 @@ jobs:
         source ./emsdk/emsdk_env.sh
         # patch assimp
         patch third_party/assimp/code/CMakeLists.txt < assimp.diff
+        git apply thrust.diff
         mkdir build
         cd build
         emcmake cmake -DCMAKE_BUILD_TYPE=Release .. && emmake make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if(MANIFOLD_USE_CUDA)
     set(THRUST_INC_DIR "")
     set(MANIFOLD_NVCC_RELEASE_FLAGS -O3 -lineinfo)
     set(MANIFOLD_NVCC_DEBUG_FLAGS -G)
-    set(MANIFOLD_NVCC_FLAGS -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --extended-lambda
+    set(MANIFOLD_NVCC_FLAGS -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --extended-lambda --expt-relaxed-constexpr
         "$<$<CONFIG:RELEASE>:${MANIFOLD_NVCC_RELEASE_FLAGS}>"
         "$<$<CONFIG:DEBUG>:${MANIFOLD_NVCC_DEBUG_FLAGS}>")
 endif()

--- a/collider/include/collider.h
+++ b/collider/include/collider.h
@@ -36,7 +36,7 @@ class Collider {
   VecDH<Box> nodeBBox_;
   VecDH<int> nodeParent_;
   // even nodes are leaves, odd nodes are internal, root is 1
-  VecDH<thrust::pair<int, int>> internalChildren_;
+  VecDH<std::pair<int, int>> internalChildren_;
 
   int NumInternal() const { return internalChildren_.size(); };
   int NumLeaves() const { return NumInternal() + 1; };

--- a/collider/src/collider.cpp
+++ b/collider/src/collider.cpp
@@ -68,7 +68,7 @@ __host__ __device__ int Leaf2Node(int leaf) { return leaf * 2; }
 
 struct CreateRadixTree {
   int* nodeParent_;
-  thrust::pair<int, int>* internalChildren_;
+  std::pair<int, int>* internalChildren_;
   const VecD<uint32_t> leafMorton_;
 
   __host__ __device__ int PrefixLength(uint32_t a, uint32_t b) const {
@@ -142,7 +142,7 @@ struct CreateRadixTree {
     int first = internal;
     // Find the range of objects with a common prefix
     int last = RangeEnd(first);
-    if (first > last) thrust::swap(first, last);
+    if (first > last) std::swap(first, last);
     // Determine where the next-highest difference occurs
     int split = FindSplit(first, last);
     int child1 = split == first ? Leaf2Node(split) : Internal2Node(split);
@@ -159,11 +159,11 @@ struct CreateRadixTree {
 
 template <typename T>
 struct FindCollisions {
-  thrust::pair<int*, int*> querryTri_;
+  std::pair<int*, int*> querryTri_;
   int* numOverlaps_;
   const int maxOverlaps_;
   const Box* nodeBBox_;
-  const thrust::pair<int, int>* internalChildren_;
+  const std::pair<int, int>* internalChildren_;
 
   __host__ __device__ int RecordCollision(int node,
                                           const thrust::tuple<T, int>& query) {
@@ -215,7 +215,7 @@ struct BuildInternalBoxes {
   Box* nodeBBox_;
   int* counter_;
   const int* nodeParent_;
-  const thrust::pair<int, int>* internalChildren_;
+  const std::pair<int, int>* internalChildren_;
 
   __host__ __device__ void operator()(int leaf) {
     int node = Leaf2Node(leaf);
@@ -252,7 +252,7 @@ Collider::Collider(const VecDH<Box>& leafBB,
   // assign and allocate members
   nodeBBox_.resize(num_nodes);
   nodeParent_.resize(num_nodes, -1);
-  internalChildren_.resize(leafBB.size() - 1, thrust::make_pair(-1, -1));
+  internalChildren_.resize(leafBB.size() - 1, std::make_pair(-1, -1));
   // organize tree
   for_each_n(autoPolicy(NumInternal()), countAt(0), NumInternal(),
              CreateRadixTree(

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
                   "manifold-${parallel-backend}";
               version = "beta";
               src = self;
-              patches = [ ./assimp.diff ];
+              patches = [ ./assimp.diff ./thrust.diff ];
               nativeBuildInputs = (with pkgs; [ cmake python38 ]) ++ build-tools ++
                 (if cuda-support then with pkgs.cudaPackages; [ cuda_nvcc cuda_cudart cuda_cccl pkgs.addOpenGLRunpath ] else [ ]);
               cmakeFlags = [
@@ -104,7 +104,7 @@
                 emcmake cmake -DCMAKE_BUILD_TYPE=Release ..
               '';
               buildPhase = ''
-                emmake make
+                emmake make -j''${NIX_BUILD_CORES}
               '';
               checkPhase = ''
                 cd test

--- a/manifold/src/boolean3.cpp
+++ b/manifold/src/boolean3.cpp
@@ -68,7 +68,7 @@ __host__ __device__ glm::vec4 Intersect(const glm::vec3 &pL,
 
 struct CopyFaceEdges {
   // x can be either vert or edge (0 or 1).
-  thrust::pair<int *, int *> pXq1;
+  std::pair<int *, int *> pXq1;
   const Halfedge *halfedgesQ;
 
   __host__ __device__ void operator()(thrust::tuple<int, int, int> in) {
@@ -105,7 +105,7 @@ __host__ __device__ bool Shadows(float p, float q, float dir) {
   return p == q ? dir < 0 : p < q;
 }
 
-__host__ __device__ thrust::pair<int, glm::vec2> Shadow01(
+__host__ __device__ std::pair<int, glm::vec2> Shadow01(
     const int p0, const int q1, const glm::vec3 *vertPosP,
     const glm::vec3 *vertPosQ, const Halfedge *halfedgeQ, const float expandP,
     const glm::vec3 *normalP, const bool reverse) {
@@ -133,7 +133,7 @@ __host__ __device__ thrust::pair<int, glm::vec2> Shadow01(
       if (!Shadows(vertPosP[p0].y, yz01[0], expandP * normalP[p0].y)) s01 = 0;
     }
   }
-  return thrust::make_pair(s01, yz01);
+  return std::make_pair(s01, yz01);
 }
 
 __host__ __device__ int BinarySearch(
@@ -391,7 +391,7 @@ struct Kernel12 {
 
     for (int vert : {edge.startVert, edge.endVert}) {
       const auto key =
-          forward ? thrust::make_pair(vert, q2) : thrust::make_pair(q2, vert);
+          forward ? std::make_pair(vert, q2) : std::make_pair(q2, vert);
       const int idx = BinarySearch(p0q2, size02, key);
       if (idx != -1) {
         const int s = s02[idx];
@@ -399,7 +399,7 @@ struct Kernel12 {
         if (k < 2 && (k == 0 || (s != 0) != shadows)) {
           shadows = s != 0;
           xzyLR0[k] = vertPosP[vert];
-          thrust::swap(xzyLR0[k].y, xzyLR0[k].z);
+          std::swap(xzyLR0[k].y, xzyLR0[k].z);
           xzyLR1[k] = xzyLR0[k];
           xzyLR1[k][1] = z02[idx];
           k++;
@@ -412,7 +412,7 @@ struct Kernel12 {
       const Halfedge edge = halfedgesQ[q1];
       const int q1F = edge.IsForward() ? q1 : edge.pairedHalfedge;
       const auto key =
-          forward ? thrust::make_pair(p1, q1F) : thrust::make_pair(q1F, p1);
+          forward ? std::make_pair(p1, q1F) : std::make_pair(q1F, p1);
       const int idx = BinarySearch(p1q1, size11, key);
       if (idx != -1) {  // s is implicitly zero for anything not found
         const int s = s11[idx];
@@ -425,7 +425,7 @@ struct Kernel12 {
           xzyLR0[k][2] = xyzz.y;
           xzyLR1[k] = xzyLR0[k];
           xzyLR1[k][1] = xyzz.w;
-          if (!forward) thrust::swap(xzyLR0[k][1], xzyLR1[k][1]);
+          if (!forward) std::swap(xzyLR0[k][1], xzyLR1[k][1]);
           k++;
         }
       }
@@ -489,7 +489,7 @@ VecDH<int> Winding03(const Manifold::Impl &inP, SparseIndices &p0q2,
 
   if (reverse)
     transform(autoPolicy(w03.size()), w03.begin(), w03.end(), w03.begin(),
-              thrust::negate<int>());
+              std::negate<int>());
   return w03;
 };
 }  // namespace

--- a/manifold/src/boolean_result.cpp
+++ b/manifold/src/boolean_result.cpp
@@ -116,9 +116,9 @@ std::tuple<VecDH<int>, VecDH<int>> SizeOutput(
       outR.faceNormal_.begin(), thrust::identity<bool>());
   if (invertQ) {
     auto start = thrust::make_transform_iterator(inQ.faceNormal_.begin(),
-                                                 thrust::negate<glm::vec3>());
+                                                 std::negate<glm::vec3>());
     auto end = thrust::make_transform_iterator(inQ.faceNormal_.end(),
-                                               thrust::negate<glm::vec3>());
+                                               std::negate<glm::vec3>());
     copy_if<decltype(inQ.faceNormal_.begin())>(policy, start, end,
                                                keepFace + inP.NumTri(), next,
                                                thrust::identity<bool>());

--- a/manifold/src/properties.cpp
+++ b/manifold/src/properties.cpp
@@ -29,7 +29,7 @@ struct FaceAreaVolume {
   const glm::vec3* vertPos;
   const float precision;
 
-  __host__ __device__ thrust::pair<float, float> operator()(int face) {
+  __host__ __device__ std::pair<float, float> operator()(int face) {
     float perimeter = 0;
     glm::vec3 edge[3];
     for (int i : {0, 1, 2}) {
@@ -44,8 +44,8 @@ struct FaceAreaVolume {
     float volume = glm::dot(crossP, vertPos[halfedges[3 * face].startVert]);
 
     return area > perimeter * precision
-               ? thrust::make_pair(area / 2.0f, volume / 6.0f)
-               : thrust::make_pair(0.0f, 0.0f);
+               ? std::make_pair(area / 2.0f, volume / 6.0f)
+               : std::make_pair(0.0f, 0.0f);
   }
 };
 

--- a/manifold/src/shared.h
+++ b/manifold/src/shared.h
@@ -14,10 +14,6 @@
 
 #pragma once
 
-#include <thrust/remove.h>
-
-#include <glm/gtx/compatibility.hpp>
-
 #include "par.h"
 #include "utils.h"
 #include "vec_dh.h"

--- a/thrust.diff
+++ b/thrust.diff
@@ -1,0 +1,49 @@
+diff --git a/third_party/thrust/thrust/detail/type_traits.h b/third_party/thrust/thrust/detail/type_traits.h
+index d147f832..60b57654 100644
+--- a/third_party/thrust/thrust/detail/type_traits.h
++++ b/third_party/thrust/thrust/detail/type_traits.h
+@@ -144,11 +144,11 @@ template<typename T> struct has_trivial_constructor
+       is_pod<T>::value
+ #if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || \
+     THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
+-      || __has_trivial_constructor(T)
++      || __is_trivially_constructible(T)
+ #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
+ // only use the intrinsic for >= 4.3
+ #if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
+-      || __has_trivial_constructor(T)
++      || __is_trivially_constructible(T)
+ #endif // GCC VERSION
+ #endif // THRUST_HOST_COMPILER
+       >
+@@ -160,11 +160,11 @@ template<typename T> struct has_trivial_copy_constructor
+       is_pod<T>::value
+ #if THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_MSVC || \
+     THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
+-      || __has_trivial_copy(T)
++      || __is_trivially_constructible(T)
+ #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
+ // only use the intrinsic for >= 4.3
+ #if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
+-      || __has_trivial_copy(T)
++      || __is_trivially_constructible(T)
+ #endif // GCC VERSION
+ #endif // THRUST_HOST_COMPILER
+     >
+diff --git a/third_party/thrust/thrust/detail/type_traits/has_trivial_assign.h b/third_party/thrust/thrust/detail/type_traits/has_trivial_assign.h
+index 8aa55165..73c8f776 100644
+--- a/third_party/thrust/thrust/detail/type_traits/has_trivial_assign.h
++++ b/third_party/thrust/thrust/detail/type_traits/has_trivial_assign.h
+@@ -39,10 +39,10 @@ template<typename T> struct has_trivial_assign
+ #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_GCC
+ // only use the intrinsic for >= 4.3
+ #if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 3)
+-      || __has_trivial_assign(T)
++      || std::is_trivially_assignable<T&, T&>::value
+ #endif // GCC VERSION
+ #elif THRUST_HOST_COMPILER == THRUST_HOST_COMPILER_CLANG
+-      || __has_trivial_assign(T)
++      || std::is_trivially_assignable<T&, T&>::value
+ #endif // THRUST_HOST_COMPILER
+     >
+ {};

--- a/utilities/include/sparse.h
+++ b/utilities/include/sparse.h
@@ -35,11 +35,11 @@ class SparseIndices {
   Iter begin(bool use_q) { return use_q ? q.begin() : p.begin(); }
   Iter end(bool use_q) { return use_q ? q.end() : p.end(); }
   int* ptrD(bool use_q) { return use_q ? q.ptrD() : p.ptrD(); }
-  thrust::pair<int*, int*> ptrDpq(int idx = 0) {
-    return thrust::make_pair(p.ptrD() + idx, q.ptrD() + idx);
+  std::pair<int*, int*> ptrDpq(int idx = 0) {
+    return std::make_pair(p.ptrD() + idx, q.ptrD() + idx);
   }
-  const thrust::pair<const int*, const int*> ptrDpq(int idx = 0) const {
-    return thrust::make_pair(p.ptrD() + idx, q.ptrD() + idx);
+  const std::pair<const int*, const int*> ptrDpq(int idx = 0) const {
+    return std::make_pair(p.ptrD() + idx, q.ptrD() + idx);
   }
   const VecDH<int>& Get(bool use_q) const { return use_q ? q : p; }
   VecDH<int> Copy(bool use_q) const {


### PR DESCRIPTION
1. Fix wasm build error.
2. Use std implementation where possible, so we can make thrust an optional dependency later (#138)

Problems:
1. We need some iterator library that is compatible with thrust in order to make thrust optional. The problem with https://github.com/dpellegr/ZipIterator is that it does not work with some thrust functions, but I'm not sure why, perhaps due to not implementing random access iterator? I haven't yet dig into it. And we need implementation for permutation iterator, transform iterator, etc.
2. Currently, the type of zip iterator has to be `thrust::zip_iterator<thrust::tuple<...>>` as they require something like `tail_type` in their zip iterator implementation which is not provided by `std::tuple`. This forces all functors to accept `thrust::tuple` and use thrust functions like `thrust::get` everywhere. We should be able to fix this by finding some other implementation of zip iterator.
