### PR TITLE
updated js binding

### DIFF
--- a/bindings/wasm/CMakeLists.txt
+++ b/bindings/wasm/CMakeLists.txt
@@ -15,11 +15,16 @@
 project(wasm)
 
 add_executable(manifoldjs bindings.cpp)
+# make sure that we recompile the wasm when bindings.js is being modified
+set_source_files_properties(bindings.cpp OBJECT_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/bindings.js)
 target_link_libraries(manifoldjs manifold)
 target_compile_options(manifoldjs PRIVATE ${MANIFOLD_FLAGS} -fexceptions)
-target_link_options(manifoldjs PUBLIC --bind)
+target_link_options(manifoldjs PUBLIC --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/bindings.js --bind)
+
 target_compile_features(manifoldjs PUBLIC cxx_std_14)
 set_target_properties(manifoldjs PROPERTIES OUTPUT_NAME "manifold")
 
 file(GLOB_RECURSE WEB_FILES CONFIGURE_DEPENDS *.html)
 file(COPY ${WEB_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${WEB_FILES})

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -29,7 +29,43 @@ void Subtract(Manifold& a, Manifold& b) { a -= b; }
 Manifold Intersection(Manifold& a, Manifold& b) { return a ^ b; }
 void Intersect(Manifold& a, Manifold& b) { a ^= b; }
 
+std::vector<SimplePolygon> ToPolygon(
+    std::vector<std::vector<glm::vec2>>& polygons) {
+  std::vector<SimplePolygon> simplePolygons(polygons.size());
+  for (int i = 0; i < polygons.size(); i++) {
+    std::vector<PolyVert> vertices(polygons[i].size());
+    for (int j = 0; j < polygons[i].size(); j++) {
+      vertices[j] = {polygons[i][j], j};
+    }
+    simplePolygons[i] = {vertices};
+  }
+  return simplePolygons;
+}
+
+Manifold Extrude(std::vector<std::vector<glm::vec2>>& polygons, float height,
+                 int nDivisions, float twistDegrees, glm::vec2 scaleTop) {
+  return Manifold::Extrude(ToPolygon(polygons), height, nDivisions,
+                           twistDegrees, scaleTop);
+}
+
+Manifold Revolve(std::vector<std::vector<glm::vec2>>& polygons,
+                 int circularSegments) {
+  return Manifold::Revolve(ToPolygon(polygons), circularSegments);
+}
+
+Manifold Transform(Manifold &manifold, std::vector<float> &mat) {
+  glm::mat4x3 matrix;
+  for (int i = 0; i < 4; i++)
+    for (int j = 0; j < 3; j++)
+      matrix[i][j] = mat[i*3+j];
+  return manifold.Transform(matrix);
+}
+
 EMSCRIPTEN_BINDINGS(whatever) {
+  value_object<glm::vec2>("vec2")
+      .field("x", &glm::vec2::x)
+      .field("y", &glm::vec2::y);
+
   value_object<glm::ivec3>("ivec3")
       .field("0", &glm::ivec3::x)
       .field("1", &glm::ivec3::y)
@@ -43,6 +79,9 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .field("z", &glm::vec3::z);
 
   register_vector<glm::vec3>("Vector_vec3");
+  register_vector<glm::vec2>("Vector_vec2");
+  register_vector<std::vector<glm::vec2>>("Vector2_vec2");
+  register_vector<float>("Vector_f32");
 
   value_object<glm::vec4>("vec4")
       .field("x", &glm::vec4::x)
@@ -60,12 +99,24 @@ EMSCRIPTEN_BINDINGS(whatever) {
 
   class_<Manifold>("Manifold")
       .constructor<Mesh>()
-      .function("Add", &Add)
-      .function("Subtract", &Subtract)
-      .function("Intersect", &Intersect)
-      .function("GetMesh", &Manifold::GetMesh);
+      .function("add", &Add)
+      .function("subtract", &Subtract)
+      .function("intersect", &Intersect)
+      .function("getMesh", &Manifold::GetMesh)
+      .function("refine", &Manifold::Refine)
+      .function("_Transform", &Transform)
+      .function("_Translate", &Manifold::Translate)
+      .function("_Rotate", &Manifold::Rotate)
+      .function("_Scale", &Manifold::Scale);
+      // .function("Warp", &Manifold::Warp);
 
-  function("Union", &Union);
-  function("Difference", &Difference);
-  function("Intersection", &Intersection);
+  function("_Cube", &Manifold::Cube);
+  function("_Cylinder", &Manifold::Cylinder);
+  function("_Sphere", &Manifold::Sphere);
+  function("_Extrude", &Extrude);
+  function("_Revolve", &Revolve);
+
+  function("union", &Union);
+  function("difference", &Difference);
+  function("intersection", &Intersection);
 }

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -53,11 +53,10 @@ Manifold Revolve(std::vector<std::vector<glm::vec2>>& polygons,
   return Manifold::Revolve(ToPolygon(polygons), circularSegments);
 }
 
-Manifold Transform(Manifold &manifold, std::vector<float> &mat) {
+Manifold Transform(Manifold& manifold, std::vector<float>& mat) {
   glm::mat4x3 matrix;
   for (int i = 0; i < 4; i++)
-    for (int j = 0; j < 3; j++)
-      matrix[i][j] = mat[i*3+j];
+    for (int j = 0; j < 3; j++) matrix[i][j] = mat[i * 3 + j];
   return manifold.Transform(matrix);
 }
 
@@ -108,7 +107,6 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("_Translate", &Manifold::Translate)
       .function("_Rotate", &Manifold::Rotate)
       .function("_Scale", &Manifold::Scale);
-      // .function("Warp", &Manifold::Warp);
 
   function("_Cube", &Manifold::Cube);
   function("_Cylinder", &Manifold::Cylinder);

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -19,51 +19,6 @@ Module.setup = function() {
         }));
   }
 
