### PR TITLE
Fix deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: manifold.yml
+        workflow_conclusion: completed
         pr: ${{github.event.pull_request.number}}
         name: wasm
         path: ./public

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -138,7 +138,7 @@ jobs:
           build/bindings/wasm/manifold.js
           build/bindings/wasm/manifold.wasm
           build/bindings/wasm/manifold.d.ts
-        retention-days: 7
+        retention-days: 90
 
   build_windows:
     timeout-minutes: 30

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -49,7 +49,7 @@
 </body>
 <script type="module" src="https://ajax.googleapis.com/ajax/libs/model-viewer/2.0.1/model-viewer.min.js"></script>
 <script type="module">
-  import { Accessor, Document, WebIO } from 'https://cdn.skypack.dev/@gltf-transform/core';
+  import { Accessor, Document, WebIO } from 'https://cdn.skypack.dev/pin/@gltf-transform/core@v3.0.0-SfbIFhNPTRdr1UE2VSan/mode=imports,min/optimized/@gltf-transform/core.js';
   import Module from '../manifold.js';
 
   const io = new WebIO();

--- a/bindings/wasm/examples/worker.js
+++ b/bindings/wasm/examples/worker.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Accessor, Document, WebIO} from 'https://cdn.skypack.dev/@gltf-transform/core';
+import {Accessor, Document, WebIO} from 'https://cdn.skypack.dev/pin/@gltf-transform/core@v3.0.0-SfbIFhNPTRdr1UE2VSan/mode=imports,min/optimized/@gltf-transform/core.js';
 
 import Module from '../manifold.js';
 


### PR DESCRIPTION
I think because the OMP runs are sometimes timing out, it makes the workflow as failed (the red X) even though they aren't required. I believe this was causing our deploy the fail because it wouldn't grab the artifacts from a "failed" run.