### PR TITLE
WASM bindings: add missing smooth function to the ManifoldStatic interface

### DIFF
--- a/bindings/wasm/manifold.d.ts
+++ b/bindings/wasm/manifold.d.ts
@@ -412,6 +412,7 @@ declare interface ManifoldStatic {
   cube: typeof cube;
   cylinder: typeof cylinder;
   sphere: typeof sphere;
+  smooth: typeof smooth;
   tetrahedron: typeof tetrahedron;
   extrude: typeof extrude;
   revolve: typeof revolve;


### PR DESCRIPTION
Add missing smooth function to the `ManifoldStatic` interface.