### PR TITLE
fix various code documentation typos

### DIFF
--- a/bindings/python/pymanifold.cpp
+++ b/bindings/python/pymanifold.cpp
@@ -132,12 +132,12 @@ PYBIND11_MODULE(pymanifold, m) {
             return self.Rotate(v_view(0), v_view(1), v_view(2));
           },
           py::arg("v"),
-          "Applys an Euler angle rotation to the manifold, first about the X "
+          "Applies an Euler angle rotation to the manifold, first about the X "
           "axis, then\n"
           "Y, then Z, in degrees. We use degrees so that we can minimize "
           "rounding error,\n"
-          "and elimiate it completely for any multiples of 90 degrees. "
-          "Addtionally, more\n"
+          "and eliminate it completely for any multiples of 90 degrees. "
+          "Additionally, more\n"
           "efficient code paths are used to update the manifold when the "
           "transforms only\n"
           "rotate by multiples of 90 degrees. This operation can be chained. "
@@ -153,12 +153,12 @@ PYBIND11_MODULE(pymanifold, m) {
           },
           py::arg("x_degrees") = 0.0f, py::arg("y_degrees") = 0.0f,
           py::arg("z_degrees") = 0.0f,
-          "Applys an Euler angle rotation to the manifold, first about the X "
+          "Applies an Euler angle rotation to the manifold, first about the X "
           "axis, then\n"
           "Y, then Z, in degrees. We use degrees so that we can minimize "
           "rounding error,\n"
-          "and elimiate it completely for any multiples of 90 degrees. "
-          "Addtionally, more\n"
+          "and eliminate it completely for any multiples of 90 degrees. "
+          "Additionally, more\n"
           "efficient code paths are used to update the manifold when the "
           "transforms only\n"
           "rotate by multiples of 90 degrees. This operation can be chained. "

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -152,7 +152,7 @@
     return geometry;
   }
 
-  // most of three.js geometries arent manifolds, so...
+  // most of three.js geometries aren't manifolds, so...
   function simplify(geometry) {
     delete geometry.attributes.normal;
     delete geometry.attributes.uv;

--- a/bindings/wasm/examples/three.html
+++ b/bindings/wasm/examples/three.html
@@ -153,7 +153,7 @@
     return geometry;
   }
 
