### PR TITLE
fixed seg fault

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -100,6 +100,7 @@
         "-DBUILD_SHARED_LIBS=ON",
         "-DMANIFOLD_USE_CUDA=OFF",
         "-DMANIFOLD_PAR=NONE",
-        "-DCODE_COVERAGE=OFF"
+        "-DCODE_COVERAGE=OFF",
+        "-DCMAKE_CXX_FLAGS=''" //'-fsanitize=address,undefined'"
     ],
 }

--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -661,7 +661,6 @@ class Monotones {
         vert = starts.back();
         starts.pop_back();
       } else {
-        vert->SetSkip();
         ++insertAt;
       }
 

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -916,13 +916,19 @@ TEST(Boolean, Close) {
   const bool intermediateChecks = PolygonParams().intermediateChecks;
   PolygonParams().intermediateChecks = false;
 
-  Manifold a = Manifold::Sphere(10, 256);
+  const float r = 10;
+  Manifold a = Manifold::Sphere(r, 256);
   Manifold result = a;
   for (int i = 0; i < 10; i++) {
     // std::cout << i << std::endl;
     result ^= a.Translate({a.Precision() / 10 * i, 0.0, 0.0});
     EXPECT_TRUE(result.IsManifold());
   }
+  auto prop = result.GetProperties();
+  const float tol = 0.002;
+  EXPECT_NEAR(prop.volume, (4.0f / 3.0f) * glm::pi<float>() * r * r * r,
+              tol * r * r * r);
+  EXPECT_NEAR(prop.surfaceArea, 4 * glm::pi<float>() * r * r, tol * r * r);
 
   if (options.exportModels) ExportMesh("close.glb", result.GetMesh(), {});
 

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -918,7 +918,7 @@ TEST(Boolean, Close) {
 
   Manifold a = Manifold::Sphere(10, 256);
   Manifold result = a;
-  for (int i = 0; i < 6; i++) {
+  for (int i = 0; i < 10; i++) {
     // std::cout << i << std::endl;
     result ^= a.Translate({a.Precision() / 10 * i, 0.0, 0.0});
     EXPECT_TRUE(result.IsManifold());

--- a/test/polygon_test.cpp
+++ b/test/polygon_test.cpp
@@ -722,6 +722,38 @@ TEST(Polygon, Precision) {
   TestPoly(polys, 5, 0.0001);
 };
 
+TEST(Polygon, Precision2) {
+  PolygonParams().processOverlaps = true;
+  const bool intermediateChecks = PolygonParams().intermediateChecks;
+  PolygonParams().intermediateChecks = false;
+
+  Polygons polys;
+  polys.push_back({
+      {glm::vec2(4.98093176, -0.247938812), 11113},   //
+      {glm::vec2(4.94630527, -0.0826399028), 22736},  //
+      {glm::vec2(4.98092985, -0.247938812), 22735},   //
+  });
+  polys.push_back({
+      {glm::vec2(4.76215458, -0.247848436), 17566},  //
+      {glm::vec2(4.76215267, -0.247860417), 22640},  //
+      {glm::vec2(4.76215553, -0.247860417), 22639},  //
+  });
+  polys.push_back({
+      {glm::vec2(4.95041943, -0.241741896), 17815},  //
+      {glm::vec2(4.85906506, -0.223121181), 17816},  //
+      {glm::vec2(4.90268326, -0.152885556), 17824},  //
+      {glm::vec2(4.82208872, -0.18590945), 17823},   //
+      {glm::vec2(4.79133606, -0.247870877), 22638},  //
+      {glm::vec2(4.98092985, -0.247938812), 22733},  //
+      {glm::vec2(4.90268326, -0.152885556), 17822},  //
+      {glm::vec2(4.95041943, -0.241741896), 17819},  //
+  });
+  TestPoly(polys, 8);
+
+  PolygonParams().processOverlaps = false;
+  PolygonParams().intermediateChecks = intermediateChecks;
+};
+
 TEST(Polygon, Comb) {
   Polygons polys;
   polys.push_back({


### PR DESCRIPTION
Fixes #162 

Turned out to be a one-line fix. Added a polygon test to catch it and pushed the `Boolean.Close` test back to 10 and tightened it by checking volume and area since it's an analytical shape. This ensures the triangulator isn't creating large zero-volume shards due to small overlaps. 