### PR TITLE
expose batch boolean API to wasm

### DIFF
--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -26,6 +26,21 @@ Manifold Difference(const Manifold& a, const Manifold& b) { return a - b; }
 
 Manifold Intersection(const Manifold& a, const Manifold& b) { return a ^ b; }
 
+Manifold UnionN(const std::vector<Manifold>& manifolds) {
+  return Manifold::BatchBoolean(manifolds, Manifold::OpType::ADD);
+  ;
+}
+
+Manifold DifferenceN(const std::vector<Manifold>& manifolds) {
+  return Manifold::BatchBoolean(manifolds, Manifold::OpType::SUBTRACT);
+  ;
+}
+
+Manifold IntersectionN(const std::vector<Manifold>& manifolds) {
+  return Manifold::BatchBoolean(manifolds, Manifold::OpType::INTERSECT);
+  ;
+}
+
 std::vector<SimplePolygon> ToPolygon(
     std::vector<std::vector<glm::vec2>>& polygons) {
   std::vector<SimplePolygon> simplePolygons(polygons.size());
@@ -78,6 +93,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
   register_vector<glm::vec2>("Vector_vec2");
   register_vector<std::vector<glm::vec2>>("Vector2_vec2");
   register_vector<float>("Vector_f32");
+  register_vector<Manifold>("Vector_manifold");
 
   value_object<glm::vec4>("vec4")
       .field("x", &glm::vec4::x)
@@ -111,7 +127,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
   function("_Extrude", &Extrude);
   function("_Revolve", &Revolve);
 
-  function("union", &Union);
-  function("difference", &Difference);
-  function("intersection", &Intersection);
+  function("_unionN", &UnionN);
+  function("_differenceN", &DifferenceN);
+  function("_intersectionN", &IntersectionN);
 }

--- a/bindings/wasm/bindings.d.ts
+++ b/bindings/wasm/bindings.d.ts
@@ -14,7 +14,7 @@ declare class Manifold {
    */
   transform(m: Matrix3x4): Manifold;
 
-  /** 
+  /**
    * Move this Manifold in space. This operation can be chained. Transforms are
    * combined and applied lazily.
    *
@@ -144,3 +144,6 @@ declare function union(a: Manifold, b: Manifold): Manifold;
 declare function difference(a: Manifold, b: Manifold): Manifold;
 declare function intersection(a: Manifold, b: Manifold): Manifold;
 
+declare function union(manifolds: Manifold[]): Manifold;
+declare function difference(manifolds: Manifold[]): Manifold;
+declare function intersection(manifolds: Manifold[]): Manifold;

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -95,4 +95,21 @@ Module.setup = function () {
     polygonsVec.delete();
     return result;
   };
+
+  function batchbool(name) {
+    return function(...args) {
+      if (args.length == 1)
+        args = args[0];
+      let v = new Module.Vector_manifold();
+      for (const m of args)
+        v.push_back(m);
+      const result = Module['_' + name + 'N'](v);
+      v.delete();
+    return result;
+    }
+  }
+
+  Module.union = batchbool('union');
+  Module.difference = batchbool('difference');
+  Module.intersection = batchbool('intersection');
 };

--- a/bindings/wasm/examples/editor.html
+++ b/bindings/wasm/examples/editor.html
@@ -173,8 +173,11 @@
           'union', 'difference', 'intersection',
         ];
         const f = new Function(...exposedFunctions, content);
+        const t0 = performance.now();
         f(...exposedFunctions.map(name => Module[name]));
         Module.cleanup();
+        const t1 = performance.now();
+        console.log(`took ${t1 - t0}ms`);
         runButton.disabled = true;
       };
     }

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -152,6 +152,8 @@ class Manifold {
    */
   enum class OpType { ADD, SUBTRACT, INTERSECT };
   Manifold Boolean(const Manifold& second, OpType op) const;
+  static Manifold BatchBoolean(const std::vector<Manifold>& manifolds,
+                               OpType op);
   // Boolean operation shorthand
   Manifold operator+(const Manifold&) const;  // ADD (Union)
   Manifold& operator+=(const Manifold&);

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -472,6 +472,14 @@ Manifold Manifold::Boolean(const Manifold& second, OpType op) const {
   return Manifold(std::make_shared<CsgOpNode>(children, op));
 }
 
+Manifold Manifold::BatchBoolean(const std::vector<Manifold>& manifolds,
+                                OpType op) {
+  std::vector<std::shared_ptr<CsgNode>> children;
+  children.reserve(manifolds.size());
+  for (const auto& m : manifolds) children.push_back(m.pNode_);
+  return Manifold(std::make_shared<CsgOpNode>(children, op));
+}
+
 /**
  * Shorthand for Boolean Union.
  */


### PR DESCRIPTION
See #215 for background. Due to the problem with reference counting not decrementing automatically in js, we have to recursively evaluate the csg tree and do a lot of copying, which wasm seems to be pretty slow. This patch expose the batch boolean interface to users directly, so users don't have to write their own batch boolean function and can get much better performance in the case of wasm. (~4000ms vs ~500ms).