### PR TITLE
use compose for disjoint union

### DIFF
--- a/bindings/python/examples/run_all.py
+++ b/bindings/python/examples/run_all.py
@@ -32,8 +32,8 @@ if __name__ == "__main__":
         module = importlib.import_module(f)
         t0 = time()
         model = module.run()
+        mesh = model.to_mesh()
         if export_models:
-            mesh = model.to_mesh()
             meshOut = trimesh.Trimesh(
                 vertices=mesh.vert_pos, faces=mesh.tri_verts)
             trimesh.exchange.export.export_mesh(meshOut, f'{f}.glb', 'glb')

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -120,10 +120,6 @@ std::shared_ptr<const Manifold::Impl> CsgLeafNode::GetImpl() const {
 
 glm::mat4x3 CsgLeafNode::GetTransform() const { return transform_; }
 
-Box CsgLeafNode::GetBoundingBox() const {
-  return pImpl_->bBox_.Transform(transform_);
-}
-
 std::shared_ptr<CsgLeafNode> CsgLeafNode::ToLeafNode() const {
   return std::make_shared<CsgLeafNode>(*this);
 }
@@ -146,7 +142,7 @@ Manifold::Impl CsgLeafNode::Compose(
   int numBary = 0;
   for (auto &node : nodes) {
     float nodeOldScale = node->pImpl_->bBox_.Scale();
-    float nodeNewScale = node->GetBoundingBox().Scale();
+    float nodeNewScale = node->pImpl_->bBox_.Transform(node->transform_).Scale();
     float nodePrecision = node->pImpl_->precision_;
     nodePrecision *= glm::max(1.0f, nodeNewScale / nodeOldScale);
     nodePrecision = glm::max(nodePrecision, kTolerance * nodeNewScale);
@@ -340,14 +336,76 @@ void CsgOpNode::BatchBoolean(
  * `BatchBoolean` instead of using `Compose` for non-intersecting manifolds.
  */
 void CsgOpNode::BatchUnion() const {
-  std::vector<std::shared_ptr<const Manifold::Impl>> impls;
+  // INVARIANT: children_ is a vector of leaf nodes
+  // this kMaxUnionSize is a heuristic to avoid the pairwise disjoint check
+  // with O(n^2) complexity to take too long.
+  // If the number of children exceeded this limit, we will operate on chunks
+  // with size kMaxUnionSize.
+  constexpr int kMaxUnionSize = 1000;
   auto &children_ = impl_->children_;
-  for (auto &child : children_) {
-    impls.push_back(std::dynamic_pointer_cast<CsgLeafNode>(child)->GetImpl());
+  while (children_.size() > 1) {
+    int start;
+    if (children_.size() > kMaxUnionSize) {
+      start = children_.size() - kMaxUnionSize;
+    } else {
+      start = 0;
+    }
+    VecDH<Box> boxes;
+    boxes.reserve(children_.size() - start);
+    for (int i = start; i < children_.size(); i++) {
+      boxes.push_back(std::dynamic_pointer_cast<CsgLeafNode>(children_[i])
+                          ->GetImpl()
+                          ->bBox_);
+      const float precision =
+          std::dynamic_pointer_cast<CsgLeafNode>(children_[i])
+              ->GetImpl()
+              ->precision_;
+      boxes.back().max += glm::vec3(precision);
+      boxes.back().min -= glm::vec3(precision);
+    }
+    const Box *boxesD = boxes.cptrD();
+    // partition the children into a set of disjoint sets
+    // each set contains a set of children that are pairwise disjoint
+    std::vector<VecDH<size_t>> disjointSets;
+    for (size_t i = 0; i < boxes.size(); i++) {
+      auto lambda = [boxesD, i](const VecDH<size_t> &set) {
+        return find_if<decltype(set.end())>(
+                   autoPolicy(set.size()), set.begin(), set.end(),
+                   [&boxesD, i](size_t j) {
+                     return boxesD[i].DoesOverlap(boxesD[j]);
+                   }) == set.end();
+      };
+      auto it = std::find_if(disjointSets.begin(), disjointSets.end(), lambda);
+      if (it == disjointSets.end()) {
+        disjointSets.push_back(std::vector<size_t>{i});
+      } else {
+        it->push_back(i);
+      }
+    }
+    // compose each set of disjoint children
+    std::vector<std::shared_ptr<const Manifold::Impl>> impls;
+    for (const auto &set : disjointSets) {
+      if (set.size() == 1) {
+        impls.push_back(
+            std::dynamic_pointer_cast<CsgLeafNode>(children_[start + set[0]])
+                ->GetImpl());
+      } else {
+        std::vector<std::shared_ptr<CsgLeafNode>> tmp;
+        for (size_t j : set) {
+          tmp.push_back(
+              std::dynamic_pointer_cast<CsgLeafNode>(children_[start + j]));
+        }
+        impls.push_back(
+            std::make_shared<const Manifold::Impl>(CsgLeafNode::Compose(tmp)));
+      }
+    }
+    BatchBoolean(Manifold::OpType::ADD, impls);
+    children_.erase(children_.begin() + start, children_.end());
+    children_.push_back(std::make_shared<CsgLeafNode>(impls.back()));
+    // move it to the front as we process from the back, and the newly added
+    // child should be quite complicated
+    std::swap(children_.front(), children_.back());
   }
-  BatchBoolean(Manifold::OpType::ADD, impls);
-  children_.clear();
-  children_.push_back(std::make_shared<CsgLeafNode>(impls.front()));
 }
 
 /**

--- a/src/manifold/src/csg_tree.h
+++ b/src/manifold/src/csg_tree.h
@@ -43,8 +43,6 @@ class CsgLeafNode final : public CsgNode {
 
   std::shared_ptr<const Manifold::Impl> GetImpl() const;
 
-  Box GetBoundingBox() const;
-
   std::shared_ptr<CsgLeafNode> ToLeafNode() const override;
 
   std::shared_ptr<CsgNode> Transform(const glm::mat4x3 &m) const override;

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -229,7 +229,7 @@ int Manifold::NumTri() const { return GetCsgLeafNode().GetImpl()->NumTri(); }
 /**
  * Returns the axis-aligned bounding box of all the Manifold's vertices.
  */
-Box Manifold::BoundingBox() const { return GetCsgLeafNode().GetBoundingBox(); }
+Box Manifold::BoundingBox() const { return GetCsgLeafNode().GetImpl()->bBox_; }
 
 /**
  * Returns the precision of this Manifold's vertices, which tracks the


### PR DESCRIPTION
Last mystery in #114. It turns out that the problem is due to misunderstanding of the bounding box API: `Box::Transform` is *not* a safe over-approximation of the bounding box of the manifold after the transform. In fact it might be smaller than that if the transform is not axis aligned (I should have just RTFM at that time). The simple fix is to apply the transform first and then compute the bounding box, this will also make sure that the bounding box is tight.

In the disjointness check, I enlarged the bounding box by the tolerance of the object, which can hopefully overapproximate the behavior of a perturbation of the vertices by at most the tolerance. However, I did not really add tests that can check this, so I am not sure if this is useful.

Note: This patch is not very important right now, maybe we can merge this after the next release, if we are not certain about this. I think the most important part of this patch is the potential performance improvement it brings and shows that our compose implementation should probably be fine.