-  Module.geometry2mesh = function(geometry) {
-    const mesh = {
-      vertPos: new Module.Vector_vec3(),
-      vertNormal: new Module.Vector_vec3(),
-      triVerts: new Module.Vector_ivec3(),
-      halfedgeTangent: new Module.Vector_vec4()
-    };
-    const temp = new THREE.Vector3();
-    const p = geometry.attributes.position;
-    const n = geometry.attributes.normal;
-    const x = geometry.index;
-    for (let i = 0; i < p.count; i++) {
-      temp.fromBufferAttribute(p, i);
-      mesh.vertPos.push_back(temp);
-      temp.fromBufferAttribute(n, i);
-      mesh.vertNormal.push_back(temp);
-    }
-    for (let i = 0; i < x.count; i += 3) {
-      mesh.triVerts.push_back(x.array.subarray(i, i + 3));
-    }
-    return mesh;
-  };
-
-  function mesh2geometry(mesh) {
-    const geometry = new THREE.BufferGeometry();
-    const p = [], n = [], x = [];
-    let i, s, v;
-    for (i = 0, s = mesh.vertPos.size(); i < s; i++) {
-      v = mesh.vertPos.get(i);
-      p.push(v.x, v.y, v.z);
-      v = mesh.vertNormal.get(i);
-      n.push(v.x, v.y, v.z);
-    }
-    for (i = 0, s = mesh.triVerts.size(); i < s; i++) {
-      v = mesh.triVerts.get(i);
-      x.push(v[0], v[1], v[2]);
-    }
-    geometry.setAttribute(
-        'position', new THREE.BufferAttribute(new Float32Array(p), 3));
-    geometry.setAttribute(
-        'normal', new THREE.BufferAttribute(new Float32Array(n), 3));
-    geometry.setIndex(new THREE.BufferAttribute(new Uint8Array(x), 1));
-    return geometry;
-  }
-
   function vararg2vec(vec) {
     if (vec[0] instanceof Array)
       return {x: vec[0][0], y: vec[0][1], z: vec[0][2]};
@@ -80,6 +35,7 @@ Module.setup = function() {
     return geometry;
   };
 
+  // note that the matrix is using column major (same as glm)
   Module.Manifold.prototype.transform = function(mat) {
     console.assert(mat.length == 4, 'expects a 4x3 matrix');
     let vec = new Module.Vector_f32();

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -1,0 +1,143 @@
+var _ManifoldInitialized = false;
+Module.setup = function() {
+  if (_ManifoldInitialized) return;
+  _ManifoldInitialized = true;
+
+  function toVec(vec, list, f = x => x) {
+    for (let x of list) {
+      vec.push_back(f(x));
+    }
+    return vec;
+  }
+
+  function polygons2vec(polygons) {
+    return toVec(
+        new Module.Vector2_vec2(), polygons,
+        poly => toVec(new Module.Vector_vec2(), poly, p => {
+          if (p instanceof Array) return {x: p[0], y: p[1]};
+          return p;
+        }));
+  }
+
+  Module.geometry2mesh = function(geometry) {
+    const mesh = {
+      vertPos: new Module.Vector_vec3(),
+      vertNormal: new Module.Vector_vec3(),
+      triVerts: new Module.Vector_ivec3(),
+      halfedgeTangent: new Module.Vector_vec4()
+    };
+    const temp = new THREE.Vector3();
+    const p = geometry.attributes.position;
+    const n = geometry.attributes.normal;
+    const x = geometry.index;
+    for (let i = 0; i < p.count; i++) {
+      temp.fromBufferAttribute(p, i);
+      mesh.vertPos.push_back(temp);
+      temp.fromBufferAttribute(n, i);
+      mesh.vertNormal.push_back(temp);
+    }
+    for (let i = 0; i < x.count; i += 3) {
+      mesh.triVerts.push_back(x.array.subarray(i, i + 3));
+    }
+    return mesh;
+  };
+
+  function mesh2geometry(mesh) {
+    const geometry = new THREE.BufferGeometry();
+    const p = [], n = [], x = [];
+    let i, s, v;
+    for (i = 0, s = mesh.vertPos.size(); i < s; i++) {
+      v = mesh.vertPos.get(i);
+      p.push(v.x, v.y, v.z);
+      v = mesh.vertNormal.get(i);
+      n.push(v.x, v.y, v.z);
+    }
+    for (i = 0, s = mesh.triVerts.size(); i < s; i++) {
+      v = mesh.triVerts.get(i);
+      x.push(v[0], v[1], v[2]);
+    }
+    geometry.setAttribute(
+        'position', new THREE.BufferAttribute(new Float32Array(p), 3));
+    geometry.setAttribute(
+        'normal', new THREE.BufferAttribute(new Float32Array(n), 3));
+    geometry.setIndex(new THREE.BufferAttribute(new Uint8Array(x), 1));
+    return geometry;
+  }
+
+  function vararg2vec(vec) {
+    if (vec[0] instanceof Array)
+      return {x: vec[0][0], y: vec[0][1], z: vec[0][2]};
+    if (typeof (vec[0]) == 'number')
+      // default to 0
+      return {x: vec[0] || 0, y: vec[1] || 0, z: vec[2] || 0};
+    return vec[0];
+  }
+
+  Module.Manifold.prototype.getGeometry = function() {
+    let mesh = this.getMesh();
+    let geometry = mesh2geometry(mesh);
+    for (let name in mesh) mesh[name].delete();
+    return geometry;
+  };
+
+  Module.Manifold.prototype.transform = function(mat) {
+    console.assert(mat.length == 4, 'expects a 4x3 matrix');
+    let vec = new Module.Vector_f32();
+    for (let row of mat) {
+      console.assert(row.length == 3, 'expects a 4x3 matrix');
+      for (let x of row) mat.push_back(x);
+    }
+    const result = this._Transform(vec);
+    vec.delete();
+    return result;
+  };
+
+  Module.Manifold.prototype.translate = function(...vec) {
+    return this._Translate(vararg2vec(vec));
+  };
+
+  Module.Manifold.prototype.rotate = function(...vec) {
+    return this._Rotate(vararg2vec(vec));
+  };
+
+  Module.Manifold.prototype.scale = function(...vec) {
+    return this._Scale(vararg2vec(vec));
+  };
+
+  Module.cube = function(...args) {
+    const size = vararg2vec(args);
+    const center = args[3] || false;
+    return Module._Cube(size, center);
+  };
+
+  Module.cylinder = function(
+      height, radiusLow, radiusHigh = -1.0, circularSegments = 0,
+      center = false) {
+    return Module._Cylinder(
+        height, radiusLow, radiusHigh, circularSegments, center);
+  };
+
+  Module.sphere = function(radius, circularSegments = 0) {
+    return Module._Sphere(radius, circularSegments);
+  };
+
+  Module.extrude = function(
+      polygons, height, nDivisions = 0, twistDegrees = 0.0,
+      scaleTop = [1.0, 1.0]) {
+    if (scaleTop instanceof Array) scaleTop = {x: scaleTop[0], y: scaleTop[1]};
+    const polygonsVec = polygons2vec(polygons);
+    const result = Module._Extrude(
+        polygonsVec, height, nDivisions, twistDegrees, scaleTop);
+    for (let i = 0; i < polygonsVec.size(); i++) polygonsVec.get(i).delete();
+    polygonsVec.delete();
+    return result;
+  };
+
+  Module.revolve = function(polygons, circularSegments = 0) {
+    const polygonsVec = polygons2vec(polygons);
+    const result = Module._Revolve(polygonsVec, circularSegments);
+    for (let i = 0; i < polygonsVec.size(); i++) polygonsVec.get(i).delete();
+    polygonsVec.delete();
+    return result;
+  };
+};

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -28,13 +28,6 @@ Module.setup = function() {
     return vec[0];
   }
 
-  Module.Manifold.prototype.getGeometry = function() {
-    let mesh = this.getMesh();
-    let geometry = mesh2geometry(mesh);
-    for (let name in mesh) mesh[name].delete();
-    return geometry;
-  };
-
   // note that the matrix is using column major (same as glm)
   Module.Manifold.prototype.transform = function(mat) {
     console.assert(mat.length == 4, 'expects a 4x3 matrix');

--- a/bindings/wasm/examples/index.html
+++ b/bindings/wasm/examples/index.html
@@ -22,11 +22,11 @@
       // const manifold_1 = Module
       //   .revolve([[[0.1, 0.1], [0.2, 0.1], [0.1, 0.2]]], 64)
       //   .translate(0, 0, -0.1);
-      const manifold_2 = new Module.Manifold(Module.geometry2mesh(icosahedron));
+      const manifold_2 = new Module.Manifold(geometry2mesh(icosahedron));
 
       const csg = function (operation) {
         mesh.geometry?.dispose();
-        mesh.geometry = Module[operation](manifold_1, manifold_2).getGeometry();
+        mesh.geometry = mesh2geometry(Module[operation](manifold_1, manifold_2).getMesh());
       };
 
       document.querySelector('select').onchange = function (event) {
@@ -46,6 +46,50 @@
 
     }
   };
+
+  // functions to convert between three.js and wasm
+  function geometry2mesh(geometry) {
+    const mesh = {
+      vertPos: new Module.Vector_vec3(),
+      vertNormal: new Module.Vector_vec3(),
+      triVerts: new Module.Vector_ivec3(),
+      halfedgeTangent: new Module.Vector_vec4()
+    };
+    const temp = new THREE.Vector3();
+    const p = geometry.attributes.position;
+    const n = geometry.attributes.normal;
+    const x = geometry.index;
+    for (let i = 0; i < p.count; i++) {
+      temp.fromBufferAttribute(p, i);
+      mesh.vertPos.push_back(temp);
+      temp.fromBufferAttribute(n, i);
+      mesh.vertNormal.push_back(temp);
+    }
+    for (let i = 0; i < x.count; i += 3) {
+      mesh.triVerts.push_back(x.array.subarray(i, i + 3));
+    }
+    return mesh;
+  }
+
+  function mesh2geometry(mesh) {
+    const geometry = new THREE.BufferGeometry();
+    const p = [], n = [], x = [];
+    let i, s, v;
+    for (i = 0, s = mesh.vertPos.size(); i < s; i++) {
+      v = mesh.vertPos.get(i);
+      p.push(v.x, v.y, v.z);
+      v = mesh.vertNormal.get(i);
+      n.push(v.x, v.y, v.z);
+    }
+    for (i = 0, s = mesh.triVerts.size(); i < s; i++) {
+      v = mesh.triVerts.get(i);
+      x.push(v[0], v[1], v[2]);
+    }
+    geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(p), 3));
+    geometry.setAttribute('normal', new THREE.BufferAttribute(new Float32Array(n), 3));
+    geometry.setIndex(new THREE.BufferAttribute(new Uint8Array(x), 1));
+    return geometry;
+  }
 
   // most of three.js geometries arent manifolds, so...
   function simplify(geometry) {

--- a/bindings/wasm/examples/index.html
+++ b/bindings/wasm/examples/index.html
@@ -9,30 +9,31 @@
       const camera = new THREE.PerspectiveCamera(30, 0.75, 0.01, 10);
       camera.position.z = 1;
 
+      Module.setup();
       const scene = new THREE.Scene();
       const mesh = new THREE.Mesh(undefined, new THREE.MeshNormalMaterial({
         flatShading: true
       }));
       scene.add(mesh);
 
-      const geometry_1 = simplify(new THREE.BoxGeometry(0.2, 0.2, 0.2));
-      const geometry_2 = simplify(new THREE.IcosahedronGeometry(0.16));
+      const icosahedron = simplify(new THREE.IcosahedronGeometry(0.16));
 
-      const manifold_1 = new Module.Manifold(geometry2mesh(geometry_1));
-      const manifold_2 = new Module.Manifold(geometry2mesh(geometry_2));
+      const manifold_1 = Module.cube(0.2, 0.2, 0.2, true);
+      // const manifold_1 = Module
+      //   .revolve([[[0.1, 0.1], [0.2, 0.1], [0.1, 0.2]]], 64)
+      //   .translate(0, 0, -0.1);
+      const manifold_2 = new Module.Manifold(Module.geometry2mesh(icosahedron));
 
       const csg = function (operation) {
         mesh.geometry?.dispose();
-        mesh.geometry = mesh2geometry(
-          Module[operation](manifold_1, manifold_2).GetMesh()
-        );
+        mesh.geometry = Module[operation](manifold_1, manifold_2).getGeometry();
       };
 
       document.querySelector('select').onchange = function (event) {
         csg(event.target.value);
       };
 
-      csg('Difference');
+      csg('difference');
 
       const renderer = new THREE.WebGLRenderer({ antialias: true });
       document.body.appendChild(renderer.domElement);
@@ -45,50 +46,6 @@
 
     }
   };
