### PR TITLE
add missing js bindings

### DIFF
--- a/bindings/wasm/CMakeLists.txt
+++ b/bindings/wasm/CMakeLists.txt
@@ -22,7 +22,7 @@ set_source_files_properties(bindings.cpp OBJECT_DEPENDS
 target_link_libraries(manifoldjs manifold sdf)
 target_compile_options(manifoldjs PRIVATE ${MANIFOLD_FLAGS} -fexceptions)
 target_link_options(manifoldjs PUBLIC --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/bindings.js --bind -s ALLOW_TABLE_GROWTH=1
-  -sEXPORTED_RUNTIME_METHODS=addFunction)
+  -sEXPORTED_RUNTIME_METHODS=addFunction,removeFunction)
 
 target_compile_features(manifoldjs PUBLIC cxx_std_14)
 set_target_properties(manifoldjs PROPERTIES OUTPUT_NAME "manifold")

--- a/bindings/wasm/CMakeLists.txt
+++ b/bindings/wasm/CMakeLists.txt
@@ -19,9 +19,10 @@ add_executable(manifoldjs bindings.cpp)
 # make sure that we recompile the wasm when bindings.js is being modified
 set_source_files_properties(bindings.cpp OBJECT_DEPENDS
   ${CMAKE_CURRENT_SOURCE_DIR}/bindings.js)
-target_link_libraries(manifoldjs manifold)
+target_link_libraries(manifoldjs manifold sdf)
 target_compile_options(manifoldjs PRIVATE ${MANIFOLD_FLAGS} -fexceptions)
-target_link_options(manifoldjs PUBLIC --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/bindings.js --bind -s ALLOW_TABLE_GROWTH=1)
+target_link_options(manifoldjs PUBLIC --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/bindings.js --bind -s ALLOW_TABLE_GROWTH=1
+  -sEXPORTED_RUNTIME_METHODS=addFunction)
 
 target_compile_features(manifoldjs PUBLIC cxx_std_14)
 set_target_properties(manifoldjs PROPERTIES OUTPUT_NAME "manifold")

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -79,8 +79,9 @@ Manifold Warp(Manifold& manifold, uintptr_t funcPtr) {
 }
 
 Manifold LevelSetJs(uintptr_t funcPtr, Box bounds, float edgeLength,
-                    float level = 0) {
-  float (*f)(glm::vec3) = reinterpret_cast<float (*)(glm::vec3)>(funcPtr);
+                    float level) {
+  float (*f)(const glm::vec3&) =
+      reinterpret_cast<float (*)(const glm::vec3&)>(funcPtr);
   Mesh m = LevelSet(f, bounds, edgeLength, level);
   return Manifold(m);
 }

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -17,6 +17,7 @@
 using namespace emscripten;
 
 #include <manifold.h>
+#include <sdf.h>
 
 using namespace manifold;
 
@@ -77,6 +78,18 @@ Manifold Warp(Manifold& manifold, uintptr_t funcPtr) {
   return manifold.Warp(f);
 }
 
