### PR TITLE
fix css issue

### DIFF
--- a/bindings/wasm/examples/editor.css
+++ b/bindings/wasm/examples/editor.css
@@ -128,7 +128,7 @@ model-viewer {
   transform: translate3d(-50%, -50%, 0);
 }
 
-.margin {
+.header .margin {
   font-size: 16px;
   margin: 1em;
 }

--- a/bindings/wasm/examples/index.html
+++ b/bindings/wasm/examples/index.html
@@ -11,7 +11,7 @@
 
 <body>
   <div class="page">
-    <div class="container" style="background-color: rgb(162 136 179);">
+    <div class="container header" style="background-color: rgb(162 136 179);">
       <p style="flex: 2;"><a href="https://github.com/elalish/manifold">Manifold</a>CAD
       </p>
       <div class="margin" style="position: relative;">


### PR DESCRIPTION
Fixed line number column margin.

Before:
![image](https://user-images.githubusercontent.com/12198657/209064597-8874da14-f1a5-4653-aed5-61a45b68d62f.png)

After:
![image](https://user-images.githubusercontent.com/12198657/209064618-c5fac68a-9a9b-4541-8eaa-860d4f67ff44.png)

Notice that the first line in the original html page is offset by 1 line.