### PR TITLE
Revert "use std if possible"

### DIFF
--- a/src/collider/include/collider.h
+++ b/src/collider/include/collider.h
@@ -36,7 +36,7 @@ class Collider {
   VecDH<Box> nodeBBox_;
   VecDH<int> nodeParent_;
   // even nodes are leaves, odd nodes are internal, root is 1
-  VecDH<std::pair<int, int>> internalChildren_;
+  VecDH<thrust::pair<int, int>> internalChildren_;
 
   int NumInternal() const { return internalChildren_.size(); };
   int NumLeaves() const { return NumInternal() + 1; };

--- a/src/collider/src/collider.cpp
+++ b/src/collider/src/collider.cpp
@@ -68,7 +68,7 @@ __host__ __device__ int Leaf2Node(int leaf) { return leaf * 2; }
 
 struct CreateRadixTree {
   int* nodeParent_;
-  std::pair<int, int>* internalChildren_;
+  thrust::pair<int, int>* internalChildren_;
   const VecD<uint32_t> leafMorton_;
 
   __host__ __device__ int PrefixLength(uint32_t a, uint32_t b) const {
@@ -142,7 +142,7 @@ struct CreateRadixTree {
     int first = internal;
     // Find the range of objects with a common prefix
     int last = RangeEnd(first);
-    if (first > last) std::swap(first, last);
+    if (first > last) thrust::swap(first, last);
     // Determine where the next-highest difference occurs
     int split = FindSplit(first, last);
     int child1 = split == first ? Leaf2Node(split) : Internal2Node(split);
@@ -159,11 +159,11 @@ struct CreateRadixTree {
 
 template <typename T>
 struct FindCollisions {
-  std::pair<int*, int*> querryTri_;
+  thrust::pair<int*, int*> querryTri_;
   int* numOverlaps_;
   const int maxOverlaps_;
   const Box* nodeBBox_;
-  const std::pair<int, int>* internalChildren_;
+  const thrust::pair<int, int>* internalChildren_;
 
   __host__ __device__ int RecordCollision(int node,
                                           const thrust::tuple<T, int>& query) {
@@ -215,7 +215,7 @@ struct BuildInternalBoxes {
   Box* nodeBBox_;
   int* counter_;
   const int* nodeParent_;
-  const std::pair<int, int>* internalChildren_;
+  const thrust::pair<int, int>* internalChildren_;
 
   __host__ __device__ void operator()(int leaf) {
     int node = Leaf2Node(leaf);
@@ -252,7 +252,7 @@ Collider::Collider(const VecDH<Box>& leafBB,
   // assign and allocate members
   nodeBBox_.resize(num_nodes);
   nodeParent_.resize(num_nodes, -1);
-  internalChildren_.resize(leafBB.size() - 1, std::make_pair(-1, -1));
+  internalChildren_.resize(leafBB.size() - 1, thrust::make_pair(-1, -1));
   // organize tree
   for_each_n(autoPolicy(NumInternal()), countAt(0), NumInternal(),
              CreateRadixTree(

--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -113,9 +113,9 @@ std::tuple<VecDH<int>, VecDH<int>> SizeOutput(
       outR.faceNormal_.begin(), thrust::identity<bool>());
   if (invertQ) {
     auto start = thrust::make_transform_iterator(inQ.faceNormal_.begin(),
-                                                 std::negate<glm::vec3>());
+                                                 thrust::negate<glm::vec3>());
     auto end = thrust::make_transform_iterator(inQ.faceNormal_.end(),
-                                               std::negate<glm::vec3>());
+                                               thrust::negate<glm::vec3>());
     copy_if<decltype(inQ.faceNormal_.begin())>(policy, start, end,
                                                keepFace + inP.NumTri(), next,
                                                thrust::identity<bool>());

--- a/src/manifold/src/properties.cpp
+++ b/src/manifold/src/properties.cpp
@@ -29,7 +29,7 @@ struct FaceAreaVolume {
   const glm::vec3* vertPos;
   const float precision;
 
-  __host__ __device__ std::pair<float, float> operator()(int face) {
+  __host__ __device__ thrust::pair<float, float> operator()(int face) {
     float perimeter = 0;
     glm::vec3 edge[3];
     for (int i : {0, 1, 2}) {
@@ -44,8 +44,8 @@ struct FaceAreaVolume {
     float volume = glm::dot(crossP, vertPos[halfedges[3 * face].startVert]);
 
     return area > perimeter * precision
-               ? std::make_pair(area / 2.0f, volume / 6.0f)
-               : std::make_pair(0.0f, 0.0f);
+               ? thrust::make_pair(area / 2.0f, volume / 6.0f)
+               : thrust::make_pair(0.0f, 0.0f);
   }
 };
 

--- a/src/manifold/src/shared.h
+++ b/src/manifold/src/shared.h
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#include <thrust/remove.h>
+
+#include <glm/gtx/compatibility.hpp>
+
 #include "par.h"
 #include "utils.h"
 #include "vec_dh.h"

--- a/src/manifold/src/shared.h
+++ b/src/manifold/src/shared.h
@@ -14,10 +14,6 @@
 
 #pragma once
 
-#include <thrust/remove.h>
-
-#include <glm/gtx/compatibility.hpp>
-
 #include "par.h"
 #include "utils.h"
 #include "vec_dh.h"

--- a/src/utilities/include/sparse.h
+++ b/src/utilities/include/sparse.h
@@ -36,11 +36,11 @@ class SparseIndices {
   Iter begin(bool use_q) { return use_q ? q.begin() : p.begin(); }
   Iter end(bool use_q) { return use_q ? q.end() : p.end(); }
   int* ptrD(bool use_q) { return use_q ? q.ptrD() : p.ptrD(); }
-  std::pair<int*, int*> ptrDpq(int idx = 0) {
-    return std::make_pair(p.ptrD() + idx, q.ptrD() + idx);
+  thrust::pair<int*, int*> ptrDpq(int idx = 0) {
+    return thrust::make_pair(p.ptrD() + idx, q.ptrD() + idx);
   }
-  const std::pair<const int*, const int*> ptrDpq(int idx = 0) const {
-    return std::make_pair(p.ptrD() + idx, q.ptrD() + idx);
+  const thrust::pair<const int*, const int*> ptrDpq(int idx = 0) const {
+    return thrust::make_pair(p.ptrD() + idx, q.ptrD() + idx);
   }
   const VecDH<int>& Get(bool use_q) const { return use_q ? q : p; }
   VecDH<int> Copy(bool use_q) const {


### PR DESCRIPTION
Fixes #172

This reverts commit 1e1fcf2dad4f0d7e57c10e61bf09dbb37356cfcf, from #153. This was the cause of CUDA failing to run our tests (weird memory errors and such). I noticed because there were some warnings in the compiler about not calling host functions from device functions regarding `std::swap` and such. I recall that the STL does not play well with device code, which pointed me to your PR, @pca006132. Sorry I forgot to test CUDA for you on that change. 

Interestingly, on CUDA I'm now seeing the infinite loop on `Boolean.Close` that you mentioned in #171, so I think that's not your PR's fault. I'll see if I can debug it here. 