### PR TITLE
WASM warp

### DIFF
--- a/bindings/wasm/CMakeLists.txt
+++ b/bindings/wasm/CMakeLists.txt
@@ -15,12 +15,13 @@
 project(wasm)
 
 add_executable(manifoldjs bindings.cpp)
+
 # make sure that we recompile the wasm when bindings.js is being modified
 set_source_files_properties(bindings.cpp OBJECT_DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/bindings.js)
+  ${CMAKE_CURRENT_SOURCE_DIR}/bindings.js)
 target_link_libraries(manifoldjs manifold)
 target_compile_options(manifoldjs PRIVATE ${MANIFOLD_FLAGS} -fexceptions)
-target_link_options(manifoldjs PUBLIC --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/bindings.js --bind)
+target_link_options(manifoldjs PUBLIC --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/bindings.js --bind -s ALLOW_TABLE_GROWTH=1)
 
 target_compile_features(manifoldjs PUBLIC cxx_std_14)
 set_target_properties(manifoldjs PROPERTIES OUTPUT_NAME "manifold")

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <emscripten.h>
 #include <emscripten/bind.h>
 
 using namespace emscripten;
@@ -72,6 +73,13 @@ Manifold Transform(Manifold& manifold, std::vector<float>& mat) {
   return manifold.Transform(matrix);
 }
 
+Manifold Warp(Manifold& manifold, void* funcPtr) {
+  void (*f)(glm::vec3&) = reinterpret_cast<void (*)(glm::vec3&)>(funcPtr);
+  Manifold out = manifold.Warp(f);
+  EM_ASM({removeFunction($0)}, f);
+  return out;
+}
+
 EMSCRIPTEN_BINDINGS(whatever) {
   value_object<glm::vec2>("vec2")
       .field("x", &glm::vec2::x)
@@ -116,6 +124,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("intersect", &Intersection)
       .function("getMesh", &Manifold::GetMesh)
       .function("refine", &Manifold::Refine)
+      .function("_Warp", &Warp, allow_raw_pointers())
       .function("_Transform", &Transform)
       .function("_Translate", &Manifold::Translate)
       .function("_Rotate", &Manifold::Rotate)

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -73,7 +73,7 @@ Manifold Transform(Manifold& manifold, std::vector<float>& mat) {
   return manifold.Transform(matrix);
 }
 
-Manifold Warp(Manifold& manifold, void* funcPtr) {
+Manifold Warp(Manifold& manifold, uintptr_t funcPtr) {
   void (*f)(glm::vec3&) = reinterpret_cast<void (*)(glm::vec3&)>(funcPtr);
   Manifold out = manifold.Warp(f);
   EM_ASM({removeFunction($0)}, f);

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <emscripten.h>
 #include <emscripten/bind.h>
 
 using namespace emscripten;
@@ -75,9 +74,7 @@ Manifold Transform(Manifold& manifold, std::vector<float>& mat) {
 
 Manifold Warp(Manifold& manifold, uintptr_t funcPtr) {
   void (*f)(glm::vec3&) = reinterpret_cast<void (*)(glm::vec3&)>(funcPtr);
-  Manifold out = manifold.Warp(f);
-  EM_ASM({removeFunction($0)}, f);
-  return out;
+  return manifold.Warp(f);
 }
 
 EMSCRIPTEN_BINDINGS(whatever) {

--- a/bindings/wasm/bindings.d.ts
+++ b/bindings/wasm/bindings.d.ts
@@ -68,6 +68,17 @@ declare class Manifold {
    * @param n The number of pieces to split every edge into. Must be > 1.
    */
   refine(n: number): Manifold;
+
+  /**
+   * This function does not change the topology, but allows the vertices to be
+   * moved according to any arbitrary input function. It is easy to create a
+   * function that warps a geometrically valid object into one which overlaps, but
+   * that is not checked here, so it is up to the user to choose their function
+   * with discretion.
+   *
+   * @param warpFunc A function that modifies a given vertex position.
+   */
+  warp(warpFunc: (vert: Vec3) => void): Manifold;
 }
 
 /**

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -28,6 +28,20 @@ Module.setup = function () {
     return vec[0];
   }
 
+  Module.Manifold.prototype.warp = function (func) {
+    const wasmFuncPtr = addFunction(function (vec3Ptr) {
+      const x = getValue(vec3Ptr, 'float');
+      const y = getValue(vec3Ptr + 1, 'float');
+      const z = getValue(vec3Ptr + 2, 'float');
+      const vert = [x, y, z];
+      func(vert);
+      setValue(vec3Ptr, vert[0], 'float');
+      setValue(vec3Ptr + 1, vert[1], 'float');
+      setValue(vec3Ptr + 2, vert[2], 'float');
+    }, 'vi');
+    return this._Warp(wasmFuncPtr);
+  };
+
   // note that the matrix is using column major (same as glm)
   Module.Manifold.prototype.transform = function (mat) {
     console.assert(mat.length == 4, 'expects a 3x4 matrix');
@@ -45,7 +59,7 @@ Module.setup = function () {
     return this._Translate(vararg2vec(vec));
   };
 
-  Module.Manifold.prototype.rotate = function(vec) {
+  Module.Manifold.prototype.rotate = function (vec) {
     return this._Rotate(...vec);
   };
 
@@ -97,7 +111,7 @@ Module.setup = function () {
   };
 
   function batchbool(name) {
-    return function(...args) {
+    return function (...args) {
       if (args.length == 1)
         args = args[0];
       let v = new Module.Vector_manifold();
@@ -105,7 +119,7 @@ Module.setup = function () {
         v.push_back(m);
       const result = Module['_' + name + 'N'](v);
       v.delete();
-    return result;
+      return result;
     }
   }
 

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -39,7 +39,9 @@ Module.setup = function () {
       setValue(vec3Ptr + 1, vert[1], 'float');
       setValue(vec3Ptr + 2, vert[2], 'float');
     }, 'vi');
-    return this._Warp(wasmFuncPtr);
+    const out = this._Warp(wasmFuncPtr);
+    removeFunction(wasmFuncPtr);
+    return out;
   };
 
   // note that the matrix is using column major (same as glm)


### PR DESCRIPTION
Fixes #197 (well, it's mostly fixed by earlier PRs)

This works! In the editor I tried this, which clearly created a squashed ball:
```
const ball = sphere(60, 100);
const func = (v: Vec3) => {
    v[2] /= 2;
};
const result = ball.warp(func);
```