### PR TITLE
updated python exporter from meshio to trimesh

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         apt-get -y update
         DEBIAN_FRONTEND=noninteractive apt install -y libomp-dev libassimp-dev git libtbb-dev pkg-config libpython3-dev python3 python3-distutils python3-pip lcov
-        pip install meshio[all]
+        pip install trimesh
     - uses: actions/checkout@v3
       with:
         submodules: true

--- a/bindings/python/examples/run_all.py
+++ b/bindings/python/examples/run_all.py
@@ -17,7 +17,7 @@
 import pathlib
 import sys
 import importlib
-import meshio
+import trimesh
 from time import time
 
 if __name__ == "__main__":
@@ -34,8 +34,9 @@ if __name__ == "__main__":
         model = module.run()
         if export_models:
             mesh = model.to_mesh()
-            cells = [("triangle", mesh.tri_verts)]
-            meshio.write_points_cells(f'{f}.ply', mesh.vert_pos, cells)
-            print(f'Exported model to {f}.ply')
+            meshOut = trimesh.Trimesh(
+                vertices=mesh.vert_pos, faces=mesh.tri_verts)
+            trimesh.exchange.export.export_mesh(meshOut, f'{f}.glb', 'glb')
+            print(f'Exported model to {f}.glb')
         t1 = time()
         print(f'Took {(t1-t0)*1000:.1f}ms for {f}')

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
               version = "beta";
               src = self;
               patches = [ ./thrust.diff ];
-              nativeBuildInputs = (with pkgs; [ cmake (python39.withPackages(ps: with ps; [meshio])) ]) ++ build-tools ++
+              nativeBuildInputs = (with pkgs; [ cmake (python39.withPackages(ps: with ps; [trimesh])) ]) ++ build-tools ++
                 (if cuda-support then with pkgs.cudaPackages; [ cuda_nvcc cuda_cudart cuda_cccl pkgs.addOpenGLRunpath ] else [ ]);
               cmakeFlags = [
                 "-DMANIFOLD_PAR=${pkgs.lib.strings.toUpper parallel-backend}"


### PR DESCRIPTION
I just found a much better and more up-to-date mesh exporter for Python: [trimesh](https://github.com/mikedh/trimesh). It supports GLB and 3MF, in addition to lots of other useful ops with an eye toward manifoldness. I also noticed this from their features section:
>Boolean operations on meshes (intersection, union, difference) using OpenSCAD or Blender as a back end. Note that mesh booleans in general are usually slow and unreliable

This makes me think our library is be something they might be interested in, since it solves those problems.