### PR TITLE
Bump std to 17 to test for Mac Union regression

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -18,7 +18,7 @@ add_subdirectory(third_party)
 pybind11_add_module(pymanifold pymanifold.cpp)
 target_link_libraries(pymanifold PRIVATE manifold)
 target_compile_options(pymanifold PRIVATE ${MANIFOLD_FLAGS})
-target_compile_features(pymanifold PUBLIC cxx_std_14)
+target_compile_features(pymanifold PUBLIC cxx_std_17)
 target_include_directories(pymanifold
     PRIVATE ${PYBIND11_DIR}/include
 )

--- a/bindings/wasm/CMakeLists.txt
+++ b/bindings/wasm/CMakeLists.txt
@@ -24,7 +24,7 @@ target_compile_options(manifoldjs PRIVATE ${MANIFOLD_FLAGS} -fexceptions)
 target_link_options(manifoldjs PUBLIC --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/bindings.js --bind -sALLOW_TABLE_GROWTH=1
   -sEXPORTED_RUNTIME_METHODS=addFunction,removeFunction -sMODULARIZE=1)
 
-target_compile_features(manifoldjs PUBLIC cxx_std_14)
+target_compile_features(manifoldjs PUBLIC cxx_std_17)
 set_target_properties(manifoldjs PROPERTIES OUTPUT_NAME "manifold")
 
 file(COPY examples;test;. DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
@@ -35,4 +35,3 @@ add_custom_command(
         COMMAND ${CMAKE_COMMAND} -E copy
                 ${CMAKE_CURRENT_BINARY_DIR}/manifold.*
                 ${CMAKE_CURRENT_BINARY_DIR}/examples/)
-                

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(perfTest perf_test.cpp)
 target_link_libraries(perfTest manifold)
 
 target_compile_options(perfTest PRIVATE ${MANIFOLD_FLAGS})
-target_compile_features(perfTest PUBLIC cxx_std_14)
+target_compile_features(perfTest PUBLIC cxx_std_17)
 
 if(BUILD_TEST_CGAL)
     add_executable(perfTestCGAL perf_test_cgal.cpp)
@@ -29,5 +29,5 @@ if(BUILD_TEST_CGAL)
     target_link_libraries(perfTestCGAL manifold CGAL::CGAL CGAL::CGAL_Core)
 
     target_compile_options(perfTestCGAL PRIVATE ${MANIFOLD_FLAGS})
-    target_compile_features(perfTestCGAL PUBLIC cxx_std_14)
+    target_compile_features(perfTestCGAL PUBLIC cxx_std_17)
 endif()

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(samples
 )
 
 target_compile_options(samples PRIVATE ${MANIFOLD_FLAGS})
-target_compile_features(samples PUBLIC cxx_std_14)
+target_compile_features(samples PUBLIC cxx_std_17)
 
 project(samplesGPU)
 
@@ -45,7 +45,4 @@ target_link_libraries(samplesGPU
 )
 
 target_compile_options(samplesGPU PRIVATE ${MANIFOLD_FLAGS})
-target_compile_features(samplesGPU
-    PUBLIC cxx_std_14
-    PRIVATE cxx_std_17
-)
+target_compile_features(samplesGPU PUBLIC cxx_std_17)

--- a/src/collider/CMakeLists.txt
+++ b/src/collider/CMakeLists.txt
@@ -25,8 +25,4 @@ endif()
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(${PROJECT_NAME} PUBLIC utilities)
 
-target_compile_features(${PROJECT_NAME} 
-    PUBLIC cxx_std_14
-    PRIVATE cxx_std_17
-)
-
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)

--- a/src/manifold/CMakeLists.txt
+++ b/src/manifold/CMakeLists.txt
@@ -28,8 +28,4 @@ target_link_libraries(${PROJECT_NAME}
     PRIVATE collider polygon ${MANIFOLD_INCLUDE} graphlite
 )
 
-target_compile_features(${PROJECT_NAME} 
-    PUBLIC cxx_std_14 
-    PRIVATE cxx_std_17
-)
-
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)

--- a/src/polygon/CMakeLists.txt
+++ b/src/polygon/CMakeLists.txt
@@ -25,4 +25,4 @@ target_link_libraries( ${PROJECT_NAME}
 )
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
-target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,7 +34,7 @@ if(MANIFOLD_USE_CUDA)
 endif()
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
-target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 
 add_test(test_all ${PROJECT_NAME})
 

--- a/test/meshIO/CMakeLists.txt
+++ b/test/meshIO/CMakeLists.txt
@@ -26,4 +26,4 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
-target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)


### PR DESCRIPTION
As [suggested](https://github.com/elalish/manifold/pull/292#issuecomment-1350679574) by @elalish, this PR contains just the std17 version bump that is part of the C binding PR (to check for regression in `TEST(Boolean, Close)` on the Mac CI.