### PR TITLE
new JS Mesh class

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -92,7 +92,13 @@
     "codecvt": "cpp",
     "regex": "cpp",
     "future": "cpp",
-    "shared_mutex": "cpp"
+    "shared_mutex": "cpp",
+    "__bits": "cpp",
+    "compare": "cpp",
+    "concepts": "cpp",
+    "queue": "cpp",
+    "stack": "cpp",
+    "__hash_table": "cpp"
   },
   "C_Cpp.clang_format_fallbackStyle": "google",
   "editor.formatOnSave": true,

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -61,13 +61,14 @@ val GetMeshJS(const Manifold& manifold) {
   val meshJS = val::object();
 
   meshJS.set("triVerts",
-             val(typed_memory_view(3 * mesh.numTri, mesh.triVerts()))
+             val(typed_memory_view(mesh.triVerts.size(), mesh.triVerts.data()))
                  .call<val>("slice"));
-  meshJS.set("vertPos", val(typed_memory_view(3 * mesh.numVert, mesh.vertPos()))
-                            .call<val>("slice"));
-  meshJS.set("vertNormal",
-             val(typed_memory_view(3 * mesh.numVert, mesh.vertNormal()))
+  meshJS.set("vertPos",
+             val(typed_memory_view(mesh.vertPos.size(), mesh.vertPos.data()))
                  .call<val>("slice"));
+  meshJS.set("vertNormal", val(typed_memory_view(mesh.vertNormal.size(),
+                                                 mesh.vertNormal.data()))
+                               .call<val>("slice"));
 
   return meshJS;
 }

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -73,6 +73,14 @@ val GetMeshJS(const Manifold& manifold) {
   return meshJS;
 }
 
+Manifold FromMeshJS(const val& mesh) {
+  MeshGL input;
+  input.vertPos = convertJSArrayToNumberVector<float>(mesh["vertPos"]);
+  input.vertNormal = convertJSArrayToNumberVector<float>(mesh["vertNormal"]);
+  input.triVerts = convertJSArrayToNumberVector<uint32_t>(mesh["triVerts"]);
+  return Manifold(input);
+}
+
 Manifold Extrude(std::vector<std::vector<glm::vec2>>& polygons, float height,
                  int nDivisions, float twistDegrees, glm::vec2 scaleTop) {
   return Manifold::Extrude(ToPolygon(polygons), height, nDivisions,
@@ -176,14 +184,8 @@ EMSCRIPTEN_BINDINGS(whatever) {
   register_vector<BaryRef>("Vector_baryRef");
   register_vector<glm::vec4>("Vector_vec4");
 
-  value_object<Mesh>("Mesh")
-      .field("vertPos", &Mesh::vertPos)
-      .field("triVerts", &Mesh::triVerts)
-      .field("vertNormal", &Mesh::vertNormal)
-      .field("halfedgeTangent", &Mesh::halfedgeTangent);
-
   class_<Manifold>("Manifold")
-      .constructor<Mesh>()
+      .constructor(&FromMeshJS)
       .function("add", &Union)
       .function("subtract", &Difference)
       .function("intersect", &Intersection)

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -69,6 +69,10 @@ val GetMeshJS(const Manifold& manifold) {
   meshJS.set("vertNormal", val(typed_memory_view(mesh.vertNormal.size(),
                                                  mesh.vertNormal.data()))
                                .call<val>("slice"));
+  meshJS.set("halfedgeTangent",
+             val(typed_memory_view(mesh.halfedgeTangent.size(),
+                                   mesh.halfedgeTangent.data()))
+                 .call<val>("slice"));
 
   return meshJS;
 }

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -73,12 +73,19 @@ val GetMeshJS(const Manifold& manifold) {
   return meshJS;
 }
 
-Manifold FromMeshJS(const val& mesh) {
-  MeshGL input;
-  input.vertPos = convertJSArrayToNumberVector<float>(mesh["vertPos"]);
-  input.vertNormal = convertJSArrayToNumberVector<float>(mesh["vertNormal"]);
-  input.triVerts = convertJSArrayToNumberVector<uint32_t>(mesh["triVerts"]);
-  return Manifold(input);
+MeshGL MeshJS2GL(const val& mesh) {
+  MeshGL out;
+  out.vertPos = convertJSArrayToNumberVector<float>(mesh["vertPos"]);
+  out.vertNormal = convertJSArrayToNumberVector<float>(mesh["vertNormal"]);
+  out.triVerts = convertJSArrayToNumberVector<uint32_t>(mesh["triVerts"]);
+  return out;
+}
+
+Manifold FromMeshJS(const val& mesh) { return Manifold(MeshJS2GL(mesh)); }
+
+Manifold Smooth(const val& mesh,
+                const std::vector<Smoothness>& sharpenedEdges = {}) {
+  return Manifold::Smooth(MeshJS2GL(mesh), sharpenedEdges);
 }
 
 Manifold Extrude(std::vector<std::vector<glm::vec2>>& polygons, float height,
@@ -215,7 +222,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
   function("_Cylinder", &Manifold::Cylinder);
   function("_Sphere", &Manifold::Sphere);
   function("tetrahedron", &Manifold::Tetrahedron);
-  function("_Smooth", &Manifold::Smooth);
+  function("_Smooth", &Smooth);
   function("_Extrude", &Extrude);
   function("_Revolve", &Revolve);
   function("_LevelSet", &LevelSetJs);

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -75,9 +75,11 @@ val GetMeshJS(const Manifold& manifold) {
 
 MeshGL MeshJS2GL(const val& mesh) {
   MeshGL out;
-  out.vertPos = convertJSArrayToNumberVector<float>(mesh["vertPos"]);
-  out.vertNormal = convertJSArrayToNumberVector<float>(mesh["vertNormal"]);
   out.triVerts = convertJSArrayToNumberVector<uint32_t>(mesh["triVerts"]);
+  out.vertPos = convertJSArrayToNumberVector<float>(mesh["vertPos"]);
+  if (mesh["vertNormal"] != val::undefined()) {
+    out.vertNormal = convertJSArrayToNumberVector<float>(mesh["vertNormal"]);
+  }
   return out;
 }
 

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -80,6 +80,10 @@ MeshGL MeshJS2GL(const val& mesh) {
   if (mesh["vertNormal"] != val::undefined()) {
     out.vertNormal = convertJSArrayToNumberVector<float>(mesh["vertNormal"]);
   }
+  if (mesh["halfedgeTangent"] != val::undefined()) {
+    out.halfedgeTangent =
+        convertJSArrayToNumberVector<float>(mesh["halfedgeTangent"]);
+  }
   return out;
 }
 

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -50,34 +50,6 @@ Module.setup = function() {
     polygonsVec.delete();
   }
 
-  function mesh2vec(mesh) {
-    const vertPos = toVec(new Module.Vector_vec3, mesh.vertPos, p => {
-      return {
-        x: p[0], y: p[1], z: p[2]
-      }
-    });
-    const triVerts = toVec(new Module.Vector_ivec3, mesh.triVerts);
-    const vertNormal = toVec(new Module.Vector_vec3, mesh.vertNormal, p => {
-      return {
-        x: p[0], y: p[1], z: p[2]
-      }
-    });
-    const halfedgeTangent =
-        toVec(new Module.Vector_vec4, mesh.halfedgeTangent, p => {
-          return {
-            x: p[0], y: p[1], z: p[2], w: p[3]
-          }
-        });
-    return {vertPos, triVerts, vertNormal, halfedgeTangent};
-  }
-
-  function disposeMesh(meshVec) {
-    meshVec.vertPos.delete();
-    meshVec.triVerts.delete();
-    meshVec.vertNormal.delete();
-    meshVec.halfedgeTangent.delete();
-  }
-
   function vararg2vec(vec) {
     if (vec[0] instanceof Array)
       return {x: vec[0][0], y: vec[0][1], z: vec[0][2]};

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -245,21 +245,14 @@ Module.setup = function() {
   });
 
   const ManifoldCtor = Module.Manifold;
-  Module.ManifoldFromMeshVec = function(meshVec) {
-    const manifold = new ManifoldCtor(meshVec);
+  Module.Manifold = function(mesh) {
+    const manifold = new ManifoldCtor(mesh);
 
     const status = manifold.status();
     if (status.value !== 0) {
       throw new Module.ManifoldError(status.value);
     }
 
-    return manifold;
-  };
-
-  Module.Manifold = function Manifold(mesh) {
-    const meshVec = mesh2vec(mesh);
-    const manifold = Module.ManifoldFromMeshVec(meshVec);
-    disposeMesh(meshVec);
     return manifold;
   };
 

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -150,7 +150,11 @@ Module.setup = function() {
   };
 
   class Mesh {
-    constructor({triVerts, vertPos, vertNormal}) {
+    constructor({
+      triVerts = new Uint32Array(),
+      vertPos = new Float32Array(),
+      vertNormal = new Float32Array()
+    } = {}) {
       this.triVerts = triVerts;
       this.vertPos = vertPos;
       this.vertNormal = vertNormal;
@@ -284,12 +288,10 @@ Module.setup = function() {
   };
 
   Module.smooth = function(mesh, sharpenedEdges = []) {
-    const meshVec = mesh2vec(mesh);
     const sharp = new Module.Vector_smoothness();
     toVec(sharp, sharpenedEdges);
-    const result = Module._Smooth(meshVec, sharp);
+    const result = Module._Smooth(mesh, sharp);
     sharp.delete();
-    disposeMesh(meshVec);
     return result;
   };
 

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -149,23 +149,36 @@ Module.setup = function() {
     return result;
   };
 
+  class Mesh {
+    constructor({triVerts, vertPos, vertNormal}) {
+      this.triVerts = triVerts;
+      this.vertPos = vertPos;
+      this.vertNormal = vertNormal;
+    }
+
+    get numTri() {
+      return result.triVerts.length / 3;
+    }
+
+    get numVert() {
+      return result.vertPos.length / 3;
+    }
+
+    verts(tri) {
+      return this.triVerts.subarray(3 * tri, 3 * (tri + 1));
+    }
+
+    position(vert) {
+      return this.vertPos.subarray(3 * vert, 3 * (vert + 1));
+    }
+
+    normal(vert) {
+      return this.vertNormal.subarray(3 * vert, 3 * (vert + 1));
+    }
+  }
+
   Module.Manifold.prototype.getMesh = function() {
-    const result = this._GetMesh();
-    const oldVertPos = result.vertPos;
-    const oldTriVerts = result.triVerts;
-    const oldVertNormal = result.vertNormal;
-    const oldHalfedgeTangent = result.halfedgeTangent;
-    const conversion1 = v => ['x', 'y', 'z'].map(f => v[f]);
-    const conversion2 = v => ['x', 'y', 'z', 'w'].map(f => v[f]);
-    result.vertPos = fromVec(oldVertPos, conversion1);
-    result.triVerts = fromVec(oldTriVerts);
-    result.vertNormal = fromVec(oldVertNormal, conversion1);
-    result.halfedgeTangent = fromVec(oldHalfedgeTangent, conversion2);
-    oldVertPos.delete();
-    oldTriVerts.delete();
-    oldVertNormal.delete();
-    oldHalfedgeTangent.delete();
-    return result;
+    return new Mesh(this._GetMeshJS());
   };
 
   Module.Manifold.prototype.getMeshRelation = function() {

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -153,11 +153,13 @@ Module.setup = function() {
     constructor({
       triVerts = new Uint32Array(),
       vertPos = new Float32Array(),
-      vertNormal
+      vertNormal,
+      halfedgeTangent
     } = {}) {
       this.triVerts = triVerts;
       this.vertPos = vertPos;
       this.vertNormal = vertNormal;
+      this.halfedgeTangent = halfedgeTangent;
     }
 
     get numTri() {
@@ -178,6 +180,10 @@ Module.setup = function() {
 
     normal(vert) {
       return this.vertNormal.subarray(3 * vert, 3 * (vert + 1));
+    }
+
+    tangent(halfedge) {
+      return this.halfedgeTangent.subarray(4 * halfedge, 4 * (halfedge + 1));
     }
   }
 

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -157,11 +157,11 @@ Module.setup = function() {
     }
 
     get numTri() {
-      return result.triVerts.length / 3;
+      return this.triVerts.length / 3;
     }
 
     get numVert() {
-      return result.vertPos.length / 3;
+      return this.vertPos.length / 3;
     }
 
     verts(tri) {

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -177,6 +177,8 @@ Module.setup = function() {
     }
   }
 
+  Module.Mesh = Mesh;
+
   Module.Manifold.prototype.getMesh = function() {
     return new Mesh(this._GetMeshJS());
   };

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -153,7 +153,7 @@ Module.setup = function() {
     constructor({
       triVerts = new Uint32Array(),
       vertPos = new Float32Array(),
-      vertNormal = new Float32Array()
+      vertNormal
     } = {}) {
       this.triVerts = triVerts;
       this.vertPos = vertPos;

--- a/bindings/wasm/examples/examples.js
+++ b/bindings/wasm/examples/examples.js
@@ -155,8 +155,9 @@ exports.functions = {
     const sharpness = 0.8;
     const n = 50;
 
-    const scallop = {vertPos: [], triVerts: []};
-    scallop.vertPos.push([-offset, 0, height], [-offset, 0, -height]);
+    const vertPos = [];
+    const triVerts = [];
+    vertPos.push(-offset, 0, height, -offset, 0, -height);
     const sharpenedEdges = [];
 
     const delta = 3.14159 / wiggles;
@@ -164,23 +165,25 @@ exports.functions = {
       const theta = (i - wiggles) * delta;
       const amp = 0.5 * height * Math.max(Math.cos(0.8 * theta), 0);
 
-      scallop.vertPos.push([
-        radius * Math.cos(theta), radius * Math.sin(theta),
-        amp * (i % 2 == 0 ? 1 : -1)
-      ]);
+      vertPos.push(
+          radius * Math.cos(theta), radius * Math.sin(theta),
+          amp * (i % 2 == 0 ? 1 : -1));
       let j = i + 1;
       if (j == 2 * wiggles) j = 0;
 
       const smoothness = 1 - sharpness * Math.cos((theta + delta / 2) / 2);
-      let halfedge = 3 * scallop.triVerts.length + 1;
+      let halfedge = triVerts.length + 1;
       sharpenedEdges.push({halfedge, smoothness});
-      scallop.triVerts.push([0, 2 + i, 2 + j]);
+      triVerts.push(0, 2 + i, 2 + j);
 
-      halfedge = 3 * scallop.triVerts.length + 1;
+      halfedge = triVerts.length + 1;
       sharpenedEdges.push({halfedge, smoothness});
-      scallop.triVerts.push([1, 2 + j, 2 + i]);
+      triVerts.push(1, 2 + j, 2 + i);
     }
 
+    const scallop = new Mesh();
+    scallop.triVerts = Uint32Array.from(triVerts);
+    scallop.vertPos = Float32Array.from(vertPos);
     const result = smooth(scallop, sharpenedEdges).refine(n);
     return result;
   },

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -101,11 +101,10 @@
 
   // functions to convert between three.js and wasm
   function geometry2mesh(geometry) {
-    const mesh = {};//new Mesh();
-    mesh.vertPos = geometry.attributes.position.array;
-    mesh.vertNormal = geometry.attributes.normal.array;
-    mesh.triVerts = geometry.index.array;
-    return mesh;
+    const vertPos = geometry.attributes.position.array;
+    const vertNormal = geometry.attributes.normal.array;
+    const triVerts = geometry.index.array;
+    return new wasm.Mesh({vertPos, vertNormal, triVerts});
   }
 
   function mesh2geometry(mesh) {

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -66,10 +66,7 @@
 
     const icosahedron = simplify(new THREE.IcosahedronGeometry(0.16));
     const manifold_1 = wasm.cube(0.2, 0.2, 0.2, true);
-    // const manifold_1 = wasm
-    //   .revolve([[[0.1, 0.1], [0.2, 0.1], [0.1, 0.2]]], 64)
-    //   .translate(0, 0, -0.1);
-    const manifold_2 = new wasm.Manifold(geometry2mesh(icosahedron));
+    const manifold_2 = new wasm.ManifoldFromMeshVec(geometry2mesh(icosahedron));
 
     const csg = function (operation) {
       mesh.geometry?.dispose();
@@ -128,29 +125,8 @@
 
   function mesh2geometry(mesh) {
     const geometry = new THREE.BufferGeometry();
-
-    const numVert = mesh.vertPos.length;
-    const vert = new Float32Array(3 * numVert);
-    for (let i = 0; i < numVert; i++) {
-      const v = mesh.vertPos[i];
-      const idx = 3 * i;
-      vert[idx] = v[0];
-      vert[idx + 1] = v[1];
-      vert[idx + 2] = v[2];
-    }
-
-    const numTri = mesh.triVerts.length;
-    const tri = new Uint32Array(3 * numTri);
-    for (let i = 0; i < numTri; i++) {
-      const v = mesh.triVerts[i];
-      const idx = 3 * i;
-      tri[idx] = v[0];
-      tri[idx + 1] = v[1];
-      tri[idx + 2] = v[2];
-    }
-
-    geometry.setAttribute('position', new THREE.BufferAttribute(vert, 3));
-    geometry.setIndex(new THREE.BufferAttribute(tri, 1));
+    geometry.setAttribute('position', new THREE.BufferAttribute(mesh.vertPos, 3));
+    geometry.setIndex(new THREE.BufferAttribute(mesh.triVerts, 1));
     return geometry;
   }
 

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -66,7 +66,7 @@
 
     const icosahedron = simplify(new THREE.IcosahedronGeometry(0.16));
     const manifold_1 = wasm.cube(0.2, 0.2, 0.2, true);
-    const manifold_2 = new wasm.ManifoldFromMeshVec(geometry2mesh(icosahedron));
+    const manifold_2 = new wasm.Manifold(geometry2mesh(icosahedron));
 
     const csg = function (operation) {
       mesh.geometry?.dispose();
@@ -101,25 +101,10 @@
 
   // functions to convert between three.js and wasm
   function geometry2mesh(geometry) {
-    const mesh = {
-      vertPos: new wasm.Vector_vec3(),
-      vertNormal: new wasm.Vector_vec3(),
-      triVerts: new wasm.Vector_ivec3(),
-      halfedgeTangent: new wasm.Vector_vec4()
-    };
-    const temp = new THREE.Vector3();
-    const p = geometry.attributes.position;
-    // const n = geometry.attributes.normal;
-    const x = geometry.index;
-    for (let i = 0; i < p.count; i++) {
-      temp.fromBufferAttribute(p, i);
-      mesh.vertPos.push_back(temp);
-      // temp.fromBufferAttribute(n, i);
-      // mesh.vertNormal.push_back(temp);
-    }
-    for (let i = 0; i < x.count; i += 3) {
-      mesh.triVerts.push_back(x.array.subarray(i, i + 3));
-    }
+    const mesh = {};//new Mesh();
+    mesh.vertPos = geometry.attributes.position.array;
+    mesh.vertNormal = geometry.attributes.normal.array;
+    mesh.triVerts = geometry.index.array;
     return mesh;
   }
 

--- a/bindings/wasm/examples/three.html
+++ b/bindings/wasm/examples/three.html
@@ -68,7 +68,7 @@
     const icosahedron = simplify(new THREE.IcosahedronGeometry(0.16));
 
     const manifold_1 = wasm.cube(0.2, 0.2, 0.2, true);
-    const manifold_2 = new wasm.ManifoldFromMeshVec(geometry2mesh(icosahedron));
+    const manifold_2 = new wasm.Manifold(geometry2mesh(icosahedron));
 
     const csg = function (operation) {
       mesh.geometry?.dispose();
@@ -94,25 +94,10 @@
 
   // functions to convert between three.js and wasm
   function geometry2mesh(geometry) {
-    const mesh = {
-      vertPos: new wasm.Vector_vec3(),
-      vertNormal: new wasm.Vector_vec3(),
-      triVerts: new wasm.Vector_ivec3(),
-      halfedgeTangent: new wasm.Vector_vec4()
-    };
-    const temp = new THREE.Vector3();
-    const p = geometry.attributes.position;
-    const n = geometry.attributes.normal;
-    const x = geometry.index;
-    for (let i = 0; i < p.count; i++) {
-      temp.fromBufferAttribute(p, i);
-      mesh.vertPos.push_back(temp);
-      temp.fromBufferAttribute(n, i);
-      mesh.vertNormal.push_back(temp);
-    }
-    for (let i = 0; i < x.count; i += 3) {
-      mesh.triVerts.push_back(x.array.subarray(i, i + 3));
-    }
+    const mesh = {};//new Mesh();
+    mesh.vertPos = geometry.attributes.position.array;
+    mesh.vertNormal = geometry.attributes.normal.array;
+    mesh.triVerts = geometry.index.array;
     return mesh;
   }
 

--- a/bindings/wasm/examples/three.html
+++ b/bindings/wasm/examples/three.html
@@ -68,10 +68,7 @@
     const icosahedron = simplify(new THREE.IcosahedronGeometry(0.16));
 
     const manifold_1 = wasm.cube(0.2, 0.2, 0.2, true);
-    // const manifold_1 = wasm
-    //   .revolve([[[0.1, 0.1], [0.2, 0.1], [0.1, 0.2]]], 64)
-    //   .translate(0, 0, -0.1);
-    const manifold_2 = new wasm.Manifold(geometry2mesh(icosahedron));
+    const manifold_2 = new wasm.ManifoldFromMeshVec(geometry2mesh(icosahedron));
 
     const csg = function (operation) {
       mesh.geometry?.dispose();
@@ -121,35 +118,9 @@
 
   function mesh2geometry(mesh) {
     const geometry = new THREE.BufferGeometry();
-
-    const numVert = mesh.vertPos.length;
-    const vert = new Float32Array(3 * numVert);
-    const norm = new Float32Array(3 * numVert);
-    for (let i = 0; i < numVert; i++) {
-      const v = mesh.vertPos[i];
-      const n = mesh.vertNormal[i];
-      const idx = 3 * i;
-      vert[idx] = v[0];
-      vert[idx + 1] = v[1];
-      vert[idx + 2] = v[2];
-      norm[idx] = n[0];
-      norm[idx + 1] = n[1];
-      norm[idx + 2] = n[2];
-    }
-
-    const numTri = mesh.triVerts.length;
-    const tri = new Uint32Array(3 * numTri);
-    for (let i = 0; i < numTri; i++) {
-      const v = mesh.triVerts[i];
-      const idx = 3 * i;
-      tri[idx] = v[0];
-      tri[idx + 1] = v[1];
-      tri[idx + 2] = v[2];
-    }
-
-    geometry.setAttribute('position', new THREE.BufferAttribute(vert, 3));
-    geometry.setAttribute('normal', new THREE.BufferAttribute(norm, 3));
-    geometry.setIndex(new THREE.BufferAttribute(tri, 1));
+    geometry.setAttribute('position', new THREE.BufferAttribute(mesh.vertPos, 3));
+    geometry.setAttribute('normal', new THREE.BufferAttribute(mesh.vertNormal, 3));
+    geometry.setIndex(new THREE.BufferAttribute(mesh.triVerts, 1));
     return geometry;
   }
 

--- a/bindings/wasm/examples/three.html
+++ b/bindings/wasm/examples/three.html
@@ -94,11 +94,10 @@
 
   // functions to convert between three.js and wasm
   function geometry2mesh(geometry) {
-    const mesh = {};//new Mesh();
-    mesh.vertPos = geometry.attributes.position.array;
-    mesh.vertNormal = geometry.attributes.normal.array;
-    mesh.triVerts = geometry.index.array;
-    return mesh;
+    const vertPos = geometry.attributes.position.array;
+    const vertNormal = geometry.attributes.normal.array;
+    const triVerts = geometry.index.array;
+    return new wasm.Mesh({vertPos, vertNormal, triVerts});
   }
 
   function mesh2geometry(mesh) {

--- a/bindings/wasm/examples/worker.js
+++ b/bindings/wasm/examples/worker.js
@@ -29,7 +29,7 @@ const constructors = [
 ];
 const utils = [
   'setMinCircularAngle', 'setMinCircularEdgeLength', 'setCircularSegments',
-  'getCircularSegments'
+  'getCircularSegments', 'Mesh'
 ];
 const exposedFunctions = constructors.concat(utils);
 

--- a/bindings/wasm/examples/worker.js
+++ b/bindings/wasm/examples/worker.js
@@ -148,28 +148,7 @@ function exportGLB(manifold) {
 
 function mesh2geometry(mesh) {
   const geometry = new THREE.BufferGeometry();
-
-  const numVert = mesh.vertPos.length;
-  const vert = new Float32Array(3 * numVert);
-  for (let i = 0; i < numVert; i++) {
-    const v = mesh.vertPos[i];
-    const idx = 3 * i;
-    vert[idx] = v[0];
-    vert[idx + 1] = v[1];
-    vert[idx + 2] = v[2];
-  }
-
-  const numTri = mesh.triVerts.length;
-  const tri = new Uint32Array(3 * numTri);
-  for (let i = 0; i < numTri; i++) {
-    const v = mesh.triVerts[i];
-    const idx = 3 * i;
-    tri[idx] = v[0];
-    tri[idx + 1] = v[1];
-    tri[idx + 2] = v[2];
-  }
-
-  geometry.setAttribute('position', new THREE.BufferAttribute(vert, 3));
-  geometry.setIndex(new THREE.BufferAttribute(tri, 1));
+  geometry.setAttribute('position', new THREE.BufferAttribute(mesh.vertPos, 3));
+  geometry.setIndex(new THREE.BufferAttribute(mesh.triVerts, 1));
   return geometry;
 }

--- a/bindings/wasm/manifold.d.ts
+++ b/bindings/wasm/manifold.d.ts
@@ -18,38 +18,6 @@ type Vec4 = [number, number, number, number];
 type Matrix3x4 = [Vec3, Vec3, Vec3, Vec3];
 type SimplePolygon = Vec2[];
 type Polygons = SimplePolygon|SimplePolygon[];
-declare class Mesh {
-  vertPos: Float32Array;
-  triVerts: Uint32Array;
-  vertNormal?: Float32Array;
-  halfedgeTangent?: Float32Array;
-  get numTri(): number;
-  get numVert(): number;
-  verts(tri: number): Uint32Array<3>;
-  position(vert: number): Float32Array<3>;
-  normal(vert: number): Float32Array<3>;
-  tangent(halfedge: number): Float32Array<4>;
-}
-type SerializedVec3 = {
-  x: number,
-  y: number,
-  z: number,
-};
-type SerializedVec4 = {
-  x: number,
-  y: number,
-  z: number,
-  w: number,
-};
-interface Vector<T> {
-  get(idx: number): T;
-  push_back(value: T): void;
-  resize(count: number, value: T): void;
-  set(idx: number, value: T): void;
-  size(): number;
-}
-type Vector_vec3 = Vector<SerializedVec3>;
-type Vector_vec4 = Vector<SerializedVec4>;
 type Box = {
   min: Vec3,
   max: Vec3
@@ -80,6 +48,19 @@ type MeshRelation = {
   barycentric: Vec3[],
   triBary: BaryRef[],
 };
+
+declare class Mesh {
+  vertPos: Float32Array;
+  triVerts: Uint32Array;
+  vertNormal?: Float32Array;
+  halfedgeTangent?: Float32Array;
+  get numTri(): number;
+  get numVert(): number;
+  verts(tri: number): Uint32Array<3>;
+  position(vert: number): Float32Array<3>;
+  normal(vert: number): Float32Array<3>;
+  tangent(halfedge: number): Float32Array<4>;
+}
 
 declare class Manifold {
   /**

--- a/bindings/wasm/manifold.d.ts
+++ b/bindings/wasm/manifold.d.ts
@@ -18,7 +18,7 @@ type Vec4 = [number, number, number, number];
 type Matrix3x4 = [Vec3, Vec3, Vec3, Vec3];
 type SimplePolygon = Vec2[];
 type Polygons = SimplePolygon|SimplePolygon[];
-interface Mesh {
+declare class Mesh {
   vertPos: Float32Array;
   triVerts: Uint32Array;
   vertNormal?: Float32Array;

--- a/bindings/wasm/manifold.d.ts
+++ b/bindings/wasm/manifold.d.ts
@@ -22,11 +22,13 @@ declare class Mesh {
   vertPos: Float32Array;
   triVerts: Uint32Array;
   vertNormal?: Float32Array;
+  halfedgeTangent?: Float32Array;
   get numTri(): number;
   get numVert(): number;
   verts(tri: number): Uint32Array<3>;
   position(vert: number): Float32Array<3>;
   normal(vert: number): Float32Array<3>;
+  tangent(halfedge: number): Float32Array<4>;
 }
 type SerializedVec3 = {
   x: number,

--- a/bindings/wasm/manifold.d.ts
+++ b/bindings/wasm/manifold.d.ts
@@ -18,12 +18,16 @@ type Vec4 = [number, number, number, number];
 type Matrix3x4 = [Vec3, Vec3, Vec3, Vec3];
 type SimplePolygon = Vec2[];
 type Polygons = SimplePolygon|SimplePolygon[];
-type Mesh = {
-  vertPos: Vec3[],
-  triVerts: Vec3[],
-  vertNormal?: Vec3[],
-  halfedgeTangent?: Vec4[]
-};
+interface Mesh {
+  vertPos: Float32Array;
+  triVerts: Uint32Array;
+  vertNormal?: Float32Array;
+  get numTri(): number;
+  get numVert(): number;
+  verts(tri: number): Uint32Array<3>;
+  position(vert: number): Float32Array<3>;
+  normal(vert: number): Float32Array<3>;
+}
 type SerializedVec3 = {
   x: number,
   y: number,
@@ -44,12 +48,6 @@ interface Vector<T> {
 }
 type Vector_vec3 = Vector<SerializedVec3>;
 type Vector_vec4 = Vector<SerializedVec4>;
-type MeshVec = {
-  vertPos: Vector_vec3,
-  triVerts: Vector_vec3,
-  vertNormal: Vector_vec3,
-  halfedgeTangent: Vector_vec4
-};
 type Box = {
   min: Vec3,
   max: Vec3

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -55,12 +55,6 @@ class Manifold {
       const std::vector<float>& properties = std::vector<float>(),
       const std::vector<float>& propertyTolerance = std::vector<float>());
 
-  Manifold(
-      const MeshGL&,
-      const std::vector<glm::ivec3>& triProperties = std::vector<glm::ivec3>(),
-      const std::vector<float>& properties = std::vector<float>(),
-      const std::vector<float>& propertyTolerance = std::vector<float>());
-
   static Manifold Smooth(const Mesh&,
                          const std::vector<Smoothness>& sharpenedEdges = {});
   static Manifold Tetrahedron();

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -55,6 +55,12 @@ class Manifold {
       const std::vector<float>& properties = std::vector<float>(),
       const std::vector<float>& propertyTolerance = std::vector<float>());
 
+  Manifold(
+      const MeshGL&,
+      const std::vector<glm::ivec3>& triProperties = std::vector<glm::ivec3>(),
+      const std::vector<float>& properties = std::vector<float>(),
+      const std::vector<float>& propertyTolerance = std::vector<float>());
+
   static Manifold Smooth(const Mesh&,
                          const std::vector<Smoothness>& sharpenedEdges = {});
   static Manifold Tetrahedron();

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -115,34 +115,6 @@ Manifold::Manifold(const Mesh& mesh,
           mesh, triProperties, properties, propertyTolerance))) {}
 
 /**
- * Same as the Mesh constructor, but allowing GL-style flat-buffers instead
- * using MeshGL.
- */
-Manifold::Manifold(const MeshGL& mesh,
-                   const std::vector<glm::ivec3>& triProperties,
-                   const std::vector<float>& properties,
-                   const std::vector<float>& propertyTolerance) {
-  Mesh input;
-  const int numVert = mesh.NumVert();
-  const int numTri = mesh.NumTri();
-  input.vertPos.resize(numVert);
-  input.vertNormal.resize(numVert);
-  input.triVerts.resize(numTri);
-  for (int i = 0; i < numVert; ++i) {
-    input.vertPos[i] = {mesh.vertPos[3 * i], mesh.vertPos[3 * i + 1],
-                        mesh.vertPos[3 * i + 2]};
-    input.vertNormal[i] = {mesh.vertNormal[3 * i], mesh.vertNormal[3 * i + 1],
-                           mesh.vertNormal[3 * i + 2]};
-  }
-  for (int i = 0; i < numTri; ++i) {
-    input.triVerts[i] = {mesh.triVerts[3 * i], mesh.triVerts[3 * i + 1],
-                         mesh.triVerts[3 * i + 2]};
-  }
-  pNode_ = std::make_shared<CsgLeafNode>(std::make_shared<Impl>(
-      input, triProperties, properties, propertyTolerance));
-}
-
-/**
  * This returns a Mesh of simple vectors of vertices and triangles suitable for
  * saving or other operations outside of the context of this library.
  */

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -141,27 +141,34 @@ Mesh Manifold::GetMesh() const {
 MeshGL Manifold::GetMeshGL() const {
   const Impl& impl = *GetCsgLeafNode().GetImpl();
 
-  int numVert = NumVert();
-  int numTri = NumTri();
+  const int numVert = NumVert();
+  const int numTri = NumTri();
 
   MeshGL out;
   out.vertPos.resize(3 * numVert);
   out.vertNormal.resize(3 * numVert);
   out.triVerts.resize(3 * numTri);
   for (int i = 0; i < numVert; ++i) {
-    glm::vec3 v = impl.vertPos_[i];
+    const glm::vec3 v = impl.vertPos_[i];
     out.vertPos[3 * i] = v.x;
     out.vertPos[3 * i + 1] = v.y;
     out.vertPos[3 * i + 2] = v.z;
-  }
-  for (int i = 0; i < numVert; ++i) {
-    glm::vec3 v = impl.vertNormal_[i];
-    out.vertNormal[3 * i] = v.x;
-    out.vertNormal[3 * i + 1] = v.y;
-    out.vertNormal[3 * i + 2] = v.z;
+    const glm::vec3 n = impl.vertNormal_[i];
+    out.vertNormal[3 * i] = n.x;
+    out.vertNormal[3 * i + 1] = n.y;
+    out.vertNormal[3 * i + 2] = n.z;
   }
   for (int i = 0; i < numTri * 3; ++i) {
     out.triVerts[i] = impl.halfedge_[i].startVert;
+  }
+  const int numHalfedge = impl.halfedgeTangent_.size();
+  out.halfedgeTangent.resize(4 * numHalfedge);
+  for (int i = 0; i < numHalfedge; ++i) {
+    const glm::vec4 t = impl.halfedgeTangent_[i];
+    out.halfedgeTangent[4 * i] = t.x;
+    out.halfedgeTangent[4 * i + 1] = t.y;
+    out.halfedgeTangent[4 * i + 2] = t.z;
+    out.halfedgeTangent[4 * i + 3] = t.w;
   }
 
   return out;

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -144,21 +144,24 @@ MeshGL Manifold::GetMeshGL() const {
   int numVert = NumVert();
   int numTri = NumTri();
 
-  MeshGL out(numVert, numTri);
+  MeshGL out;
+  out.vertPos.resize(3 * numVert);
+  out.vertNormal.resize(3 * numVert);
+  out.triVerts.resize(3 * numTri);
   for (int i = 0; i < numVert; ++i) {
     glm::vec3 v = impl.vertPos_[i];
-    out.vertPos()[3 * i] = v.x;
-    out.vertPos()[3 * i + 1] = v.y;
-    out.vertPos()[3 * i + 2] = v.z;
+    out.vertPos[3 * i] = v.x;
+    out.vertPos[3 * i + 1] = v.y;
+    out.vertPos[3 * i + 2] = v.z;
   }
   for (int i = 0; i < numVert; ++i) {
     glm::vec3 v = impl.vertNormal_[i];
-    out.vertNormal()[3 * i] = v.x;
-    out.vertNormal()[3 * i + 1] = v.y;
-    out.vertNormal()[3 * i + 2] = v.z;
+    out.vertNormal[3 * i] = v.x;
+    out.vertNormal[3 * i + 1] = v.y;
+    out.vertNormal[3 * i + 2] = v.z;
   }
   for (int i = 0; i < numTri * 3; ++i) {
-    out.triVerts()[i] = impl.halfedge_[i].startVert;
+    out.triVerts[i] = impl.halfedge_[i].startVert;
   }
 
   return out;

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -115,6 +115,34 @@ Manifold::Manifold(const Mesh& mesh,
           mesh, triProperties, properties, propertyTolerance))) {}
 
 /**
+ * Same as the Mesh constructor, but allowing GL-style flat-buffers instead
+ * using MeshGL.
+ */
+Manifold::Manifold(const MeshGL& mesh,
+                   const std::vector<glm::ivec3>& triProperties,
+                   const std::vector<float>& properties,
+                   const std::vector<float>& propertyTolerance) {
+  Mesh input;
+  const int numVert = mesh.NumVert();
+  const int numTri = mesh.NumTri();
+  input.vertPos.resize(numVert);
+  input.vertNormal.resize(numVert);
+  input.triVerts.resize(numTri);
+  for (int i = 0; i < numVert; ++i) {
+    input.vertPos[i] = {mesh.vertPos[3 * i], mesh.vertPos[3 * i + 1],
+                        mesh.vertPos[3 * i + 2]};
+    input.vertNormal[i] = {mesh.vertNormal[3 * i], mesh.vertNormal[3 * i + 1],
+                           mesh.vertNormal[3 * i + 2]};
+  }
+  for (int i = 0; i < numTri; ++i) {
+    input.triVerts[i] = {mesh.triVerts[3 * i], mesh.triVerts[3 * i + 1],
+                         mesh.triVerts[3 * i + 2]};
+  }
+  pNode_ = std::make_shared<CsgLeafNode>(std::make_shared<Impl>(
+      input, triProperties, properties, propertyTolerance));
+}
+
+/**
  * This returns a Mesh of simple vectors of vertices and triangles suitable for
  * saving or other operations outside of the context of this library.
  */

--- a/src/utilities/include/public.h
+++ b/src/utilities/include/public.h
@@ -172,30 +172,15 @@ struct Mesh {
  * An alternative to Mesh for output suitable for pushing into graphics
  * libraries directly.
  */
-class MeshGL {
- public:
-  MeshGL(int _numVert, int _numTri)
-      : numVert(_numVert),
-        numTri(_numTri),
-        vertPos_(std::make_unique<float[]>(3 * _numVert)),
-        vertNormal_(std::make_unique<float[]>(3 * _numVert)),
-        triVerts_(std::make_unique<uint32_t[]>(3 * _numTri)) {}
-
-  /// A flat buffer of positions, length 3 * numVert [x, y, z, x, y, z, ...].
-  float* vertPos() const { return this->vertPos_.get(); }
-  /// A flat buffer of normals, length 3 * numVert [x, y, z, x, y, z, ...].
-  float* vertNormal() const { return this->vertNormal_.get(); }
-  /// A flat buffer of verts, length 3 * numTri [0, 1, 2, 0, 1, 2, ...].
-  uint32_t* triVerts() const { return this->triVerts_.get(); }
+struct MeshGL {
   /// Number of vertices
-  const int numVert;
+  int NumVert() const { return this->vertPos.size() / 3; };
   /// Number of triangles
-  const int numTri;
+  int NumTri() const { return this->triVerts.size() / 3; };
 
- private:
-  std::unique_ptr<float[]> vertPos_;
-  std::unique_ptr<float[]> vertNormal_;
-  std::unique_ptr<uint32_t[]> triVerts_;
+  std::vector<float> vertPos;
+  std::vector<float> vertNormal;
+  std::vector<uint32_t> triVerts;
 };
 
 /**
@@ -483,19 +468,6 @@ struct ExecutionParams {
 };
 
 #ifdef MANIFOLD_DEBUG
-/**
- * Print the contents of this vector to standard output. Only exists if compiled
- * with MANIFOLD_DEBUG flag.
- */
-template <typename T>
-void Dump(const std::vector<T>& vec) {
-  std::cout << "Vec = " << std::endl;
-  for (int i = 0; i < vec.size(); ++i) {
-    std::cout << i << ", " << vec[i] << ", " << std::endl;
-  }
-  std::cout << std::endl;
-}
-/** @} */
 
 inline std::ostream& operator<<(std::ostream& stream, const Box& box) {
   return stream << "min: " << box.min.x << ", " << box.min.y << ", "
@@ -532,6 +504,20 @@ inline std::ostream& operator<<(std::ostream& stream, const BaryRef& ref) {
                 << ", originalID: " << ref.originalID << ", tri: " << ref.tri
                 << ", uvw idx: " << ref.vertBary;
 }
+
+/**
+ * Print the contents of this vector to standard output. Only exists if compiled
+ * with MANIFOLD_DEBUG flag.
+ */
+template <typename T>
+void Dump(const std::vector<T>& vec) {
+  std::cout << "Vec = " << std::endl;
+  for (int i = 0; i < vec.size(); ++i) {
+    std::cout << i << ", " << vec[i] << ", " << std::endl;
+  }
+  std::cout << std::endl;
+}
+/** @} */
 #endif
 }  // namespace manifold
 

--- a/src/utilities/include/public.h
+++ b/src/utilities/include/public.h
@@ -149,6 +149,21 @@ using Polygons = std::vector<SimplePolygon>;
 /** @} */
 
 /**
+ * An alternative to Mesh for output suitable for pushing into graphics
+ * libraries directly.
+ */
+struct MeshGL {
+  /// Number of vertices
+  int NumVert() const { return this->vertPos.size() / 3; };
+  /// Number of triangles
+  int NumTri() const { return this->triVerts.size() / 3; };
+
+  std::vector<float> vertPos;
+  std::vector<float> vertNormal;
+  std::vector<uint32_t> triVerts;
+};
+
+/**
  * The triangle-mesh input and output of this library.
  */
 struct Mesh {
@@ -166,21 +181,30 @@ struct Mesh {
   /// as 3 * tri + i, representing the tangent from Mesh.triVerts[tri][i] along
   /// the CCW edge. If empty, mesh is faceted.
   std::vector<glm::vec4> halfedgeTangent;
-};
 
-/**
- * An alternative to Mesh for output suitable for pushing into graphics
- * libraries directly.
- */
-struct MeshGL {
-  /// Number of vertices
-  int NumVert() const { return this->vertPos.size() / 3; };
-  /// Number of triangles
-  int NumTri() const { return this->triVerts.size() / 3; };
+  Mesh() {}
+  Mesh(const MeshGL& in) {
+    const int numTri = in.NumTri();
+    const int numVert = in.NumVert();
+    triVerts.resize(numTri);
+    vertPos.resize(numVert);
+    if (!in.vertNormal.empty()) {
+      vertNormal.resize(numVert);
+    }
 
-  std::vector<float> vertPos;
-  std::vector<float> vertNormal;
-  std::vector<uint32_t> triVerts;
+    for (int i = 0; i < numVert; ++i) {
+      vertPos[i] = {in.vertPos[3 * i], in.vertPos[3 * i + 1],
+                    in.vertPos[3 * i + 2]};
+      if (!in.vertNormal.empty()) {
+        vertNormal[i] = {in.vertNormal[3 * i], in.vertNormal[3 * i + 1],
+                         in.vertNormal[3 * i + 2]};
+      }
+    }
+    for (int i = 0; i < numTri; ++i) {
+      triVerts[i] = {in.triVerts[3 * i], in.triVerts[3 * i + 1],
+                     in.triVerts[3 * i + 2]};
+    }
+  }
 };
 
 /**

--- a/src/utilities/include/public.h
+++ b/src/utilities/include/public.h
@@ -161,6 +161,7 @@ struct MeshGL {
   std::vector<float> vertPos;
   std::vector<float> vertNormal;
   std::vector<uint32_t> triVerts;
+  std::vector<float> halfedgeTangent;
 };
 
 /**
@@ -212,6 +213,14 @@ struct Mesh {
     for (int i = 0; i < numTri; ++i) {
       triVerts[i] = {in.triVerts[3 * i], in.triVerts[3 * i + 1],
                      in.triVerts[3 * i + 2]};
+      if (!in.halfedgeTangent.empty()) {
+        for (const int j : {0, 1, 2})
+          halfedgeTangent[3 * i + j] = {
+              in.halfedgeTangent[4 * (3 * i + j)],
+              in.halfedgeTangent[4 * (3 * i + j) + 1],
+              in.halfedgeTangent[4 * (3 * i + j) + 2],
+              in.halfedgeTangent[4 * (3 * i + j) + 3]};
+      }
     }
   }
 };

--- a/src/utilities/include/public.h
+++ b/src/utilities/include/public.h
@@ -182,7 +182,16 @@ struct Mesh {
   /// the CCW edge. If empty, mesh is faceted.
   std::vector<glm::vec4> halfedgeTangent;
 
-  Mesh() {}
+  Mesh() = default;
+  Mesh(const std::vector<glm::vec3>& vertPos_,
+       const std::vector<glm::ivec3>& triVerts_,
+       const std::vector<glm::vec3>& vertNormal_ = {},
+       const std::vector<glm::vec4>& halfedgeTangent_ = {})
+      : vertPos(vertPos_),
+        triVerts(triVerts_),
+        vertNormal(vertNormal_),
+        halfedgeTangent(halfedgeTangent_) {}
+
   Mesh(const MeshGL& in) {
     const int numTri = in.NumTri();
     const int numVert = in.NumVert();

--- a/test/mesh_test.cpp
+++ b/test/mesh_test.cpp
@@ -192,17 +192,17 @@ TEST(Manifold, GetMeshGL) {
   Manifold manifold = Manifold::Sphere(1);
   Mesh mesh_out = manifold.GetMesh();
   MeshGL meshGL_out = manifold.GetMeshGL();
-  ASSERT_EQ(meshGL_out.numVert, mesh_out.vertPos.size());
-  ASSERT_EQ(meshGL_out.numTri, mesh_out.triVerts.size());
-  for (int i = 0; i < meshGL_out.numVert; ++i) {
+  ASSERT_EQ(meshGL_out.NumVert(), mesh_out.vertPos.size());
+  ASSERT_EQ(meshGL_out.NumTri(), mesh_out.triVerts.size());
+  for (int i = 0; i < meshGL_out.NumVert(); ++i) {
     for (const int j : {0, 1, 2}) {
-      ASSERT_EQ(meshGL_out.vertPos()[3 * i + j], mesh_out.vertPos[i][j]);
-      ASSERT_EQ(meshGL_out.vertNormal()[3 * i + j], mesh_out.vertNormal[i][j]);
+      ASSERT_EQ(meshGL_out.vertPos[3 * i + j], mesh_out.vertPos[i][j]);
+      ASSERT_EQ(meshGL_out.vertNormal[3 * i + j], mesh_out.vertNormal[i][j]);
     }
   }
-  for (int i = 0; i < meshGL_out.numTri; ++i) {
+  for (int i = 0; i < meshGL_out.NumTri(); ++i) {
     for (const int j : {0, 1, 2})
-      ASSERT_EQ(meshGL_out.triVerts()[3 * i + j], mesh_out.triVerts[i][j]);
+      ASSERT_EQ(meshGL_out.triVerts[3 * i + j], mesh_out.triVerts[i][j]);
   }
 }
 


### PR DESCRIPTION
I think I have a much better, cleaner, and faster way to expose our `Mesh` in JS. @stewartoallen, @rafern would you mind taking a look at this breaking API change? The only copy operation is `slice`, which ensures our memory is managed by the JS garbage collector, rather than needing manual C++ deletion, I believe. I believe this should be pretty fast, but it would be great if someone wanted to benchmark it to verify. 