### PR TITLE
Fixed duplicate edge handling

### DIFF
--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -655,6 +655,9 @@ Manifold::Impl Boolean3::Result(Manifold::OpType op) const {
 
   // Level 6
 
+  if (ManifoldParams().intermediateChecks)
+    ASSERT(outR.IsManifold(), logicErr, "polygon mesh is not manifold!");
+
   outR.Face2Tri(faceEdge, faceRef, halfedgeBary);
 
 #ifdef MANIFOLD_DEBUG
@@ -663,7 +666,13 @@ Manifold::Impl Boolean3::Result(Manifold::OpType op) const {
   simplify.Start();
 #endif
 
+  if (ManifoldParams().intermediateChecks)
+    ASSERT(outR.IsManifold(), logicErr, "triangulated mesh is not manifold!");
+
   outR.SimplifyTopology();
+
+  if (ManifoldParams().intermediateChecks)
+    ASSERT(outR.Is2Manifold(), logicErr, "simplified mesh is not 2-manifold!");
 
   // Index starting from 0 is chosen because I want the kernel part as simple as
   // possible.

--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -92,6 +92,7 @@ struct Manifold::Impl {
   bool IsIndexInBounds(const VecDH<glm::ivec3>& triVerts) const;
   void SetPrecision(float minPrecision = -1);
   bool IsManifold() const;
+  bool Is2Manifold() const;
   bool MatchesTriNormals() const;
   int NumDegenerateTris() const;
 

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -342,7 +342,7 @@ Manifold Manifold::AsOriginal() const {
  * Should always be true. Also checks saneness of the internal data structures.
  */
 bool Manifold::IsManifold() const {
-  return GetCsgLeafNode().GetImpl()->IsManifold();
+  return GetCsgLeafNode().GetImpl()->Is2Manifold();
 }
 
 /**

--- a/src/manifold/src/properties.cpp
+++ b/src/manifold/src/properties.cpp
@@ -233,22 +233,32 @@ struct CheckCCW {
 namespace manifold {
 
 /**
- * Returns true if this manifold is in fact an oriented 2-manifold and all of
+ * Returns true if this manifold is in fact an oriented even manifold and all of
  * the data structures are consistent.
  */
 bool Manifold::Impl::IsManifold() const {
   if (halfedge_.size() == 0) return true;
   auto policy = autoPolicy(halfedge_.size());
-  bool isManifold = all_of(policy, countAt(0), countAt(halfedge_.size()),
-                           CheckManifold({halfedge_.cptrD()}));
-  // std::cout << (isManifold ? "" : "Not ") << "Manifold" << std::endl;
+
+  return all_of(policy, countAt(0), countAt(halfedge_.size()),
+                CheckManifold({halfedge_.cptrD()}));
+}
+
+/**
+ * Returns true if this manifold is in fact an oriented 2-manifold and all of
+ * the data structures are consistent.
+ */
+bool Manifold::Impl::Is2Manifold() const {
+  if (halfedge_.size() == 0) return true;
+  auto policy = autoPolicy(halfedge_.size());
+
+  if (!IsManifold()) return false;
 
   VecDH<Halfedge> halfedge(halfedge_);
   sort(policy, halfedge.begin(), halfedge.end());
-  bool noDupes = all_of(policy, countAt(0), countAt(2 * NumEdge() - 1),
-                        NoDuplicates({halfedge.cptrD()}));
-  // std::cout << (noDupes ? "" : "Not ") << "2-Manifold" << std::endl;
-  return isManifold && noDupes;
+
+  return all_of(policy, countAt(0), countAt(2 * NumEdge() - 1),
+                NoDuplicates({halfedge.cptrD()}));
 }
 
 /**

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -47,6 +47,7 @@ int main(int argc, char **argv) {
       case 'v':
         options.params.verbose = true;
         manifold::ManifoldParams().verbose = true;
+        manifold::ManifoldParams().intermediateChecks = true;
         break;
       default:
         fprintf(stderr, "Unknown option: %s\n", argv[i]);


### PR DESCRIPTION
Fixes #176 

In pairing halfedges to construct the manifold, in the case of a duplicate edge (not a 2-manifold, which is occasionally caused by the triangulation), it was possible that I would pair the two forward edges together and the two backward edges together, which doesn't work. Now I've adjusted the way I sort to ensure I always pair a forward edge with a backward edge. 

I've also separated the internal `IsManifold` check into two: `IsManifold` now only checks for data structure sanity (the problem we had here, and something that should be true at every step of the algorithm), while the new `Is2Manifold` also checks for edge duplication. The public `IsManifold`'s behavior is unchanged. I've added asserts for `IsManifold` to catch this kind of problem in the future more quickly, but they only get triggered in verbose mode. 