### PR TITLE
fixed csg_tree bugs

### DIFF
--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -474,6 +474,10 @@ Manifold Manifold::Boolean(const Manifold& second, OpType op) const {
 
 Manifold Manifold::BatchBoolean(const std::vector<Manifold>& manifolds,
                                 OpType op) {
+  if (manifolds.size() == 0)
+    return Manifold();
+  else if (manifolds.size() == 1)
+    return manifolds[0];
   std::vector<std::shared_ptr<CsgNode>> children;
   children.reserve(manifolds.size());
   for (const auto& m : manifolds) children.push_back(m.pNode_);

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -1058,3 +1058,11 @@ TEST(Boolean, Close) {
 
   PolygonParams().processOverlaps = false;
 }
+
+TEST(Boolean, UnionDifference) {
+  Manifold block = Manifold::Cube({1, 1, 1}, true) - Manifold::Cylinder(1, 0.5);
+  Manifold result = block + block.Translate({0, 0, 1});
+  float resultsize = result.GetProperties().volume;
+  float blocksize = block.GetProperties().volume;
+  EXPECT_NEAR(resultsize, blocksize * 2, 0.0001);
+}


### PR DESCRIPTION
1. Due to the shared cache between op nodes, the children list can have only 1 child and the original code will access a dangling pointer.
2. Users may supply empty/singleton lists to BatchBoolean, which CsgOpNode cannot handle the empty case correctly.

The new test is for bug 1. This bug is found when I port the old keyboard code (in python) to typescript and trying to clean it up.