-
-  // functions to convert between three.js and wasm
-  function geometry2mesh(geometry) {
-    const mesh = {
-      vertPos: new Module.Vector_vec3(),
-      vertNormal: new Module.Vector_vec3(),
-      triVerts: new Module.Vector_ivec3(),
-      halfedgeTangent: new Module.Vector_vec4()
-    };
-    const temp = new THREE.Vector3();
-    const p = geometry.attributes.position;
-    const n = geometry.attributes.normal;
-    const x = geometry.index;
-    for (let i = 0; i < p.count; i++) {
-      temp.fromBufferAttribute(p, i);
-      mesh.vertPos.push_back(temp);
-      temp.fromBufferAttribute(n, i);
-      mesh.vertNormal.push_back(temp);
-    }
-    for (let i = 0; i < x.count; i += 3) {
-      mesh.triVerts.push_back(x.array.subarray(i, i + 3));
-    }
-    return mesh;
-  }
-
-  function mesh2geometry(mesh) {
-    const geometry = new THREE.BufferGeometry();
-    const p = [], n = [], x = [];
-    let i, s, v;
-    for (i = 0, s = mesh.vertPos.size(); i < s; i++) {
-      v = mesh.vertPos.get(i);
-      p.push(v.x, v.y, v.z);
-      v = mesh.vertNormal.get(i);
-      n.push(v.x, v.y, v.z);
-    }
-    for (i = 0, s = mesh.triVerts.size(); i < s; i++) {
-      v = mesh.triVerts.get(i);
-      x.push(v[0], v[1], v[2]);
-    }
-    geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(p), 3));
-    geometry.setAttribute('normal', new THREE.BufferAttribute(new Float32Array(n), 3));
-    geometry.setIndex(new THREE.BufferAttribute(new Uint8Array(x), 1));
-    return geometry;
-  }
 
   // most of three.js geometries arent manifolds, so...
   function simplify(geometry) {
@@ -105,9 +62,9 @@
   This demonstrates the minimum code to connect Manifold to a three.js rendering. A slightly more complex example
   involving GLTF export and &lt;model-viewer&gt; can be found <a href="model-viewer.html">here</a>.<br />
   <select>
-    <option value="Difference" selected>Difference</option>
-    <option value="Intersection">Intersection</option>
-    <option value="Union">Union</option>
+    <option value="difference" selected>Difference</option>
+    <option value="intersection">Intersection</option>
+    <option value="union">Union</option>
   </select>
 </body>
 

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -38,11 +38,11 @@
       // const manifold_1 = Module
       //   .revolve([[[0.1, 0.1], [0.2, 0.1], [0.1, 0.2]]], 64)
       //   .translate(0, 0, -0.1);
-      const manifold_2 = new Module.Manifold(Module.geometry2mesh(icosahedron));
+      const manifold_2 = new Module.Manifold(geometry2mesh(icosahedron));
 
       const csg = function (operation) {
         mesh.geometry?.dispose();
-        mesh.geometry = Module[operation](manifold_1, manifold_2).getGeometry();
+        mesh.geometry = mesh2geometry(Module[operation](manifold_1, manifold_2).getMesh());
         push2MV(mesh);
       };
 

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -6,9 +6,9 @@
   This example demonstrates feeding Manifold's output into <a href="https://modelviewer.dev/">&lt;model-viewer&gt;</a>
   via the three.js GLTFExporter. The most basic three.js example is <a href="index.html">here</a>.<br />
   <select>
-    <option value="Difference" selected>Difference</option>
-    <option value="Intersection">Intersection</option>
-    <option value="Union">Union</option>
+    <option value="difference" selected>Difference</option>
+    <option value="intersection">Intersection</option>
+    <option value="union">Union</option>
   </select>
   <model-viewer camera-controls shadow-intensity="1" alt="Output of mesh Boolean operation"></model-viewer>
 </body>
@@ -26,23 +26,23 @@
 <script>
   var Module = {
     onRuntimeInitialized: function () {
+      Module.setup();
       const mesh = new THREE.Mesh(undefined, new THREE.MeshStandardMaterial({
         color: 'yellow',
         metalness: 1,
         roughness: 0.2
       }));
 
-      const geometry_1 = simplify(new THREE.BoxGeometry(0.2, 0.2, 0.2));
-      const geometry_2 = simplify(new THREE.IcosahedronGeometry(0.16));
-
-      const manifold_1 = new Module.Manifold(geometry2mesh(geometry_1));
-      const manifold_2 = new Module.Manifold(geometry2mesh(geometry_2));
+      const icosahedron = simplify(new THREE.IcosahedronGeometry(0.16));
+      const manifold_1 = Module.cube(0.2, 0.2, 0.2, true);
+      // const manifold_1 = Module
+      //   .revolve([[[0.1, 0.1], [0.2, 0.1], [0.1, 0.2]]], 64)
+      //   .translate(0, 0, -0.1);
+      const manifold_2 = new Module.Manifold(Module.geometry2mesh(icosahedron));
 
       const csg = function (operation) {
         mesh.geometry?.dispose();
-        mesh.geometry = mesh2geometry(
-          Module[operation](manifold_1, manifold_2).GetMesh()
-        );
+        mesh.geometry = Module[operation](manifold_1, manifold_2).getGeometry();
         push2MV(mesh);
       };
 
@@ -50,7 +50,7 @@
         csg(event.target.value);
       };
 
-      csg('Difference');
+      csg('difference');
     }
   };
 


### PR DESCRIPTION
Partially addresses #197, except that `warp` is not yet implemented. The API is now very permissive, e.g. translate can be called with `translate(1, 2, 3)`, `translate([1, 2, 3])` or `translate({x: 1, y: 2, z: 3})`, and most of the APIs now have optional parameters, matching the behavior in the C++ API. Some three.js helper functions are moved to the JS API or provided as a method in the `Manifold` class, such as `manifold.getGeometry()` will now return a three.js geometry directly.

For warp, I'm thinking about whether the proposed API (giving user access to the buffer) is a good way to implement it, because the vector class is different from list class in js, so users may find it not very natural to use. Performing automatic conversion is easy, but probably very slow because we need to do a lot of copying that way.