### PR TITLE
weird bug for python binding

### DIFF
--- a/bindings/python/examples/union_failure.py
+++ b/bindings/python/examples/union_failure.py
@@ -1,0 +1,7 @@
+from pymanifold import Manifold
+
+def run():
+    # for some reason this causes collider error
+    obj = Manifold.cube()
+    obj += Manifold([Manifold.cube()]).rotate(0, 0, 45+180)
+    return obj

--- a/bindings/python/pymanifold.cpp
+++ b/bindings/python/pymanifold.cpp
@@ -45,8 +45,7 @@ PYBIND11_MODULE(pymanifold, m) {
                // will cause failure for python specifically
                // unable to reproduce with c++ directly
                Manifold first = manifolds[0];
-               for (int i = 1; i < manifolds.size(); i++)
-                 first += manifolds[i];
+               for (int i = 1; i < manifolds.size(); i++) first += manifolds[i];
                return first;
              } else {
                return Manifold();

--- a/bindings/python/pymanifold.cpp
+++ b/bindings/python/pymanifold.cpp
@@ -40,8 +40,17 @@ PYBIND11_MODULE(pymanifold, m) {
       .def(py::init<>())
       .def(py::init([](std::vector<Manifold> &manifolds) {
              Manifold result;
-             for (Manifold &manifold : manifolds) result += manifold;
-             return result;
+             if (manifolds.size() >= 1) {
+               // for some reason using Manifold() as the initial object
+               // will cause failure for python specifically
+               // unable to reproduce with c++ directly
+               Manifold first = manifolds[0];
+               for (int i = 1; i < manifolds.size(); i++)
+                 first += manifolds[i];
+               return first;
+             } else {
+               return Manifold();
+             }
            }),
            "Construct manifold as the union of a set of manifolds.")
       .def(py::self + py::self, "Boolean union.")


### PR DESCRIPTION
For some reason the ``union_failure.py` will cause collider error. I have no idea why and no idea why the fix works... Unable to reproduce with c++.