### PR TITLE
try a different download action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,10 @@ jobs:
       run: ./deploy.sh
 
     - name: Download WASM files
-      uses: actions/download-artifact@v3
+      uses: dawidd6/action-download-artifact@v2
       with:
+        workflow: manifold.yml
+        pr: ${{github.event.pull_request.number}}
         name: wasm
         path: docs/html/bindings/wasm/examples
 


### PR DESCRIPTION
Fixing #163 

`download-artifact` doesn't work across workflows, so that failed. This one should, supposedly. Let's see.