### PR TITLE
model-viewer WASM example

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -104,7 +104,7 @@ jobs:
         path: |
           build/bindings/wasm/manifold.js
           build/bindings/wasm/manifold.wasm
-        retention-days: 1
+        retention-days: 7
 
   build_windows:
     strategy:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -110,4 +110,6 @@
         "build*": true,
         "docs/*": true
     },
+    "editor.tabSize": 2,
+    "editor.detectIndentation": false,
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Manifold
 
-[**High-level Documentation**](https://elalish.blogspot.com/search/label/Manifold) | [**API Documentation**](https://elalish.github.io/manifold/modules.html) | [**Algorithm Documentation**](https://github.com/elalish/manifold/wiki/Manifold-Library)
+[**High-level Documentation**](https://elalish.blogspot.com/search/label/Manifold) | [**API Documentation**](https://elalish.github.io/manifold/modules.html) | [**Algorithm Documentation**](https://github.com/elalish/manifold/wiki/Manifold-Library) | [**Web Examples**](https://elalish.github.io/manifold/bindings/wasm/examples/model-viewer.html)
 
 [Manifold](https://github.com/elalish/manifold) is a geometry library dedicated to creating and operating on manifold triangle meshes. A [manifold mesh](https://github.com/elalish/manifold/wiki/Manifold-Library#manifoldness) is a mesh that represents a solid object, and so is very important in manufacturing, CAD, structural analysis, etc. Further information can be found on the [wiki](https://github.com/elalish/manifold/wiki/Manifold-Library).
 

--- a/bindings/wasm/CMakeLists.txt
+++ b/bindings/wasm/CMakeLists.txt
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+# https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,4 +20,6 @@ target_compile_options(manifoldjs PRIVATE ${MANIFOLD_FLAGS} -fexceptions)
 target_link_options(manifoldjs PUBLIC --bind)
 target_compile_features(manifoldjs PUBLIC cxx_std_14)
 set_target_properties(manifoldjs PROPERTIES OUTPUT_NAME "manifold")
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples/index.html DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+file(GLOB_RECURSE WEB_FILES CONFIGURE_DEPENDS *.html)
+file(COPY ${WEB_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/bindings/wasm/examples/index.html
+++ b/bindings/wasm/examples/index.html
@@ -102,7 +102,8 @@
 <script src="manifold.js"></script>
 
 <body>
-  A more complex <a href="model-viewer.html">example</a>.
+  This demonstrates the minimum code to connect Manifold to a three.js rendering. A slightly more complex example
+  involving GLTF export and &lt;model-viewer&gt; can be found <a href="model-viewer.html">here</a>.<br />
   <select>
     <option value="Difference" selected>Difference</option>
     <option value="Intersection">Intersection</option>

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -3,13 +3,14 @@
 <meta name="viewport">
 
 <body>
-  Back to <a href="index.html">basics</a>.
+  This example demonstrates feeding Manifold's output into <a href="https://modelviewer.dev/">&lt;model-viewer&gt;</a>
+  via the three.js GLTFExporter. The most basic three.js example is <a href="index.html">here</a>.<br />
   <select>
     <option value="Difference" selected>Difference</option>
     <option value="Intersection">Intersection</option>
     <option value="Union">Union</option>
   </select>
-  <model-viewer camera-controls shadow-intensity="1"></model-viewer>
+  <model-viewer camera-controls shadow-intensity="1" alt="Output of mesh Boolean operation"></model-viewer>
 </body>
 
 <style>
@@ -25,18 +26,11 @@
 <script>
   var Module = {
     onRuntimeInitialized: function () {
-      // we have manifold module, let's do some three.js
-      const camera = new THREE.PerspectiveCamera(30, 0.75, 0.01, 10);
-      camera.position.z = 1;
-
-      const scene = new THREE.Scene();
       const mesh = new THREE.Mesh(undefined, new THREE.MeshStandardMaterial({
         color: 'yellow',
-        flatShading: true,
         metalness: 1,
         roughness: 0.2
       }));
-      scene.add(mesh);
 
       const geometry_1 = simplify(new THREE.BoxGeometry(0.2, 0.2, 0.2));
       const geometry_2 = simplify(new THREE.IcosahedronGeometry(0.16));
@@ -49,7 +43,7 @@
         mesh.geometry = mesh2geometry(
           Module[operation](manifold_1, manifold_2).GetMesh()
         );
-        exportGLTF(mesh);
+        push2MV(mesh);
       };
 
       document.querySelector('select').onchange = function (event) {
@@ -64,7 +58,7 @@
   let objectURL = null;
   const exporter = new THREE.GLTFExporter();
 
-  function exportGLTF(mesh) {
+  function push2MV(mesh) {
     exporter.parse(
       mesh,
       (gltf) => {
@@ -73,7 +67,7 @@
         objectURL = URL.createObjectURL(blob);
         mv.src = objectURL;
       },
-      () => console.log('export failed!'),
+      () => console.log('GLTF export failed!'),
       { binary: true }
     );
   }
@@ -131,7 +125,7 @@
     return simplified;
   }
 </script>
-<script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
 <script src="manifold.js"></script>
+<script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
 
 </html>

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -102,7 +102,7 @@
 <script src="manifold.js"></script>
 
 <body>
-  A more complex <a href="model-viewer.html">example</a>.
+  Back to <a href="index.html">basics</a>.
   <select>
     <option value="Difference" selected>Difference</option>
     <option value="Intersection">Intersection</option>

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -1,7 +1,27 @@
 <!doctype html>
 <html>
-<script src="https://unpkg.com/three@0.142.0/build/three.js"></script>
-<script src="https://unpkg.com/three@0.142.0/examples/js/utils/BufferGeometryUtils.js"></script>
+<meta name="viewport">
+
+<body>
+  Back to <a href="index.html">basics</a>.
+  <select>
+    <option value="Difference" selected>Difference</option>
+    <option value="Intersection">Intersection</option>
+    <option value="Union">Union</option>
+  </select>
+  <model-viewer camera-controls shadow-intensity="1"></model-viewer>
+</body>
+
+<style>
+  model-viewer {
+    width: 600px;
+    height: 600px;
+  }
+</style>
+
+<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
+<script src="https://unpkg.com/three@0.144.0/examples/js/utils/BufferGeometryUtils.js"></script>
+<script src="https://unpkg.com/three@0.144.0/examples/js/exporters/GLTFExporter.js"></script>
 <script>
   var Module = {
     onRuntimeInitialized: function () {
@@ -10,8 +30,11 @@
       camera.position.z = 1;
 
       const scene = new THREE.Scene();
-      const mesh = new THREE.Mesh(undefined, new THREE.MeshNormalMaterial({
-        flatShading: true
+      const mesh = new THREE.Mesh(undefined, new THREE.MeshStandardMaterial({
+        color: 'yellow',
+        flatShading: true,
+        metalness: 1,
+        roughness: 0.2
       }));
       scene.add(mesh);
 
@@ -26,6 +49,7 @@
         mesh.geometry = mesh2geometry(
           Module[operation](manifold_1, manifold_2).GetMesh()
         );
+        exportGLTF(mesh);
       };
 
       document.querySelector('select').onchange = function (event) {
@@ -33,18 +57,26 @@
       };
 
       csg('Difference');
-
-      const renderer = new THREE.WebGLRenderer({ antialias: true });
-      document.body.appendChild(renderer.domElement);
-      renderer.setSize(300, 400);
-      renderer.setAnimationLoop(function (time) {
-        mesh.rotation.x = time / 2000;
-        mesh.rotation.y = time / 1000;
-        renderer.render(scene, camera);
-      });
-
     }
   };
+
+  const mv = document.querySelector('model-viewer');
+  let objectURL = null;
+  const exporter = new THREE.GLTFExporter();
+
+  function exportGLTF(mesh) {
+    exporter.parse(
+      mesh,
+      (gltf) => {
+        const blob = new Blob([gltf], { type: 'application/octet-stream' });
+        URL.revokeObjectURL(objectURL);
+        objectURL = URL.createObjectURL(blob);
+        mv.src = objectURL;
+      },
+      () => console.log('export failed!'),
+      { binary: true }
+    );
+  }
 
   // functions to convert between three.js and wasm
   function geometry2mesh(geometry) {
@@ -56,13 +88,13 @@
     };
     const temp = new THREE.Vector3();
     const p = geometry.attributes.position;
-    const n = geometry.attributes.normal;
+    // const n = geometry.attributes.normal;
     const x = geometry.index;
     for (let i = 0; i < p.count; i++) {
       temp.fromBufferAttribute(p, i);
       mesh.vertPos.push_back(temp);
-      temp.fromBufferAttribute(n, i);
-      mesh.vertNormal.push_back(temp);
+      // temp.fromBufferAttribute(n, i);
+      // mesh.vertNormal.push_back(temp);
     }
     for (let i = 0; i < x.count; i += 3) {
       mesh.triVerts.push_back(x.array.subarray(i, i + 3));
@@ -77,15 +109,15 @@
     for (i = 0, s = mesh.vertPos.size(); i < s; i++) {
       v = mesh.vertPos.get(i);
       p.push(v.x, v.y, v.z);
-      v = mesh.vertNormal.get(i);
-      n.push(v.x, v.y, v.z);
+      // v = mesh.vertNormal.get(i);
+      // n.push(v.x, v.y, v.z);
     }
     for (i = 0, s = mesh.triVerts.size(); i < s; i++) {
       v = mesh.triVerts.get(i);
       x.push(v[0], v[1], v[2]);
     }
     geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(p), 3));
-    geometry.setAttribute('normal', new THREE.BufferAttribute(new Float32Array(n), 3));
+    // geometry.setAttribute('normal', new THREE.BufferAttribute(new Float32Array(n), 3));
     geometry.setIndex(new THREE.BufferAttribute(new Uint8Array(x), 1));
     return geometry;
   }
@@ -99,15 +131,7 @@
     return simplified;
   }
 </script>
+<script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
 <script src="manifold.js"></script>
-
-<body>
-  Back to <a href="index.html">basics</a>.
-  <select>
-    <option value="Difference" selected>Difference</option>
-    <option value="Intersection">Intersection</option>
-    <option value="Union">Union</option>
-  </select>
-</body>
 
 </html>


### PR DESCRIPTION
This solves the first part of #196, which is making a new example that exports a GLTF in order to run `<model-viewer>`. Now we have a nice interactive example with PBR. I've also linked it from the README so it's easier to find. 

Next I'll work on the multi-material piece with textures.

FYI, the changes in index.html are almost entirely just auto-formatting. 