### PR TITLE
free memory for js editor

### DIFF
--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -45,8 +45,8 @@ Module.setup = function () {
     return this._Translate(vararg2vec(vec));
   };
 
-  Module.Manifold.prototype.rotate = function (...vec) {
-    return this._Rotate(...vararg2vec(vec));
+  Module.Manifold.prototype.rotate = function(vec) {
+    return this._Rotate(...vec);
   };
 
   Module.Manifold.prototype.scale = function (...vec) {

--- a/bindings/wasm/examples/editor.html
+++ b/bindings/wasm/examples/editor.html
@@ -129,6 +129,42 @@
   var Module = {
     onRuntimeInitialized: function () {
       Module.setup();
+      // Setup memory management, such that users don't have to care about
+      // calling `delete` manually.
+      // Note that this only fixes memory leak across different runs: the memory
+      // will only be freed when the compilation finishes.
+
+      let manifoldRegistry = [];
+      for (const name of
+               ['add', 'subtract', 'intersect', 'refine', 'transform', 'translate',
+                'rotate', 'scale']) {
+        const originalFn = Module.Manifold.prototype[name];
+        Module.Manifold.prototype["_" + name] = originalFn;
+        Module.Manifold.prototype[name] = function(...args) {
+          const result = this["_" + name](...args);
+          manifoldRegistry.push(result);
+          return result;
+        }
+      }
+
+      for (const name
+               of ['cube', 'cylinder', 'sphere', 'extrude', 'revolve', 'union',
+                   'difference', 'intersection']) {
+        const originalFn = Module[name];
+        Module[name] = function(...args) {
+          const result = originalFn(...args);
+          manifoldRegistry.push(result);
+          return result;
+        }
+      }
+
+      Module.cleanup = function() {
+        for (const obj of manifoldRegistry) {
+          obj.delete();
+        }
+        manifoldRegistry = [];
+      }
+
       runButton.onclick = async function (e) {
         const output = await worker.getEmitOutput(editor.getModel().uri.toString());
         const content = output.outputFiles[0].text + 'push2MV(result);';
@@ -138,6 +174,7 @@
         ];
         const f = new Function(...exposedFunctions, content);
         f(...exposedFunctions.map(name => Module[name]));
+        Module.cleanup();
         runButton.disabled = true;
       };
     }
@@ -192,6 +229,11 @@
       tri[idx + 1] = v[1];
       tri[idx + 2] = v[2];
     }
+
+    mesh.vertPos.delete();
+    mesh.triVerts.delete();
+    mesh.vertNormal.delete();
+    mesh.halfedgeTangent.delete();
 
     geometry.setAttribute('position', new THREE.BufferAttribute(vert, 3));
     geometry.setIndex(new THREE.BufferAttribute(tri, 1));


### PR DESCRIPTION
This should free up most of the memory for the js editor. I tested using the menger sponge example (n=4) several times, and it seems that the memory usage is pretty stable. Debugging this is pretty hard as it seems that the heap for wasm will not be freed by the GC (it is retained until you reload the tab). The only way is to use leak sanitizer but it is pretty slow. It seems that there is still some minor leak somewhere (when I run the menger sponge example with n=3 for several times, the memory usage will slowly increase), but considering the memory usage for complicated example is pretty stable, I think minor leak should not be a big deal.

Code for the example:
<details>

```js
function vec2add(a: Vec2, b: Vec2): Vec2 {
  return [a[0] + b[0], a[1] + b[1]];
}

// union a set of objects together
// we did not expose the compose interface so we have to do this manually
function compose(objs: Manifold[]): Manifold {
  let result = objs.pop();
  for (let obj of objs) {
    result = union(result, obj);
  }
  return result;
}

function fractal(
    holes: Manifold[], hole: Manifold, w: number, position: Vec2, depth: number,
    maxDepth: number) {
  w /= 3;
  holes.push(
      hole.scale([w, w, 1.0]).translate([position[0], position[1], 0.0]));
  if (depth == maxDepth) return;
  let offsets: Vec2[] = [
    [-w, -w], [-w, 0.0], [-w, w], [0.0, w], [w, w], [w, 0.0], [w, -w], [0.0, -w]
  ];
  for (let offset of offsets)
    fractal(holes, hole, w, vec2add(position, offset), depth + 1, maxDepth);
}

function mengerSponge(n: number) {
  let result = cube([1, 1, 1], true);
  let holes: Manifold[] = [];
  fractal(holes, result, 1.0, [0.0, 0.0], 1, n);

  let hole = compose(holes);

  result = difference(result, hole);
  hole = hole.rotate([90, 0, 0]);
  result = difference(result, hole);
  hole = hole.rotate([0, 0, 90]);
  result = difference(result, hole);

  return result;
}

const result = mengerSponge(4);
```

</details>