+Manifold LevelSetJs(uintptr_t funcPtr, Box bounds, float edgeLength,
+                    float level = 0) {
+  float (*f)(glm::vec3) = reinterpret_cast<float (*)(glm::vec3)>(funcPtr);
+  Mesh m = LevelSet(f, bounds, edgeLength, level);
+  return Manifold(m);
+}
+
+Manifold Smooth(Manifold& manifold,
+                const std::vector<Smoothness>& sharpenedEdges) {
+  return Manifold::Smooth(manifold.GetMesh(), sharpenedEdges);
+}
+
 EMSCRIPTEN_BINDINGS(whatever) {
   value_object<glm::vec2>("vec2")
       .field("x", &glm::vec2::x)
@@ -87,18 +100,60 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .field("1", &glm::ivec3::y)
       .field("2", &glm::ivec3::z);
 
-  register_vector<glm::ivec3>("Vector_ivec3");
+  enum_<Manifold::Error>("status")
+      .value("NO_ERROR", Manifold::Error::NO_ERROR)
+      .value("NON_FINITE_VERTEX", Manifold::Error::NON_FINITE_VERTEX)
+      .value("NOT_MANIFOLD", Manifold::Error::NOT_MANIFOLD)
+      .value("VERTEX_INDEX_OUT_OF_BOUNDS",
+             Manifold::Error::VERTEX_INDEX_OUT_OF_BOUNDS)
+      .value("PROPERTIES_WRONG_LENGTH",
+             Manifold::Error::PROPERTIES_WRONG_LENGTH)
+      .value("TRI_PROPERTIES_WRONG_LENGTH",
+             Manifold::Error::TRI_PROPERTIES_WRONG_LENGTH)
+      .value("TRI_PROPERTIES_OUT_OF_BOUNDS",
+             Manifold::Error::TRI_PROPERTIES_OUT_OF_BOUNDS);
+
+  value_object<Box>("box").field("min", &Box::min).field("max", &Box::max);
+
+  value_object<Smoothness>("smoothness")
+      .field("hafledge", &Smoothness::halfedge)
+      .field("smoothness", &Smoothness::smoothness);
+
+  value_object<Properties>("properties")
+      .field("surfaceArea", &Properties::surfaceArea)
+      .field("volume", &Properties::volume);
+
+  value_object<BaryRef>("baryRef")
+      .field("meshID", &BaryRef::meshID)
+      .field("originalID", &BaryRef::originalID)
+      .field("tri", &BaryRef::tri)
+      .field("vertBary", &BaryRef::vertBary);
+
+  value_object<MeshRelation>("meshRelation")
+      .field("barycentric", &MeshRelation::barycentric)
+      .field("triBary", &MeshRelation::triBary);
+
+  value_object<Curvature>("curvature")
+      .field("maxMeanCurvature", &Curvature::maxMeanCurvature)
+      .field("minMeanCurvature", &Curvature::minMeanCurvature)
+      .field("maxGaussianCurvature", &Curvature::maxGaussianCurvature)
+      .field("minGaussianCurvature", &Curvature::minGaussianCurvature)
+      .field("vertMeanCurvature", &Curvature::vertMeanCurvature)
+      .field("vertGaussianCurvature", &Curvature::vertGaussianCurvature);
 
   value_object<glm::vec3>("vec3")
       .field("x", &glm::vec3::x)
       .field("y", &glm::vec3::y)
       .field("z", &glm::vec3::z);
 
+  register_vector<glm::ivec3>("Vector_ivec3");
   register_vector<glm::vec3>("Vector_vec3");
   register_vector<glm::vec2>("Vector_vec2");
   register_vector<std::vector<glm::vec2>>("Vector2_vec2");
   register_vector<float>("Vector_f32");
   register_vector<Manifold>("Vector_manifold");
+  register_vector<Smoothness>("Vector_smoothness");
+  register_vector<BaryRef>("Vector_baryRef");
 
   value_object<glm::vec4>("vec4")
       .field("x", &glm::vec4::x)
@@ -125,15 +180,38 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("_Transform", &Transform)
       .function("_Translate", &Manifold::Translate)
       .function("_Rotate", &Manifold::Rotate)
-      .function("_Scale", &Manifold::Scale);
+      .function("_Scale", &Manifold::Scale)
+      .function("_Smooth", &Smooth)
+      .function("_Decompose", &Manifold::Decompose)
+      .function("isEmpty", &Manifold::IsEmpty)
+      .function("status", &Manifold::Status)
+      .function("numVert", &Manifold::NumVert)
+      .function("numEdge", &Manifold::NumEdge)
+      .function("numTri", &Manifold::NumTri)
+      .function("_boundingBox", &Manifold::BoundingBox)
+      .function("precision", &Manifold::Precision)
+      .function("genus", &Manifold::Genus)
+      .function("getProperties", &Manifold::GetProperties)
+      .function("_getCurvature", &Manifold::GetCurvature)
+      .function("originalID", &Manifold::OriginalID)
+      .function("asOriginal", &Manifold::AsOriginal)
+      .function("_getMeshRelation", &Manifold::GetMeshRelation);
 
   function("_Cube", &Manifold::Cube);
   function("_Cylinder", &Manifold::Cylinder);
   function("_Sphere", &Manifold::Sphere);
+  function("tetrahedron", &Manifold::Tetrahedron);
   function("_Extrude", &Extrude);
   function("_Revolve", &Revolve);
+  function("_LevelSet", &LevelSetJs);
 
   function("_unionN", &UnionN);
   function("_differenceN", &DifferenceN);
   function("_intersectionN", &IntersectionN);
+  function("_Compose", &Manifold::Compose);
+
+  function("setMinCircularAngle", &Manifold::SetMinCircularAngle);
+  function("setMinCircularEdgeLength", &Manifold::SetMinCircularEdgeLength);
+  function("setCircularSegments", &Manifold::SetCircularSegments);
+  function("getCircularSegments", &Manifold::GetCircularSegments);
 }

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -39,13 +39,13 @@ Module.setup = function () {
   Module.Manifold.prototype.warp = function (func) {
     const wasmFuncPtr = addFunction(function (vec3Ptr) {
       const x = getValue(vec3Ptr, 'float');
-      const y = getValue(vec3Ptr + 1, 'float');
-      const z = getValue(vec3Ptr + 2, 'float');
+      const y = getValue(vec3Ptr + 4, 'float');
+      const z = getValue(vec3Ptr + 8, 'float');
       const vert = [x, y, z];
       func(vert);
       setValue(vec3Ptr, vert[0], 'float');
-      setValue(vec3Ptr + 1, vert[1], 'float');
-      setValue(vec3Ptr + 2, vert[2], 'float');
+      setValue(vec3Ptr + 4, vert[1], 'float');
+      setValue(vec3Ptr + 8, vert[2], 'float');
     }, 'vi');
     const out = this._Warp(wasmFuncPtr);
     removeFunction(wasmFuncPtr);
@@ -189,8 +189,8 @@ Module.setup = function () {
     };
     const wasmFuncPtr = addFunction(function (vec3Ptr) {
       const x = getValue(vec3Ptr, 'float');
-      const y = getValue(vec3Ptr + 1, 'float');
-      const z = getValue(vec3Ptr + 2, 'float');
+      const y = getValue(vec3Ptr + 4, 'float');
+      const z = getValue(vec3Ptr + 8, 'float');
       const vert = [x, y, z];
       return sdf(vert);
     }, 'fi');

--- a/bindings/wasm/examples/editor.js
+++ b/bindings/wasm/examples/editor.js
@@ -245,10 +245,23 @@ var Module = {
     // Note that this only fixes memory leak across different runs: the memory
     // will only be freed when the compilation finishes.
 
+    // manifold member functions that returns a new manifold
+    const memberFunctions = [
+      'add', 'subtract', 'intersect', 'refine', 'transform', 'translate', 'rotate',
+      'scale', 'asOriginal', 'smooth', 'decompose'
+    ];
+    // top level functions that constructs a new manifold
+    const constructors = [
+      'cube', 'cylinder', 'sphere', 'tetrahedron', 'extrude', 'revolve', 'union',
+      'difference', 'intersection', 'compose', 'levelSet'
+    ];
+    const utils = [
+      'setMinCircularAngle', 'setMinCircularEdgeLength', 'setCircularSegments',
+      'getCircularSegments'
+    ];
+
     let manifoldRegistry = [];
-    for (const name of
-      ['add', 'subtract', 'intersect', 'refine', 'transform', 'translate',
-       'rotate', 'scale', 'asOriginal', 'smooth', 'decompose']) {
+    for (const name of memberFunctions) {
       const originalFn = Module.Manifold.prototype[name];
       Module.Manifold.prototype["_" + name] = originalFn;
       Module.Manifold.prototype[name] = function (...args) {
@@ -258,9 +271,7 @@ var Module = {
       }
     }
 
-    for (const name
-      of ['cube', 'cylinder', 'sphere', 'tetrahedron', 'extrude', 'revolve', 'union',
-          'difference', 'intersection', 'compose', 'levelSet']) {
+    for (const name of constructors) {
       const originalFn = Module[name];
       Module[name] = function (...args) {
         const result = originalFn(...args);
@@ -284,12 +295,7 @@ var Module = {
     runButton.onclick = async function (e) {
       const output = await worker.getEmitOutput(editor.getModel().uri.toString());
       const content = output.outputFiles[0].text + 'push2MV(result);';
-      const exposedFunctions = [
-        'cube', 'cylinder', 'sphere', 'tetrahedron', 'extrude', 'revolve',
-        'union', 'difference', 'intersection', 'compose', 'levelSet',
-        'setMinCircularAngle', 'setMinCircularEdgeLength', 'setCircularSegments',
-        'getCircularSegments'
-      ];
+      const exposedFunctions = constructors.concat(utils);
       const f = new Function(...exposedFunctions, content);
       const t0 = performance.now();
       try {

--- a/bindings/wasm/examples/editor.js
+++ b/bindings/wasm/examples/editor.js
@@ -248,7 +248,7 @@ var Module = {
     let manifoldRegistry = [];
     for (const name of
       ['add', 'subtract', 'intersect', 'refine', 'transform', 'translate',
-        'rotate', 'scale']) {
+       'rotate', 'scale', 'asOriginal', 'smooth', 'decompose']) {
       const originalFn = Module.Manifold.prototype[name];
       Module.Manifold.prototype["_" + name] = originalFn;
       Module.Manifold.prototype[name] = function (...args) {
@@ -259,8 +259,8 @@ var Module = {
     }
 
     for (const name
-      of ['cube', 'cylinder', 'sphere', 'extrude', 'revolve', 'union',
-        'difference', 'intersection']) {
+      of ['cube', 'cylinder', 'sphere', 'tetrahedron', 'extrude', 'revolve', 'union',
+          'difference', 'intersection', 'compose', 'levelSet']) {
       const originalFn = Module[name];
       Module[name] = function (...args) {
         const result = originalFn(...args);
@@ -271,7 +271,12 @@ var Module = {
 
     Module.cleanup = function () {
       for (const obj of manifoldRegistry) {
-        obj.delete();
+        // decompose result is an array of manifolds
+        if (obj instanceof Array)
+          for (const elem of obj)
+            elem.delete();
+        else
+          obj.delete();
       }
       manifoldRegistry = [];
     }
@@ -280,8 +285,10 @@ var Module = {
       const output = await worker.getEmitOutput(editor.getModel().uri.toString());
       const content = output.outputFiles[0].text + 'push2MV(result);';
       const exposedFunctions = [
-        'cube', 'cylinder', 'sphere', 'extrude', 'revolve',
-        'union', 'difference', 'intersection',
+        'cube', 'cylinder', 'sphere', 'tetrahedron', 'extrude', 'revolve',
+        'union', 'difference', 'intersection', 'compose', 'levelSet',
+        'setMinCircularAngle', 'setMinCircularEdgeLength', 'setCircularSegments',
+        'getCircularSegments'
       ];
       const f = new Function(...exposedFunctions, content);
       const t0 = performance.now();


### PR DESCRIPTION
Added most of the missing js bindings, there are still two missing bindings for now.

1. `status`: not sure if we should just convert this to an integer or something. This is actually exported but not yet added to the typescript as the type signature is subject to changes. Or maybe we should check this status in our js binding directly without exposing it to the users. (just throw an error when non-zero?)
2. construct manifold from a mesh.

Also, when debugging SDF, I found that the offset computation for warp is incorrect: it should be +4 and +8, as f32 occupies 4 bytes.