### PR TITLE
Add missing triProperties, properties and propertyTolerance JS bindings

### DIFF
--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -91,7 +91,8 @@ MeshGL MeshJS2GL(const val& mesh) {
   return out;
 }
 
-Manifold FromMeshJS(const val& mesh, const val& inTriProperties, const val& inProperties, const val& inPropertyTolerance) {
+Manifold FromMeshJS(const val& mesh, const val& inTriProperties,
+                    const val& inProperties, const val& inPropertyTolerance) {
   const MeshGL meshGL = MeshJS2GL(mesh);
   const int numTri = meshGL.NumTri();
   std::vector<glm::ivec3> triProperties;
@@ -99,7 +100,8 @@ Manifold FromMeshJS(const val& mesh, const val& inTriProperties, const val& inPr
 
   if (inTriProperties != val::undefined()) {
     triProperties.resize(numTri);
-    const auto flatTriProperties = convertJSArrayToNumberVector<uint32_t>(inTriProperties);
+    const auto flatTriProperties =
+        convertJSArrayToNumberVector<uint32_t>(inTriProperties);
     for (int i = 0; i < numTri; ++i) {
       triProperties[i] = {flatTriProperties[3 * i],
                           flatTriProperties[3 * i + 1],
@@ -112,7 +114,8 @@ Manifold FromMeshJS(const val& mesh, const val& inTriProperties, const val& inPr
   }
 
   if (inPropertyTolerance != val::undefined()) {
-    propertyTolerance = convertJSArrayToNumberVector<float>(inPropertyTolerance);
+    propertyTolerance =
+        convertJSArrayToNumberVector<float>(inPropertyTolerance);
   }
 
   return Manifold(meshGL, triProperties, properties, propertyTolerance);

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -91,7 +91,32 @@ MeshGL MeshJS2GL(const val& mesh) {
   return out;
 }
 
-Manifold FromMeshJS(const val& mesh) { return Manifold(MeshJS2GL(mesh)); }
+Manifold FromMeshJS(const val& mesh, const val& inTriProperties, const val& inProperties, const val& inPropertyTolerance) {
+  const MeshGL meshGL = MeshJS2GL(mesh);
+  const int numTri = meshGL.NumTri();
+  std::vector<glm::ivec3> triProperties;
+  std::vector<float> properties, propertyTolerance;
+
+  if (inTriProperties != val::undefined()) {
+    triProperties.resize(numTri);
+    const auto flatTriProperties = convertJSArrayToNumberVector<uint32_t>(inTriProperties);
+    for (int i = 0; i < numTri; ++i) {
+      triProperties[i] = {flatTriProperties[3 * i],
+                          flatTriProperties[3 * i + 1],
+                          flatTriProperties[3 * i + 2]};
+    }
+  }
+
+  if (inProperties != val::undefined()) {
+    properties = convertJSArrayToNumberVector<float>(inProperties);
+  }
+
+  if (inPropertyTolerance != val::undefined()) {
+    propertyTolerance = convertJSArrayToNumberVector<float>(inPropertyTolerance);
+  }
+
+  return Manifold(meshGL, triProperties, properties, propertyTolerance);
+}
 
 Manifold Smooth(const val& mesh,
                 const std::vector<Smoothness>& sharpenedEdges = {}) {

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -229,8 +229,8 @@ Module.setup = function() {
   });
 
   const ManifoldCtor = Module.Manifold;
-  Module.Manifold = function(mesh) {
-    const manifold = new ManifoldCtor(mesh);
+  Module.Manifold = function(mesh, triProperties, properties, propertyTolerance) {
+    const manifold = new ManifoldCtor(mesh, triProperties, properties, propertyTolerance);
 
     const status = manifold.status();
     if (status.value !== 0) {

--- a/bindings/wasm/manifold.d.ts
+++ b/bindings/wasm/manifold.d.ts
@@ -65,8 +65,12 @@ declare class Mesh {
 declare class Manifold {
   /**
    * Create a Manifold from a Mesh object.
+   *
+   * @param triProperties An array of the same length as mesh.triVerts, filled with references to the properties index. Note the same vertex can have different properties in different triangles.
+   * @param properties An array whose length is the largest index in triProperties times the length of propertyTolerance (the number of properties). Think of it as a property matrix indexed as [index * numProperties + propertyNum].
+   * @param propertyTolerance An array of precision values for each property. This is the amount of interpolation error allowed before two neighboring triangles are considered not coplanar. A good place to start is 1e-5 times the largest value you expect this property to take.
    */
-  constructor(mesh: Mesh);
+  constructor(mesh: Mesh, triProperties?: Uint32Array, properties?: Float32Array, propertyTolerance?: Float32Array);
   /**
    * Transform this Manifold in space. The first three columns form a 3x3 matrix
    * transform and the last is a translation vector. This operation can be


### PR DESCRIPTION
Turns out these properties were missing in the Manifold constructor for the JS bindings.

Related issue: #286

Also, I just saw #290. ~~Feel free to merge both PRs into one~~ Actually, it looks like the other PR might completely replace this one, since it moves the missing properties to the MeshGL class? Keeping this open just in case.