### PR TITLE
cache intermediate results (#199)

### DIFF
--- a/samples/src/rounded_frame.cpp
+++ b/samples/src/rounded_frame.cpp
@@ -32,12 +32,10 @@ Manifold RoundedFrame(float edgeLength, float radius, int circularSegments) {
 
   Manifold edge1 = corner + edge;
   edge1 = edge1.Rotate(-90).Translate({-edgeLength / 2, -edgeLength / 2, 0});
-  edge1.NumVert();  // Force caching
 
   Manifold edge2 = edge1.Rotate(0, 0, 180);
   edge2 += edge1;
   edge2 += edge.Translate({-edgeLength / 2, -edgeLength / 2, 0});
-  edge2.NumVert();
 
   Manifold edge4 = edge2.Rotate(0, 0, 90);
   edge4 += edge2;

--- a/src/manifold/src/csg_tree.h
+++ b/src/manifold/src/csg_tree.h
@@ -75,18 +75,21 @@ class CsgOpNode final : public CsgNode {
 
   std::shared_ptr<CsgLeafNode> ToLeafNode() const override;
 
-  CsgNodeType GetNodeType() const override { return op_; }
+  CsgNodeType GetNodeType() const override { return impl_->op_; }
 
   glm::mat4x3 GetTransform() const override;
 
  private:
-  CsgNodeType op_;
+  struct Impl {
+    CsgNodeType op_;
+    mutable std::vector<std::shared_ptr<CsgNode>> children_;
+    mutable bool simplified_ = false;
+    mutable bool flattened_ = false;
+  };
+  std::shared_ptr<Impl> impl_ = nullptr;
   glm::mat4x3 transform_ = glm::mat4x3(1.0f);
   // the following fields are for lazy evaluation, so they are mutable
-  mutable std::vector<std::shared_ptr<CsgNode>> children_;
   mutable std::shared_ptr<CsgLeafNode> cache_ = nullptr;
-  mutable bool simplified_ = false;
-  mutable bool flattened_ = false;
 
   void SetOp(Manifold::OpType);
 


### PR DESCRIPTION
Should fix #199, the number of boolean operations required by `Samples.Frame` is now 5.