-  // most of three.js geometries arent manifolds, so...
+  // most of three.js geometries aren't manifolds, so...
   function simplify(geometry) {
     delete geometry.attributes.normal;
     delete geometry.attributes.uv;

--- a/samples/src/knot.cpp
+++ b/samples/src/knot.cpp
@@ -22,7 +22,7 @@ int gcd(int a, int b) { return b == 0 ? a : gcd(b, a % b); }
 namespace manifold {
 
 /**
- * Creates a classic torus knot, defined as a string wrapping peroidically
+ * Creates a classic torus knot, defined as a string wrapping periodically
  * around the surface of an imaginary donut. If p and q have a common factor
  * then you will get multiple separate, interwoven knots. This is an example of
  * using the Manifold.Warp() method, thus avoiding any handling of triangles.

--- a/samples/src/rounded_frame.cpp
+++ b/samples/src/rounded_frame.cpp
@@ -23,7 +23,7 @@ namespace manifold {
  *
  * @param edgeLength Distance between the corners.
  * @param radius Radius of the frame members.
- * @param circularSegments Number of segements in the cylinders and spheres.
+ * @param circularSegments Number of segments in the cylinders and spheres.
  * Defaults to Manifold.GetCircularSegments().
  */
 Manifold RoundedFrame(float edgeLength, float radius, int circularSegments) {

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -83,7 +83,7 @@ class Manifold {
    * default on construction. If circularSegments is specified, it takes
    * precedence. If it is zero, then instead the minimum is used of the segments
    * calculated based on edge length and angle, rounded up to the nearest
-   * multiple of four. To get numbers not divisible by four, circularSegements
+   * multiple of four. To get numbers not divisible by four, circularSegments
    * must be specified.
    */
   ///@{

--- a/src/manifold/src/boolean3.h
+++ b/src/manifold/src/boolean3.h
@@ -38,7 +38,7 @@
  *
  * Note many functions are designed to work symmetrically, for instance for both
  * p2q1 and p1q2. Inside of these functions P and Q are marked as though the
- * funtion is forwards, but it may include a Boolean "reverse" that indicates P
+ * function is forwards, but it may include a Boolean "reverse" that indicates P
  * and Q have been swapped.
  */
 

--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -212,7 +212,7 @@ void AppendPartialEdges(Manifold::Impl &outR, VecDH<char> &wholeHalfedgeP,
                         const VecDH<int>::IterC faceP2R, bool forward) {
   // Each edge in the map is partially retained; for each of these, look up
   // their original verts and include them based on their winding number (i03),
-  // while remaping them to the output using vP2R. Use the verts position
+  // while remapping them to the output using vP2R. Use the verts position
   // projected along the edge vector to pair them up, then distribute these
   // edges to their faces.
   VecDH<Halfedge> &halfedgeR = outR.halfedge_;

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -230,7 +230,7 @@ CsgOpNode::CsgOpNode(const std::vector<std::shared_ptr<CsgNode>> &children,
     : impl_(std::make_shared<Impl>()) {
   impl_->children_ = children;
   SetOp(op);
-  // opportunisticly flatten the tree without costly evaluation
+  // opportunistically flatten the tree without costly evaluation
   GetChildren(false);
 }
 
@@ -239,7 +239,7 @@ CsgOpNode::CsgOpNode(std::vector<std::shared_ptr<CsgNode>> &&children,
     : impl_(std::make_shared<Impl>()) {
   impl_->children_ = children;
   SetOp(op);
-  // opportunisticly flatten the tree without costly evaluation
+  // opportunistically flatten the tree without costly evaluation
   GetChildren(false);
 }
 

--- a/src/manifold/src/edge_op.cpp
+++ b/src/manifold/src/edge_op.cpp
@@ -116,7 +116,7 @@ namespace manifold {
 
 /**
  * Collapses degenerate triangles by removing edges shorter than precision_ and
- * any edge that is preceeded by an edge that joins the same two face relations.
+ * any edge that is preceded by an edge that joins the same two face relations.
  * It also performs edge swaps on the long edges of degenerate triangles, though
  * there are some configurations of degenerates that cannot be removed this way.
  *

--- a/src/manifold/src/face_op.cpp
+++ b/src/manifold/src/face_op.cpp
@@ -23,7 +23,7 @@ namespace manifold {
  * Triangulates the faces. In this case, the halfedge_ vector is not yet a set
  * of triangles as required by this data structure, but is instead a set of
  * general faces with the input faceEdge vector having length of the number of
- * faces + 1. The values are indicies into the halfedge_ vector for the first
+ * faces + 1. The values are indices into the halfedge_ vector for the first
  * edge of each face, with the final value being the length of the halfedge_
  * vector itself. Upon return, halfedge_ has been lengthened and properly
  * represents the mesh as a set of triangles as usual. In this process the

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -332,8 +332,8 @@ Manifold::Impl::Impl(const Mesh& mesh,
 }
 
 /**
- * Create either a unit tetrahedron, cube or octahedron. The cube is in the first
- * octant, while the others are symmetric about the origin.
+ * Create either a unit tetrahedron, cube or octahedron. The cube is in the
+ * first octant, while the others are symmetric about the origin.
  */
 Manifold::Impl::Impl(Shape shape) {
   std::vector<glm::vec3> vertPos;

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -332,7 +332,7 @@ Manifold::Impl::Impl(const Mesh& mesh,
 }
 
 /**
- * Create eiter a unit tetrahedron, cube or octahedron. The cube is in the first
+ * Create either a unit tetrahedron, cube or octahedron. The cube is in the first
  * octant, while the others are symmetric about the origin.
  */
 Manifold::Impl::Impl(Shape shape) {

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -100,7 +100,7 @@ CsgLeafNode& Manifold::GetCsgLeafNode() const {
  * properties in different triangles.
  * @param properties A vector whose length is the largest index in
  * triProperties times the length of propertyTolerance (the number of
- * properties). Think of it as a propery matrix indexed as [index *
+ * properties). Think of it as a property matrix indexed as [index *
  * numProperties + propertyNum].
  * @param propertyTolerance A vector of precision values for each property.
  * This is the amount of interpolation error allowed before two neighboring
@@ -172,7 +172,7 @@ void Manifold::SetMinCircularEdgeLength(float length) {
 /**
  * Sets the default number of circular segments for the
  * Cylinder(), Sphere(), and Revolve() constructors. Overrides the edge length
- * and angle constraints and sets the number of segements to exactly this value.
+ * and angle constraints and sets the number of segments to exactly this value.
  *
  * @param number Number of circular segments. Default is 0, meaning no
  * constraint is applied.
@@ -275,7 +275,7 @@ Curvature Manifold::GetCurvature() const {
 }
 
 /**
- * Gets the relationship to the previous meshes, for the purpose of assinging
+ * Gets the relationship to the previous meshes, for the purpose of assigning
  * properties like texture coordinates. The triBary vector is the same length as
  * Mesh.triVerts: BaryRef.originalID indicates the source mesh and BaryRef.tri
  * is that mesh's triangle index to which these barycentric coordinates refer.
@@ -390,9 +390,9 @@ Manifold Manifold::Scale(glm::vec3 v) const {
 }
 
 /**
- * Applys an Euler angle rotation to the manifold, first about the X axis, then
+ * Applies an Euler angle rotation to the manifold, first about the X axis, then
  * Y, then Z, in degrees. We use degrees so that we can minimize rounding error,
- * and elimiate it completely for any multiples of 90 degrees. Addtionally, more
+ * and eliminate it completely for any multiples of 90 degrees. Additionally, more
  * efficient code paths are used to update the manifold when the transforms only
  * rotate by multiples of 90 degrees. This operation can be chained. Transforms
  * are combined and applied lazily.
@@ -549,7 +549,7 @@ std::pair<Manifold, Manifold> Manifold::Split(const Manifold& cutter) const {
 }
 
 /**
- * Convient version of Split() for a half-space.
+ * Convenient version of Split() for a half-space.
  *
  * @param normal This vector is normal to the cutting plane and its length does
  * not matter. The first result is in the direction of this vector, the second

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -392,10 +392,10 @@ Manifold Manifold::Scale(glm::vec3 v) const {
 /**
  * Applies an Euler angle rotation to the manifold, first about the X axis, then
  * Y, then Z, in degrees. We use degrees so that we can minimize rounding error,
- * and eliminate it completely for any multiples of 90 degrees. Additionally, more
- * efficient code paths are used to update the manifold when the transforms only
- * rotate by multiples of 90 degrees. This operation can be chained. Transforms
- * are combined and applied lazily.
+ * and eliminate it completely for any multiples of 90 degrees. Additionally,
+ * more efficient code paths are used to update the manifold when the transforms
+ * only rotate by multiples of 90 degrees. This operation can be chained.
+ * Transforms are combined and applied lazily.
  *
  * @param xDegrees First rotation, degrees about the X-axis.
  * @param yDegrees Second rotation, degrees about the Y-axis.

--- a/src/manifold/src/shared.h
+++ b/src/manifold/src/shared.h
@@ -126,7 +126,7 @@ struct Halfedge {
 };
 
 /**
- * This is a temporary edge strcture which only stores edges forward and
+ * This is a temporary edge structure which only stores edges forward and
  * references the halfedge it was created from.
  */
 struct TmpEdge {

--- a/src/manifold/src/sort.cpp
+++ b/src/manifold/src/sort.cpp
@@ -171,7 +171,7 @@ void Manifold::Impl::Finish() {
   CalculateBBox();
   SetPrecision(precision_);
   if (!bBox_.IsFinite()) {
-    // Decimated out of existance - early out.
+    // Decimated out of existence - early out.
     MarkFailure(Error::NO_ERROR);
     return;
   }

--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -319,8 +319,8 @@ class Monotones {
   /**
    * This is the data structure of the polygons themselves. They are stored as a
    * list in sweep-line order. The left and right pointers form the polygons,
-   * while the mesh_idx describes the input indices that will be tranfered to
-   * the output triangulation. The edgeRight value represents an extra contraint
+   * while the mesh_idx describes the input indices that will be transferred to
+   * the output triangulation. The edgeRight value represents an extra constraint
    * from the mesh Boolean algorithm.
    */
   struct VertAdj {
@@ -1043,7 +1043,7 @@ namespace manifold {
  * references back to the original vertices
  * @param precision The value of epsilon, bounding the uncertainty of the input
  * @return std::vector<glm::ivec3> The triangles, referencing the original
- * vertex indicies.
+ * vertex indices.
  */
 std::vector<glm::ivec3> Triangulate(const Polygons &polys, float precision) {
   std::vector<glm::ivec3> triangles;

--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -320,8 +320,8 @@ class Monotones {
    * This is the data structure of the polygons themselves. They are stored as a
    * list in sweep-line order. The left and right pointers form the polygons,
    * while the mesh_idx describes the input indices that will be transferred to
-   * the output triangulation. The edgeRight value represents an extra constraint
-   * from the mesh Boolean algorithm.
+   * the output triangulation. The edgeRight value represents an extra
+   * constraint from the mesh Boolean algorithm.
    */
   struct VertAdj {
     glm::vec2 pos;

--- a/src/sdf/include/sdf.h
+++ b/src/sdf/include/sdf.h
@@ -385,7 +385,7 @@ namespace manifold {
  * it with a negative value.
  * @return Mesh This class does not depend on Manifold, so it just returns a
  * Mesh, but it is guaranteed to be manifold and so can always be used as
- * input to the Manifold contructor for further operations.
+ * input to the Manifold constructor for further operations.
  */
 template <typename Func>
 inline Mesh LevelSet(Func sdf, Box bounds, float edgeLength, float level = 0) {

--- a/src/utilities/include/sparse.h
+++ b/src/utilities/include/sparse.h
@@ -25,7 +25,7 @@ namespace manifold {
 
 /** @ingroup Private */
 class SparseIndices {
-  // COO-style sparse matrix storage. Values corresponding to these indicies are
+  // COO-style sparse matrix storage. Values corresponding to these indices are
   // stored in vectors separate from this class, but having the same length.
  public:
   SparseIndices(int size = 0) : p(size), q(size) {}
@@ -84,7 +84,7 @@ class SparseIndices {
 
   size_t RemoveZeros(VecDH<int>& S) {
     ASSERT(S.size() == p.size(), userErr,
-           "Different number of values than indicies!");
+           "Different number of values than indices!");
     auto zBegin = zip(S.begin(), begin(false), begin(true));
     auto zEnd = zip(S.end(), end(false), end(true));
     size_t size = remove_if<decltype(zBegin)>(autoPolicy(S.size()), zBegin,
@@ -119,7 +119,7 @@ class SparseIndices {
   template <typename T>
   size_t KeepFinite(VecDH<T>& v, VecDH<int>& x) {
     ASSERT(x.size() == p.size(), userErr,
-           "Different number of values than indicies!");
+           "Different number of values than indices!");
     auto zBegin = zip(v.begin(), x.begin(), begin(false), begin(true));
     auto zEnd = zip(v.end(), x.end(), end(false), end(true));
     size_t size = remove_if<decltype(zBegin)>(autoPolicy(v.size()), zBegin,
@@ -136,7 +136,7 @@ class SparseIndices {
   VecDH<T> Gather(const VecDH<T>& val, const Iter pqBegin, const Iter pqEnd,
                   T missingVal) const {
     ASSERT(val.size() == p.size(), userErr,
-           "Different number of values than indicies!");
+           "Different number of values than indices!");
     size_t size = pqEnd - pqBegin;
     VecDH<T> result(size);
     VecDH<char> found(size);

--- a/src/utilities/include/vec_dh.h
+++ b/src/utilities/include/vec_dh.h
@@ -29,7 +29,7 @@ namespace manifold {
 // Vector implementation optimized for managed memory, will perform memory
 // prefetching to minimize page faults and use parallel/GPU copy/fill depending
 // on data size. This will also handle builds without CUDA or builds with CUDA
-// but runned without CUDA GPU properly.
+// but are run without CUDA GPU properly.
 //
 // Note that the constructor and resize function will not perform initialization
 // if the parameter val is not set. Also, this implementation is a toy

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -513,7 +513,7 @@ TEST(Manifold, Precision2) {
  * positive is convex and negative is concave. There are two orthogonal
  * principal curvatures at any point on a manifold, with one maximum and the
  * other minimum. Gaussian curvature is their product, while mean
- * curvature is their sum. Here we check our discrete appoximations calculated
+ * curvature is their sum. Here we check our discrete approximations calculated
  * at each vertex against the constant expected values of spheres of different
  * radii and at different mesh resolutions.
  */
@@ -715,7 +715,7 @@ TEST(Boolean, CornerUnion) {
 }
 
 /**
- * These tests verify that the spliting helper functions return meshes with
+ * These tests verify that the splitting helper functions return meshes with
  * volumes that make sense.
  */
 TEST(Boolean, Split) {


### PR DESCRIPTION
Found via `codespell -q 3 -S *.pdf,./**/third_party -L boxs,inout,intstruct`