### PR TITLE
Remove Mesh from interface + memcpy depuplication

### DIFF
--- a/bindings/c/conv.cpp
+++ b/bindings/c/conv.cpp
@@ -132,7 +132,7 @@ glm::ivec3 from_c(ManifoldIVec3 v) { return glm::ivec3(v.x, v.y, v.z); }
 
 glm::vec4 from_c(ManifoldVec4 v) { return glm::vec4(v.x, v.y, v.z, v.w); }
 
-std::vector<glm::vec3> vector_of_array(ManifoldVec3 *vs, size_t length) {
+std::vector<glm::vec3> vector_of_vec_array(ManifoldVec3 *vs, size_t length) {
   auto vec = std::vector<glm::vec3>();
   for (int i = 0; i < length; ++i) {
     vec.push_back(from_c(vs[i]));
@@ -140,15 +140,7 @@ std::vector<glm::vec3> vector_of_array(ManifoldVec3 *vs, size_t length) {
   return vec;
 }
 
-std::vector<float> vector_of_array(float *fs, size_t length) {
-  auto vec = std::vector<float>();
-  for (int i = 0; i < length; ++i) {
-    vec.push_back(fs[i]);
-  }
-  return vec;
-}
-
-std::vector<glm::ivec3> vector_of_array(ManifoldIVec3 *vs, size_t length) {
+std::vector<glm::ivec3> vector_of_vec_array(ManifoldIVec3 *vs, size_t length) {
   auto vec = std::vector<glm::ivec3>();
   for (int i = 0; i < length; ++i) {
     vec.push_back(from_c(vs[i]));
@@ -156,7 +148,7 @@ std::vector<glm::ivec3> vector_of_array(ManifoldIVec3 *vs, size_t length) {
   return vec;
 }
 
-std::vector<glm::vec4> vector_of_array(ManifoldVec4 *vs, size_t length) {
+std::vector<glm::vec4> vector_of_vec_array(ManifoldVec4 *vs, size_t length) {
   auto vec = std::vector<glm::vec4>();
   for (int i = 0; i < length; ++i) {
     vec.push_back(from_c(vs[i]));

--- a/bindings/c/include/conv.h
+++ b/bindings/c/include/conv.h
@@ -34,7 +34,22 @@ glm::vec3 from_c(ManifoldVec3 v);
 glm::ivec3 from_c(ManifoldIVec3 v);
 glm::vec4 from_c(ManifoldVec4 v);
 
-std::vector<float> vector_of_array(float *fs, size_t length);
-std::vector<glm::vec3> vector_of_array(ManifoldVec3 *vs, size_t length);
-std::vector<glm::ivec3> vector_of_array(ManifoldIVec3 *vs, size_t length);
-std::vector<glm::vec4> vector_of_array(ManifoldVec4 *vs, size_t length);
+std::vector<glm::vec3> vector_of_vec_array(ManifoldVec3 *vs, size_t length);
+std::vector<glm::ivec3> vector_of_vec_array(ManifoldIVec3 *vs, size_t length);
+std::vector<glm::vec4> vector_of_vec_array(ManifoldVec4 *vs, size_t length);
+
+template <typename T>
+std::vector<T> vector_of_array(T *ts, size_t length) {
+  auto vec = std::vector<T>();
+  for (int i = 0; i < length; ++i) {
+    vec.push_back(ts[i]);
+  }
+  return vec;
+}
+
+template <typename T>
+T *copy_data(void *mem, std::vector<T> v) {
+  T *ts = reinterpret_cast<T *>(mem);
+  memcpy(ts, v.data(), sizeof(T) * v.size());
+  return ts;
+}

--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -13,20 +13,16 @@ ManifoldPolygons *manifold_polygons(void *mem, ManifoldSimplePolygon **ps,
                                     size_t length);
 
 // Mesh Construction
-ManifoldMesh *manifold_mesh(void *mem, ManifoldVec3 *vert_pos, size_t n_verts,
-                            ManifoldIVec3 *tri_verts, size_t n_tris);
-ManifoldMesh *manifold_mesh_w_normals(void *mem, ManifoldVec3 *vert_pos,
-                                      size_t n_verts, ManifoldIVec3 *tri_verts,
-                                      size_t n_tris, ManifoldVec3 *vert_normal);
-ManifoldMesh *manifold_mesh_w_tangents(void *mem, ManifoldVec3 *vert_pos,
-                                       size_t n_verts, ManifoldIVec3 *tri_verts,
-                                       size_t n_tris,
-                                       ManifoldVec4 *halfedge_tangent);
-ManifoldMesh *manifold_mesh_w_normals_tangents(
-    void *mem, ManifoldVec3 *vert_pos, size_t n_verts, ManifoldIVec3 *tri_verts,
-    size_t n_tris, ManifoldVec3 *vert_normal, ManifoldVec4 *halfedge_tangent);
+ManifoldMeshGL *manifold_meshgl(void *mem, float *vert_props, size_t n_verts,
+                                size_t n_props, uint32_t *tri_verts,
+                                size_t n_tris);
 
-ManifoldMesh *manifold_mesh_copy(void *mem, ManifoldMesh *m);
+ManifoldMeshGL *manifold_meshgl_w_tangents(void *mem, float *vert_props,
+                                           size_t n_verts, size_t n_props,
+                                           uint32_t *tri_verts, size_t n_tris,
+                                           float *halfedge_tangent);
+ManifoldMeshGL *manifold_get_meshgl(void *mem, ManifoldManifold *m);
+ManifoldMeshGL *manifold_meshgl_copy(void *mem, ManifoldMeshGL *m);
 
 // SDF
 // By default, the execution policy (sequential or parallel) of
@@ -35,13 +31,13 @@ ManifoldMesh *manifold_mesh_copy(void *mem, ManifoldMesh *m);
 // using these bindings from a language that has a runtime lock preventing the
 // parallel execution of closures, then you should use manifold_level_set_seq to
 // force sequential execution.
-ManifoldMesh *manifold_level_set(void *mem, float (*sdf)(float, float, float),
-                                 ManifoldBox *bounds, float edge_length,
-                                 float level);
-ManifoldMesh *manifold_level_set_seq(void *mem,
-                                     float (*sdf)(float, float, float),
-                                     ManifoldBox *bounds, float edge_length,
-                                     float level);
+ManifoldMeshGL *manifold_level_set(void *mem, float (*sdf)(float, float, float),
+                                   ManifoldBox *bounds, float edge_length,
+                                   float level);
+ManifoldMeshGL *manifold_level_set_seq(void *mem,
+                                       float (*sdf)(float, float, float),
+                                       ManifoldBox *bounds, float edge_length,
+                                       float level);
 
 // Manifold Booleans
 ManifoldManifold *manifold_union(void *mem, ManifoldManifold *a,
@@ -86,8 +82,8 @@ ManifoldManifold *manifold_cylinder(void *mem, float height, float radius_low,
                                     int center);
 ManifoldManifold *manifold_sphere(void *mem, float radius,
                                   int circular_segments);
-ManifoldManifold *manifold_of_mesh(void *mem, ManifoldMesh *mesh);
-ManifoldManifold *manifold_smooth(void *mem, ManifoldMesh *mesh,
+ManifoldManifold *manifold_of_meshgl(void *mem, ManifoldMeshGL *mesh);
+ManifoldManifold *manifold_smooth(void *mem, ManifoldMeshGL *mesh,
                                   int *half_edges, float *smoothness,
                                   int n_idxs);
 ManifoldManifold *manifold_extrude(void *mem, ManifoldPolygons *polygons,
@@ -153,18 +149,6 @@ void manifold_set_min_circular_edge_length(float length);
 void manifold_set_circular_segments(int number);
 
 // Manifold Mesh Extraction
-ManifoldMesh *manifold_get_mesh(void *mem, ManifoldManifold *m);
-size_t manifold_mesh_vert_length(ManifoldMesh *m);
-size_t manifold_mesh_tri_length(ManifoldMesh *m);
-size_t manifold_mesh_normal_length(ManifoldMesh *m);
-size_t manifold_mesh_tangent_length(ManifoldMesh *m);
-ManifoldVec3 *manifold_mesh_vert_pos(void *mem, ManifoldMesh *m);
-ManifoldIVec3 *manifold_mesh_tri_verts(void *mem, ManifoldMesh *m);
-ManifoldVec3 *manifold_mesh_vert_normal(void *mem, ManifoldMesh *m);
-ManifoldVec4 *manifold_mesh_halfedge_tangent(void *mem, ManifoldMesh *m);
-
-ManifoldMeshGL *manifold_get_meshgl(void *mem, ManifoldManifold *m);
-ManifoldMeshGL *manifold_meshgl_copy(void *mem, ManifoldMeshGL *m);
 int manifold_meshgl_num_prop(ManifoldMeshGL *m);
 int manifold_meshgl_num_vert(ManifoldMeshGL *m);
 int manifold_meshgl_num_tri(ManifoldMeshGL *m);
@@ -196,15 +180,14 @@ void manifold_export_options_set_faceted(ManifoldExportOptions *options,
                                          int faceted);
 void manifold_export_options_set_material(ManifoldExportOptions *options,
                                           ManifoldMaterial *mat);
-void manifold_export_mesh(const char *filename, ManifoldMesh *mesh,
-                          ManifoldExportOptions *options);
+void manifold_export_meshgl(const char *filename, ManifoldMeshGL *mesh,
+                            ManifoldExportOptions *options);
 
 // memory size
 size_t manifold_simple_polygon_size();
 size_t manifold_polygons_size();
 size_t manifold_manifold_size();
 size_t manifold_manifold_pair_size();
-size_t manifold_mesh_size();
 size_t manifold_meshgl_size();
 size_t manifold_box_size();
 size_t manifold_curvature_size();
@@ -216,7 +199,6 @@ size_t manifold_export_options_size();
 void manifold_destruct_simple_polygon(ManifoldSimplePolygon *p);
 void manifold_destruct_polygons(ManifoldPolygons *p);
 void manifold_destruct_manifold(ManifoldManifold *m);
-void manifold_destruct_mesh(ManifoldMesh *m);
 void manifold_destruct_meshgl(ManifoldMeshGL *m);
 void manifold_destruct_box(ManifoldBox *b);
 void manifold_destruct_curvature(ManifoldCurvature *c);
@@ -228,7 +210,6 @@ void manifold_destruct_export_options(ManifoldExportOptions *options);
 void manifold_delete_simple_polygon(ManifoldSimplePolygon *p);
 void manifold_delete_polygons(ManifoldPolygons *p);
 void manifold_delete_manifold(ManifoldManifold *m);
-void manifold_delete_mesh(ManifoldMesh *m);
 void manifold_delete_meshgl(ManifoldMeshGL *m);
 void manifold_delete_box(ManifoldBox *b);
 void manifold_delete_curvature(ManifoldCurvature *c);

--- a/bindings/c/meshio.cpp
+++ b/bindings/c/meshio.cpp
@@ -24,7 +24,7 @@ void manifold_material_set_color(ManifoldMaterial *mat, ManifoldVec4 color) {
 
 void manifold_material_set_vert_color(ManifoldMaterial *mat,
                                       ManifoldVec4 *vert_color, size_t n_vert) {
-  from_c(mat)->vertColor = vector_of_array(vert_color, n_vert);
+  from_c(mat)->vertColor = vector_of_vec_array(vert_color, n_vert);
 }
 
 ManifoldExportOptions *manifold_export_options(void *mem) {
@@ -41,8 +41,8 @@ void manifold_export_options_set_material(ManifoldExportOptions *options,
   from_c(options)->mat = *from_c(mat);
 }
 
-void manifold_export_mesh(const char *filename, ManifoldMesh *mesh,
-                          ManifoldExportOptions *options) {
+void manifold_export_meshgl(const char *filename, ManifoldMeshGL *mesh,
+                            ManifoldExportOptions *options) {
   manifold::ExportMesh(std::string(filename), *from_c(mesh), *from_c(options));
 }
 


### PR DESCRIPTION
In addition to the cleanup in the closed PR, I've removed Mesh from the interface in the spirit of your intention to keep it as a C++ only implementation detail.