### PR TITLE
wasm: transform accepts mat4

### DIFF
--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -32,17 +32,14 @@ Manifold Intersection(const Manifold& a, const Manifold& b) { return a ^ b; }
 
 Manifold UnionN(const std::vector<Manifold>& manifolds) {
   return Manifold::BatchBoolean(manifolds, Manifold::OpType::Add);
-  ;
 }
 
 Manifold DifferenceN(const std::vector<Manifold>& manifolds) {
   return Manifold::BatchBoolean(manifolds, Manifold::OpType::Subtract);
-  ;
 }
 
 Manifold IntersectionN(const std::vector<Manifold>& manifolds) {
   return Manifold::BatchBoolean(manifolds, Manifold::OpType::Intersect);
-  ;
 }
 
 std::vector<SimplePolygon> ToPolygon(

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -77,11 +77,19 @@ Module.setup = function() {
 
   // note that the matrix is using column major (same as glm)
   Module.Manifold.prototype.transform = function(mat) {
-    console.assert(mat.length == 4, 'expects a 3x4 matrix');
     const vec = new Module.Vector_f32();
-    for (let col of mat) {
-      console.assert(col.length == 3, 'expects a 3x4 matrix');
-      for (let x of col) mat.push_back(x);
+    if (mat.length == 16) {
+      // assuming glMatrix format (column major)
+      // skip the last row
+      for (let i = 0; i < 16; i++)
+        if (i % 4 != 3)
+          vec.push_back(mat[i]);
+    } else {
+      console.assert(mat.length == 4, 'expects a 3x4 matrix');
+      for (let col of mat) {
+        console.assert(col.length == 3, 'expects a 3x4 matrix');
+        for (let x of col) vec.push_back(x);
+      }
     }
     const result = this._Transform(vec);
     vec.delete();

--- a/bindings/wasm/manifold.d.ts
+++ b/bindings/wasm/manifold.d.ts
@@ -92,7 +92,7 @@ declare class Manifold {
    *
    * @param m The affine transform matrix to apply to all the vertices.
    */
-  transform(m: Matrix3x4): Manifold;
+  transform(m: Matrix3x4 | number[16]): Manifold;
 
   /**
    * Move this Manifold in space. This operation can be chained. Transforms are


### PR DESCRIPTION
This is for #324, it seems that we only need to change `transform` to accept glMatrix mat4 type. This also fixes a silly bug in  the existing transform code.

I tried adding the type definition for glMatrix to the editor. However, the typescript file they provide only contains type declaration but no function declaration, and typescript engine doesn't evaluate the minified js file so it cannot get the definitions.