### PR TITLE
Use sqrtf to return float rather than double in level_set test.

### DIFF
--- a/test/manifoldc_test.cpp
+++ b/test/manifoldc_test.cpp
@@ -78,7 +78,7 @@ TEST(CBIND, level_set) {
     float xs = x / xscale;
     float ys = y / yscale;
     float zs = z / zscale;
-    return radius - sqrt(xs * xs + ys * ys + zs * zs);
+    return radius - sqrtf(xs * xs + ys * ys + zs * zs);
   };
 
   const float bb = 30;  // (radius * 2)


### PR DESCRIPTION
This hasn't been a problem on my machine, or in the Manifold CI, but the double <> float mismatch gave a type error in an ubuntu 22.04 workflow on my omanifold project. Not totally sure why as of yet, but this gets rid of the implicit conversion at the root of it.