### PR TITLE
Add gl-matrix to editor

### DIFF
--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -238,7 +238,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("_GetMeshJS", &GetMeshJS)
       .function("refine", &Manifold::Refine)
       .function("_Warp", &Warp)
-      .function("transform", &Transform)
+      .function("_Transform", &Transform)
       .function("_Translate", &Manifold::Translate)
       .function("_Rotate", &Manifold::Rotate)
       .function("_Scale", &Manifold::Scale)

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -146,10 +146,11 @@ Manifold Revolve(std::vector<std::vector<glm::vec2>>& polygons,
   return Manifold::Revolve(ToPolygon(polygons), circularSegments);
 }
 
-Manifold Transform(Manifold& manifold, std::vector<float>& mat) {
+Manifold Transform(Manifold& manifold, const val& mat) {
+  std::vector<float> array = convertJSArrayToNumberVector<float>(mat);
   glm::mat4x3 matrix;
-  for (int i = 0; i < 4; i++)
-    for (int j = 0; j < 3; j++) matrix[i][j] = mat[i * 3 + j];
+  for (const int col : {0, 1, 2, 3})
+    for (const int row : {0, 1, 2}) matrix[col][row] = array[col * 4 + row];
   return manifold.Transform(matrix);
 }
 
@@ -237,7 +238,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("_GetMeshJS", &GetMeshJS)
       .function("refine", &Manifold::Refine)
       .function("_Warp", &Warp)
-      .function("_Transform", &Transform)
+      .function("transform", &Transform)
       .function("_Translate", &Manifold::Translate)
       .function("_Rotate", &Manifold::Rotate)
       .function("_Scale", &Manifold::Scale)

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -75,27 +75,6 @@ Module.setup = function() {
     return out;
   };
 
-  // note that the matrix is using column major (same as glm)
-  Module.Manifold.prototype.transform = function(mat) {
-    const vec = new Module.Vector_f32();
-    if (mat.length == 16) {
-      // assuming glMatrix format (column major)
-      // skip the last row
-      for (let i = 0; i < 16; i++)
-        if (i % 4 != 3)
-          vec.push_back(mat[i]);
-    } else {
-      console.assert(mat.length == 4, 'expects a 3x4 matrix');
-      for (let col of mat) {
-        console.assert(col.length == 3, 'expects a 3x4 matrix');
-        for (let x of col) vec.push_back(x);
-      }
-    }
-    const result = this._Transform(vec);
-    vec.delete();
-    return result;
-  };
-
   Module.Manifold.prototype.translate = function(...vec) {
     return this._Translate(vararg2vec(vec));
   };
@@ -184,7 +163,14 @@ Module.setup = function() {
     }
 
     transform(run) {
-      return this.runTransform.subarray(12 * run, 12 * (run + 1));
+      const mat4 = new Float32Array(16);
+      for (const col of [0, 1, 2, 3]) {
+        for (const row of [0, 1, 2]) {
+          mat4[4 * col + row] = transform[12 * run + 3 * col + row];
+        }
+      }
+      mat4[15] = 1;
+      return mat4;
     }
   }
 

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -163,10 +163,10 @@ Module.setup = function() {
     }
 
     transform(run) {
-      const mat4 = new Float32Array(16);
+      const mat4 = new Array(16);
       for (const col of [0, 1, 2, 3]) {
         for (const row of [0, 1, 2]) {
-          mat4[4 * col + row] = transform[12 * run + 3 * col + row];
+          mat4[4 * col + row] = this.runTransform[12 * run + 3 * col + row];
         }
       }
       mat4[15] = 1;

--- a/bindings/wasm/examples/editor.d.ts
+++ b/bindings/wasm/examples/editor.d.ts
@@ -63,69 +63,69 @@ interface GLMatrix {
    */
   equals(a: number, b: number): boolean;
 
-  vec2: Vec2;
-  vec3: Vec3;
-  vec4: Vec4;
-  mat2: Mat2;
-  mat2d: Mat2d;
-  mat3: Mat3;
-  mat4: Mat4;
-  quat: Quat;
+  vec2: Vec2Type;
+  vec3: Vec3Type;
+  vec4: Vec4Type;
+  mat2: Mat2Type;
+  mat2d: Mat2dType;
+  mat3: Mat3Type;
+  mat4: Mat4Type;
+  quat: QuatType;
 }
 
-interface Vec2 extends Float32Array {
+interface Vec2Type extends Float32Array {
   /**
-   * Creates a new, empty Vec2
+   * Creates a new, empty Vec2Type
    *
    * @returns a new 2D vector
    */
-  create(): Vec2;
+  create(): Vec2Type;
 
   /**
-   * Creates a new Vec2 initialized with values from an existing vector
+   * Creates a new Vec2Type initialized with values from an existing vector
    *
    * @param a a vector to clone
    * @returns a new 2D vector
    */
-  clone(a: Vec2|number[]): Vec2;
+  clone(a: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Creates a new Vec2 initialized with the given values
+   * Creates a new Vec2Type initialized with the given values
    *
    * @param x X component
    * @param y Y component
    * @returns a new 2D vector
    */
-  fromValues(x: number, y: number): Vec2;
+  fromValues(x: number, y: number): Vec2Type;
 
   /**
-   * Copy the values from one Vec2 to another
+   * Copy the values from one Vec2Type to another
    *
    * @param out the receiving vector
    * @param a the source vector
    * @returns out
    */
-  copy(out: Vec2, a: Vec2|number[]): Vec2;
+  copy(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Set the components of a Vec2 to the given values
+   * Set the components of a Vec2Type to the given values
    *
    * @param out the receiving vector
    * @param x X component
    * @param y Y component
    * @returns out
    */
-  set(out: Vec2, x: number, y: number): Vec2;
+  set(out: Vec2Type, x: number, y: number): Vec2Type;
 
   /**
-   * Adds two Vec2's
+   * Adds two Vec2Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  add(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  add(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
 
   /**
    * Subtracts vector b from vector a
@@ -135,7 +135,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  subtract(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  subtract(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
 
   /**
    * Subtracts vector b from vector a
@@ -145,108 +145,108 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  sub(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  sub(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Multiplies two Vec2's
+   * Multiplies two Vec2Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  multiply(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Multiplies two Vec2's
+   * Multiplies two Vec2Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  mul(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Divides two Vec2's
+   * Divides two Vec2Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  divide(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  divide(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Divides two Vec2's
+   * Divides two Vec2Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  div(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  div(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Math.ceil the components of a Vec2
+   * Math.ceil the components of a Vec2Type
    *
-   * @param {Vec2} out the receiving vector
-   * @param {Vec2} a vector to ceil
-   * @returns {Vec2} out
+   * @param {Vec2Type} out the receiving vector
+   * @param {Vec2Type} a vector to ceil
+   * @returns {Vec2Type} out
    */
-  ceil(out: Vec2, a: Vec2|number[]): Vec2;
+  ceil(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Math.floor the components of a Vec2
+   * Math.floor the components of a Vec2Type
    *
-   * @param {Vec2} out the receiving vector
-   * @param {Vec2} a vector to floor
-   * @returns {Vec2} out
+   * @param {Vec2Type} out the receiving vector
+   * @param {Vec2Type} a vector to floor
+   * @returns {Vec2Type} out
    */
-  floor(out: Vec2, a: Vec2|number[]): Vec2;
+  floor(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Returns the minimum of two Vec2's
-   *
-   * @param out the receiving vector
-   * @param a the first operand
-   * @param b the second operand
-   * @returns out
-   */
-  min(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
-
-  /**
-   * Returns the maximum of two Vec2's
+   * Returns the minimum of two Vec2Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  max(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  min(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Math.round the components of a Vec2
+   * Returns the maximum of two Vec2Type's
    *
-   * @param {Vec2} out the receiving vector
-   * @param {Vec2} a vector to round
-   * @returns {Vec2} out
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
    */
-  round(out: Vec2, a: Vec2|number[]): Vec2;
+  max(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
+
+  /**
+   * Math.round the components of a Vec2Type
+   *
+   * @param {Vec2Type} out the receiving vector
+   * @param {Vec2Type} a vector to round
+   * @returns {Vec2Type} out
+   */
+  round(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
 
 
   /**
-   * Scales a Vec2 by a scalar number
+   * Scales a Vec2Type by a scalar number
    *
    * @param out the receiving vector
    * @param a the vector to scale
    * @param b amount to scale the vector by
    * @returns out
    */
-  scale(out: Vec2, a: Vec2|number[], b: number): Vec2;
+  scale(out: Vec2Type, a: Vec2Type|number[], b: number): Vec2Type;
 
   /**
-   * Adds two Vec2's after scaling the second operand by a scalar value
+   * Adds two Vec2Type's after scaling the second operand by a scalar value
    *
    * @param out the receiving vector
    * @param a the first operand
@@ -254,115 +254,116 @@ interface Vec2 extends Float32Array {
    * @param scale the amount to scale b by before adding
    * @returns out
    */
-  scaleAndAdd(out: Vec2, a: Vec2|number[], b: Vec2|number[], scale: number):
-      Vec2;
+  scaleAndAdd(
+      out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[],
+      scale: number): Vec2Type;
 
   /**
-   * Calculates the euclidian distance between two Vec2's
+   * Calculates the euclidian distance between two Vec2Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns distance between a and b
    */
-  distance(a: Vec2|number[], b: Vec2|number[]): number;
+  distance(a: Vec2Type|number[], b: Vec2Type|number[]): number;
 
   /**
-   * Calculates the euclidian distance between two Vec2's
+   * Calculates the euclidian distance between two Vec2Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns distance between a and b
    */
-  dist(a: Vec2|number[], b: Vec2|number[]): number;
+  dist(a: Vec2Type|number[], b: Vec2Type|number[]): number;
 
   /**
-   * Calculates the squared euclidian distance between two Vec2's
+   * Calculates the squared euclidian distance between two Vec2Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  squaredDistance(a: Vec2|number[], b: Vec2|number[]): number;
+  squaredDistance(a: Vec2Type|number[], b: Vec2Type|number[]): number;
 
   /**
-   * Calculates the squared euclidian distance between two Vec2's
+   * Calculates the squared euclidian distance between two Vec2Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  sqrDist(a: Vec2|number[], b: Vec2|number[]): number;
+  sqrDist(a: Vec2Type|number[], b: Vec2Type|number[]): number;
 
   /**
-   * Calculates the length of a Vec2
+   * Calculates the length of a Vec2Type
    *
    * @param a vector to calculate length of
    * @returns length of a
    */
-  length(a: Vec2|number[]): number;
+  length(a: Vec2Type|number[]): number;
 
   /**
-   * Calculates the length of a Vec2
+   * Calculates the length of a Vec2Type
    *
    * @param a vector to calculate length of
    * @returns length of a
    */
-  len(a: Vec2|number[]): number;
+  len(a: Vec2Type|number[]): number;
 
   /**
-   * Calculates the squared length of a Vec2
+   * Calculates the squared length of a Vec2Type
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  squaredLength(a: Vec2|number[]): number;
+  squaredLength(a: Vec2Type|number[]): number;
 
   /**
-   * Calculates the squared length of a Vec2
+   * Calculates the squared length of a Vec2Type
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  sqrLen(a: Vec2|number[]): number;
+  sqrLen(a: Vec2Type|number[]): number;
 
   /**
-   * Negates the components of a Vec2
+   * Negates the components of a Vec2Type
    *
    * @param out the receiving vector
    * @param a vector to negate
    * @returns out
    */
-  negate(out: Vec2, a: Vec2|number[]): Vec2;
+  negate(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Returns the inverse of the components of a Vec2
+   * Returns the inverse of the components of a Vec2Type
    *
    * @param out the receiving vector
    * @param a vector to invert
    * @returns out
    */
-  inverse(out: Vec2, a: Vec2|number[]): Vec2;
+  inverse(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Normalize a Vec2
+   * Normalize a Vec2Type
    *
    * @param out the receiving vector
    * @param a vector to normalize
    * @returns out
    */
-  normalize(out: Vec2, a: Vec2|number[]): Vec2;
+  normalize(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Calculates the dot product of two Vec2's
+   * Calculates the dot product of two Vec2Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns dot product of a and b
    */
-  dot(a: Vec2|number[], b: Vec2|number[]): number;
+  dot(a: Vec2Type|number[], b: Vec2Type|number[]): number;
 
   /**
-   * Computes the cross product of two Vec2's
+   * Computes the cross product of two Vec2Type's
    * Note that the cross product must by definition produce a 3D vector
    *
    * @param out the receiving vector
@@ -370,10 +371,10 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  cross(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  cross(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
 
   /**
-   * Performs a linear interpolation between two Vec2's
+   * Performs a linear interpolation between two Vec2Type's
    *
    * @param out the receiving vector
    * @param a the first operand
@@ -381,7 +382,8 @@ interface Vec2 extends Float32Array {
    * @param t interpolation amount between the two inputs
    * @returns out
    */
-  lerp(out: Vec2, a: Vec2|number[], b: Vec2|number[], t: number): Vec2;
+  lerp(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[], t: number):
+      Vec2Type;
 
   /**
    * Generates a random unit vector
@@ -389,7 +391,7 @@ interface Vec2 extends Float32Array {
    * @param out the receiving vector
    * @returns out
    */
-  random(out: Vec2): Vec2;
+  random(out: Vec2Type): Vec2Type;
 
   /**
    * Generates a random vector with the given scale
@@ -399,30 +401,30 @@ interface Vec2 extends Float32Array {
    *     will be returned
    * @returns out
    */
-  random(out: Vec2, scale: number): Vec2;
+  random(out: Vec2Type, scale: number): Vec2Type;
 
   /**
-   * Transforms the Vec2 with a Mat2
+   * Transforms the Vec2Type with a Mat2Type
    *
    * @param out the receiving vector
    * @param a the vector to transform
    * @param m matrix to transform with
    * @returns out
    */
-  transformMat2(out: Vec2, a: Vec2|number[], m: Mat2): Vec2;
+  transformMat2(out: Vec2Type, a: Vec2Type|number[], m: Mat2Type): Vec2Type;
 
   /**
-   * Transforms the Vec2 with a Mat2d
+   * Transforms the Vec2Type with a Mat2dType
    *
    * @param out the receiving vector
    * @param a the vector to transform
    * @param m matrix to transform with
    * @returns out
    */
-  transformMat2d(out: Vec2, a: Vec2|number[], m: Mat2d): Vec2;
+  transformMat2d(out: Vec2Type, a: Vec2Type|number[], m: Mat2dType): Vec2Type;
 
   /**
-   * Transforms the Vec2 with a Mat3
+   * Transforms the Vec2Type with a Mat3Type
    * 3rd vector component is implicitly '1'
    *
    * @param out the receiving vector
@@ -430,10 +432,10 @@ interface Vec2 extends Float32Array {
    * @param m matrix to transform with
    * @returns out
    */
-  transformMat3(out: Vec2, a: Vec2|number[], m: Mat3): Vec2;
+  transformMat3(out: Vec2Type, a: Vec2Type|number[], m: Mat3Type): Vec2Type;
 
   /**
-   * Transforms the Vec2 with a Mat4
+   * Transforms the Vec2Type with a Mat4Type
    * 3rd vector component is implicitly '0'
    * 4th vector component is implicitly '1'
    *
@@ -442,16 +444,16 @@ interface Vec2 extends Float32Array {
    * @param m matrix to transform with
    * @returns out
    */
-  transformMat4(out: Vec2, a: Vec2|number[], m: Mat4): Vec2;
+  transformMat4(out: Vec2Type, a: Vec2Type|number[], m: Mat4Type): Vec2Type;
 
   /**
-   * Perform some operation over an array of vec2s.
+   * Perform some operation over an array of vec2Types.
    *
    * @param a the array of vectors to iterate over
-   * @param stride Number of elements between the start of each Vec2. If 0
+   * @param stride Number of elements between the start of each Vec2Type. If 0
    *     assumes tightly packed
    * @param offset Number of elements to skip at the beginning of the array
-   * @param count Number of vec2s to iterate over. If 0 iterates over entire
+   * @param count Number of vec2Types to iterate over. If 0 iterates over entire
    *     array
    * @param fn Function to call for each vector in the array
    * @param arg additional argument to pass to fn
@@ -459,24 +461,24 @@ interface Vec2 extends Float32Array {
    */
   forEach(
       a: Float32Array, stride: number, offset: number, count: number,
-      fn: (a: Vec2|number[], b: Vec2|number[], arg: any) => void,
+      fn: (a: Vec2Type|number[], b: Vec2Type|number[], arg: any) => void,
       arg: any): Float32Array;
 
   /**
-   * Perform some operation over an array of vec2s.
+   * Perform some operation over an array of vec2Types.
    *
    * @param a the array of vectors to iterate over
-   * @param stride Number of elements between the start of each Vec2. If 0
+   * @param stride Number of elements between the start of each Vec2Type. If 0
    *     assumes tightly packed
    * @param offset Number of elements to skip at the beginning of the array
-   * @param count Number of vec2s to iterate over. If 0 iterates over entire
+   * @param count Number of vec2Types to iterate over. If 0 iterates over entire
    *     array
    * @param fn Function to call for each vector in the array
    * @returns a
    */
   forEach(
       a: Float32Array, stride: number, offset: number, count: number,
-      fn: (a: Vec2|number[], b: Vec2|number[]) => void): Float32Array;
+      fn: (a: Vec2Type|number[], b: Vec2Type|number[]) => void): Float32Array;
 
   /**
    * Returns a string representation of a vector
@@ -484,67 +486,67 @@ interface Vec2 extends Float32Array {
    * @param a vector to represent as a string
    * @returns string representation of the vector
    */
-  str(a: Vec2|number[]): string;
+  str(a: Vec2Type|number[]): string;
 
   /**
    * Returns whether or not the vectors exactly have the same elements in the
    * same position (when compared with ===)
    *
-   * @param {Vec2} a The first vector.
-   * @param {Vec2} b The second vector.
+   * @param {Vec2Type} a The first vector.
+   * @param {Vec2Type} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  exactEquals(a: Vec2|number[], b: Vec2|number[]): boolean;
+  exactEquals(a: Vec2Type|number[], b: Vec2Type|number[]): boolean;
 
   /**
    * Returns whether or not the vectors have approximately the same elements
    * in the same position.
    *
-   * @param {Vec2} a The first vector.
-   * @param {Vec2} b The second vector.
+   * @param {Vec2Type} a The first vector.
+   * @param {Vec2Type} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  equals(a: Vec2|number[], b: Vec2|number[]): boolean;
+  equals(a: Vec2Type|number[], b: Vec2Type|number[]): boolean;
 }
 
-// Vec3
-interface Vec3 extends Float32Array {
+// Vec3Type
+interface Vec3Type extends Float32Array {
   /**
-   * Creates a new, empty Vec3
+   * Creates a new, empty Vec3Type
    *
    * @returns a new 3D vector
    */
-  create(): Vec3;
+  create(): Vec3Type;
 
   /**
-   * Creates a new Vec3 initialized with values from an existing vector
+   * Creates a new Vec3Type initialized with values from an existing vector
    *
    * @param a vector to clone
    * @returns a new 3D vector
    */
-  clone(a: Vec3|number[]): Vec3;
+  clone(a: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Creates a new Vec3 initialized with the given values
+   * Creates a new Vec3Type initialized with the given values
    *
    * @param x X component
    * @param y Y component
    * @param z Z component
    * @returns a new 3D vector
    */
-  fromValues(x: number, y: number, z: number): Vec3;
+  fromValues(x: number, y: number, z: number): Vec3Type;
 
   /**
-   * Copy the values from one Vec3 to another
+   * Copy the values from one Vec3Type to another
    *
    * @param out the receiving vector
    * @param a the source vector
    * @returns out
    */
-  copy(out: Vec3, a: Vec3|number[]): Vec3;
+  copy(out: Vec3Type, a: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Set the components of a Vec3 to the given values
+   * Set the components of a Vec3Type to the given values
    *
    * @param out the receiving vector
    * @param x X component
@@ -552,17 +554,17 @@ interface Vec3 extends Float32Array {
    * @param z Z component
    * @returns out
    */
-  set(out: Vec3, x: number, y: number, z: number): Vec3;
+  set(out: Vec3Type, x: number, y: number, z: number): Vec3Type;
 
   /**
-   * Adds two Vec3's
+   * Adds two Vec3Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  add(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  add(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
 
   /**
    * Subtracts vector b from vector a
@@ -572,7 +574,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  subtract(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  subtract(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
 
   /**
    * Subtracts vector b from vector a
@@ -582,107 +584,107 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  sub(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3
+  sub(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type
 
   /**
-   * Multiplies two Vec3's
+   * Multiplies two Vec3Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  multiply(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Multiplies two Vec3's
+   * Multiplies two Vec3Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  mul(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Divides two Vec3's
+   * Divides two Vec3Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  divide(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  divide(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Divides two Vec3's
+   * Divides two Vec3Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  div(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  div(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Math.ceil the components of a Vec3
+   * Math.ceil the components of a Vec3Type
    *
-   * @param {Vec3} out the receiving vector
-   * @param {Vec3} a vector to ceil
-   * @returns {Vec3} out
+   * @param {Vec3Type} out the receiving vector
+   * @param {Vec3Type} a vector to ceil
+   * @returns {Vec3Type} out
    */
-  ceil(out: Vec3, a: Vec3|number[]): Vec3;
+  ceil(out: Vec3Type, a: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Math.floor the components of a Vec3
+   * Math.floor the components of a Vec3Type
    *
-   * @param {Vec3} out the receiving vector
-   * @param {Vec3} a vector to floor
-   * @returns {Vec3} out
+   * @param {Vec3Type} out the receiving vector
+   * @param {Vec3Type} a vector to floor
+   * @returns {Vec3Type} out
    */
-  floor(out: Vec3, a: Vec3|number[]): Vec3;
+  floor(out: Vec3Type, a: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Returns the minimum of two Vec3's
-   *
-   * @param out the receiving vector
-   * @param a the first operand
-   * @param b the second operand
-   * @returns out
-   */
-  min(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
-
-  /**
-   * Returns the maximum of two Vec3's
+   * Returns the minimum of two Vec3Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  max(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  min(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Math.round the components of a Vec3
+   * Returns the maximum of two Vec3Type's
    *
-   * @param {Vec3} out the receiving vector
-   * @param {Vec3} a vector to round
-   * @returns {Vec3} out
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
    */
-  round(out: Vec3, a: Vec3|number[]): Vec3
+  max(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Scales a Vec3 by a scalar number
+   * Math.round the components of a Vec3Type
+   *
+   * @param {Vec3Type} out the receiving vector
+   * @param {Vec3Type} a vector to round
+   * @returns {Vec3Type} out
+   */
+  round(out: Vec3Type, a: Vec3Type|number[]): Vec3Type
+
+  /**
+   * Scales a Vec3Type by a scalar number
    *
    * @param out the receiving vector
    * @param a the vector to scale
    * @param b amount to scale the vector by
    * @returns out
    */
-  scale(out: Vec3, a: Vec3|number[], b: number): Vec3;
+  scale(out: Vec3Type, a: Vec3Type|number[], b: number): Vec3Type;
 
   /**
-   * Adds two Vec3's after scaling the second operand by a scalar value
+   * Adds two Vec3Type's after scaling the second operand by a scalar value
    *
    * @param out the receiving vector
    * @param a the first operand
@@ -690,125 +692,126 @@ interface Vec3 extends Float32Array {
    * @param scale the amount to scale b by before adding
    * @returns out
    */
-  scaleAndAdd(out: Vec3, a: Vec3|number[], b: Vec3|number[], scale: number):
-      Vec3;
+  scaleAndAdd(
+      out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[],
+      scale: number): Vec3Type;
 
   /**
-   * Calculates the euclidian distance between two Vec3's
+   * Calculates the euclidian distance between two Vec3Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns distance between a and b
    */
-  distance(a: Vec3|number[], b: Vec3|number[]): number;
+  distance(a: Vec3Type|number[], b: Vec3Type|number[]): number;
 
   /**
-   * Calculates the euclidian distance between two Vec3's
+   * Calculates the euclidian distance between two Vec3Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns distance between a and b
    */
-  dist(a: Vec3|number[], b: Vec3|number[]): number;
+  dist(a: Vec3Type|number[], b: Vec3Type|number[]): number;
 
   /**
-   * Calculates the squared euclidian distance between two Vec3's
+   * Calculates the squared euclidian distance between two Vec3Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  squaredDistance(a: Vec3|number[], b: Vec3|number[]): number;
+  squaredDistance(a: Vec3Type|number[], b: Vec3Type|number[]): number;
 
   /**
-   * Calculates the squared euclidian distance between two Vec3's
+   * Calculates the squared euclidian distance between two Vec3Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  sqrDist(a: Vec3|number[], b: Vec3|number[]): number;
+  sqrDist(a: Vec3Type|number[], b: Vec3Type|number[]): number;
 
   /**
-   * Calculates the length of a Vec3
+   * Calculates the length of a Vec3Type
    *
    * @param a vector to calculate length of
    * @returns length of a
    */
-  length(a: Vec3|number[]): number;
+  length(a: Vec3Type|number[]): number;
 
   /**
-   * Calculates the length of a Vec3
+   * Calculates the length of a Vec3Type
    *
    * @param a vector to calculate length of
    * @returns length of a
    */
-  len(a: Vec3|number[]): number;
+  len(a: Vec3Type|number[]): number;
 
   /**
-   * Calculates the squared length of a Vec3
+   * Calculates the squared length of a Vec3Type
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  squaredLength(a: Vec3|number[]): number;
+  squaredLength(a: Vec3Type|number[]): number;
 
   /**
-   * Calculates the squared length of a Vec3
+   * Calculates the squared length of a Vec3Type
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  sqrLen(a: Vec3|number[]): number;
+  sqrLen(a: Vec3Type|number[]): number;
 
   /**
-   * Negates the components of a Vec3
+   * Negates the components of a Vec3Type
    *
    * @param out the receiving vector
    * @param a vector to negate
    * @returns out
    */
-  negate(out: Vec3, a: Vec3|number[]): Vec3;
+  negate(out: Vec3Type, a: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Returns the inverse of the components of a Vec3
+   * Returns the inverse of the components of a Vec3Type
    *
    * @param out the receiving vector
    * @param a vector to invert
    * @returns out
    */
-  inverse(out: Vec3, a: Vec3|number[]): Vec3;
+  inverse(out: Vec3Type, a: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Normalize a Vec3
+   * Normalize a Vec3Type
    *
    * @param out the receiving vector
    * @param a vector to normalize
    * @returns out
    */
-  normalize(out: Vec3, a: Vec3|number[]): Vec3;
+  normalize(out: Vec3Type, a: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Calculates the dot product of two Vec3's
+   * Calculates the dot product of two Vec3Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns dot product of a and b
    */
-  dot(a: Vec3|number[], b: Vec3|number[]): number;
+  dot(a: Vec3Type|number[], b: Vec3Type|number[]): number;
 
   /**
-   * Computes the cross product of two Vec3's
+   * Computes the cross product of two Vec3Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  cross(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  cross(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
 
   /**
-   * Performs a linear interpolation between two Vec3's
+   * Performs a linear interpolation between two Vec3Type's
    *
    * @param out the receiving vector
    * @param a the first operand
@@ -816,37 +819,38 @@ interface Vec3 extends Float32Array {
    * @param t interpolation amount between the two inputs
    * @returns out
    */
-  lerp(out: Vec3, a: Vec3|number[], b: Vec3|number[], t: number): Vec3;
+  lerp(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[], t: number):
+      Vec3Type;
 
   /**
    * Performs a hermite interpolation with two control points
    *
-   * @param {Vec3} out the receiving vector
-   * @param {Vec3} a the first operand
-   * @param {Vec3} b the second operand
-   * @param {Vec3} c the third operand
-   * @param {Vec3} d the fourth operand
+   * @param {Vec3Type} out the receiving vector
+   * @param {Vec3Type} a the first operand
+   * @param {Vec3Type} b the second operand
+   * @param {Vec3Type} c the third operand
+   * @param {Vec3Type} d the fourth operand
    * @param {number} t interpolation amount between the two inputs
-   * @returns {Vec3} out
+   * @returns {Vec3Type} out
    */
   hermite(
-      out: Vec3, a: Vec3|number[], b: Vec3|number[], c: Vec3|number[],
-      d: Vec3|number[], t: number): Vec3;
+      out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[],
+      c: Vec3Type|number[], d: Vec3Type|number[], t: number): Vec3Type;
 
   /**
    * Performs a bezier interpolation with two control points
    *
-   * @param {Vec3} out the receiving vector
-   * @param {Vec3} a the first operand
-   * @param {Vec3} b the second operand
-   * @param {Vec3} c the third operand
-   * @param {Vec3} d the fourth operand
+   * @param {Vec3Type} out the receiving vector
+   * @param {Vec3Type} a the first operand
+   * @param {Vec3Type} b the second operand
+   * @param {Vec3Type} c the third operand
+   * @param {Vec3Type} d the fourth operand
    * @param {number} t interpolation amount between the two inputs
-   * @returns {Vec3} out
+   * @returns {Vec3Type} out
    */
   bezier(
-      out: Vec3, a: Vec3|number[], b: Vec3|number[], c: Vec3|number[],
-      d: Vec3|number[], t: number): Vec3;
+      out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[],
+      c: Vec3Type|number[], d: Vec3Type|number[], t: number): Vec3Type;
 
   /**
    * Generates a random unit vector
@@ -854,7 +858,7 @@ interface Vec3 extends Float32Array {
    * @param out the receiving vector
    * @returns out
    */
-  random(out: Vec3): Vec3;
+  random(out: Vec3Type): Vec3Type;
 
   /**
    * Generates a random vector with the given scale
@@ -864,20 +868,20 @@ interface Vec3 extends Float32Array {
    *     will be returned
    * @returns out
    */
-  random(out: Vec3, scale: number): Vec3;
+  random(out: Vec3Type, scale: number): Vec3Type;
 
   /**
-   * Transforms the Vec3 with a Mat3.
+   * Transforms the Vec3Type with a Mat3Type.
    *
    * @param out the receiving vector
    * @param a the vector to transform
    * @param m the 3x3 matrix to transform with
    * @returns out
    */
-  transformMat3(out: Vec3, a: Vec3|number[], m: Mat3): Vec3;
+  transformMat3(out: Vec3Type, a: Vec3Type|number[], m: Mat3Type): Vec3Type;
 
   /**
-   * Transforms the Vec3 with a Mat4.
+   * Transforms the Vec3Type with a Mat4Type.
    * 4th vector component is implicitly '1'
    *
    * @param out the receiving vector
@@ -885,54 +889,57 @@ interface Vec3 extends Float32Array {
    * @param m matrix to transform with
    * @returns out
    */
-  transformMat4(out: Vec3, a: Vec3|number[], m: Mat4): Vec3;
+  transformMat4(out: Vec3Type, a: Vec3Type|number[], m: Mat4Type): Vec3Type;
 
   /**
-   * Transforms the Vec3 with a Quat
+   * Transforms the Vec3Type with a QuatType
    *
    * @param out the receiving vector
    * @param a the vector to transform
    * @param q Quaternion to transform with
    * @returns out
    */
-  transformQuat(out: Vec3, a: Vec3|number[], q: Quat): Vec3;
+  transformQuat(out: Vec3Type, a: Vec3Type|number[], q: QuatType): Vec3Type;
 
 
   /**
    * Rotate a 3D vector around the x-axis
-   * @param out The receiving Vec3
-   * @param a The Vec3 point to rotate
+   * @param out The receiving Vec3Type
+   * @param a The Vec3Type point to rotate
    * @param b The origin of the rotation
    * @param c The angle of rotation
    * @returns out
    */
-  rotateX(out: Vec3, a: Vec3|number[], b: Vec3|number[], c: number): Vec3;
+  rotateX(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[], c: number):
+      Vec3Type;
 
   /**
    * Rotate a 3D vector around the y-axis
-   * @param out The receiving Vec3
-   * @param a The Vec3 point to rotate
+   * @param out The receiving Vec3Type
+   * @param a The Vec3Type point to rotate
    * @param b The origin of the rotation
    * @param c The angle of rotation
    * @returns out
    */
-  rotateY(out: Vec3, a: Vec3|number[], b: Vec3|number[], c: number): Vec3;
+  rotateY(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[], c: number):
+      Vec3Type;
 
   /**
    * Rotate a 3D vector around the z-axis
-   * @param out The receiving Vec3
-   * @param a The Vec3 point to rotate
+   * @param out The receiving Vec3Type
+   * @param a The Vec3Type point to rotate
    * @param b The origin of the rotation
    * @param c The angle of rotation
    * @returns out
    */
-  rotateZ(out: Vec3, a: Vec3|number[], b: Vec3|number[], c: number): Vec3;
+  rotateZ(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[], c: number):
+      Vec3Type;
 
   /**
    * Perform some operation over an array of vec3s.
    *
    * @param a the array of vectors to iterate over
-   * @param stride Number of elements between the start of each Vec3. If 0
+   * @param stride Number of elements between the start of each Vec3Type. If 0
    *     assumes tightly packed
    * @param offset Number of elements to skip at the beginning of the array
    * @param count Number of vec3s to iterate over. If 0 iterates over entire
@@ -944,14 +951,14 @@ interface Vec3 extends Float32Array {
    */
   forEach(
       a: Float32Array, stride: number, offset: number, count: number,
-      fn: (a: Vec3|number[], b: Vec3|number[], arg: any) => void,
+      fn: (a: Vec3Type|number[], b: Vec3Type|number[], arg: any) => void,
       arg: any): Float32Array;
 
   /**
    * Perform some operation over an array of vec3s.
    *
    * @param a the array of vectors to iterate over
-   * @param stride Number of elements between the start of each Vec3. If 0
+   * @param stride Number of elements between the start of each Vec3Type. If 0
    *     assumes tightly packed
    * @param offset Number of elements to skip at the beginning of the array
    * @param count Number of vec3s to iterate over. If 0 iterates over entire
@@ -962,7 +969,7 @@ interface Vec3 extends Float32Array {
    */
   forEach(
       a: Float32Array, stride: number, offset: number, count: number,
-      fn: (a: Vec3|number[], b: Vec3|number[]) => void): Float32Array;
+      fn: (a: Vec3Type|number[], b: Vec3Type|number[]) => void): Float32Array;
 
   /**
    * Get the angle between two 3D vectors
@@ -970,7 +977,7 @@ interface Vec3 extends Float32Array {
    * @param b The second operand
    * @returns The angle in radians
    */
-  angle(a: Vec3|number[], b: Vec3|number[]): number;
+  angle(a: Vec3Type|number[], b: Vec3Type|number[]): number;
 
   /**
    * Returns a string representation of a vector
@@ -978,48 +985,48 @@ interface Vec3 extends Float32Array {
    * @param a vector to represent as a string
    * @returns string representation of the vector
    */
-  str(a: Vec3|number[]): string;
+  str(a: Vec3Type|number[]): string;
 
   /**
    * Returns whether or not the vectors have exactly the same elements in the
    * same position (when compared with ===)
    *
-   * @param {Vec3} a The first vector.
-   * @param {Vec3} b The second vector.
+   * @param {Vec3Type} a The first vector.
+   * @param {Vec3Type} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  exactEquals(a: Vec3|number[], b: Vec3|number[]): boolean
+  exactEquals(a: Vec3Type|number[], b: Vec3Type|number[]): boolean
 
   /**
    * Returns whether or not the vectors have approximately the same
    * elements in the same position.
    *
-   * @param {Vec3} a The first vector.
-   * @param {Vec3} b The second vector.
+   * @param {Vec3Type} a The first vector.
+   * @param {Vec3Type} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  equals(a: Vec3|number[], b: Vec3|number[]): boolean
+  equals(a: Vec3Type|number[], b: Vec3Type|number[]): boolean
 }
 
-// Vec4
-interface Vec4 extends Float32Array {
+// Vec4Type
+interface Vec4Type extends Float32Array {
   /**
-   * Creates a new, empty Vec4
+   * Creates a new, empty Vec4Type
    *
    * @returns a new 4D vector
    */
-  create(): Vec4;
+  create(): Vec4Type;
 
   /**
-   * Creates a new Vec4 initialized with values from an existing vector
+   * Creates a new Vec4Type initialized with values from an existing vector
    *
    * @param a vector to clone
    * @returns a new 4D vector
    */
-  clone(a: Vec4|number[]): Vec4;
+  clone(a: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Creates a new Vec4 initialized with the given values
+   * Creates a new Vec4Type initialized with the given values
    *
    * @param x X component
    * @param y Y component
@@ -1027,19 +1034,19 @@ interface Vec4 extends Float32Array {
    * @param w W component
    * @returns a new 4D vector
    */
-  fromValues(x: number, y: number, z: number, w: number): Vec4;
+  fromValues(x: number, y: number, z: number, w: number): Vec4Type;
 
   /**
-   * Copy the values from one Vec4 to another
+   * Copy the values from one Vec4Type to another
    *
    * @param out the receiving vector
    * @param a the source vector
    * @returns out
    */
-  copy(out: Vec4, a: Vec4|number[]): Vec4;
+  copy(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Set the components of a Vec4 to the given values
+   * Set the components of a Vec4Type to the given values
    *
    * @param out the receiving vector
    * @param x X component
@@ -1048,17 +1055,17 @@ interface Vec4 extends Float32Array {
    * @param w W component
    * @returns out
    */
-  set(out: Vec4, x: number, y: number, z: number, w: number): Vec4;
+  set(out: Vec4Type, x: number, y: number, z: number, w: number): Vec4Type;
 
   /**
-   * Adds two Vec4's
+   * Adds two Vec4Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  add(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  add(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
 
   /**
    * Subtracts vector b from vector a
@@ -1068,7 +1075,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  subtract(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  subtract(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
 
   /**
    * Subtracts vector b from vector a
@@ -1078,107 +1085,107 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  sub(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  sub(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Multiplies two Vec4's
+   * Multiplies two Vec4Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  multiply(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Multiplies two Vec4's
+   * Multiplies two Vec4Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  mul(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Divides two Vec4's
+   * Divides two Vec4Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  divide(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  divide(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Divides two Vec4's
+   * Divides two Vec4Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  div(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  div(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Math.ceil the components of a Vec4
+   * Math.ceil the components of a Vec4Type
    *
-   * @param {Vec4} out the receiving vector
-   * @param {Vec4} a vector to ceil
-   * @returns {Vec4} out
+   * @param {Vec4Type} out the receiving vector
+   * @param {Vec4Type} a vector to ceil
+   * @returns {Vec4Type} out
    */
-  ceil(out: Vec4, a: Vec4|number[]): Vec4;
+  ceil(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Math.floor the components of a Vec4
+   * Math.floor the components of a Vec4Type
    *
-   * @param {Vec4} out the receiving vector
-   * @param {Vec4} a vector to floor
-   * @returns {Vec4} out
+   * @param {Vec4Type} out the receiving vector
+   * @param {Vec4Type} a vector to floor
+   * @returns {Vec4Type} out
    */
-  floor(out: Vec4, a: Vec4|number[]): Vec4;
+  floor(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Returns the minimum of two Vec4's
-   *
-   * @param out the receiving vector
-   * @param a the first operand
-   * @param b the second operand
-   * @returns out
-   */
-  min(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
-
-  /**
-   * Returns the maximum of two Vec4's
+   * Returns the minimum of two Vec4Type's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  max(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  min(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Math.round the components of a Vec4
+   * Returns the maximum of two Vec4Type's
    *
-   * @param {Vec4} out the receiving vector
-   * @param {Vec4} a vector to round
-   * @returns {Vec4} out
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
    */
-  round(out: Vec4, a: Vec4|number[]): Vec4;
+  max(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Scales a Vec4 by a scalar number
+   * Math.round the components of a Vec4Type
+   *
+   * @param {Vec4Type} out the receiving vector
+   * @param {Vec4Type} a vector to round
+   * @returns {Vec4Type} out
+   */
+  round(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
+
+  /**
+   * Scales a Vec4Type by a scalar number
    *
    * @param out the receiving vector
    * @param a the vector to scale
    * @param b amount to scale the vector by
    * @returns out
    */
-  scale(out: Vec4, a: Vec4|number[], b: number): Vec4;
+  scale(out: Vec4Type, a: Vec4Type|number[], b: number): Vec4Type;
 
   /**
-   * Adds two Vec4's after scaling the second operand by a scalar value
+   * Adds two Vec4Type's after scaling the second operand by a scalar value
    *
    * @param out the receiving vector
    * @param a the first operand
@@ -1186,115 +1193,116 @@ interface Vec4 extends Float32Array {
    * @param scale the amount to scale b by before adding
    * @returns out
    */
-  scaleAndAdd(out: Vec4, a: Vec4|number[], b: Vec4|number[], scale: number):
-      Vec4;
+  scaleAndAdd(
+      out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[],
+      scale: number): Vec4Type;
 
   /**
-   * Calculates the euclidian distance between two Vec4's
+   * Calculates the euclidian distance between two Vec4Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns distance between a and b
    */
-  distance(a: Vec4|number[], b: Vec4|number[]): number;
+  distance(a: Vec4Type|number[], b: Vec4Type|number[]): number;
 
   /**
-   * Calculates the euclidian distance between two Vec4's
+   * Calculates the euclidian distance between two Vec4Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns distance between a and b
    */
-  dist(a: Vec4|number[], b: Vec4|number[]): number;
+  dist(a: Vec4Type|number[], b: Vec4Type|number[]): number;
 
   /**
-   * Calculates the squared euclidian distance between two Vec4's
+   * Calculates the squared euclidian distance between two Vec4Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  squaredDistance(a: Vec4|number[], b: Vec4|number[]): number;
+  squaredDistance(a: Vec4Type|number[], b: Vec4Type|number[]): number;
 
   /**
-   * Calculates the squared euclidian distance between two Vec4's
+   * Calculates the squared euclidian distance between two Vec4Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  sqrDist(a: Vec4|number[], b: Vec4|number[]): number;
+  sqrDist(a: Vec4Type|number[], b: Vec4Type|number[]): number;
 
   /**
-   * Calculates the length of a Vec4
+   * Calculates the length of a Vec4Type
    *
    * @param a vector to calculate length of
    * @returns length of a
    */
-  length(a: Vec4|number[]): number;
+  length(a: Vec4Type|number[]): number;
 
   /**
-   * Calculates the length of a Vec4
+   * Calculates the length of a Vec4Type
    *
    * @param a vector to calculate length of
    * @returns length of a
    */
-  len(a: Vec4|number[]): number;
+  len(a: Vec4Type|number[]): number;
 
   /**
-   * Calculates the squared length of a Vec4
+   * Calculates the squared length of a Vec4Type
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  squaredLength(a: Vec4|number[]): number;
+  squaredLength(a: Vec4Type|number[]): number;
 
   /**
-   * Calculates the squared length of a Vec4
+   * Calculates the squared length of a Vec4Type
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  sqrLen(a: Vec4|number[]): number;
+  sqrLen(a: Vec4Type|number[]): number;
 
   /**
-   * Negates the components of a Vec4
+   * Negates the components of a Vec4Type
    *
    * @param out the receiving vector
    * @param a vector to negate
    * @returns out
    */
-  negate(out: Vec4, a: Vec4|number[]): Vec4;
+  negate(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Returns the inverse of the components of a Vec4
+   * Returns the inverse of the components of a Vec4Type
    *
    * @param out the receiving vector
    * @param a vector to invert
    * @returns out
    */
-  inverse(out: Vec4, a: Vec4|number[]): Vec4;
+  inverse(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Normalize a Vec4
+   * Normalize a Vec4Type
    *
    * @param out the receiving vector
    * @param a vector to normalize
    * @returns out
    */
-  normalize(out: Vec4, a: Vec4|number[]): Vec4;
+  normalize(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
 
   /**
-   * Calculates the dot product of two Vec4's
+   * Calculates the dot product of two Vec4Type's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns dot product of a and b
    */
-  dot(a: Vec4|number[], b: Vec4|number[]): number;
+  dot(a: Vec4Type|number[], b: Vec4Type|number[]): number;
 
   /**
-   * Performs a linear interpolation between two Vec4's
+   * Performs a linear interpolation between two Vec4Type's
    *
    * @param out the receiving vector
    * @param a the first operand
@@ -1302,7 +1310,8 @@ interface Vec4 extends Float32Array {
    * @param t interpolation amount between the two inputs
    * @returns out
    */
-  lerp(out: Vec4, a: Vec4|number[], b: Vec4|number[], t: number): Vec4;
+  lerp(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[], t: number):
+      Vec4Type;
 
   /**
    * Generates a random unit vector
@@ -1310,7 +1319,7 @@ interface Vec4 extends Float32Array {
    * @param out the receiving vector
    * @returns out
    */
-  random(out: Vec4): Vec4;
+  random(out: Vec4Type): Vec4Type;
 
   /**
    * Generates a random vector with the given scale
@@ -1320,20 +1329,20 @@ interface Vec4 extends Float32Array {
    *     will be returned
    * @returns out
    */
-  random(out: Vec4, scale: number): Vec4;
+  random(out: Vec4Type, scale: number): Vec4Type;
 
   /**
-   * Transforms the Vec4 with a Mat4.
+   * Transforms the Vec4Type with a Mat4Type.
    *
    * @param out the receiving vector
    * @param a the vector to transform
    * @param m matrix to transform with
    * @returns out
    */
-  transformMat4(out: Vec4, a: Vec4|number[], m: Mat4): Vec4;
+  transformMat4(out: Vec4Type, a: Vec4Type|number[], m: Mat4Type): Vec4Type;
 
   /**
-   * Transforms the Vec4 with a Quat
+   * Transforms the Vec4Type with a QuatType
    *
    * @param out the receiving vector
    * @param a the vector to transform
@@ -1341,13 +1350,13 @@ interface Vec4 extends Float32Array {
    * @returns out
    */
 
-  transformQuat(out: Vec4, a: Vec4|number[], q: Quat): Vec4;
+  transformQuat(out: Vec4Type, a: Vec4Type|number[], q: QuatType): Vec4Type;
 
   /**
    * Perform some operation over an array of Vec4s.
    *
    * @param a the array of vectors to iterate over
-   * @param stride Number of elements between the start of each Vec4. If 0
+   * @param stride Number of elements between the start of each Vec4Type. If 0
    *     assumes tightly packed
    * @param offset Number of elements to skip at the beginning of the array
    * @param count Number of Vec4s to iterate over. If 0 iterates over entire
@@ -1359,14 +1368,14 @@ interface Vec4 extends Float32Array {
    */
   forEach(
       a: Float32Array, stride: number, offset: number, count: number,
-      fn: (a: Vec4|number[], b: Vec4|number[], arg: any) => void,
+      fn: (a: Vec4Type|number[], b: Vec4Type|number[], arg: any) => void,
       arg: any): Float32Array;
 
   /**
    * Perform some operation over an array of Vec4s.
    *
    * @param a the array of vectors to iterate over
-   * @param stride Number of elements between the start of each Vec4. If 0
+   * @param stride Number of elements between the start of each Vec4Type. If 0
    *     assumes tightly packed
    * @param offset Number of elements to skip at the beginning of the array
    * @param count Number of Vec4s to iterate over. If 0 iterates over entire
@@ -1377,7 +1386,7 @@ interface Vec4 extends Float32Array {
    */
   forEach(
       a: Float32Array, stride: number, offset: number, count: number,
-      fn: (a: Vec4|number[], b: Vec4|number[]) => void): Float32Array;
+      fn: (a: Vec4Type|number[], b: Vec4Type|number[]) => void): Float32Array;
 
   /**
    * Returns a string representation of a vector
@@ -1385,202 +1394,203 @@ interface Vec4 extends Float32Array {
    * @param a vector to represent as a string
    * @returns string representation of the vector
    */
-  str(a: Vec4|number[]): string;
+  str(a: Vec4Type|number[]): string;
 
   /**
    * Returns whether or not the vectors have exactly the same elements in the
    * same position (when compared with ===)
    *
-   * @param {Vec4} a The first vector.
-   * @param {Vec4} b The second vector.
+   * @param {Vec4Type} a The first vector.
+   * @param {Vec4Type} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  exactEquals(a: Vec4|number[], b: Vec4|number[]): boolean;
+  exactEquals(a: Vec4Type|number[], b: Vec4Type|number[]): boolean;
 
   /**
    * Returns whether or not the vectors have approximately the same elements
    * in the same position.
    *
-   * @param {Vec4} a The first vector.
-   * @param {Vec4} b The second vector.
+   * @param {Vec4Type} a The first vector.
+   * @param {Vec4Type} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  equals(a: Vec4|number[], b: Vec4|number[]): boolean;
+  equals(a: Vec4Type|number[], b: Vec4Type|number[]): boolean;
 }
 
-// Mat2
-interface Mat2 extends Float32Array {
+// Mat2Type
+interface Mat2Type extends Float32Array {
   /**
-   * Creates a new identity Mat2
+   * Creates a new identity Mat2Type
    *
    * @returns a new 2x2 matrix
    */
-  create(): Mat2;
+  create(): Mat2Type;
 
   /**
-   * Creates a new Mat2 initialized with values from an existing matrix
+   * Creates a new Mat2Type initialized with values from an existing matrix
    *
    * @param a matrix to clone
    * @returns a new 2x2 matrix
    */
-  clone(a: Mat2): Mat2;
+  clone(a: Mat2Type): Mat2Type;
 
   /**
-   * Copy the values from one Mat2 to another
+   * Copy the values from one Mat2Type to another
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  copy(out: Mat2, a: Mat2): Mat2;
+  copy(out: Mat2Type, a: Mat2Type): Mat2Type;
 
   /**
-   * Set a Mat2 to the identity matrix
+   * Set a Mat2Type to the identity matrix
    *
    * @param out the receiving matrix
    * @returns out
    */
-  identity(out: Mat2): Mat2;
+  identity(out: Mat2Type): Mat2Type;
 
   /**
-   * Create a new Mat2 with the given values
+   * Create a new Mat2Type with the given values
    *
    * @param {number} m00 Component in column 0, row 0 position (index 0)
    * @param {number} m01 Component in column 0, row 1 position (index 1)
    * @param {number} m10 Component in column 1, row 0 position (index 2)
    * @param {number} m11 Component in column 1, row 1 position (index 3)
-   * @returns {Mat2} out A new 2x2 matrix
+   * @returns {Mat2Type} out A new 2x2 matrix
    */
-  fromValues(m00: number, m01: number, m10: number, m11: number): Mat2;
+  fromValues(m00: number, m01: number, m10: number, m11: number): Mat2Type;
 
   /**
-   * Set the components of a Mat2 to the given values
+   * Set the components of a Mat2Type to the given values
    *
-   * @param {Mat2} out the receiving matrix
+   * @param {Mat2Type} out the receiving matrix
    * @param {number} m00 Component in column 0, row 0 position (index 0)
    * @param {number} m01 Component in column 0, row 1 position (index 1)
    * @param {number} m10 Component in column 1, row 0 position (index 2)
    * @param {number} m11 Component in column 1, row 1 position (index 3)
-   * @returns {Mat2} out
+   * @returns {Mat2Type} out
    */
-  set(out: Mat2, m00: number, m01: number, m10: number, m11: number): Mat2;
+  set(out: Mat2Type, m00: number, m01: number, m10: number,
+      m11: number): Mat2Type;
 
   /**
-   * Transpose the values of a Mat2
+   * Transpose the values of a Mat2Type
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  transpose(out: Mat2, a: Mat2): Mat2;
+  transpose(out: Mat2Type, a: Mat2Type): Mat2Type;
 
   /**
-   * Inverts a Mat2
+   * Inverts a Mat2Type
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  invert(out: Mat2, a: Mat2): Mat2|null;
+  invert(out: Mat2Type, a: Mat2Type): Mat2Type|null;
 
   /**
-   * Calculates the adjugate of a Mat2
+   * Calculates the adjugate of a Mat2Type
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  adjoint(out: Mat2, a: Mat2): Mat2;
+  adjoint(out: Mat2Type, a: Mat2Type): Mat2Type;
 
   /**
-   * Calculates the determinant of a Mat2
+   * Calculates the determinant of a Mat2Type
    *
    * @param a the source matrix
    * @returns determinant of a
    */
-  determinant(a: Mat2): number;
+  determinant(a: Mat2Type): number;
 
   /**
-   * Multiplies two Mat2's
+   * Multiplies two Mat2Type's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Mat2, a: Mat2, b: Mat2): Mat2;
+  multiply(out: Mat2Type, a: Mat2Type, b: Mat2Type): Mat2Type;
 
   /**
-   * Multiplies two Mat2's
+   * Multiplies two Mat2Type's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Mat2, a: Mat2, b: Mat2): Mat2;
+  mul(out: Mat2Type, a: Mat2Type, b: Mat2Type): Mat2Type;
 
   /**
-   * Rotates a Mat2 by the given angle
+   * Rotates a Mat2Type by the given angle
    *
    * @param out the receiving matrix
    * @param a the matrix to rotate
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  rotate(out: Mat2, a: Mat2, rad: number): Mat2;
+  rotate(out: Mat2Type, a: Mat2Type, rad: number): Mat2Type;
 
   /**
-   * Scales the Mat2 by the dimensions in the given Vec2
+   * Scales the Mat2Type by the dimensions in the given Vec2Type
    *
    * @param out the receiving matrix
    * @param a the matrix to rotate
-   * @param v the Vec2 to scale the matrix by
+   * @param v the Vec2Type to scale the matrix by
    * @returns out
    **/
-  scale(out: Mat2, a: Mat2, v: Vec2|number[]): Mat2;
+  scale(out: Mat2Type, a: Mat2Type, v: Vec2Type|number[]): Mat2Type;
 
   /**
    * Creates a matrix from a given angle
    * This is equivalent to (but much faster than):
    *
-   *     Mat2.identity(dest);
-   *     Mat2.rotate(dest, dest, rad);
+   *     Mat2Type.identity(dest);
+   *     Mat2Type.rotate(dest, dest, rad);
    *
-   * @param {Mat2} out Mat2 receiving operation result
+   * @param {Mat2Type} out Mat2Type receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @returns {Mat2} out
+   * @returns {Mat2Type} out
    */
-  fromRotation(out: Mat2, rad: number): Mat2;
+  fromRotation(out: Mat2Type, rad: number): Mat2Type;
 
   /**
    * Creates a matrix from a vector scaling
    * This is equivalent to (but much faster than):
    *
-   *     Mat2.identity(dest);
-   *     Mat2.scale(dest, dest, vec);
+   *     Mat2Type.identity(dest);
+   *     Mat2Type.scale(dest, dest, vec);
    *
-   * @param {Mat2} out Mat2 receiving operation result
-   * @param {Vec2} v Scaling vector
-   * @returns {Mat2} out
+   * @param {Mat2Type} out Mat2Type receiving operation result
+   * @param {Vec2Type} v Scaling vector
+   * @returns {Mat2Type} out
    */
-  fromScaling(out: Mat2, v: Vec2|number[]): Mat2;
+  fromScaling(out: Mat2Type, v: Vec2Type|number[]): Mat2Type;
 
   /**
-   * Returns a string representation of a Mat2
+   * Returns a string representation of a Mat2Type
    *
    * @param a matrix to represent as a string
    * @returns string representation of the matrix
    */
-  str(a: Mat2): string;
+  str(a: Mat2Type): string;
 
   /**
-   * Returns Frobenius norm of a Mat2
+   * Returns Frobenius norm of a Mat2Type
    *
    * @param a the matrix to calculate Frobenius norm of
    * @returns Frobenius norm
    */
-  frob(a: Mat2): number;
+  frob(a: Mat2Type): number;
 
   /**
    * Returns L, D and U matrices (Lower triangular, Diagonal and Upper
@@ -1590,118 +1600,119 @@ interface Mat2 extends Float32Array {
    * @param U the upper triangular matrix
    * @param a the input matrix to factorize
    */
-  LDU(L: Mat2, D: Mat2, U: Mat2, a: Mat2): Mat2;
+  LDU(L: Mat2Type, D: Mat2Type, U: Mat2Type, a: Mat2Type): Mat2Type;
 
   /**
-   * Adds two Mat2's
+   * Adds two Mat2Type's
    *
-   * @param {Mat2} out the receiving matrix
-   * @param {Mat2} a the first operand
-   * @param {Mat2} b the second operand
-   * @returns {Mat2} out
+   * @param {Mat2Type} out the receiving matrix
+   * @param {Mat2Type} a the first operand
+   * @param {Mat2Type} b the second operand
+   * @returns {Mat2Type} out
    */
-  add(out: Mat2, a: Mat2, b: Mat2): Mat2;
-
-  /**
-   * Subtracts matrix b from matrix a
-   *
-   * @param {Mat2} out the receiving matrix
-   * @param {Mat2} a the first operand
-   * @param {Mat2} b the second operand
-   * @returns {Mat2} out
-   */
-  subtract(out: Mat2, a: Mat2, b: Mat2): Mat2;
+  add(out: Mat2Type, a: Mat2Type, b: Mat2Type): Mat2Type;
 
   /**
    * Subtracts matrix b from matrix a
    *
-   * @param {Mat2} out the receiving matrix
-   * @param {Mat2} a the first operand
-   * @param {Mat2} b the second operand
-   * @returns {Mat2} out
+   * @param {Mat2Type} out the receiving matrix
+   * @param {Mat2Type} a the first operand
+   * @param {Mat2Type} b the second operand
+   * @returns {Mat2Type} out
    */
-  sub(out: Mat2, a: Mat2, b: Mat2): Mat2;
+  subtract(out: Mat2Type, a: Mat2Type, b: Mat2Type): Mat2Type;
+
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat2Type} out the receiving matrix
+   * @param {Mat2Type} a the first operand
+   * @param {Mat2Type} b the second operand
+   * @returns {Mat2Type} out
+   */
+  sub(out: Mat2Type, a: Mat2Type, b: Mat2Type): Mat2Type;
 
   /**
    * Returns whether or not the matrices have exactly the same elements in the
    * same position (when compared with ===)
    *
-   * @param {Mat2} a The first matrix.
-   * @param {Mat2} b The second matrix.
+   * @param {Mat2Type} a The first matrix.
+   * @param {Mat2Type} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  exactEquals(a: Mat2, b: Mat2): boolean;
+  exactEquals(a: Mat2Type, b: Mat2Type): boolean;
 
   /**
    * Returns whether or not the matrices have approximately the same elements
    * in the same position.
    *
-   * @param {Mat2} a The first matrix.
-   * @param {Mat2} b The second matrix.
+   * @param {Mat2Type} a The first matrix.
+   * @param {Mat2Type} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  equals(a: Mat2, b: Mat2): boolean;
+  equals(a: Mat2Type, b: Mat2Type): boolean;
 
   /**
    * Multiply each element of the matrix by a scalar.
    *
-   * @param {Mat2} out the receiving matrix
-   * @param {Mat2} a the matrix to scale
+   * @param {Mat2Type} out the receiving matrix
+   * @param {Mat2Type} a the matrix to scale
    * @param {number} b amount to scale the matrix's elements by
-   * @returns {Mat2} out
+   * @returns {Mat2Type} out
    */
-  multiplyScalar(out: Mat2, a: Mat2, b: number): Mat2
+  multiplyScalar(out: Mat2Type, a: Mat2Type, b: number): Mat2Type
 
   /**
-   * Adds two Mat2's after multiplying each element of the second operand
+   * Adds two Mat2Type's after multiplying each element of the second operand
    * by a scalar value.
    *
-   * @param {Mat2} out the receiving vector
-   * @param {Mat2} a the first operand
-   * @param {Mat2} b the second operand
+   * @param {Mat2Type} out the receiving vector
+   * @param {Mat2Type} a the first operand
+   * @param {Mat2Type} b the second operand
    * @param {number} scale the amount to scale b's elements by before
    *     adding
-   * @returns {Mat2} out
+   * @returns {Mat2Type} out
    */
-  multiplyScalarAndAdd(out: Mat2, a: Mat2, b: Mat2, scale: number): Mat2
+  multiplyScalarAndAdd(out: Mat2Type, a: Mat2Type, b: Mat2Type, scale: number):
+      Mat2Type
 }
 
-// Mat2d
-interface Mat2d extends Float32Array {
+// Mat2dType
+interface Mat2dType extends Float32Array {
   /**
-   * Creates a new identity Mat2d
+   * Creates a new identity Mat2dType
    *
    * @returns a new 2x3 matrix
    */
-  create(): Mat2d;
+  create(): Mat2dType;
 
   /**
-   * Creates a new Mat2d initialized with values from an existing matrix
+   * Creates a new Mat2dType initialized with values from an existing matrix
    *
    * @param a matrix to clone
    * @returns a new 2x3 matrix
    */
-  clone(a: Mat2d): Mat2d;
+  clone(a: Mat2dType): Mat2dType;
 
   /**
-   * Copy the values from one Mat2d to another
+   * Copy the values from one Mat2dType to another
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  copy(out: Mat2d, a: Mat2d): Mat2d;
+  copy(out: Mat2dType, a: Mat2dType): Mat2dType;
 
   /**
-   * Set a Mat2d to the identity matrix
+   * Set a Mat2dType to the identity matrix
    *
    * @param out the receiving matrix
    * @returns out
    */
-  identity(out: Mat2d): Mat2d;
+  identity(out: Mat2dType): Mat2dType;
 
   /**
-   * Create a new Mat2d with the given values
+   * Create a new Mat2dType with the given values
    *
    * @param {number} a Component A (index 0)
    * @param {number} b Component B (index 1)
@@ -1709,259 +1720,261 @@ interface Mat2d extends Float32Array {
    * @param {number} d Component D (index 3)
    * @param {number} tx Component TX (index 4)
    * @param {number} ty Component TY (index 5)
-   * @returns {Mat2d} A new Mat2d
+   * @returns {Mat2dType} A new Mat2dType
    */
   fromValues(
-      a: number, b: number, c: number, d: number, tx: number, ty: number): Mat2d
+      a: number, b: number, c: number, d: number, tx: number,
+      ty: number): Mat2dType
 
 
   /**
-   * Set the components of a Mat2d to the given values
+   * Set the components of a Mat2dType to the given values
    *
-   * @param {Mat2d} out the receiving matrix
+   * @param {Mat2dType} out the receiving matrix
    * @param {number} a Component A (index 0)
    * @param {number} b Component B (index 1)
    * @param {number} c Component C (index 2)
    * @param {number} d Component D (index 3)
    * @param {number} tx Component TX (index 4)
    * @param {number} ty Component TY (index 5)
-   * @returns {Mat2d} out
+   * @returns {Mat2dType} out
    */
-  set(out: Mat2d, a: number, b: number, c: number, d: number, tx: number,
-      ty: number): Mat2d
+  set(out: Mat2dType, a: number, b: number, c: number, d: number, tx: number,
+      ty: number): Mat2dType
 
   /**
-   * Inverts a Mat2d
+   * Inverts a Mat2dType
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  invert(out: Mat2d, a: Mat2d): Mat2d|null;
+  invert(out: Mat2dType, a: Mat2dType): Mat2dType|null;
 
   /**
-   * Calculates the determinant of a Mat2d
+   * Calculates the determinant of a Mat2dType
    *
    * @param a the source matrix
    * @returns determinant of a
    */
-  determinant(a: Mat2d): number;
+  determinant(a: Mat2dType): number;
 
   /**
-   * Multiplies two Mat2d's
+   * Multiplies two Mat2dType's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d;
+  multiply(out: Mat2dType, a: Mat2dType, b: Mat2dType): Mat2dType;
 
   /**
-   * Multiplies two Mat2d's
+   * Multiplies two Mat2dType's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d;
+  mul(out: Mat2dType, a: Mat2dType, b: Mat2dType): Mat2dType;
 
   /**
-   * Rotates a Mat2d by the given angle
+   * Rotates a Mat2dType by the given angle
    *
    * @param out the receiving matrix
    * @param a the matrix to rotate
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  rotate(out: Mat2d, a: Mat2d, rad: number): Mat2d;
+  rotate(out: Mat2dType, a: Mat2dType, rad: number): Mat2dType;
 
   /**
-   * Scales the Mat2d by the dimensions in the given Vec2
+   * Scales the Mat2dType by the dimensions in the given Vec2Type
    *
    * @param out the receiving matrix
    * @param a the matrix to translate
-   * @param v the Vec2 to scale the matrix by
+   * @param v the Vec2Type to scale the matrix by
    * @returns out
    **/
-  scale(out: Mat2d, a: Mat2d, v: Vec2|number[]): Mat2d;
+  scale(out: Mat2dType, a: Mat2dType, v: Vec2Type|number[]): Mat2dType;
 
   /**
-   * Translates the Mat2d by the dimensions in the given Vec2
+   * Translates the Mat2dType by the dimensions in the given Vec2Type
    *
    * @param out the receiving matrix
    * @param a the matrix to translate
-   * @param v the Vec2 to translate the matrix by
+   * @param v the Vec2Type to translate the matrix by
    * @returns out
    **/
-  translate(out: Mat2d, a: Mat2d, v: Vec2|number[]): Mat2d;
+  translate(out: Mat2dType, a: Mat2dType, v: Vec2Type|number[]): Mat2dType;
 
   /**
    * Creates a matrix from a given angle
    * This is equivalent to (but much faster than):
    *
-   *     Mat2d.identity(dest);
-   *     Mat2d.rotate(dest, dest, rad);
+   *     Mat2dType.identity(dest);
+   *     Mat2dType.rotate(dest, dest, rad);
    *
-   * @param {Mat2d} out Mat2d receiving operation result
+   * @param {Mat2dType} out Mat2dType receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @returns {Mat2d} out
+   * @returns {Mat2dType} out
    */
-  fromRotation(out: Mat2d, rad: number): Mat2d;
+  fromRotation(out: Mat2dType, rad: number): Mat2dType;
 
   /**
    * Creates a matrix from a vector scaling
    * This is equivalent to (but much faster than):
    *
-   *     Mat2d.identity(dest);
-   *     Mat2d.scale(dest, dest, vec);
+   *     Mat2dType.identity(dest);
+   *     Mat2dType.scale(dest, dest, vec);
    *
-   * @param {Mat2d} out Mat2d receiving operation result
-   * @param {Vec2} v Scaling vector
-   * @returns {Mat2d} out
+   * @param {Mat2dType} out Mat2dType receiving operation result
+   * @param {Vec2Type} v Scaling vector
+   * @returns {Mat2dType} out
    */
-  fromScaling(out: Mat2d, v: Vec2|number[]): Mat2d;
+  fromScaling(out: Mat2dType, v: Vec2Type|number[]): Mat2dType;
 
   /**
    * Creates a matrix from a vector translation
    * This is equivalent to (but much faster than):
    *
-   *     Mat2d.identity(dest);
-   *     Mat2d.translate(dest, dest, vec);
+   *     Mat2dType.identity(dest);
+   *     Mat2dType.translate(dest, dest, vec);
    *
-   * @param {Mat2d} out Mat2d receiving operation result
-   * @param {Vec2} v Translation vector
-   * @returns {Mat2d} out
+   * @param {Mat2dType} out Mat2dType receiving operation result
+   * @param {Vec2Type} v Translation vector
+   * @returns {Mat2dType} out
    */
-  fromTranslation(out: Mat2d, v: Vec2|number[]): Mat2d
+  fromTranslation(out: Mat2dType, v: Vec2Type|number[]): Mat2dType
 
   /**
-   * Returns a string representation of a Mat2d
+   * Returns a string representation of a Mat2dType
    *
    * @param a matrix to represent as a string
    * @returns string representation of the matrix
    */
-  str(a: Mat2d): string;
+  str(a: Mat2dType): string;
 
   /**
-   * Returns Frobenius norm of a Mat2d
+   * Returns Frobenius norm of a Mat2dType
    *
    * @param a the matrix to calculate Frobenius norm of
    * @returns Frobenius norm
    */
-  frob(a: Mat2d): number;
+  frob(a: Mat2dType): number;
 
   /**
-   * Adds two Mat2d's
+   * Adds two Mat2dType's
    *
-   * @param {Mat2d} out the receiving matrix
-   * @param {Mat2d} a the first operand
-   * @param {Mat2d} b the second operand
-   * @returns {Mat2d} out
+   * @param {Mat2dType} out the receiving matrix
+   * @param {Mat2dType} a the first operand
+   * @param {Mat2dType} b the second operand
+   * @returns {Mat2dType} out
    */
-  add(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
-
-  /**
-   * Subtracts matrix b from matrix a
-   *
-   * @param {Mat2d} out the receiving matrix
-   * @param {Mat2d} a the first operand
-   * @param {Mat2d} b the second operand
-   * @returns {Mat2d} out
-   */
-  subtract(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
+  add(out: Mat2dType, a: Mat2dType, b: Mat2dType): Mat2dType
 
   /**
    * Subtracts matrix b from matrix a
    *
-   * @param {Mat2d} out the receiving matrix
-   * @param {Mat2d} a the first operand
-   * @param {Mat2d} b the second operand
-   * @returns {Mat2d} out
+   * @param {Mat2dType} out the receiving matrix
+   * @param {Mat2dType} a the first operand
+   * @param {Mat2dType} b the second operand
+   * @returns {Mat2dType} out
    */
-  sub(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
+  subtract(out: Mat2dType, a: Mat2dType, b: Mat2dType): Mat2dType
+
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat2dType} out the receiving matrix
+   * @param {Mat2dType} a the first operand
+   * @param {Mat2dType} b the second operand
+   * @returns {Mat2dType} out
+   */
+  sub(out: Mat2dType, a: Mat2dType, b: Mat2dType): Mat2dType
 
   /**
    * Multiply each element of the matrix by a scalar.
    *
-   * @param {Mat2d} out the receiving matrix
-   * @param {Mat2d} a the matrix to scale
+   * @param {Mat2dType} out the receiving matrix
+   * @param {Mat2dType} a the matrix to scale
    * @param {number} b amount to scale the matrix's elements by
-   * @returns {Mat2d} out
+   * @returns {Mat2dType} out
    */
-  multiplyScalar(out: Mat2d, a: Mat2d, b: number): Mat2d;
+  multiplyScalar(out: Mat2dType, a: Mat2dType, b: number): Mat2dType;
 
   /**
-   * Adds two Mat2d's after multiplying each element of the second operand by
-   * a scalar value.
+   * Adds two Mat2dType's after multiplying each element of the second operand
+   * by a scalar value.
    *
-   * @param {Mat2d} out the receiving vector
-   * @param {Mat2d} a the first operand
-   * @param {Mat2d} b the second operand
+   * @param {Mat2dType} out the receiving vector
+   * @param {Mat2dType} a the first operand
+   * @param {Mat2dType} b the second operand
    * @param {number} scale the amount to scale b's elements by before adding
-   * @returns {Mat2d} out
+   * @returns {Mat2dType} out
    */
-  multiplyScalarAndAdd(out: Mat2d, a: Mat2d, b: Mat2d, scale: number): Mat2d
+  multiplyScalarAndAdd(
+      out: Mat2dType, a: Mat2dType, b: Mat2dType, scale: number): Mat2dType
 
   /**
    * Returns whether or not the matrices have exactly the same elements in
    * the same position (when compared with ===)
    *
-   * @param {Mat2d} a The first matrix.
-   * @param {Mat2d} b The second matrix.
+   * @param {Mat2dType} a The first matrix.
+   * @param {Mat2dType} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  exactEquals(a: Mat2d, b: Mat2d): boolean;
+  exactEquals(a: Mat2dType, b: Mat2dType): boolean;
 
   /**
    * Returns whether or not the matrices have approximately the same elements
    * in the same position.
    *
-   * @param {Mat2d} a The first matrix.
-   * @param {Mat2d} b The second matrix.
+   * @param {Mat2dType} a The first matrix.
+   * @param {Mat2dType} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  equals(a: Mat2d, b: Mat2d): boolean
+  equals(a: Mat2dType, b: Mat2dType): boolean
 }
 
-// Mat3
-interface Mat3 extends Float32Array {
+// Mat3Type
+interface Mat3Type extends Float32Array {
   /**
-   * Creates a new identity Mat3
+   * Creates a new identity Mat3Type
    *
    * @returns a new 3x3 matrix
    */
-  create(): Mat3;
+  create(): Mat3Type;
 
   /**
-   * Copies the upper-left 3x3 values into the given Mat3.
+   * Copies the upper-left 3x3 values into the given Mat3Type.
    *
-   * @param {Mat3} out the receiving 3x3 matrix
-   * @param {Mat4} a   the source 4x4 matrix
-   * @returns {Mat3} out
+   * @param {Mat3Type} out the receiving 3x3 matrix
+   * @param {Mat4Type} a   the source 4x4 matrix
+   * @returns {Mat3Type} out
    */
-  fromMat4(out: Mat3, a: Mat4): Mat3
+  fromMat4(out: Mat3Type, a: Mat4Type): Mat3Type
 
   /**
-   * Creates a new Mat3 initialized with values from an existing matrix
+   * Creates a new Mat3Type initialized with values from an existing matrix
    *
    * @param a matrix to clone
    * @returns a new 3x3 matrix
    */
-  clone(a: Mat3): Mat3;
+  clone(a: Mat3Type): Mat3Type;
 
   /**
-   * Copy the values from one Mat3 to another
+   * Copy the values from one Mat3Type to another
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  copy(out: Mat3, a: Mat3): Mat3;
+  copy(out: Mat3Type, a: Mat3Type): Mat3Type;
 
   /**
-   * Create a new Mat3 with the given values
+   * Create a new Mat3Type with the given values
    *
    * @param {number} m00 Component in column 0, row 0 position (index 0)
    * @param {number} m01 Component in column 0, row 1 position (index 1)
@@ -1972,17 +1985,17 @@ interface Mat3 extends Float32Array {
    * @param {number} m20 Component in column 2, row 0 position (index 6)
    * @param {number} m21 Component in column 2, row 1 position (index 7)
    * @param {number} m22 Component in column 2, row 2 position (index 8)
-   * @returns {Mat3} A new Mat3
+   * @returns {Mat3Type} A new Mat3Type
    */
   fromValues(
       m00: number, m01: number, m02: number, m10: number, m11: number,
-      m12: number, m20: number, m21: number, m22: number): Mat3;
+      m12: number, m20: number, m21: number, m22: number): Mat3Type;
 
 
   /**
-   * Set the components of a Mat3 to the given values
+   * Set the components of a Mat3Type to the given values
    *
-   * @param {Mat3} out the receiving matrix
+   * @param {Mat3Type} out the receiving matrix
    * @param {number} m00 Component in column 0, row 0 position (index 0)
    * @param {number} m01 Component in column 0, row 1 position (index 1)
    * @param {number} m02 Component in column 0, row 2 position (index 2)
@@ -1992,292 +2005,293 @@ interface Mat3 extends Float32Array {
    * @param {number} m20 Component in column 2, row 0 position (index 6)
    * @param {number} m21 Component in column 2, row 1 position (index 7)
    * @param {number} m22 Component in column 2, row 2 position (index 8)
-   * @returns {Mat3} out
+   * @returns {Mat3Type} out
    */
-  set(out: Mat3, m00: number, m01: number, m02: number, m10: number,
-      m11: number, m12: number, m20: number, m21: number, m22: number): Mat3
+  set(out: Mat3Type, m00: number, m01: number, m02: number, m10: number,
+      m11: number, m12: number, m20: number, m21: number, m22: number): Mat3Type
 
   /**
-   * Set a Mat3 to the identity matrix
+   * Set a Mat3Type to the identity matrix
    *
    * @param out the receiving matrix
    * @returns out
    */
-  identity(out: Mat3): Mat3;
+  identity(out: Mat3Type): Mat3Type;
 
   /**
-   * Transpose the values of a Mat3
-   *
-   * @param out the receiving matrix
-   * @param a the source matrix
-   * @returns out
-   */
-  transpose(out: Mat3, a: Mat3): Mat3;
-
-  /**
-   * Inverts a Mat3
+   * Transpose the values of a Mat3Type
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  invert(out: Mat3, a: Mat3): Mat3|null;
+  transpose(out: Mat3Type, a: Mat3Type): Mat3Type;
 
   /**
-   * Calculates the adjugate of a Mat3
+   * Inverts a Mat3Type
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  adjoint(out: Mat3, a: Mat3): Mat3;
+  invert(out: Mat3Type, a: Mat3Type): Mat3Type|null;
 
   /**
-   * Calculates the determinant of a Mat3
+   * Calculates the adjugate of a Mat3Type
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  adjoint(out: Mat3Type, a: Mat3Type): Mat3Type;
+
+  /**
+   * Calculates the determinant of a Mat3Type
    *
    * @param a the source matrix
    * @returns determinant of a
    */
-  determinant(a: Mat3): number;
+  determinant(a: Mat3Type): number;
 
   /**
-   * Multiplies two Mat3's
+   * Multiplies two Mat3Type's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Mat3, a: Mat3, b: Mat3): Mat3;
+  multiply(out: Mat3Type, a: Mat3Type, b: Mat3Type): Mat3Type;
 
   /**
-   * Multiplies two Mat3's
+   * Multiplies two Mat3Type's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Mat3, a: Mat3, b: Mat3): Mat3;
+  mul(out: Mat3Type, a: Mat3Type, b: Mat3Type): Mat3Type;
 
 
   /**
-   * Translate a Mat3 by the given vector
+   * Translate a Mat3Type by the given vector
    *
    * @param out the receiving matrix
    * @param a the matrix to translate
    * @param v vector to translate by
    * @returns out
    */
-  translate(out: Mat3, a: Mat3, v: Vec3|number[]): Mat3;
+  translate(out: Mat3Type, a: Mat3Type, v: Vec3Type|number[]): Mat3Type;
 
   /**
-   * Rotates a Mat3 by the given angle
+   * Rotates a Mat3Type by the given angle
    *
    * @param out the receiving matrix
    * @param a the matrix to rotate
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  rotate(out: Mat3, a: Mat3, rad: number): Mat3;
+  rotate(out: Mat3Type, a: Mat3Type, rad: number): Mat3Type;
 
   /**
-   * Scales the Mat3 by the dimensions in the given Vec2
+   * Scales the Mat3Type by the dimensions in the given Vec2Type
    *
    * @param out the receiving matrix
    * @param a the matrix to rotate
-   * @param v the Vec2 to scale the matrix by
+   * @param v the Vec2Type to scale the matrix by
    * @returns out
    **/
-  scale(out: Mat3, a: Mat3, v: Vec2|number[]): Mat3;
+  scale(out: Mat3Type, a: Mat3Type, v: Vec2Type|number[]): Mat3Type;
 
   /**
    * Creates a matrix from a vector translation
    * This is equivalent to (but much faster than):
    *
-   *     Mat3.identity(dest);
-   *     Mat3.translate(dest, dest, vec);
+   *     Mat3Type.identity(dest);
+   *     Mat3Type.translate(dest, dest, vec);
    *
-   * @param {Mat3} out Mat3 receiving operation result
-   * @param {Vec2} v Translation vector
-   * @returns {Mat3} out
+   * @param {Mat3Type} out Mat3Type receiving operation result
+   * @param {Vec2Type} v Translation vector
+   * @returns {Mat3Type} out
    */
-  fromTranslation(out: Mat3, v: Vec2|number[]): Mat3
+  fromTranslation(out: Mat3Type, v: Vec2Type|number[]): Mat3Type
 
   /**
    * Creates a matrix from a given angle
    * This is equivalent to (but much faster than):
    *
-   *     Mat3.identity(dest);
-   *     Mat3.rotate(dest, dest, rad);
+   *     Mat3Type.identity(dest);
+   *     Mat3Type.rotate(dest, dest, rad);
    *
-   * @param {Mat3} out Mat3 receiving operation result
+   * @param {Mat3Type} out Mat3Type receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @returns {Mat3} out
+   * @returns {Mat3Type} out
    */
-  fromRotation(out: Mat3, rad: number): Mat3
+  fromRotation(out: Mat3Type, rad: number): Mat3Type
 
   /**
    * Creates a matrix from a vector scaling
    * This is equivalent to (but much faster than):
    *
-   *     Mat3.identity(dest);
-   *     Mat3.scale(dest, dest, vec);
+   *     Mat3Type.identity(dest);
+   *     Mat3Type.scale(dest, dest, vec);
    *
-   * @param {Mat3} out Mat3 receiving operation result
-   * @param {Vec2} v Scaling vector
-   * @returns {Mat3} out
+   * @param {Mat3Type} out Mat3Type receiving operation result
+   * @param {Vec2Type} v Scaling vector
+   * @returns {Mat3Type} out
    */
-  fromScaling(out: Mat3, v: Vec2|number[]): Mat3
+  fromScaling(out: Mat3Type, v: Vec2Type|number[]): Mat3Type
 
   /**
-   * Copies the values from a Mat2d into a Mat3
+   * Copies the values from a Mat2dType into a Mat3Type
    *
    * @param out the receiving matrix
-   * @param {Mat2d} a the matrix to copy
+   * @param {Mat2dType} a the matrix to copy
    * @returns out
    **/
-  fromMat2d(out: Mat3, a: Mat2d): Mat3;
+  fromMat2d(out: Mat3Type, a: Mat2dType): Mat3Type;
 
   /**
    * Calculates a 3x3 matrix from the given Quaternion
    *
-   * @param out Mat3 receiving operation result
+   * @param out Mat3Type receiving operation result
    * @param q Quaternion to create matrix from
    *
    * @returns out
    */
-  fromQuat(out: Mat3, q: Quat): Mat3;
+  fromQuat(out: Mat3Type, q: QuatType): Mat3Type;
 
   /**
    * Calculates a 3x3 normal matrix (transpose inverse) from the 4x4 matrix
    *
-   * @param out Mat3 receiving operation result
-   * @param a Mat4 to derive the normal matrix from
+   * @param out Mat3Type receiving operation result
+   * @param a Mat4Type to derive the normal matrix from
    *
    * @returns out
    */
-  normalFromMat4(out: Mat3, a: Mat4): Mat3|null;
+  normalFromMat4(out: Mat3Type, a: Mat4Type): Mat3Type|null;
 
   /**
-   * Returns a string representation of a Mat3
+   * Returns a string representation of a Mat3Type
    *
    * @param mat matrix to represent as a string
    * @returns string representation of the matrix
    */
-  str(mat: Mat3): string;
+  str(mat: Mat3Type): string;
 
   /**
-   * Returns Frobenius norm of a Mat3
+   * Returns Frobenius norm of a Mat3Type
    *
    * @param a the matrix to calculate Frobenius norm of
    * @returns Frobenius norm
    */
-  frob(a: Mat3): number;
+  frob(a: Mat3Type): number;
 
   /**
-   * Adds two Mat3's
+   * Adds two Mat3Type's
    *
-   * @param {Mat3} out the receiving matrix
-   * @param {Mat3} a the first operand
-   * @param {Mat3} b the second operand
-   * @returns {Mat3} out
+   * @param {Mat3Type} out the receiving matrix
+   * @param {Mat3Type} a the first operand
+   * @param {Mat3Type} b the second operand
+   * @returns {Mat3Type} out
    */
-  add(out: Mat3, a: Mat3, b: Mat3): Mat3
-
-  /**
-   * Subtracts matrix b from matrix a
-   *
-   * @param {Mat3} out the receiving matrix
-   * @param {Mat3} a the first operand
-   * @param {Mat3} b the second operand
-   * @returns {Mat3} out
-   */
-  subtract(out: Mat3, a: Mat3, b: Mat3): Mat3
+  add(out: Mat3Type, a: Mat3Type, b: Mat3Type): Mat3Type
 
   /**
    * Subtracts matrix b from matrix a
    *
-   * @param {Mat3} out the receiving matrix
-   * @param {Mat3} a the first operand
-   * @param {Mat3} b the second operand
-   * @returns {Mat3} out
+   * @param {Mat3Type} out the receiving matrix
+   * @param {Mat3Type} a the first operand
+   * @param {Mat3Type} b the second operand
+   * @returns {Mat3Type} out
    */
-  sub(out: Mat3, a: Mat3, b: Mat3): Mat3
+  subtract(out: Mat3Type, a: Mat3Type, b: Mat3Type): Mat3Type
+
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat3Type} out the receiving matrix
+   * @param {Mat3Type} a the first operand
+   * @param {Mat3Type} b the second operand
+   * @returns {Mat3Type} out
+   */
+  sub(out: Mat3Type, a: Mat3Type, b: Mat3Type): Mat3Type
 
   /**
    * Multiply each element of the matrix by a scalar.
    *
-   * @param {Mat3} out the receiving matrix
-   * @param {Mat3} a the matrix to scale
+   * @param {Mat3Type} out the receiving matrix
+   * @param {Mat3Type} a the matrix to scale
    * @param {number} b amount to scale the matrix's elements by
-   * @returns {Mat3} out
+   * @returns {Mat3Type} out
    */
-  multiplyScalar(out: Mat3, a: Mat3, b: number): Mat3
+  multiplyScalar(out: Mat3Type, a: Mat3Type, b: number): Mat3Type
 
   /**
-   * Adds two Mat3's after multiplying each element of the second operand
+   * Adds two Mat3Type's after multiplying each element of the second operand
    * by a scalar value.
    *
-   * @param {Mat3} out the receiving vector
-   * @param {Mat3} a the first operand
-   * @param {Mat3} b the second operand
+   * @param {Mat3Type} out the receiving vector
+   * @param {Mat3Type} a the first operand
+   * @param {Mat3Type} b the second operand
    * @param {number} scale the amount to scale b's elements by before
    *     adding
-   * @returns {Mat3} out
+   * @returns {Mat3Type} out
    */
-  multiplyScalarAndAdd(out: Mat3, a: Mat3, b: Mat3, scale: number): Mat3
+  multiplyScalarAndAdd(out: Mat3Type, a: Mat3Type, b: Mat3Type, scale: number):
+      Mat3Type
 
   /**
    * Returns whether or not the matrices have exactly the same elements in
    * the same position (when compared with ===)
    *
-   * @param {Mat3} a The first matrix.
-   * @param {Mat3} b The second matrix.
+   * @param {Mat3Type} a The first matrix.
+   * @param {Mat3Type} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  exactEquals(a: Mat3, b: Mat3): boolean;
+  exactEquals(a: Mat3Type, b: Mat3Type): boolean;
 
   /**
    * Returns whether or not the matrices have approximately the same elements
    * in the same position.
    *
-   * @param {Mat3} a The first matrix.
-   * @param {Mat3} b The second matrix.
+   * @param {Mat3Type} a The first matrix.
+   * @param {Mat3Type} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  equals(a: Mat3, b: Mat3): boolean
+  equals(a: Mat3Type, b: Mat3Type): boolean
 }
 
-// Mat4
-interface Mat4 extends Float32Array {
+// Mat4Type
+interface Mat4Type extends Float32Array {
   /**
-   * Creates a new identity Mat4
+   * Creates a new identity Mat4Type
    *
    * @returns a new 4x4 matrix
    */
-  create(): Mat4;
+  create(): Mat4Type;
 
   /**
-   * Creates a new Mat4 initialized with values from an existing matrix
+   * Creates a new Mat4Type initialized with values from an existing matrix
    *
    * @param a matrix to clone
    * @returns a new 4x4 matrix
    */
-  clone(a: Mat4): Mat4;
+  clone(a: Mat4Type): Mat4Type;
 
   /**
-   * Copy the values from one Mat4 to another
+   * Copy the values from one Mat4Type to another
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  copy(out: Mat4, a: Mat4): Mat4;
+  copy(out: Mat4Type, a: Mat4Type): Mat4Type;
 
 
   /**
-   * Create a new Mat4 with the given values
+   * Create a new Mat4Type with the given values
    *
    * @param {number} m00 Component in column 0, row 0 position (index 0)
    * @param {number} m01 Component in column 0, row 1 position (index 1)
@@ -2295,18 +2309,18 @@ interface Mat4 extends Float32Array {
    * @param {number} m31 Component in column 3, row 1 position (index 13)
    * @param {number} m32 Component in column 3, row 2 position (index 14)
    * @param {number} m33 Component in column 3, row 3 position (index 15)
-   * @returns {Mat4} A new Mat4
+   * @returns {Mat4Type} A new Mat4Type
    */
   fromValues(
       m00: number, m01: number, m02: number, m03: number, m10: number,
       m11: number, m12: number, m13: number, m20: number, m21: number,
       m22: number, m23: number, m30: number, m31: number, m32: number,
-      m33: number): Mat4;
+      m33: number): Mat4Type;
 
   /**
-   * Set the components of a Mat4 to the given values
+   * Set the components of a Mat4Type to the given values
    *
-   * @param {Mat4} out the receiving matrix
+   * @param {Mat4Type} out the receiving matrix
    * @param {number} m00 Component in column 0, row 0 position (index 0)
    * @param {number} m01 Component in column 0, row 1 position (index 1)
    * @param {number} m02 Component in column 0, row 2 position (index 2)
@@ -2323,98 +2337,98 @@ interface Mat4 extends Float32Array {
    * @param {number} m31 Component in column 3, row 1 position (index 13)
    * @param {number} m32 Component in column 3, row 2 position (index 14)
    * @param {number} m33 Component in column 3, row 3 position (index 15)
-   * @returns {Mat4} out
+   * @returns {Mat4Type} out
    */
-  set(out: Mat4, m00: number, m01: number, m02: number, m03: number,
+  set(out: Mat4Type, m00: number, m01: number, m02: number, m03: number,
       m10: number, m11: number, m12: number, m13: number, m20: number,
       m21: number, m22: number, m23: number, m30: number, m31: number,
-      m32: number, m33: number): Mat4;
+      m32: number, m33: number): Mat4Type;
 
   /**
-   * Set a Mat4 to the identity matrix
+   * Set a Mat4Type to the identity matrix
    *
    * @param out the receiving matrix
    * @returns out
    */
-  identity(out: Mat4): Mat4;
+  identity(out: Mat4Type): Mat4Type;
 
   /**
-   * Transpose the values of a Mat4
-   *
-   * @param out the receiving matrix
-   * @param a the source matrix
-   * @returns out
-   */
-  transpose(out: Mat4, a: Mat4): Mat4;
-
-  /**
-   * Inverts a Mat4
+   * Transpose the values of a Mat4Type
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  invert(out: Mat4, a: Mat4): Mat4|null;
+  transpose(out: Mat4Type, a: Mat4Type): Mat4Type;
 
   /**
-   * Calculates the adjugate of a Mat4
+   * Inverts a Mat4Type
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  adjoint(out: Mat4, a: Mat4): Mat4;
+  invert(out: Mat4Type, a: Mat4Type): Mat4Type|null;
 
   /**
-   * Calculates the determinant of a Mat4
+   * Calculates the adjugate of a Mat4Type
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  adjoint(out: Mat4Type, a: Mat4Type): Mat4Type;
+
+  /**
+   * Calculates the determinant of a Mat4Type
    *
    * @param a the source matrix
    * @returns determinant of a
    */
-  determinant(a: Mat4): number;
+  determinant(a: Mat4Type): number;
 
   /**
-   * Multiplies two Mat4's
+   * Multiplies two Mat4Type's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Mat4, a: Mat4, b: Mat4): Mat4;
+  multiply(out: Mat4Type, a: Mat4Type, b: Mat4Type): Mat4Type;
 
   /**
-   * Multiplies two Mat4's
+   * Multiplies two Mat4Type's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Mat4, a: Mat4, b: Mat4): Mat4;
+  mul(out: Mat4Type, a: Mat4Type, b: Mat4Type): Mat4Type;
 
   /**
-   * Translate a Mat4 by the given vector
+   * Translate a Mat4Type by the given vector
    *
    * @param out the receiving matrix
    * @param a the matrix to translate
    * @param v vector to translate by
    * @returns out
    */
-  translate(out: Mat4, a: Mat4, v: Vec3|number[]): Mat4;
+  translate(out: Mat4Type, a: Mat4Type, v: Vec3Type|number[]): Mat4Type;
 
   /**
-   * Scales the Mat4 by the dimensions in the given Vec3
+   * Scales the Mat4Type by the dimensions in the given Vec3Type
    *
    * @param out the receiving matrix
    * @param a the matrix to scale
-   * @param v the Vec3 to scale the matrix by
+   * @param v the Vec3Type to scale the matrix by
    * @returns out
    **/
-  scale(out: Mat4, a: Mat4, v: Vec3|number[]): Mat4;
+  scale(out: Mat4Type, a: Mat4Type, v: Vec3Type|number[]): Mat4Type;
 
   /**
-   * Rotates a Mat4 by the given angle
+   * Rotates a Mat4Type by the given angle
    *
    * @param out the receiving matrix
    * @param a the matrix to rotate
@@ -2422,7 +2436,8 @@ interface Mat4 extends Float32Array {
    * @param axis the axis to rotate around
    * @returns out
    */
-  rotate(out: Mat4, a: Mat4, rad: number, axis: Vec3|number[]): Mat4;
+  rotate(out: Mat4Type, a: Mat4Type, rad: number, axis: Vec3Type|number[]):
+      Mat4Type;
 
   /**
    * Rotates a matrix by the given angle around the X axis
@@ -2432,7 +2447,7 @@ interface Mat4 extends Float32Array {
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  rotateX(out: Mat4, a: Mat4, rad: number): Mat4;
+  rotateX(out: Mat4Type, a: Mat4Type, rad: number): Mat4Type;
 
   /**
    * Rotates a matrix by the given angle around the Y axis
@@ -2442,7 +2457,7 @@ interface Mat4 extends Float32Array {
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  rotateY(out: Mat4, a: Mat4, rad: number): Mat4;
+  rotateY(out: Mat4Type, a: Mat4Type, rad: number): Mat4Type;
 
   /**
    * Rotates a matrix by the given angle around the Z axis
@@ -2452,186 +2467,188 @@ interface Mat4 extends Float32Array {
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  rotateZ(out: Mat4, a: Mat4, rad: number): Mat4;
+  rotateZ(out: Mat4Type, a: Mat4Type, rad: number): Mat4Type;
 
   /**
    * Creates a matrix from a vector translation
    * This is equivalent to (but much faster than):
    *
-   *     Mat4.identity(dest);
-   *     Mat4.translate(dest, dest, vec);
+   *     Mat4Type.identity(dest);
+   *     Mat4Type.translate(dest, dest, vec);
    *
-   * @param {Mat4} out Mat4 receiving operation result
-   * @param {Vec3} v Translation vector
-   * @returns {Mat4} out
+   * @param {Mat4Type} out Mat4Type receiving operation result
+   * @param {Vec3Type} v Translation vector
+   * @returns {Mat4Type} out
    */
-  fromTranslation(out: Mat4, v: Vec3|number[]): Mat4
+  fromTranslation(out: Mat4Type, v: Vec3Type|number[]): Mat4Type
 
   /**
    * Creates a matrix from a vector scaling
    * This is equivalent to (but much faster than):
    *
-   *     Mat4.identity(dest);
-   *     Mat4.scale(dest, dest, vec);
+   *     Mat4Type.identity(dest);
+   *     Mat4Type.scale(dest, dest, vec);
    *
-   * @param {Mat4} out Mat4 receiving operation result
-   * @param {Vec3} v Scaling vector
-   * @returns {Mat4} out
+   * @param {Mat4Type} out Mat4Type receiving operation result
+   * @param {Vec3Type} v Scaling vector
+   * @returns {Mat4Type} out
    */
-  fromScaling(out: Mat4, v: Vec3|number[]): Mat4
+  fromScaling(out: Mat4Type, v: Vec3Type|number[]): Mat4Type
 
   /**
    * Creates a matrix from a given angle around a given axis
    * This is equivalent to (but much faster than):
    *
-   *     Mat4.identity(dest);
-   *     Mat4.rotate(dest, dest, rad, axis);
+   *     Mat4Type.identity(dest);
+   *     Mat4Type.rotate(dest, dest, rad, axis);
    *
-   * @param {Mat4} out Mat4 receiving operation result
+   * @param {Mat4Type} out Mat4Type receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @param {Vec3} axis the axis to rotate around
-   * @returns {Mat4} out
+   * @param {Vec3Type} axis the axis to rotate around
+   * @returns {Mat4Type} out
    */
-  fromRotation(out: Mat4, rad: number, axis: Vec3|number[]): Mat4
+  fromRotation(out: Mat4Type, rad: number, axis: Vec3Type|number[]): Mat4Type
 
   /**
    * Creates a matrix from the given angle around the X axis
    * This is equivalent to (but much faster than):
    *
-   *     Mat4.identity(dest);
-   *     Mat4.rotateX(dest, dest, rad);
+   *     Mat4Type.identity(dest);
+   *     Mat4Type.rotateX(dest, dest, rad);
    *
-   * @param {Mat4} out Mat4 receiving operation result
+   * @param {Mat4Type} out Mat4Type receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @returns {Mat4} out
+   * @returns {Mat4Type} out
    */
-  fromXRotation(out: Mat4, rad: number): Mat4
+  fromXRotation(out: Mat4Type, rad: number): Mat4Type
 
   /**
    * Creates a matrix from the given angle around the Y axis
    * This is equivalent to (but much faster than):
    *
-   *     Mat4.identity(dest);
-   *     Mat4.rotateY(dest, dest, rad);
+   *     Mat4Type.identity(dest);
+   *     Mat4Type.rotateY(dest, dest, rad);
    *
-   * @param {Mat4} out Mat4 receiving operation result
+   * @param {Mat4Type} out Mat4Type receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @returns {Mat4} out
+   * @returns {Mat4Type} out
    */
-  fromYRotation(out: Mat4, rad: number): Mat4
+  fromYRotation(out: Mat4Type, rad: number): Mat4Type
 
 
   /**
    * Creates a matrix from the given angle around the Z axis
    * This is equivalent to (but much faster than):
    *
-   *     Mat4.identity(dest);
-   *     Mat4.rotateZ(dest, dest, rad);
+   *     Mat4Type.identity(dest);
+   *     Mat4Type.rotateZ(dest, dest, rad);
    *
-   * @param {Mat4} out Mat4 receiving operation result
+   * @param {Mat4Type} out Mat4Type receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @returns {Mat4} out
+   * @returns {Mat4Type} out
    */
-  fromZRotation(out: Mat4, rad: number): Mat4
+  fromZRotation(out: Mat4Type, rad: number): Mat4Type
 
   /**
    * Creates a matrix from a Quaternion rotation and vector translation
    * This is equivalent to (but much faster than):
    *
-   *     Mat4.identity(dest);
-   *     Mat4.translate(dest, vec);
-   *     var QuatMat = Mat4.create();
-   *     Quat4.toMat4(Quat, QuatMat);
-   *     Mat4.multiply(dest, QuatMat);
+   *     Mat4Type.identity(dest);
+   *     Mat4Type.translate(dest, vec);
+   *     var QuatMat = Mat4Type.create();
+   *     Quat4.toMat4(QuatType, QuatMat);
+   *     Mat4Type.multiply(dest, QuatMat);
    *
-   * @param out Mat4 receiving operation result
+   * @param out Mat4Type receiving operation result
    * @param q Rotation Quaternion
    * @param v Translation vector
    * @returns out
    */
-  fromRotationTranslation(out: Mat4, q: Quat, v: Vec3|number[]): Mat4;
+  fromRotationTranslation(out: Mat4Type, q: QuatType, v: Vec3Type|number[]):
+      Mat4Type;
 
   /**
    * Returns the translation vector component of a transformation
    *  matrix. If a matrix is built with fromRotationTranslation,
    *  the returned vector will be the same as the translation vector
    *  originally supplied.
-   * @param  {Vec3} out Vector to receive translation component
-   * @param  {Mat4} mat Matrix to be decomposed (input)
-   * @return {Vec3} out
+   * @param  {Vec3Type} out Vector to receive translation component
+   * @param  {Mat4Type} mat Matrix to be decomposed (input)
+   * @return {Vec3Type} out
    */
-  getTranslation(out: Vec3, mat: Mat4): Vec3;
+  getTranslation(out: Vec3Type, mat: Mat4Type): Vec3Type;
 
   /**
    * Returns a Quaternion representing the rotational component
    *  of a transformation matrix. If a matrix is built with
    *  fromRotationTranslation, the returned Quaternion will be the
    *  same as the Quaternion originally supplied.
-   * @param {Quat} out Quaternion to receive the rotation component
-   * @param {Mat4} mat Matrix to be decomposed (input)
-   * @return {Quat} out
+   * @param {QuatType} out Quaternion to receive the rotation component
+   * @param {Mat4Type} mat Matrix to be decomposed (input)
+   * @return {QuatType} out
    */
-  getRotation(out: Quat, mat: Mat4): Quat;
+  getRotation(out: QuatType, mat: Mat4Type): QuatType;
 
   /**
    * Creates a matrix from a Quaternion rotation, vector translation and
    * vector scale This is equivalent to (but much faster than):
    *
-   *     Mat4.identity(dest);
-   *     Mat4.translate(dest, vec);
-   *     var QuatMat = Mat4.create();
-   *     Quat4.toMat4(Quat, QuatMat);
-   *     Mat4.multiply(dest, QuatMat);
-   *     Mat4.scale(dest, scale)
+   *     Mat4Type.identity(dest);
+   *     Mat4Type.translate(dest, vec);
+   *     var QuatMat = Mat4Type.create();
+   *     Quat4.toMat4(QuatType, QuatMat);
+   *     Mat4Type.multiply(dest, QuatMat);
+   *     Mat4Type.scale(dest, scale)
    *
-   * @param out Mat4 receiving operation result
+   * @param out Mat4Type receiving operation result
    * @param q Rotation Quaternion
    * @param v Translation vector
    * @param s Scaling vector
    * @returns out
    */
   fromRotationTranslationScale(
-      out: Mat4, q: Quat, v: Vec3|number[], s: Vec3|number[]): Mat4;
+      out: Mat4Type, q: QuatType, v: Vec3Type|number[],
+      s: Vec3Type|number[]): Mat4Type;
 
   /**
    * Creates a matrix from a Quaternion rotation, vector translation and
    * vector scale, rotating and scaling around the given origin This is
    * equivalent to (but much faster than):
    *
-   *     Mat4.identity(dest);
-   *     Mat4.translate(dest, vec);
-   *     Mat4.translate(dest, origin);
-   *     var QuatMat = Mat4.create();
-   *     Quat4.toMat4(Quat, QuatMat);
-   *     Mat4.multiply(dest, QuatMat);
-   *     Mat4.scale(dest, scale)
-   *     Mat4.translate(dest, negativeOrigin);
+   *     Mat4Type.identity(dest);
+   *     Mat4Type.translate(dest, vec);
+   *     Mat4Type.translate(dest, origin);
+   *     var QuatMat = Mat4Type.create();
+   *     Quat4.toMat4(QuatType, QuatMat);
+   *     Mat4Type.multiply(dest, QuatMat);
+   *     Mat4Type.scale(dest, scale)
+   *     Mat4Type.translate(dest, negativeOrigin);
    *
-   * @param {Mat4} out Mat4 receiving operation result
-   * @param {Quat} q Rotation Quaternion
-   * @param {Vec3} v Translation vector
-   * @param {Vec3} s Scaling vector
-   * @param {Vec3} o The origin vector around which to scale and rotate
-   * @returns {Mat4} out
+   * @param {Mat4Type} out Mat4Type receiving operation result
+   * @param {QuatType} q Rotation Quaternion
+   * @param {Vec3Type} v Translation vector
+   * @param {Vec3Type} s Scaling vector
+   * @param {Vec3Type} o The origin vector around which to scale and rotate
+   * @returns {Mat4Type} out
    */
   fromRotationTranslationScaleOrigin(
-      out: Mat4, q: Quat, v: Vec3|number[], s: Vec3|number[],
-      o: Vec3|number[]): Mat4
+      out: Mat4Type, q: QuatType, v: Vec3Type|number[], s: Vec3Type|number[],
+      o: Vec3Type|number[]): Mat4Type
 
   /**
    * Calculates a 4x4 matrix from the given Quaternion
    *
-   * @param {Mat4} out Mat4 receiving operation result
-   * @param {Quat} q Quaternion to create matrix from
+   * @param {Mat4Type} out Mat4Type receiving operation result
+   * @param {QuatType} q Quaternion to create matrix from
    *
-   * @returns {Mat4} out
+   * @returns {Mat4Type} out
    */
-  fromQuat(out: Mat4, q: Quat): Mat4
+  fromQuat(out: Mat4Type, q: QuatType): Mat4Type
 
   /**
    * Generates a frustum matrix with the given bounds
    *
-   * @param out Mat4 frustum matrix will be written into
+   * @param out Mat4Type frustum matrix will be written into
    * @param left Left bound of the frustum
    * @param right Right bound of the frustum
    * @param bottom Bottom bound of the frustum
@@ -2641,13 +2658,13 @@ interface Mat4 extends Float32Array {
    * @returns out
    */
   frustum(
-      out: Mat4, left: number, right: number, bottom: number, top: number,
-      near: number, far: number): Mat4;
+      out: Mat4Type, left: number, right: number, bottom: number, top: number,
+      near: number, far: number): Mat4Type;
 
   /**
    * Generates a perspective projection matrix with the given bounds
    *
-   * @param out Mat4 frustum matrix will be written into
+   * @param out Mat4Type frustum matrix will be written into
    * @param fovy Vertical field of view in radians
    * @param aspect Aspect ratio. typically viewport width/height
    * @param near Near bound of the frustum
@@ -2655,33 +2672,34 @@ interface Mat4 extends Float32Array {
    * @returns out
    */
   perspective(
-      out: Mat4, fovy: number, aspect: number, near: number, far: number): Mat4;
+      out: Mat4Type, fovy: number, aspect: number, near: number,
+      far: number): Mat4Type;
 
   /**
    * Generates a perspective projection matrix with the given field of view.
    * This is primarily useful for generating projection matrices to be used
    * with the still experimental WebVR API.
    *
-   * @param {Mat4} out Mat4 frustum matrix will be written into
+   * @param {Mat4Type} out Mat4Type frustum matrix will be written into
    * @param {Object} fov Object containing the following values: upDegrees,
    *     downDegrees, leftDegrees, rightDegrees
    * @param {number} near Near bound of the frustum
    * @param {number} far Far bound of the frustum
-   * @returns {Mat4} out
+   * @returns {Mat4Type} out
    */
   perspectiveFromFieldOfView(
-      out: Mat4, fov: {
+      out: Mat4Type, fov: {
         upDegrees: number,
         downDegrees: number,
         leftDegrees: number,
         rightDegrees: number
       },
-      near: number, far: number): Mat4
+      near: number, far: number): Mat4Type
 
   /**
    * Generates a orthogonal projection matrix with the given bounds
    *
-   * @param out Mat4 frustum matrix will be written into
+   * @param out Mat4Type frustum matrix will be written into
    * @param left Left bound of the frustum
    * @param right Right bound of the frustum
    * @param bottom Bottom bound of the frustum
@@ -2691,133 +2709,134 @@ interface Mat4 extends Float32Array {
    * @returns out
    */
   ortho(
-      out: Mat4, left: number, right: number, bottom: number, top: number,
-      near: number, far: number): Mat4;
+      out: Mat4Type, left: number, right: number, bottom: number, top: number,
+      near: number, far: number): Mat4Type;
 
   /**
    * Generates a look-at matrix with the given eye position, focal point, and
    * up axis
    *
-   * @param out Mat4 frustum matrix will be written into
+   * @param out Mat4Type frustum matrix will be written into
    * @param eye Position of the viewer
    * @param center Point the viewer is looking at
-   * @param up Vec3 pointing up
+   * @param up Vec3Type pointing up
    * @returns out
    */
   lookAt(
-      out: Mat4, eye: Vec3|number[], center: Vec3|number[],
-      up: Vec3|number[]): Mat4;
+      out: Mat4Type, eye: Vec3Type|number[], center: Vec3Type|number[],
+      up: Vec3Type|number[]): Mat4Type;
 
   /**
-   * Returns a string representation of a Mat4
+   * Returns a string representation of a Mat4Type
    *
    * @param mat matrix to represent as a string
    * @returns string representation of the matrix
    */
-  str(mat: Mat4): string;
+  str(mat: Mat4Type): string;
 
   /**
-   * Returns Frobenius norm of a Mat4
+   * Returns Frobenius norm of a Mat4Type
    *
    * @param a the matrix to calculate Frobenius norm of
    * @returns Frobenius norm
    */
-  frob(a: Mat4): number;
+  frob(a: Mat4Type): number;
 
   /**
-   * Adds two Mat4's
+   * Adds two Mat4Type's
    *
-   * @param {Mat4} out the receiving matrix
-   * @param {Mat4} a the first operand
-   * @param {Mat4} b the second operand
-   * @returns {Mat4} out
+   * @param {Mat4Type} out the receiving matrix
+   * @param {Mat4Type} a the first operand
+   * @param {Mat4Type} b the second operand
+   * @returns {Mat4Type} out
    */
-  add(out: Mat4, a: Mat4, b: Mat4): Mat4
-
-  /**
-   * Subtracts matrix b from matrix a
-   *
-   * @param {Mat4} out the receiving matrix
-   * @param {Mat4} a the first operand
-   * @param {Mat4} b the second operand
-   * @returns {Mat4} out
-   */
-  subtract(out: Mat4, a: Mat4, b: Mat4): Mat4
+  add(out: Mat4Type, a: Mat4Type, b: Mat4Type): Mat4Type
 
   /**
    * Subtracts matrix b from matrix a
    *
-   * @param {Mat4} out the receiving matrix
-   * @param {Mat4} a the first operand
-   * @param {Mat4} b the second operand
-   * @returns {Mat4} out
+   * @param {Mat4Type} out the receiving matrix
+   * @param {Mat4Type} a the first operand
+   * @param {Mat4Type} b the second operand
+   * @returns {Mat4Type} out
    */
-  sub(out: Mat4, a: Mat4, b: Mat4): Mat4
+  subtract(out: Mat4Type, a: Mat4Type, b: Mat4Type): Mat4Type
+
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat4Type} out the receiving matrix
+   * @param {Mat4Type} a the first operand
+   * @param {Mat4Type} b the second operand
+   * @returns {Mat4Type} out
+   */
+  sub(out: Mat4Type, a: Mat4Type, b: Mat4Type): Mat4Type
 
   /**
    * Multiply each element of the matrix by a scalar.
    *
-   * @param {Mat4} out the receiving matrix
-   * @param {Mat4} a the matrix to scale
+   * @param {Mat4Type} out the receiving matrix
+   * @param {Mat4Type} a the matrix to scale
    * @param {number} b amount to scale the matrix's elements by
-   * @returns {Mat4} out
+   * @returns {Mat4Type} out
    */
-  multiplyScalar(out: Mat4, a: Mat4, b: number): Mat4
+  multiplyScalar(out: Mat4Type, a: Mat4Type, b: number): Mat4Type
 
   /**
-   * Adds two Mat4's after multiplying each element of the second operand
+   * Adds two Mat4Type's after multiplying each element of the second operand
    * by a scalar value.
    *
-   * @param {Mat4} out the receiving vector
-   * @param {Mat4} a the first operand
-   * @param {Mat4} b the second operand
+   * @param {Mat4Type} out the receiving vector
+   * @param {Mat4Type} a the first operand
+   * @param {Mat4Type} b the second operand
    * @param {number} scale the amount to scale b's elements by before
    *     adding
-   * @returns {Mat4} out
+   * @returns {Mat4Type} out
    */
-  multiplyScalarAndAdd(out: Mat4, a: Mat4, b: Mat4, scale: number): Mat4
+  multiplyScalarAndAdd(out: Mat4Type, a: Mat4Type, b: Mat4Type, scale: number):
+      Mat4Type
 
   /**
    * Returns whether or not the matrices have exactly the same elements in
    * the same position (when compared with ===)
    *
-   * @param {Mat4} a The first matrix.
-   * @param {Mat4} b The second matrix.
+   * @param {Mat4Type} a The first matrix.
+   * @param {Mat4Type} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  exactEquals(a: Mat4, b: Mat4): boolean
+  exactEquals(a: Mat4Type, b: Mat4Type): boolean
 
   /**
    * Returns whether or not the matrices have approximately the same
    * elements in the same position.
    *
-   * @param {Mat4} a The first matrix.
-   * @param {Mat4} b The second matrix.
+   * @param {Mat4Type} a The first matrix.
+   * @param {Mat4Type} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  equals(a: Mat4, b: Mat4): boolean
+  equals(a: Mat4Type, b: Mat4Type): boolean
 }
 
-// Quat
-interface Quat extends Float32Array {
+// QuatType
+interface QuatType extends Float32Array {
   /**
-   * Creates a new identity Quat
+   * Creates a new identity QuatType
    *
    * @returns a new Quaternion
    */
-  create(): Quat;
+  create(): QuatType;
 
   /**
-   * Creates a new Quat initialized with values from an existing Quaternion
+   * Creates a new QuatType initialized with values from an existing Quaternion
    *
    * @param a Quaternion to clone
    * @returns a new Quaternion
    * @function
    */
-  clone(a: Quat): Quat;
+  clone(a: QuatType): QuatType;
 
   /**
-   * Creates a new Quat initialized with the given values
+   * Creates a new QuatType initialized with the given values
    *
    * @param x X component
    * @param y Y component
@@ -2826,20 +2845,20 @@ interface Quat extends Float32Array {
    * @returns a new Quaternion
    * @function
    */
-  fromValues(x: number, y: number, z: number, w: number): Quat;
+  fromValues(x: number, y: number, z: number, w: number): QuatType;
 
   /**
-   * Copy the values from one Quat to another
+   * Copy the values from one QuatType to another
    *
    * @param out the receiving Quaternion
    * @param a the source Quaternion
    * @returns out
    * @function
    */
-  copy(out: Quat, a: Quat): Quat;
+  copy(out: QuatType, a: QuatType): QuatType;
 
   /**
-   * Set the components of a Quat to the given values
+   * Set the components of a QuatType to the given values
    *
    * @param out the receiving Quaternion
    * @param x X component
@@ -2849,15 +2868,15 @@ interface Quat extends Float32Array {
    * @returns out
    * @function
    */
-  set(out: Quat, x: number, y: number, z: number, w: number): Quat;
+  set(out: QuatType, x: number, y: number, z: number, w: number): QuatType;
 
   /**
-   * Set a Quat to the identity Quaternion
+   * Set a QuatType to the identity Quaternion
    *
    * @param out the receiving Quaternion
    * @returns out
    */
-  identity(out: Quat): Quat;
+  identity(out: QuatType): QuatType;
 
   /**
    * Sets a Quaternion to represent the shortest rotation from one
@@ -2865,31 +2884,32 @@ interface Quat extends Float32Array {
    *
    * Both vectors are assumed to be unit length.
    *
-   * @param {Quat} out the receiving Quaternion.
-   * @param {Vec3} a the initial vector
-   * @param {Vec3} b the destination vector
-   * @returns {Quat} out
+   * @param {QuatType} out the receiving Quaternion.
+   * @param {Vec3Type} a the initial vector
+   * @param {Vec3Type} b the destination vector
+   * @returns {QuatType} out
    */
-  rotationTo(out: Quat, a: Vec3|number[], b: Vec3|number[]): Quat;
+  rotationTo(out: QuatType, a: Vec3Type|number[], b: Vec3Type|number[]):
+      QuatType;
 
   /**
    * Sets the specified Quaternion with values corresponding to the given
-   * axes. Each axis is a Vec3 and is expected to be unit length and
+   * axes. Each axis is a Vec3Type and is expected to be unit length and
    * perpendicular to all other specified axes.
    *
-   * @param {Vec3} view  the vector representing the viewing direction
-   * @param {Vec3} right the vector representing the local "right" direction
-   * @param {Vec3} up    the vector representing the local "up" direction
-   * @returns {Quat} out
+   * @param {Vec3Type} view  the vector representing the viewing direction
+   * @param {Vec3Type} right the vector representing the local "right" direction
+   * @param {Vec3Type} up    the vector representing the local "up" direction
+   * @returns {QuatType} out
    */
   setAxes(
-      out: Quat, view: Vec3|number[], right: Vec3|number[],
-      up: Vec3|number[]): Quat
+      out: QuatType, view: Vec3Type|number[], right: Vec3Type|number[],
+      up: Vec3Type|number[]): QuatType
 
 
 
   /**
-   * Sets a Quat from the given angle and rotation axis,
+   * Sets a QuatType from the given angle and rotation axis,
    * then returns it.
    *
    * @param out the receiving Quaternion
@@ -2897,7 +2917,7 @@ interface Quat extends Float32Array {
    * @param rad the angle in radians
    * @returns out
    **/
-  setAxisAngle(out: Quat, axis: Vec3|number[], rad: number): Quat;
+  setAxisAngle(out: QuatType, axis: Vec3Type|number[], rad: number): QuatType;
 
   /**
    * Gets the rotation axis and angle for a given
@@ -2908,14 +2928,14 @@ interface Quat extends Float32Array {
    * Example: The Quaternion formed by axis [0, 0, 1] and
    *  angle -90 is the same as the Quaternion formed by
    *  [0, 0, 1] and 270. This method favors the latter.
-   * @param  {Vec3} out_axis  Vector receiving the axis of rotation
-   * @param  {Quat} q     Quaternion to be decomposed
+   * @param  {Vec3Type} out_axis  Vector receiving the axis of rotation
+   * @param  {QuatType} q     Quaternion to be decomposed
    * @return {number}     Angle, in radians, of the rotation
    */
-  getAxisAngle(out_axis: Vec3|number[], q: Quat): number
+  getAxisAngle(out_axis: Vec3Type|number[], q: QuatType): number
 
   /**
-   * Adds two Quat's
+   * Adds two QuatType's
    *
    * @param out the receiving Quaternion
    * @param a the first operand
@@ -2923,30 +2943,30 @@ interface Quat extends Float32Array {
    * @returns out
    * @function
    */
-  add(out: Quat, a: Quat, b: Quat): Quat;
+  add(out: QuatType, a: QuatType, b: QuatType): QuatType;
 
   /**
-   * Multiplies two Quat's
+   * Multiplies two QuatType's
    *
    * @param out the receiving Quaternion
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Quat, a: Quat, b: Quat): Quat;
+  multiply(out: QuatType, a: QuatType, b: QuatType): QuatType;
 
   /**
-   * Multiplies two Quat's
+   * Multiplies two QuatType's
    *
    * @param out the receiving Quaternion
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Quat, a: Quat, b: Quat): Quat;
+  mul(out: QuatType, a: QuatType, b: QuatType): QuatType;
 
   /**
-   * Scales a Quat by a scalar number
+   * Scales a QuatType by a scalar number
    *
    * @param out the receiving vector
    * @param a the vector to scale
@@ -2954,66 +2974,66 @@ interface Quat extends Float32Array {
    * @returns out
    * @function
    */
-  scale(out: Quat, a: Quat, b: number): Quat;
+  scale(out: QuatType, a: QuatType, b: number): QuatType;
 
   /**
-   * Calculates the length of a Quat
+   * Calculates the length of a QuatType
    *
    * @param a vector to calculate length of
    * @returns length of a
    * @function
    */
-  length(a: Quat): number;
+  length(a: QuatType): number;
 
   /**
-   * Calculates the length of a Quat
+   * Calculates the length of a QuatType
    *
    * @param a vector to calculate length of
    * @returns length of a
    * @function
    */
-  len(a: Quat): number;
+  len(a: QuatType): number;
 
   /**
-   * Calculates the squared length of a Quat
+   * Calculates the squared length of a QuatType
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    * @function
    */
-  squaredLength(a: Quat): number;
+  squaredLength(a: QuatType): number;
 
   /**
-   * Calculates the squared length of a Quat
+   * Calculates the squared length of a QuatType
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    * @function
    */
-  sqrLen(a: Quat): number;
+  sqrLen(a: QuatType): number;
 
   /**
-   * Normalize a Quat
+   * Normalize a QuatType
    *
    * @param out the receiving Quaternion
    * @param a Quaternion to normalize
    * @returns out
    * @function
    */
-  normalize(out: Quat, a: Quat): Quat;
+  normalize(out: QuatType, a: QuatType): QuatType;
 
   /**
-   * Calculates the dot product of two Quat's
+   * Calculates the dot product of two QuatType's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns dot product of a and b
    * @function
    */
-  dot(a: Quat, b: Quat): number;
+  dot(a: QuatType, b: QuatType): number;
 
   /**
-   * Performs a linear interpolation between two Quat's
+   * Performs a linear interpolation between two QuatType's
    *
    * @param out the receiving Quaternion
    * @param a the first operand
@@ -3022,10 +3042,10 @@ interface Quat extends Float32Array {
    * @returns out
    * @function
    */
-  lerp(out: Quat, a: Quat, b: Quat, t: number): Quat;
+  lerp(out: QuatType, a: QuatType, b: QuatType, t: number): QuatType;
 
   /**
-   * Performs a spherical linear interpolation between two Quat
+   * Performs a spherical linear interpolation between two QuatType
    *
    * @param out the receiving Quaternion
    * @param a the first operand
@@ -3033,78 +3053,80 @@ interface Quat extends Float32Array {
    * @param t interpolation amount between the two inputs
    * @returns out
    */
-  slerp(out: Quat, a: Quat, b: Quat, t: number): Quat;
+  slerp(out: QuatType, a: QuatType, b: QuatType, t: number): QuatType;
 
   /**
    * Performs a spherical linear interpolation with two control points
    *
-   * @param {Quat} out the receiving Quaternion
-   * @param {Quat} a the first operand
-   * @param {Quat} b the second operand
-   * @param {Quat} c the third operand
-   * @param {Quat} d the fourth operand
+   * @param {QuatType} out the receiving Quaternion
+   * @param {QuatType} a the first operand
+   * @param {QuatType} b the second operand
+   * @param {QuatType} c the third operand
+   * @param {QuatType} d the fourth operand
    * @param {number} t interpolation amount
-   * @returns {Quat} out
+   * @returns {QuatType} out
    */
-  sqlerp(out: Quat, a: Quat, b: Quat, c: Quat, d: Quat, t: number): Quat;
+  sqlerp(
+      out: QuatType, a: QuatType, b: QuatType, c: QuatType, d: QuatType,
+      t: number): QuatType;
 
   /**
-   * Calculates the inverse of a Quat
+   * Calculates the inverse of a QuatType
    *
    * @param out the receiving Quaternion
-   * @param a Quat to calculate inverse of
+   * @param a QuatType to calculate inverse of
    * @returns out
    */
-  invert(out: Quat, a: Quat): Quat;
+  invert(out: QuatType, a: QuatType): QuatType;
 
   /**
-   * Calculates the conjugate of a Quat
+   * Calculates the conjugate of a QuatType
    * If the Quaternion is normalized, this function is faster than
-   * Quat.inverse and produces the same result.
+   * QuatType.inverse and produces the same result.
    *
    * @param out the receiving Quaternion
-   * @param a Quat to calculate conjugate of
+   * @param a QuatType to calculate conjugate of
    * @returns out
    */
-  conjugate(out: Quat, a: Quat): Quat;
+  conjugate(out: QuatType, a: QuatType): QuatType;
 
   /**
    * Returns a string representation of a Quaternion
    *
-   * @param a Quat to represent as a string
-   * @returns string representation of the Quat
+   * @param a QuatType to represent as a string
+   * @returns string representation of the QuatType
    */
-  str(a: Quat): string;
+  str(a: QuatType): string;
 
   /**
    * Rotates a Quaternion by the given angle about the X axis
    *
-   * @param out Quat receiving operation result
-   * @param a Quat to rotate
+   * @param out QuatType receiving operation result
+   * @param a QuatType to rotate
    * @param rad angle (in radians) to rotate
    * @returns out
    */
-  rotateX(out: Quat, a: Quat, rad: number): Quat;
+  rotateX(out: QuatType, a: QuatType, rad: number): QuatType;
 
   /**
    * Rotates a Quaternion by the given angle about the Y axis
    *
-   * @param out Quat receiving operation result
-   * @param a Quat to rotate
+   * @param out QuatType receiving operation result
+   * @param a QuatType to rotate
    * @param rad angle (in radians) to rotate
    * @returns out
    */
-  rotateY(out: Quat, a: Quat, rad: number): Quat;
+  rotateY(out: QuatType, a: QuatType, rad: number): QuatType;
 
   /**
    * Rotates a Quaternion by the given angle about the Z axis
    *
-   * @param out Quat receiving operation result
-   * @param a Quat to rotate
+   * @param out QuatType receiving operation result
+   * @param a QuatType to rotate
    * @param rad angle (in radians) to rotate
    * @returns out
    */
-  rotateZ(out: Quat, a: Quat, rad: number): Quat;
+  rotateZ(out: QuatType, a: QuatType, rad: number): QuatType;
 
   /**
    * Creates a Quaternion from the given 3x3 rotation matrix.
@@ -3117,22 +3139,22 @@ interface Quat extends Float32Array {
    * @returns out
    * @function
    */
-  fromMat3(out: Quat, m: Mat3): Quat;
+  fromMat3(out: QuatType, m: Mat3Type): QuatType;
 
   /**
    * Sets the specified Quaternion with values corresponding to the given
-   * axes. Each axis is a Vec3 and is expected to be unit length and
+   * axes. Each axis is a Vec3Type and is expected to be unit length and
    * perpendicular to all other specified axes.
    *
-   * @param out the receiving Quat
+   * @param out the receiving QuatType
    * @param view  the vector representing the viewing direction
    * @param right the vector representing the local "right" direction
    * @param up    the vector representing the local "up" direction
    * @returns out
    */
   setAxes(
-      out: Quat, view: Vec3|number[], right: Vec3|number[],
-      up: Vec3|number[]): Quat;
+      out: QuatType, view: Vec3Type|number[], right: Vec3Type|number[],
+      up: Vec3Type|number[]): QuatType;
 
   /**
    * Sets a Quaternion to represent the shortest rotation from one
@@ -3145,36 +3167,37 @@ interface Quat extends Float32Array {
    * @param b the destination vector
    * @returns out
    */
-  rotationTo(out: Quat, a: Vec3|number[], b: Vec3|number[]): Quat;
+  rotationTo(out: QuatType, a: Vec3Type|number[], b: Vec3Type|number[]):
+      QuatType;
 
   /**
-   * Calculates the W component of a Quat from the X, Y, and Z components.
+   * Calculates the W component of a QuatType from the X, Y, and Z components.
    * Assumes that Quaternion is 1 unit in length.
    * Any existing W component will be ignored.
    *
    * @param out the receiving Quaternion
-   * @param a Quat to calculate W component of
+   * @param a QuatType to calculate W component of
    * @returns out
    */
-  calculateW(out: Quat, a: Quat): Quat;
+  calculateW(out: QuatType, a: QuatType): QuatType;
 
   /**
    * Returns whether or not the Quaternions have exactly the same elements in
    * the same position (when compared with ===)
    *
-   * @param {Quat} a The first vector.
-   * @param {Quat} b The second vector.
+   * @param {QuatType} a The first vector.
+   * @param {QuatType} b The second vector.
    * @returns {boolean} True if the Quaternions are equal, false otherwise.
    */
-  exactEquals(a: Quat, b: Quat): boolean;
+  exactEquals(a: QuatType, b: QuatType): boolean;
 
   /**
    * Returns whether or not the Quaternions have approximately the same
    * elements in the same position.
    *
-   * @param {Quat} a The first vector.
-   * @param {Quat} b The second vector.
+   * @param {QuatType} a The first vector.
+   * @param {QuatType} b The second vector.
    * @returns {boolean} True if the Quaternions are equal, false otherwise.
    */
-  equals(a: Quat, b: Quat): boolean;
+  equals(a: QuatType, b: QuatType): boolean;
 }

--- a/bindings/wasm/examples/editor.d.ts
+++ b/bindings/wasm/examples/editor.d.ts
@@ -226,6 +226,19 @@ interface Vec2Type extends Float32Array {
   max(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
 
   /**
+   * Rotates the 2D vector.
+   *
+   * @param {Vec2Type} out the receiving vector
+   * @param {Vec2Type} a vector to rotate
+   * @param {Vec2Type} b origin of the rotation
+   * @param {number} rad angle of rotation in radians
+   * @returns {Vec2Type} out
+   */
+  rotate(
+      out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[],
+      rad: number): Vec2Type;
+
+  /**
    * Math.round the components of a Vec2Type
    *
    * @param {Vec2Type} out the receiving vector
@@ -233,7 +246,6 @@ interface Vec2Type extends Float32Array {
    * @returns {Vec2Type} out
    */
   round(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
-
 
   /**
    * Scales a Vec2Type by a scalar number

--- a/bindings/wasm/examples/editor.d.ts
+++ b/bindings/wasm/examples/editor.d.ts
@@ -13,3 +13,3207 @@
 // limitations under the License.
 
 declare function show(manifold: Manifold): Manifold;
+
+// Type definitions for gl-matrix 3.4.3 Project:
+// https://github.com/toji/gl-matrix
+//
+// Definitions by: Mattijs Kneppers <https://github.com/mattijskneppers>,
+//
+// based on definitions by Tat <https://github.com/tatchx>
+//
+// Definitions by: Nikolay Babanov <https://github.com/nbabanov>
+
+declare glMatrix as GLMatrix;
+
+interface GLMatrix {
+  // Configuration constants
+  static EPSILON: number;
+  static ARRAY_TYPE: any;
+  static RANDOM(): number;
+  static ENABLE_SIMD: boolean;
+
+  // Compatibility detection
+  static SIMD_AVAILABLE: boolean;
+  static USE_SIMD: boolean;
+
+  /**
+   * Sets the type of array used when creating new vectors and matrices
+   *
+   * @param {any} type - Array type, such as Float32Array or Array
+   */
+  static setMatrixArrayType(type: any): void;
+
+  /**
+   * Convert Degree To Radian
+   *
+   * @param {number} a - Angle in Degrees
+   */
+  static toRadian(a: number): number;
+
+  /**
+   * Tests whether or not the arguments have approximately the same value,
+   * within an absolute or relative tolerance of glMatrix.EPSILON (an absolute
+   * tolerance is used for values less than or equal to 1.0, and a relative
+   * tolerance is used for larger values)
+   *
+   * @param {number} a - The first number to test.
+   * @param {number} b - The second number to test.
+   * @returns {boolean} True if the numbers are approximately equal, false
+   *     otherwise.
+   */
+  static equals(a: number, b: number): boolean;
+
+  static vec2: Vec2;
+  static vec3: Vec3;
+  static vec4: Vec4;
+  static mat2: Mat2;
+  static mat2d: Mat2d;
+  static mat3: Mat3;
+  static mat4: Mat4;
+  static quat: Quat;
+}
+
+interface Vec2 extends Float32Array {
+  private typeVec2: number;
+
+  /**
+   * Creates a new, empty Vec2
+   *
+   * @returns a new 2D vector
+   */
+  public static create(): Vec2;
+
+  /**
+   * Creates a new Vec2 initialized with values from an existing vector
+   *
+   * @param a a vector to clone
+   * @returns a new 2D vector
+   */
+  public static clone(a: Vec2|number[]): Vec2;
+
+  /**
+   * Creates a new Vec2 initialized with the given values
+   *
+   * @param x X component
+   * @param y Y component
+   * @returns a new 2D vector
+   */
+  public static fromValues(x: number, y: number): Vec2;
+
+  /**
+   * Copy the values from one Vec2 to another
+   *
+   * @param out the receiving vector
+   * @param a the source vector
+   * @returns out
+   */
+  public static copy(out: Vec2, a: Vec2|number[]): Vec2;
+
+  /**
+   * Set the components of a Vec2 to the given values
+   *
+   * @param out the receiving vector
+   * @param x X component
+   * @param y Y component
+   * @returns out
+   */
+  public static set(out: Vec2, x: number, y: number): Vec2;
+
+  /**
+   * Adds two Vec2's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static add(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+
+  /**
+   * Subtracts vector b from vector a
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static subtract(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+
+  /**
+   * Subtracts vector b from vector a
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static sub(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+
+  /**
+   * Multiplies two Vec2's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static multiply(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+
+  /**
+   * Multiplies two Vec2's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static mul(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+
+  /**
+   * Divides two Vec2's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static divide(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+
+  /**
+   * Divides two Vec2's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static div(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+
+  /**
+   * Math.ceil the components of a Vec2
+   *
+   * @param {Vec2} out the receiving vector
+   * @param {Vec2} a vector to ceil
+   * @returns {Vec2} out
+   */
+  public static ceil(out: Vec2, a: Vec2|number[]): Vec2;
+
+  /**
+   * Math.floor the components of a Vec2
+   *
+   * @param {Vec2} out the receiving vector
+   * @param {Vec2} a vector to floor
+   * @returns {Vec2} out
+   */
+  public static floor(out: Vec2, a: Vec2|number[]): Vec2;
+
+  /**
+   * Returns the minimum of two Vec2's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static min(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+
+  /**
+   * Returns the maximum of two Vec2's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static max(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+
+  /**
+   * Math.round the components of a Vec2
+   *
+   * @param {Vec2} out the receiving vector
+   * @param {Vec2} a vector to round
+   * @returns {Vec2} out
+   */
+  public static round(out: Vec2, a: Vec2|number[]): Vec2;
+
+
+  /**
+   * Scales a Vec2 by a scalar number
+   *
+   * @param out the receiving vector
+   * @param a the vector to scale
+   * @param b amount to scale the vector by
+   * @returns out
+   */
+  public static scale(out: Vec2, a: Vec2|number[], b: number): Vec2;
+
+  /**
+   * Adds two Vec2's after scaling the second operand by a scalar value
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @param scale the amount to scale b by before adding
+   * @returns out
+   */
+  public static scaleAndAdd(
+      out: Vec2, a: Vec2|number[], b: Vec2|number[], scale: number): Vec2;
+
+  /**
+   * Calculates the euclidian distance between two Vec2's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns distance between a and b
+   */
+  public static distance(a: Vec2|number[], b: Vec2|number[]): number;
+
+  /**
+   * Calculates the euclidian distance between two Vec2's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns distance between a and b
+   */
+  public static dist(a: Vec2|number[], b: Vec2|number[]): number;
+
+  /**
+   * Calculates the squared euclidian distance between two Vec2's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns squared distance between a and b
+   */
+  public static squaredDistance(a: Vec2|number[], b: Vec2|number[]): number;
+
+  /**
+   * Calculates the squared euclidian distance between two Vec2's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns squared distance between a and b
+   */
+  public static sqrDist(a: Vec2|number[], b: Vec2|number[]): number;
+
+  /**
+   * Calculates the length of a Vec2
+   *
+   * @param a vector to calculate length of
+   * @returns length of a
+   */
+  public static length(a: Vec2|number[]): number;
+
+  /**
+   * Calculates the length of a Vec2
+   *
+   * @param a vector to calculate length of
+   * @returns length of a
+   */
+  public static len(a: Vec2|number[]): number;
+
+  /**
+   * Calculates the squared length of a Vec2
+   *
+   * @param a vector to calculate squared length of
+   * @returns squared length of a
+   */
+  public static squaredLength(a: Vec2|number[]): number;
+
+  /**
+   * Calculates the squared length of a Vec2
+   *
+   * @param a vector to calculate squared length of
+   * @returns squared length of a
+   */
+  public static sqrLen(a: Vec2|number[]): number;
+
+  /**
+   * Negates the components of a Vec2
+   *
+   * @param out the receiving vector
+   * @param a vector to negate
+   * @returns out
+   */
+  public static negate(out: Vec2, a: Vec2|number[]): Vec2;
+
+  /**
+   * Returns the inverse of the components of a Vec2
+   *
+   * @param out the receiving vector
+   * @param a vector to invert
+   * @returns out
+   */
+  public static inverse(out: Vec2, a: Vec2|number[]): Vec2;
+
+  /**
+   * Normalize a Vec2
+   *
+   * @param out the receiving vector
+   * @param a vector to normalize
+   * @returns out
+   */
+  public static normalize(out: Vec2, a: Vec2|number[]): Vec2;
+
+  /**
+   * Calculates the dot product of two Vec2's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns dot product of a and b
+   */
+  public static dot(a: Vec2|number[], b: Vec2|number[]): number;
+
+  /**
+   * Computes the cross product of two Vec2's
+   * Note that the cross product must by definition produce a 3D vector
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static cross(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+
+  /**
+   * Performs a linear interpolation between two Vec2's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @param t interpolation amount between the two inputs
+   * @returns out
+   */
+  public static lerp(out: Vec2, a: Vec2|number[], b: Vec2|number[], t: number):
+      Vec2;
+
+  /**
+   * Generates a random unit vector
+   *
+   * @param out the receiving vector
+   * @returns out
+   */
+  public static random(out: Vec2): Vec2;
+
+  /**
+   * Generates a random vector with the given scale
+   *
+   * @param out the receiving vector
+   * @param scale Length of the resulting vector. If ommitted, a unit vector
+   *     will be returned
+   * @returns out
+   */
+  public static random(out: Vec2, scale: number): Vec2;
+
+  /**
+   * Transforms the Vec2 with a Mat2
+   *
+   * @param out the receiving vector
+   * @param a the vector to transform
+   * @param m matrix to transform with
+   * @returns out
+   */
+  public static transformMat2(out: Vec2, a: Vec2|number[], m: Mat2): Vec2;
+
+  /**
+   * Transforms the Vec2 with a Mat2d
+   *
+   * @param out the receiving vector
+   * @param a the vector to transform
+   * @param m matrix to transform with
+   * @returns out
+   */
+  public static transformMat2d(out: Vec2, a: Vec2|number[], m: Mat2d): Vec2;
+
+  /**
+   * Transforms the Vec2 with a Mat3
+   * 3rd vector component is implicitly '1'
+   *
+   * @param out the receiving vector
+   * @param a the vector to transform
+   * @param m matrix to transform with
+   * @returns out
+   */
+  public static transformMat3(out: Vec2, a: Vec2|number[], m: Mat3): Vec2;
+
+  /**
+   * Transforms the Vec2 with a Mat4
+   * 3rd vector component is implicitly '0'
+   * 4th vector component is implicitly '1'
+   *
+   * @param out the receiving vector
+   * @param a the vector to transform
+   * @param m matrix to transform with
+   * @returns out
+   */
+  public static transformMat4(out: Vec2, a: Vec2|number[], m: Mat4): Vec2;
+
+  /**
+   * Perform some operation over an array of vec2s.
+   *
+   * @param a the array of vectors to iterate over
+   * @param stride Number of elements between the start of each Vec2. If 0
+   *     assumes tightly packed
+   * @param offset Number of elements to skip at the beginning of the array
+   * @param count Number of vec2s to iterate over. If 0 iterates over entire
+   *     array
+   * @param fn Function to call for each vector in the array
+   * @param arg additional argument to pass to fn
+   * @returns a
+   */
+  public static forEach(
+      a: Float32Array, stride: number, offset: number, count: number,
+      fn: (a: Vec2|number[], b: Vec2|number[], arg: any) => void,
+      arg: any): Float32Array;
+
+  /**
+   * Perform some operation over an array of vec2s.
+   *
+   * @param a the array of vectors to iterate over
+   * @param stride Number of elements between the start of each Vec2. If 0
+   *     assumes tightly packed
+   * @param offset Number of elements to skip at the beginning of the array
+   * @param count Number of vec2s to iterate over. If 0 iterates over entire
+   *     array
+   * @param fn Function to call for each vector in the array
+   * @returns a
+   */
+  public static forEach(
+      a: Float32Array, stride: number, offset: number, count: number,
+      fn: (a: Vec2|number[], b: Vec2|number[]) => void): Float32Array;
+
+  /**
+   * Returns a string representation of a vector
+   *
+   * @param a vector to represent as a string
+   * @returns string representation of the vector
+   */
+  public static str(a: Vec2|number[]): string;
+
+  /**
+   * Returns whether or not the vectors exactly have the same elements in the
+   * same position (when compared with ===)
+   *
+   * @param {Vec2} a The first vector.
+   * @param {Vec2} b The second vector.
+   * @returns {boolean} True if the vectors are equal, false otherwise.
+   */
+  public static exactEquals(a: Vec2|number[], b: Vec2|number[]): boolean;
+
+  /**
+   * Returns whether or not the vectors have approximately the same elements
+   * in the same position.
+   *
+   * @param {Vec2} a The first vector.
+   * @param {Vec2} b The second vector.
+   * @returns {boolean} True if the vectors are equal, false otherwise.
+   */
+  public static equals(a: Vec2|number[], b: Vec2|number[]): boolean;
+}
+
+// Vec3
+interface Vec3 extends Float32Array {
+  private typeVec3: number;
+
+  /**
+   * Creates a new, empty Vec3
+   *
+   * @returns a new 3D vector
+   */
+  public static create(): Vec3;
+
+  /**
+   * Creates a new Vec3 initialized with values from an existing vector
+   *
+   * @param a vector to clone
+   * @returns a new 3D vector
+   */
+  public static clone(a: Vec3|number[]): Vec3;
+
+  /**
+   * Creates a new Vec3 initialized with the given values
+   *
+   * @param x X component
+   * @param y Y component
+   * @param z Z component
+   * @returns a new 3D vector
+   */
+  public static fromValues(x: number, y: number, z: number): Vec3;
+
+  /**
+   * Copy the values from one Vec3 to another
+   *
+   * @param out the receiving vector
+   * @param a the source vector
+   * @returns out
+   */
+  public static copy(out: Vec3, a: Vec3|number[]): Vec3;
+
+  /**
+   * Set the components of a Vec3 to the given values
+   *
+   * @param out the receiving vector
+   * @param x X component
+   * @param y Y component
+   * @param z Z component
+   * @returns out
+   */
+  public static set(out: Vec3, x: number, y: number, z: number): Vec3;
+
+  /**
+   * Adds two Vec3's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static add(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+
+  /**
+   * Subtracts vector b from vector a
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static subtract(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+
+  /**
+   * Subtracts vector b from vector a
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static sub(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3
+
+      /**
+       * Multiplies two Vec3's
+       *
+       * @param out the receiving vector
+       * @param a the first operand
+       * @param b the second operand
+       * @returns out
+       */
+      public static multiply(out: Vec3, a: Vec3|number[], b: Vec3|number[]):
+          Vec3;
+
+  /**
+   * Multiplies two Vec3's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static mul(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+
+  /**
+   * Divides two Vec3's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static divide(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+
+  /**
+   * Divides two Vec3's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static div(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+
+  /**
+   * Math.ceil the components of a Vec3
+   *
+   * @param {Vec3} out the receiving vector
+   * @param {Vec3} a vector to ceil
+   * @returns {Vec3} out
+   */
+  public static ceil(out: Vec3, a: Vec3|number[]): Vec3;
+
+  /**
+   * Math.floor the components of a Vec3
+   *
+   * @param {Vec3} out the receiving vector
+   * @param {Vec3} a vector to floor
+   * @returns {Vec3} out
+   */
+  public static floor(out: Vec3, a: Vec3|number[]): Vec3;
+
+  /**
+   * Returns the minimum of two Vec3's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static min(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+
+  /**
+   * Returns the maximum of two Vec3's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static max(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+
+  /**
+   * Math.round the components of a Vec3
+   *
+   * @param {Vec3} out the receiving vector
+   * @param {Vec3} a vector to round
+   * @returns {Vec3} out
+   */
+  public static round(out: Vec3, a: Vec3|number[]): Vec3
+
+      /**
+       * Scales a Vec3 by a scalar number
+       *
+       * @param out the receiving vector
+       * @param a the vector to scale
+       * @param b amount to scale the vector by
+       * @returns out
+       */
+      public static scale(out: Vec3, a: Vec3|number[], b: number): Vec3;
+
+  /**
+   * Adds two Vec3's after scaling the second operand by a scalar value
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @param scale the amount to scale b by before adding
+   * @returns out
+   */
+  public static scaleAndAdd(
+      out: Vec3, a: Vec3|number[], b: Vec3|number[], scale: number): Vec3;
+
+  /**
+   * Calculates the euclidian distance between two Vec3's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns distance between a and b
+   */
+  public static distance(a: Vec3|number[], b: Vec3|number[]): number;
+
+  /**
+   * Calculates the euclidian distance between two Vec3's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns distance between a and b
+   */
+  public static dist(a: Vec3|number[], b: Vec3|number[]): number;
+
+  /**
+   * Calculates the squared euclidian distance between two Vec3's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns squared distance between a and b
+   */
+  public static squaredDistance(a: Vec3|number[], b: Vec3|number[]): number;
+
+  /**
+   * Calculates the squared euclidian distance between two Vec3's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns squared distance between a and b
+   */
+  public static sqrDist(a: Vec3|number[], b: Vec3|number[]): number;
+
+  /**
+   * Calculates the length of a Vec3
+   *
+   * @param a vector to calculate length of
+   * @returns length of a
+   */
+  public static length(a: Vec3|number[]): number;
+
+  /**
+   * Calculates the length of a Vec3
+   *
+   * @param a vector to calculate length of
+   * @returns length of a
+   */
+  public static len(a: Vec3|number[]): number;
+
+  /**
+   * Calculates the squared length of a Vec3
+   *
+   * @param a vector to calculate squared length of
+   * @returns squared length of a
+   */
+  public static squaredLength(a: Vec3|number[]): number;
+
+  /**
+   * Calculates the squared length of a Vec3
+   *
+   * @param a vector to calculate squared length of
+   * @returns squared length of a
+   */
+  public static sqrLen(a: Vec3|number[]): number;
+
+  /**
+   * Negates the components of a Vec3
+   *
+   * @param out the receiving vector
+   * @param a vector to negate
+   * @returns out
+   */
+  public static negate(out: Vec3, a: Vec3|number[]): Vec3;
+
+  /**
+   * Returns the inverse of the components of a Vec3
+   *
+   * @param out the receiving vector
+   * @param a vector to invert
+   * @returns out
+   */
+  public static inverse(out: Vec3, a: Vec3|number[]): Vec3;
+
+  /**
+   * Normalize a Vec3
+   *
+   * @param out the receiving vector
+   * @param a vector to normalize
+   * @returns out
+   */
+  public static normalize(out: Vec3, a: Vec3|number[]): Vec3;
+
+  /**
+   * Calculates the dot product of two Vec3's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns dot product of a and b
+   */
+  public static dot(a: Vec3|number[], b: Vec3|number[]): number;
+
+  /**
+   * Computes the cross product of two Vec3's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static cross(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+
+  /**
+   * Performs a linear interpolation between two Vec3's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @param t interpolation amount between the two inputs
+   * @returns out
+   */
+  public static lerp(out: Vec3, a: Vec3|number[], b: Vec3|number[], t: number):
+      Vec3;
+
+  /**
+   * Performs a hermite interpolation with two control points
+   *
+   * @param {Vec3} out the receiving vector
+   * @param {Vec3} a the first operand
+   * @param {Vec3} b the second operand
+   * @param {Vec3} c the third operand
+   * @param {Vec3} d the fourth operand
+   * @param {number} t interpolation amount between the two inputs
+   * @returns {Vec3} out
+   */
+  public static hermite(
+      out: Vec3, a: Vec3|number[], b: Vec3|number[], c: Vec3|number[],
+      d: Vec3|number[], t: number): Vec3;
+
+  /**
+   * Performs a bezier interpolation with two control points
+   *
+   * @param {Vec3} out the receiving vector
+   * @param {Vec3} a the first operand
+   * @param {Vec3} b the second operand
+   * @param {Vec3} c the third operand
+   * @param {Vec3} d the fourth operand
+   * @param {number} t interpolation amount between the two inputs
+   * @returns {Vec3} out
+   */
+  public static bezier(
+      out: Vec3, a: Vec3|number[], b: Vec3|number[], c: Vec3|number[],
+      d: Vec3|number[], t: number): Vec3;
+
+  /**
+   * Generates a random unit vector
+   *
+   * @param out the receiving vector
+   * @returns out
+   */
+  public static random(out: Vec3): Vec3;
+
+  /**
+   * Generates a random vector with the given scale
+   *
+   * @param out the receiving vector
+   * @param [scale] Length of the resulting vector. If omitted, a unit vector
+   *     will be returned
+   * @returns out
+   */
+  public static random(out: Vec3, scale: number): Vec3;
+
+  /**
+   * Transforms the Vec3 with a Mat3.
+   *
+   * @param out the receiving vector
+   * @param a the vector to transform
+   * @param m the 3x3 matrix to transform with
+   * @returns out
+   */
+  public static transformMat3(out: Vec3, a: Vec3|number[], m: Mat3): Vec3;
+
+  /**
+   * Transforms the Vec3 with a Mat4.
+   * 4th vector component is implicitly '1'
+   *
+   * @param out the receiving vector
+   * @param a the vector to transform
+   * @param m matrix to transform with
+   * @returns out
+   */
+  public static transformMat4(out: Vec3, a: Vec3|number[], m: Mat4): Vec3;
+
+  /**
+   * Transforms the Vec3 with a Quat
+   *
+   * @param out the receiving vector
+   * @param a the vector to transform
+   * @param q Quaternion to transform with
+   * @returns out
+   */
+  public static transformQuat(out: Vec3, a: Vec3|number[], q: Quat): Vec3;
+
+
+  /**
+   * Rotate a 3D vector around the x-axis
+   * @param out The receiving Vec3
+   * @param a The Vec3 point to rotate
+   * @param b The origin of the rotation
+   * @param c The angle of rotation
+   * @returns out
+   */
+  public static rotateX(
+      out: Vec3, a: Vec3|number[], b: Vec3|number[], c: number): Vec3;
+
+  /**
+   * Rotate a 3D vector around the y-axis
+   * @param out The receiving Vec3
+   * @param a The Vec3 point to rotate
+   * @param b The origin of the rotation
+   * @param c The angle of rotation
+   * @returns out
+   */
+  public static rotateY(
+      out: Vec3, a: Vec3|number[], b: Vec3|number[], c: number): Vec3;
+
+  /**
+   * Rotate a 3D vector around the z-axis
+   * @param out The receiving Vec3
+   * @param a The Vec3 point to rotate
+   * @param b The origin of the rotation
+   * @param c The angle of rotation
+   * @returns out
+   */
+  public static rotateZ(
+      out: Vec3, a: Vec3|number[], b: Vec3|number[], c: number): Vec3;
+
+  /**
+   * Perform some operation over an array of vec3s.
+   *
+   * @param a the array of vectors to iterate over
+   * @param stride Number of elements between the start of each Vec3. If 0
+   *     assumes tightly packed
+   * @param offset Number of elements to skip at the beginning of the array
+   * @param count Number of vec3s to iterate over. If 0 iterates over entire
+   *     array
+   * @param fn Function to call for each vector in the array
+   * @param arg additional argument to pass to fn
+   * @returns a
+   * @function
+   */
+  public static forEach(
+      a: Float32Array, stride: number, offset: number, count: number,
+      fn: (a: Vec3|number[], b: Vec3|number[], arg: any) => void,
+      arg: any): Float32Array;
+
+  /**
+   * Perform some operation over an array of vec3s.
+   *
+   * @param a the array of vectors to iterate over
+   * @param stride Number of elements between the start of each Vec3. If 0
+   *     assumes tightly packed
+   * @param offset Number of elements to skip at the beginning of the array
+   * @param count Number of vec3s to iterate over. If 0 iterates over entire
+   *     array
+   * @param fn Function to call for each vector in the array
+   * @returns a
+   * @function
+   */
+  public static forEach(
+      a: Float32Array, stride: number, offset: number, count: number,
+      fn: (a: Vec3|number[], b: Vec3|number[]) => void): Float32Array;
+
+  /**
+   * Get the angle between two 3D vectors
+   * @param a The first operand
+   * @param b The second operand
+   * @returns The angle in radians
+   */
+  public static angle(a: Vec3|number[], b: Vec3|number[]): number;
+
+  /**
+   * Returns a string representation of a vector
+   *
+   * @param a vector to represent as a string
+   * @returns string representation of the vector
+   */
+  public static str(a: Vec3|number[]): string;
+
+  /**
+   * Returns whether or not the vectors have exactly the same elements in the
+   * same position (when compared with ===)
+   *
+   * @param {Vec3} a The first vector.
+   * @param {Vec3} b The second vector.
+   * @returns {boolean} True if the vectors are equal, false otherwise.
+   */
+  public static exactEquals(a: Vec3|number[], b: Vec3|number[]): boolean
+
+      /**
+       * Returns whether or not the vectors have approximately the same
+       * elements in the same position.
+       *
+       * @param {Vec3} a The first vector.
+       * @param {Vec3} b The second vector.
+       * @returns {boolean} True if the vectors are equal, false otherwise.
+       */
+      public static equals(a: Vec3|number[], b: Vec3|number[]): boolean
+}
+
+// Vec4
+interface Vec4 extends Float32Array {
+  private typeVec3: number;
+
+  /**
+   * Creates a new, empty Vec4
+   *
+   * @returns a new 4D vector
+   */
+  public static create(): Vec4;
+
+  /**
+   * Creates a new Vec4 initialized with values from an existing vector
+   *
+   * @param a vector to clone
+   * @returns a new 4D vector
+   */
+  public static clone(a: Vec4|number[]): Vec4;
+
+  /**
+   * Creates a new Vec4 initialized with the given values
+   *
+   * @param x X component
+   * @param y Y component
+   * @param z Z component
+   * @param w W component
+   * @returns a new 4D vector
+   */
+  public static fromValues(x: number, y: number, z: number, w: number): Vec4;
+
+  /**
+   * Copy the values from one Vec4 to another
+   *
+   * @param out the receiving vector
+   * @param a the source vector
+   * @returns out
+   */
+  public static copy(out: Vec4, a: Vec4|number[]): Vec4;
+
+  /**
+   * Set the components of a Vec4 to the given values
+   *
+   * @param out the receiving vector
+   * @param x X component
+   * @param y Y component
+   * @param z Z component
+   * @param w W component
+   * @returns out
+   */
+  public static set(out: Vec4, x: number, y: number, z: number, w: number):
+      Vec4;
+
+  /**
+   * Adds two Vec4's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static add(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+
+  /**
+   * Subtracts vector b from vector a
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static subtract(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+
+  /**
+   * Subtracts vector b from vector a
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static sub(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+
+  /**
+   * Multiplies two Vec4's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static multiply(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+
+  /**
+   * Multiplies two Vec4's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static mul(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+
+  /**
+   * Divides two Vec4's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static divide(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+
+  /**
+   * Divides two Vec4's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static div(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+
+  /**
+   * Math.ceil the components of a Vec4
+   *
+   * @param {Vec4} out the receiving vector
+   * @param {Vec4} a vector to ceil
+   * @returns {Vec4} out
+   */
+  public static ceil(out: Vec4, a: Vec4|number[]): Vec4;
+
+  /**
+   * Math.floor the components of a Vec4
+   *
+   * @param {Vec4} out the receiving vector
+   * @param {Vec4} a vector to floor
+   * @returns {Vec4} out
+   */
+  public static floor(out: Vec4, a: Vec4|number[]): Vec4;
+
+  /**
+   * Returns the minimum of two Vec4's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static min(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+
+  /**
+   * Returns the maximum of two Vec4's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static max(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+
+  /**
+   * Math.round the components of a Vec4
+   *
+   * @param {Vec4} out the receiving vector
+   * @param {Vec4} a vector to round
+   * @returns {Vec4} out
+   */
+  public static round(out: Vec4, a: Vec4|number[]): Vec4;
+
+  /**
+   * Scales a Vec4 by a scalar number
+   *
+   * @param out the receiving vector
+   * @param a the vector to scale
+   * @param b amount to scale the vector by
+   * @returns out
+   */
+  public static scale(out: Vec4, a: Vec4|number[], b: number): Vec4;
+
+  /**
+   * Adds two Vec4's after scaling the second operand by a scalar value
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @param scale the amount to scale b by before adding
+   * @returns out
+   */
+  public static scaleAndAdd(
+      out: Vec4, a: Vec4|number[], b: Vec4|number[], scale: number): Vec4;
+
+  /**
+   * Calculates the euclidian distance between two Vec4's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns distance between a and b
+   */
+  public static distance(a: Vec4|number[], b: Vec4|number[]): number;
+
+  /**
+   * Calculates the euclidian distance between two Vec4's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns distance between a and b
+   */
+  public static dist(a: Vec4|number[], b: Vec4|number[]): number;
+
+  /**
+   * Calculates the squared euclidian distance between two Vec4's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns squared distance between a and b
+   */
+  public static squaredDistance(a: Vec4|number[], b: Vec4|number[]): number;
+
+  /**
+   * Calculates the squared euclidian distance between two Vec4's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns squared distance between a and b
+   */
+  public static sqrDist(a: Vec4|number[], b: Vec4|number[]): number;
+
+  /**
+   * Calculates the length of a Vec4
+   *
+   * @param a vector to calculate length of
+   * @returns length of a
+   */
+  public static length(a: Vec4|number[]): number;
+
+  /**
+   * Calculates the length of a Vec4
+   *
+   * @param a vector to calculate length of
+   * @returns length of a
+   */
+  public static len(a: Vec4|number[]): number;
+
+  /**
+   * Calculates the squared length of a Vec4
+   *
+   * @param a vector to calculate squared length of
+   * @returns squared length of a
+   */
+  public static squaredLength(a: Vec4|number[]): number;
+
+  /**
+   * Calculates the squared length of a Vec4
+   *
+   * @param a vector to calculate squared length of
+   * @returns squared length of a
+   */
+  public static sqrLen(a: Vec4|number[]): number;
+
+  /**
+   * Negates the components of a Vec4
+   *
+   * @param out the receiving vector
+   * @param a vector to negate
+   * @returns out
+   */
+  public static negate(out: Vec4, a: Vec4|number[]): Vec4;
+
+  /**
+   * Returns the inverse of the components of a Vec4
+   *
+   * @param out the receiving vector
+   * @param a vector to invert
+   * @returns out
+   */
+  public static inverse(out: Vec4, a: Vec4|number[]): Vec4;
+
+  /**
+   * Normalize a Vec4
+   *
+   * @param out the receiving vector
+   * @param a vector to normalize
+   * @returns out
+   */
+  public static normalize(out: Vec4, a: Vec4|number[]): Vec4;
+
+  /**
+   * Calculates the dot product of two Vec4's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns dot product of a and b
+   */
+  public static dot(a: Vec4|number[], b: Vec4|number[]): number;
+
+  /**
+   * Performs a linear interpolation between two Vec4's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @param t interpolation amount between the two inputs
+   * @returns out
+   */
+  public static lerp(out: Vec4, a: Vec4|number[], b: Vec4|number[], t: number):
+      Vec4;
+
+  /**
+   * Generates a random unit vector
+   *
+   * @param out the receiving vector
+   * @returns out
+   */
+  public static random(out: Vec4): Vec4;
+
+  /**
+   * Generates a random vector with the given scale
+   *
+   * @param out the receiving vector
+   * @param scale length of the resulting vector. If ommitted, a unit vector
+   *     will be returned
+   * @returns out
+   */
+  public static random(out: Vec4, scale: number): Vec4;
+
+  /**
+   * Transforms the Vec4 with a Mat4.
+   *
+   * @param out the receiving vector
+   * @param a the vector to transform
+   * @param m matrix to transform with
+   * @returns out
+   */
+  public static transformMat4(out: Vec4, a: Vec4|number[], m: Mat4): Vec4;
+
+  /**
+   * Transforms the Vec4 with a Quat
+   *
+   * @param out the receiving vector
+   * @param a the vector to transform
+   * @param q Quaternion to transform with
+   * @returns out
+   */
+
+  public static transformQuat(out: Vec4, a: Vec4|number[], q: Quat): Vec4;
+
+  /**
+   * Perform some operation over an array of Vec4s.
+   *
+   * @param a the array of vectors to iterate over
+   * @param stride Number of elements between the start of each Vec4. If 0
+   *     assumes tightly packed
+   * @param offset Number of elements to skip at the beginning of the array
+   * @param count Number of Vec4s to iterate over. If 0 iterates over entire
+   *     array
+   * @param fn Function to call for each vector in the array
+   * @param arg additional argument to pass to fn
+   * @returns a
+   * @function
+   */
+  public static forEach(
+      a: Float32Array, stride: number, offset: number, count: number,
+      fn: (a: Vec4|number[], b: Vec4|number[], arg: any) => void,
+      arg: any): Float32Array;
+
+  /**
+   * Perform some operation over an array of Vec4s.
+   *
+   * @param a the array of vectors to iterate over
+   * @param stride Number of elements between the start of each Vec4. If 0
+   *     assumes tightly packed
+   * @param offset Number of elements to skip at the beginning of the array
+   * @param count Number of Vec4s to iterate over. If 0 iterates over entire
+   *     array
+   * @param fn Function to call for each vector in the array
+   * @returns a
+   * @function
+   */
+  public static forEach(
+      a: Float32Array, stride: number, offset: number, count: number,
+      fn: (a: Vec4|number[], b: Vec4|number[]) => void): Float32Array;
+
+  /**
+   * Returns a string representation of a vector
+   *
+   * @param a vector to represent as a string
+   * @returns string representation of the vector
+   */
+  public static str(a: Vec4|number[]): string;
+
+  /**
+   * Returns whether or not the vectors have exactly the same elements in the
+   * same position (when compared with ===)
+   *
+   * @param {Vec4} a The first vector.
+   * @param {Vec4} b The second vector.
+   * @returns {boolean} True if the vectors are equal, false otherwise.
+   */
+  public static exactEquals(a: Vec4|number[], b: Vec4|number[]): boolean;
+
+  /**
+   * Returns whether or not the vectors have approximately the same elements
+   * in the same position.
+   *
+   * @param {Vec4} a The first vector.
+   * @param {Vec4} b The second vector.
+   * @returns {boolean} True if the vectors are equal, false otherwise.
+   */
+  public static equals(a: Vec4|number[], b: Vec4|number[]): boolean;
+}
+
+// Mat2
+interface Mat2 extends Float32Array {
+  private typeMat2: number;
+
+  /**
+   * Creates a new identity Mat2
+   *
+   * @returns a new 2x2 matrix
+   */
+  public static create(): Mat2;
+
+  /**
+   * Creates a new Mat2 initialized with values from an existing matrix
+   *
+   * @param a matrix to clone
+   * @returns a new 2x2 matrix
+   */
+  public static clone(a: Mat2): Mat2;
+
+  /**
+   * Copy the values from one Mat2 to another
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  public static copy(out: Mat2, a: Mat2): Mat2;
+
+  /**
+   * Set a Mat2 to the identity matrix
+   *
+   * @param out the receiving matrix
+   * @returns out
+   */
+  public static identity(out: Mat2): Mat2;
+
+  /**
+   * Create a new Mat2 with the given values
+   *
+   * @param {number} m00 Component in column 0, row 0 position (index 0)
+   * @param {number} m01 Component in column 0, row 1 position (index 1)
+   * @param {number} m10 Component in column 1, row 0 position (index 2)
+   * @param {number} m11 Component in column 1, row 1 position (index 3)
+   * @returns {Mat2} out A new 2x2 matrix
+   */
+  public static fromValues(m00: number, m01: number, m10: number, m11: number):
+      Mat2;
+
+  /**
+   * Set the components of a Mat2 to the given values
+   *
+   * @param {Mat2} out the receiving matrix
+   * @param {number} m00 Component in column 0, row 0 position (index 0)
+   * @param {number} m01 Component in column 0, row 1 position (index 1)
+   * @param {number} m10 Component in column 1, row 0 position (index 2)
+   * @param {number} m11 Component in column 1, row 1 position (index 3)
+   * @returns {Mat2} out
+   */
+  public static set(
+      out: Mat2, m00: number, m01: number, m10: number, m11: number): Mat2;
+
+  /**
+   * Transpose the values of a Mat2
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  public static transpose(out: Mat2, a: Mat2): Mat2;
+
+  /**
+   * Inverts a Mat2
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  public static invert(out: Mat2, a: Mat2): Mat2|null;
+
+  /**
+   * Calculates the adjugate of a Mat2
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  public static adjoint(out: Mat2, a: Mat2): Mat2;
+
+  /**
+   * Calculates the determinant of a Mat2
+   *
+   * @param a the source matrix
+   * @returns determinant of a
+   */
+  public static determinant(a: Mat2): number;
+
+  /**
+   * Multiplies two Mat2's
+   *
+   * @param out the receiving matrix
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static multiply(out: Mat2, a: Mat2, b: Mat2): Mat2;
+
+  /**
+   * Multiplies two Mat2's
+   *
+   * @param out the receiving matrix
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static mul(out: Mat2, a: Mat2, b: Mat2): Mat2;
+
+  /**
+   * Rotates a Mat2 by the given angle
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to rotate
+   * @param rad the angle to rotate the matrix by
+   * @returns out
+   */
+  public static rotate(out: Mat2, a: Mat2, rad: number): Mat2;
+
+  /**
+   * Scales the Mat2 by the dimensions in the given Vec2
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to rotate
+   * @param v the Vec2 to scale the matrix by
+   * @returns out
+   **/
+  public static scale(out: Mat2, a: Mat2, v: Vec2|number[]): Mat2;
+
+  /**
+   * Creates a matrix from a given angle
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat2.identity(dest);
+   *     Mat2.rotate(dest, dest, rad);
+   *
+   * @param {Mat2} out Mat2 receiving operation result
+   * @param {number} rad the angle to rotate the matrix by
+   * @returns {Mat2} out
+   */
+  public static fromRotation(out: Mat2, rad: number): Mat2;
+
+  /**
+   * Creates a matrix from a vector scaling
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat2.identity(dest);
+   *     Mat2.scale(dest, dest, vec);
+   *
+   * @param {Mat2} out Mat2 receiving operation result
+   * @param {Vec2} v Scaling vector
+   * @returns {Mat2} out
+   */
+  public static fromScaling(out: Mat2, v: Vec2|number[]): Mat2;
+
+  /**
+   * Returns a string representation of a Mat2
+   *
+   * @param a matrix to represent as a string
+   * @returns string representation of the matrix
+   */
+  public static str(a: Mat2): string;
+
+  /**
+   * Returns Frobenius norm of a Mat2
+   *
+   * @param a the matrix to calculate Frobenius norm of
+   * @returns Frobenius norm
+   */
+  public static frob(a: Mat2): number;
+
+  /**
+   * Returns L, D and U matrices (Lower triangular, Diagonal and Upper
+   * triangular) by factorizing the input matrix
+   * @param L the lower triangular matrix
+   * @param D the diagonal matrix
+   * @param U the upper triangular matrix
+   * @param a the input matrix to factorize
+   */
+  public static LDU(L: Mat2, D: Mat2, U: Mat2, a: Mat2): Mat2;
+
+  /**
+   * Adds two Mat2's
+   *
+   * @param {Mat2} out the receiving matrix
+   * @param {Mat2} a the first operand
+   * @param {Mat2} b the second operand
+   * @returns {Mat2} out
+   */
+  public static add(out: Mat2, a: Mat2, b: Mat2): Mat2;
+
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat2} out the receiving matrix
+   * @param {Mat2} a the first operand
+   * @param {Mat2} b the second operand
+   * @returns {Mat2} out
+   */
+  public static subtract(out: Mat2, a: Mat2, b: Mat2): Mat2;
+
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat2} out the receiving matrix
+   * @param {Mat2} a the first operand
+   * @param {Mat2} b the second operand
+   * @returns {Mat2} out
+   */
+  public static sub(out: Mat2, a: Mat2, b: Mat2): Mat2;
+
+  /**
+   * Returns whether or not the matrices have exactly the same elements in the
+   * same position (when compared with ===)
+   *
+   * @param {Mat2} a The first matrix.
+   * @param {Mat2} b The second matrix.
+   * @returns {boolean} True if the matrices are equal, false otherwise.
+   */
+  public static exactEquals(a: Mat2, b: Mat2): boolean;
+
+  /**
+   * Returns whether or not the matrices have approximately the same elements
+   * in the same position.
+   *
+   * @param {Mat2} a The first matrix.
+   * @param {Mat2} b The second matrix.
+   * @returns {boolean} True if the matrices are equal, false otherwise.
+   */
+  public static equals(a: Mat2, b: Mat2): boolean;
+
+  /**
+   * Multiply each element of the matrix by a scalar.
+   *
+   * @param {Mat2} out the receiving matrix
+   * @param {Mat2} a the matrix to scale
+   * @param {number} b amount to scale the matrix's elements by
+   * @returns {Mat2} out
+   */
+  public static multiplyScalar(out: Mat2, a: Mat2, b: number): Mat2
+
+      /**
+       * Adds two Mat2's after multiplying each element of the second operand
+       * by a scalar value.
+       *
+       * @param {Mat2} out the receiving vector
+       * @param {Mat2} a the first operand
+       * @param {Mat2} b the second operand
+       * @param {number} scale the amount to scale b's elements by before
+       *     adding
+       * @returns {Mat2} out
+       */
+      public static multiplyScalarAndAdd(
+          out: Mat2, a: Mat2, b: Mat2, scale: number): Mat2
+}
+
+// Mat2d
+interface Mat2d extends Float32Array {
+  private typeMat2d: number;
+
+  /**
+   * Creates a new identity Mat2d
+   *
+   * @returns a new 2x3 matrix
+   */
+  public static create(): Mat2d;
+
+  /**
+   * Creates a new Mat2d initialized with values from an existing matrix
+   *
+   * @param a matrix to clone
+   * @returns a new 2x3 matrix
+   */
+  public static clone(a: Mat2d): Mat2d;
+
+  /**
+   * Copy the values from one Mat2d to another
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  public static copy(out: Mat2d, a: Mat2d): Mat2d;
+
+  /**
+   * Set a Mat2d to the identity matrix
+   *
+   * @param out the receiving matrix
+   * @returns out
+   */
+  public static identity(out: Mat2d): Mat2d;
+
+  /**
+   * Create a new Mat2d with the given values
+   *
+   * @param {number} a Component A (index 0)
+   * @param {number} b Component B (index 1)
+   * @param {number} c Component C (index 2)
+   * @param {number} d Component D (index 3)
+   * @param {number} tx Component TX (index 4)
+   * @param {number} ty Component TY (index 5)
+   * @returns {Mat2d} A new Mat2d
+   */
+  public static fromValues(
+      a: number, b: number, c: number, d: number, tx: number, ty: number): Mat2d
+
+
+      /**
+       * Set the components of a Mat2d to the given values
+       *
+       * @param {Mat2d} out the receiving matrix
+       * @param {number} a Component A (index 0)
+       * @param {number} b Component B (index 1)
+       * @param {number} c Component C (index 2)
+       * @param {number} d Component D (index 3)
+       * @param {number} tx Component TX (index 4)
+       * @param {number} ty Component TY (index 5)
+       * @returns {Mat2d} out
+       */
+      public static set(
+          out: Mat2d, a: number, b: number, c: number, d: number, tx: number,
+          ty: number): Mat2d
+
+      /**
+       * Inverts a Mat2d
+       *
+       * @param out the receiving matrix
+       * @param a the source matrix
+       * @returns out
+       */
+      public static invert(out: Mat2d, a: Mat2d): Mat2d|null;
+
+  /**
+   * Calculates the determinant of a Mat2d
+   *
+   * @param a the source matrix
+   * @returns determinant of a
+   */
+  public static determinant(a: Mat2d): number;
+
+  /**
+   * Multiplies two Mat2d's
+   *
+   * @param out the receiving matrix
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static multiply(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d;
+
+  /**
+   * Multiplies two Mat2d's
+   *
+   * @param out the receiving matrix
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static mul(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d;
+
+  /**
+   * Rotates a Mat2d by the given angle
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to rotate
+   * @param rad the angle to rotate the matrix by
+   * @returns out
+   */
+  public static rotate(out: Mat2d, a: Mat2d, rad: number): Mat2d;
+
+  /**
+   * Scales the Mat2d by the dimensions in the given Vec2
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to translate
+   * @param v the Vec2 to scale the matrix by
+   * @returns out
+   **/
+  public static scale(out: Mat2d, a: Mat2d, v: Vec2|number[]): Mat2d;
+
+  /**
+   * Translates the Mat2d by the dimensions in the given Vec2
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to translate
+   * @param v the Vec2 to translate the matrix by
+   * @returns out
+   **/
+  public static translate(out: Mat2d, a: Mat2d, v: Vec2|number[]): Mat2d;
+
+  /**
+   * Creates a matrix from a given angle
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat2d.identity(dest);
+   *     Mat2d.rotate(dest, dest, rad);
+   *
+   * @param {Mat2d} out Mat2d receiving operation result
+   * @param {number} rad the angle to rotate the matrix by
+   * @returns {Mat2d} out
+   */
+  public static fromRotation(out: Mat2d, rad: number): Mat2d;
+
+  /**
+   * Creates a matrix from a vector scaling
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat2d.identity(dest);
+   *     Mat2d.scale(dest, dest, vec);
+   *
+   * @param {Mat2d} out Mat2d receiving operation result
+   * @param {Vec2} v Scaling vector
+   * @returns {Mat2d} out
+   */
+  public static fromScaling(out: Mat2d, v: Vec2|number[]): Mat2d;
+
+  /**
+   * Creates a matrix from a vector translation
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat2d.identity(dest);
+   *     Mat2d.translate(dest, dest, vec);
+   *
+   * @param {Mat2d} out Mat2d receiving operation result
+   * @param {Vec2} v Translation vector
+   * @returns {Mat2d} out
+   */
+  public static fromTranslation(out: Mat2d, v: Vec2|number[]): Mat2d
+
+      /**
+       * Returns a string representation of a Mat2d
+       *
+       * @param a matrix to represent as a string
+       * @returns string representation of the matrix
+       */
+      public static str(a: Mat2d): string;
+
+  /**
+   * Returns Frobenius norm of a Mat2d
+   *
+   * @param a the matrix to calculate Frobenius norm of
+   * @returns Frobenius norm
+   */
+  public static frob(a: Mat2d): number;
+
+  /**
+   * Adds two Mat2d's
+   *
+   * @param {Mat2d} out the receiving matrix
+   * @param {Mat2d} a the first operand
+   * @param {Mat2d} b the second operand
+   * @returns {Mat2d} out
+   */
+  public static add(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
+
+      /**
+       * Subtracts matrix b from matrix a
+       *
+       * @param {Mat2d} out the receiving matrix
+       * @param {Mat2d} a the first operand
+       * @param {Mat2d} b the second operand
+       * @returns {Mat2d} out
+       */
+      public static subtract(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
+
+      /**
+       * Subtracts matrix b from matrix a
+       *
+       * @param {Mat2d} out the receiving matrix
+       * @param {Mat2d} a the first operand
+       * @param {Mat2d} b the second operand
+       * @returns {Mat2d} out
+       */
+      public static sub(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
+
+      /**
+       * Multiply each element of the matrix by a scalar.
+       *
+       * @param {Mat2d} out the receiving matrix
+       * @param {Mat2d} a the matrix to scale
+       * @param {number} b amount to scale the matrix's elements by
+       * @returns {Mat2d} out
+       */
+      public static multiplyScalar(out: Mat2d, a: Mat2d, b: number): Mat2d;
+
+  /**
+   * Adds two Mat2d's after multiplying each element of the second operand by
+   * a scalar value.
+   *
+   * @param {Mat2d} out the receiving vector
+   * @param {Mat2d} a the first operand
+   * @param {Mat2d} b the second operand
+   * @param {number} scale the amount to scale b's elements by before adding
+   * @returns {Mat2d} out
+   */
+  public static multiplyScalarAndAdd(
+      out: Mat2d, a: Mat2d, b: Mat2d, scale: number): Mat2d
+
+      /**
+       * Returns whether or not the matrices have exactly the same elements in
+       * the same position (when compared with ===)
+       *
+       * @param {Mat2d} a The first matrix.
+       * @param {Mat2d} b The second matrix.
+       * @returns {boolean} True if the matrices are equal, false otherwise.
+       */
+      public static exactEquals(a: Mat2d, b: Mat2d): boolean;
+
+  /**
+   * Returns whether or not the matrices have approximately the same elements
+   * in the same position.
+   *
+   * @param {Mat2d} a The first matrix.
+   * @param {Mat2d} b The second matrix.
+   * @returns {boolean} True if the matrices are equal, false otherwise.
+   */
+  public static equals(a: Mat2d, b: Mat2d): boolean
+}
+
+// Mat3
+interface Mat3 extends Float32Array {
+  private typeMat3: number;
+
+  /**
+   * Creates a new identity Mat3
+   *
+   * @returns a new 3x3 matrix
+   */
+  public static create(): Mat3;
+
+  /**
+   * Copies the upper-left 3x3 values into the given Mat3.
+   *
+   * @param {Mat3} out the receiving 3x3 matrix
+   * @param {Mat4} a   the source 4x4 matrix
+   * @returns {Mat3} out
+   */
+  public static fromMat4(out: Mat3, a: Mat4): Mat3
+
+      /**
+       * Creates a new Mat3 initialized with values from an existing matrix
+       *
+       * @param a matrix to clone
+       * @returns a new 3x3 matrix
+       */
+      public static clone(a: Mat3): Mat3;
+
+  /**
+   * Copy the values from one Mat3 to another
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  public static copy(out: Mat3, a: Mat3): Mat3;
+
+  /**
+   * Create a new Mat3 with the given values
+   *
+   * @param {number} m00 Component in column 0, row 0 position (index 0)
+   * @param {number} m01 Component in column 0, row 1 position (index 1)
+   * @param {number} m02 Component in column 0, row 2 position (index 2)
+   * @param {number} m10 Component in column 1, row 0 position (index 3)
+   * @param {number} m11 Component in column 1, row 1 position (index 4)
+   * @param {number} m12 Component in column 1, row 2 position (index 5)
+   * @param {number} m20 Component in column 2, row 0 position (index 6)
+   * @param {number} m21 Component in column 2, row 1 position (index 7)
+   * @param {number} m22 Component in column 2, row 2 position (index 8)
+   * @returns {Mat3} A new Mat3
+   */
+  public static fromValues(
+      m00: number, m01: number, m02: number, m10: number, m11: number,
+      m12: number, m20: number, m21: number, m22: number): Mat3;
+
+
+  /**
+   * Set the components of a Mat3 to the given values
+   *
+   * @param {Mat3} out the receiving matrix
+   * @param {number} m00 Component in column 0, row 0 position (index 0)
+   * @param {number} m01 Component in column 0, row 1 position (index 1)
+   * @param {number} m02 Component in column 0, row 2 position (index 2)
+   * @param {number} m10 Component in column 1, row 0 position (index 3)
+   * @param {number} m11 Component in column 1, row 1 position (index 4)
+   * @param {number} m12 Component in column 1, row 2 position (index 5)
+   * @param {number} m20 Component in column 2, row 0 position (index 6)
+   * @param {number} m21 Component in column 2, row 1 position (index 7)
+   * @param {number} m22 Component in column 2, row 2 position (index 8)
+   * @returns {Mat3} out
+   */
+  public static set(
+      out: Mat3, m00: number, m01: number, m02: number, m10: number,
+      m11: number, m12: number, m20: number, m21: number, m22: number): Mat3
+
+      /**
+       * Set a Mat3 to the identity matrix
+       *
+       * @param out the receiving matrix
+       * @returns out
+       */
+      public static identity(out: Mat3): Mat3;
+
+  /**
+   * Transpose the values of a Mat3
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  public static transpose(out: Mat3, a: Mat3): Mat3;
+
+  /**
+   * Inverts a Mat3
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  public static invert(out: Mat3, a: Mat3): Mat3|null;
+
+  /**
+   * Calculates the adjugate of a Mat3
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  public static adjoint(out: Mat3, a: Mat3): Mat3;
+
+  /**
+   * Calculates the determinant of a Mat3
+   *
+   * @param a the source matrix
+   * @returns determinant of a
+   */
+  public static determinant(a: Mat3): number;
+
+  /**
+   * Multiplies two Mat3's
+   *
+   * @param out the receiving matrix
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static multiply(out: Mat3, a: Mat3, b: Mat3): Mat3;
+
+  /**
+   * Multiplies two Mat3's
+   *
+   * @param out the receiving matrix
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static mul(out: Mat3, a: Mat3, b: Mat3): Mat3;
+
+
+  /**
+   * Translate a Mat3 by the given vector
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to translate
+   * @param v vector to translate by
+   * @returns out
+   */
+  public static translate(out: Mat3, a: Mat3, v: Vec3|number[]): Mat3;
+
+  /**
+   * Rotates a Mat3 by the given angle
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to rotate
+   * @param rad the angle to rotate the matrix by
+   * @returns out
+   */
+  public static rotate(out: Mat3, a: Mat3, rad: number): Mat3;
+
+  /**
+   * Scales the Mat3 by the dimensions in the given Vec2
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to rotate
+   * @param v the Vec2 to scale the matrix by
+   * @returns out
+   **/
+  public static scale(out: Mat3, a: Mat3, v: Vec2|number[]): Mat3;
+
+  /**
+   * Creates a matrix from a vector translation
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat3.identity(dest);
+   *     Mat3.translate(dest, dest, vec);
+   *
+   * @param {Mat3} out Mat3 receiving operation result
+   * @param {Vec2} v Translation vector
+   * @returns {Mat3} out
+   */
+  public static fromTranslation(out: Mat3, v: Vec2|number[]): Mat3
+
+      /**
+       * Creates a matrix from a given angle
+       * This is equivalent to (but much faster than):
+       *
+       *     Mat3.identity(dest);
+       *     Mat3.rotate(dest, dest, rad);
+       *
+       * @param {Mat3} out Mat3 receiving operation result
+       * @param {number} rad the angle to rotate the matrix by
+       * @returns {Mat3} out
+       */
+      public static fromRotation(out: Mat3, rad: number): Mat3
+
+      /**
+       * Creates a matrix from a vector scaling
+       * This is equivalent to (but much faster than):
+       *
+       *     Mat3.identity(dest);
+       *     Mat3.scale(dest, dest, vec);
+       *
+       * @param {Mat3} out Mat3 receiving operation result
+       * @param {Vec2} v Scaling vector
+       * @returns {Mat3} out
+       */
+      public static fromScaling(out: Mat3, v: Vec2|number[]): Mat3
+
+      /**
+       * Copies the values from a Mat2d into a Mat3
+       *
+       * @param out the receiving matrix
+       * @param {Mat2d} a the matrix to copy
+       * @returns out
+       **/
+      public static fromMat2d(out: Mat3, a: Mat2d): Mat3;
+
+  /**
+   * Calculates a 3x3 matrix from the given Quaternion
+   *
+   * @param out Mat3 receiving operation result
+   * @param q Quaternion to create matrix from
+   *
+   * @returns out
+   */
+  public static fromQuat(out: Mat3, q: Quat): Mat3;
+
+  /**
+   * Calculates a 3x3 normal matrix (transpose inverse) from the 4x4 matrix
+   *
+   * @param out Mat3 receiving operation result
+   * @param a Mat4 to derive the normal matrix from
+   *
+   * @returns out
+   */
+  public static normalFromMat4(out: Mat3, a: Mat4): Mat3|null;
+
+  /**
+   * Returns a string representation of a Mat3
+   *
+   * @param mat matrix to represent as a string
+   * @returns string representation of the matrix
+   */
+  public static str(mat: Mat3): string;
+
+  /**
+   * Returns Frobenius norm of a Mat3
+   *
+   * @param a the matrix to calculate Frobenius norm of
+   * @returns Frobenius norm
+   */
+  public static frob(a: Mat3): number;
+
+  /**
+   * Adds two Mat3's
+   *
+   * @param {Mat3} out the receiving matrix
+   * @param {Mat3} a the first operand
+   * @param {Mat3} b the second operand
+   * @returns {Mat3} out
+   */
+  public static add(out: Mat3, a: Mat3, b: Mat3): Mat3
+
+      /**
+       * Subtracts matrix b from matrix a
+       *
+       * @param {Mat3} out the receiving matrix
+       * @param {Mat3} a the first operand
+       * @param {Mat3} b the second operand
+       * @returns {Mat3} out
+       */
+      public static subtract(out: Mat3, a: Mat3, b: Mat3): Mat3
+
+      /**
+       * Subtracts matrix b from matrix a
+       *
+       * @param {Mat3} out the receiving matrix
+       * @param {Mat3} a the first operand
+       * @param {Mat3} b the second operand
+       * @returns {Mat3} out
+       */
+      public static sub(out: Mat3, a: Mat3, b: Mat3): Mat3
+
+      /**
+       * Multiply each element of the matrix by a scalar.
+       *
+       * @param {Mat3} out the receiving matrix
+       * @param {Mat3} a the matrix to scale
+       * @param {number} b amount to scale the matrix's elements by
+       * @returns {Mat3} out
+       */
+      public static multiplyScalar(out: Mat3, a: Mat3, b: number): Mat3
+
+      /**
+       * Adds two Mat3's after multiplying each element of the second operand
+       * by a scalar value.
+       *
+       * @param {Mat3} out the receiving vector
+       * @param {Mat3} a the first operand
+       * @param {Mat3} b the second operand
+       * @param {number} scale the amount to scale b's elements by before
+       *     adding
+       * @returns {Mat3} out
+       */
+      public static multiplyScalarAndAdd(
+          out: Mat3, a: Mat3, b: Mat3, scale: number): Mat3
+
+      /**
+       * Returns whether or not the matrices have exactly the same elements in
+       * the same position (when compared with ===)
+       *
+       * @param {Mat3} a The first matrix.
+       * @param {Mat3} b The second matrix.
+       * @returns {boolean} True if the matrices are equal, false otherwise.
+       */
+      public static exactEquals(a: Mat3, b: Mat3): boolean;
+
+  /**
+   * Returns whether or not the matrices have approximately the same elements
+   * in the same position.
+   *
+   * @param {Mat3} a The first matrix.
+   * @param {Mat3} b The second matrix.
+   * @returns {boolean} True if the matrices are equal, false otherwise.
+   */
+  public static equals(a: Mat3, b: Mat3): boolean
+}
+
+// Mat4
+interface Mat4 extends Float32Array {
+  private typeMat4: number;
+
+  /**
+   * Creates a new identity Mat4
+   *
+   * @returns a new 4x4 matrix
+   */
+  public static create(): Mat4;
+
+  /**
+   * Creates a new Mat4 initialized with values from an existing matrix
+   *
+   * @param a matrix to clone
+   * @returns a new 4x4 matrix
+   */
+  public static clone(a: Mat4): Mat4;
+
+  /**
+   * Copy the values from one Mat4 to another
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  public static copy(out: Mat4, a: Mat4): Mat4;
+
+
+  /**
+   * Create a new Mat4 with the given values
+   *
+   * @param {number} m00 Component in column 0, row 0 position (index 0)
+   * @param {number} m01 Component in column 0, row 1 position (index 1)
+   * @param {number} m02 Component in column 0, row 2 position (index 2)
+   * @param {number} m03 Component in column 0, row 3 position (index 3)
+   * @param {number} m10 Component in column 1, row 0 position (index 4)
+   * @param {number} m11 Component in column 1, row 1 position (index 5)
+   * @param {number} m12 Component in column 1, row 2 position (index 6)
+   * @param {number} m13 Component in column 1, row 3 position (index 7)
+   * @param {number} m20 Component in column 2, row 0 position (index 8)
+   * @param {number} m21 Component in column 2, row 1 position (index 9)
+   * @param {number} m22 Component in column 2, row 2 position (index 10)
+   * @param {number} m23 Component in column 2, row 3 position (index 11)
+   * @param {number} m30 Component in column 3, row 0 position (index 12)
+   * @param {number} m31 Component in column 3, row 1 position (index 13)
+   * @param {number} m32 Component in column 3, row 2 position (index 14)
+   * @param {number} m33 Component in column 3, row 3 position (index 15)
+   * @returns {Mat4} A new Mat4
+   */
+  public static fromValues(
+      m00: number, m01: number, m02: number, m03: number, m10: number,
+      m11: number, m12: number, m13: number, m20: number, m21: number,
+      m22: number, m23: number, m30: number, m31: number, m32: number,
+      m33: number): Mat4;
+
+  /**
+   * Set the components of a Mat4 to the given values
+   *
+   * @param {Mat4} out the receiving matrix
+   * @param {number} m00 Component in column 0, row 0 position (index 0)
+   * @param {number} m01 Component in column 0, row 1 position (index 1)
+   * @param {number} m02 Component in column 0, row 2 position (index 2)
+   * @param {number} m03 Component in column 0, row 3 position (index 3)
+   * @param {number} m10 Component in column 1, row 0 position (index 4)
+   * @param {number} m11 Component in column 1, row 1 position (index 5)
+   * @param {number} m12 Component in column 1, row 2 position (index 6)
+   * @param {number} m13 Component in column 1, row 3 position (index 7)
+   * @param {number} m20 Component in column 2, row 0 position (index 8)
+   * @param {number} m21 Component in column 2, row 1 position (index 9)
+   * @param {number} m22 Component in column 2, row 2 position (index 10)
+   * @param {number} m23 Component in column 2, row 3 position (index 11)
+   * @param {number} m30 Component in column 3, row 0 position (index 12)
+   * @param {number} m31 Component in column 3, row 1 position (index 13)
+   * @param {number} m32 Component in column 3, row 2 position (index 14)
+   * @param {number} m33 Component in column 3, row 3 position (index 15)
+   * @returns {Mat4} out
+   */
+  public static set(
+      out: Mat4, m00: number, m01: number, m02: number, m03: number,
+      m10: number, m11: number, m12: number, m13: number, m20: number,
+      m21: number, m22: number, m23: number, m30: number, m31: number,
+      m32: number, m33: number): Mat4;
+
+  /**
+   * Set a Mat4 to the identity matrix
+   *
+   * @param out the receiving matrix
+   * @returns out
+   */
+  public static identity(out: Mat4): Mat4;
+
+  /**
+   * Transpose the values of a Mat4
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  public static transpose(out: Mat4, a: Mat4): Mat4;
+
+  /**
+   * Inverts a Mat4
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  public static invert(out: Mat4, a: Mat4): Mat4|null;
+
+  /**
+   * Calculates the adjugate of a Mat4
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  public static adjoint(out: Mat4, a: Mat4): Mat4;
+
+  /**
+   * Calculates the determinant of a Mat4
+   *
+   * @param a the source matrix
+   * @returns determinant of a
+   */
+  public static determinant(a: Mat4): number;
+
+  /**
+   * Multiplies two Mat4's
+   *
+   * @param out the receiving matrix
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static multiply(out: Mat4, a: Mat4, b: Mat4): Mat4;
+
+  /**
+   * Multiplies two Mat4's
+   *
+   * @param out the receiving matrix
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static mul(out: Mat4, a: Mat4, b: Mat4): Mat4;
+
+  /**
+   * Translate a Mat4 by the given vector
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to translate
+   * @param v vector to translate by
+   * @returns out
+   */
+  public static translate(out: Mat4, a: Mat4, v: Vec3|number[]): Mat4;
+
+  /**
+   * Scales the Mat4 by the dimensions in the given Vec3
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to scale
+   * @param v the Vec3 to scale the matrix by
+   * @returns out
+   **/
+  public static scale(out: Mat4, a: Mat4, v: Vec3|number[]): Mat4;
+
+  /**
+   * Rotates a Mat4 by the given angle
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to rotate
+   * @param rad the angle to rotate the matrix by
+   * @param axis the axis to rotate around
+   * @returns out
+   */
+  public static rotate(out: Mat4, a: Mat4, rad: number, axis: Vec3|number[]):
+      Mat4;
+
+  /**
+   * Rotates a matrix by the given angle around the X axis
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to rotate
+   * @param rad the angle to rotate the matrix by
+   * @returns out
+   */
+  public static rotateX(out: Mat4, a: Mat4, rad: number): Mat4;
+
+  /**
+   * Rotates a matrix by the given angle around the Y axis
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to rotate
+   * @param rad the angle to rotate the matrix by
+   * @returns out
+   */
+  public static rotateY(out: Mat4, a: Mat4, rad: number): Mat4;
+
+  /**
+   * Rotates a matrix by the given angle around the Z axis
+   *
+   * @param out the receiving matrix
+   * @param a the matrix to rotate
+   * @param rad the angle to rotate the matrix by
+   * @returns out
+   */
+  public static rotateZ(out: Mat4, a: Mat4, rad: number): Mat4;
+
+  /**
+   * Creates a matrix from a vector translation
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat4.identity(dest);
+   *     Mat4.translate(dest, dest, vec);
+   *
+   * @param {Mat4} out Mat4 receiving operation result
+   * @param {Vec3} v Translation vector
+   * @returns {Mat4} out
+   */
+  public static fromTranslation(out: Mat4, v: Vec3|number[]): Mat4
+
+      /**
+       * Creates a matrix from a vector scaling
+       * This is equivalent to (but much faster than):
+       *
+       *     Mat4.identity(dest);
+       *     Mat4.scale(dest, dest, vec);
+       *
+       * @param {Mat4} out Mat4 receiving operation result
+       * @param {Vec3} v Scaling vector
+       * @returns {Mat4} out
+       */
+      public static fromScaling(out: Mat4, v: Vec3|number[]): Mat4
+
+      /**
+       * Creates a matrix from a given angle around a given axis
+       * This is equivalent to (but much faster than):
+       *
+       *     Mat4.identity(dest);
+       *     Mat4.rotate(dest, dest, rad, axis);
+       *
+       * @param {Mat4} out Mat4 receiving operation result
+       * @param {number} rad the angle to rotate the matrix by
+       * @param {Vec3} axis the axis to rotate around
+       * @returns {Mat4} out
+       */
+      public static fromRotation(out: Mat4, rad: number, axis: Vec3|number[]):
+          Mat4
+
+      /**
+       * Creates a matrix from the given angle around the X axis
+       * This is equivalent to (but much faster than):
+       *
+       *     Mat4.identity(dest);
+       *     Mat4.rotateX(dest, dest, rad);
+       *
+       * @param {Mat4} out Mat4 receiving operation result
+       * @param {number} rad the angle to rotate the matrix by
+       * @returns {Mat4} out
+       */
+      public static fromXRotation(out: Mat4, rad: number): Mat4
+
+      /**
+       * Creates a matrix from the given angle around the Y axis
+       * This is equivalent to (but much faster than):
+       *
+       *     Mat4.identity(dest);
+       *     Mat4.rotateY(dest, dest, rad);
+       *
+       * @param {Mat4} out Mat4 receiving operation result
+       * @param {number} rad the angle to rotate the matrix by
+       * @returns {Mat4} out
+       */
+      public static fromYRotation(out: Mat4, rad: number): Mat4
+
+
+      /**
+       * Creates a matrix from the given angle around the Z axis
+       * This is equivalent to (but much faster than):
+       *
+       *     Mat4.identity(dest);
+       *     Mat4.rotateZ(dest, dest, rad);
+       *
+       * @param {Mat4} out Mat4 receiving operation result
+       * @param {number} rad the angle to rotate the matrix by
+       * @returns {Mat4} out
+       */
+      public static fromZRotation(out: Mat4, rad: number): Mat4
+
+      /**
+       * Creates a matrix from a Quaternion rotation and vector translation
+       * This is equivalent to (but much faster than):
+       *
+       *     Mat4.identity(dest);
+       *     Mat4.translate(dest, vec);
+       *     var QuatMat = Mat4.create();
+       *     Quat4.toMat4(Quat, QuatMat);
+       *     Mat4.multiply(dest, QuatMat);
+       *
+       * @param out Mat4 receiving operation result
+       * @param q Rotation Quaternion
+       * @param v Translation vector
+       * @returns out
+       */
+      public static fromRotationTranslation(
+          out: Mat4, q: Quat, v: Vec3|number[]): Mat4;
+
+  /**
+   * Returns the translation vector component of a transformation
+   *  matrix. If a matrix is built with fromRotationTranslation,
+   *  the returned vector will be the same as the translation vector
+   *  originally supplied.
+   * @param  {Vec3} out Vector to receive translation component
+   * @param  {Mat4} mat Matrix to be decomposed (input)
+   * @return {Vec3} out
+   */
+  public static getTranslation(out: Vec3, mat: Mat4): Vec3;
+
+  /**
+   * Returns a Quaternion representing the rotational component
+   *  of a transformation matrix. If a matrix is built with
+   *  fromRotationTranslation, the returned Quaternion will be the
+   *  same as the Quaternion originally supplied.
+   * @param {Quat} out Quaternion to receive the rotation component
+   * @param {Mat4} mat Matrix to be decomposed (input)
+   * @return {Quat} out
+   */
+  public static getRotation(out: Quat, mat: Mat4): Quat;
+
+  /**
+   * Creates a matrix from a Quaternion rotation, vector translation and
+   * vector scale This is equivalent to (but much faster than):
+   *
+   *     Mat4.identity(dest);
+   *     Mat4.translate(dest, vec);
+   *     var QuatMat = Mat4.create();
+   *     Quat4.toMat4(Quat, QuatMat);
+   *     Mat4.multiply(dest, QuatMat);
+   *     Mat4.scale(dest, scale)
+   *
+   * @param out Mat4 receiving operation result
+   * @param q Rotation Quaternion
+   * @param v Translation vector
+   * @param s Scaling vector
+   * @returns out
+   */
+  public static fromRotationTranslationScale(
+      out: Mat4, q: Quat, v: Vec3|number[], s: Vec3|number[]): Mat4;
+
+  /**
+   * Creates a matrix from a Quaternion rotation, vector translation and
+   * vector scale, rotating and scaling around the given origin This is
+   * equivalent to (but much faster than):
+   *
+   *     Mat4.identity(dest);
+   *     Mat4.translate(dest, vec);
+   *     Mat4.translate(dest, origin);
+   *     var QuatMat = Mat4.create();
+   *     Quat4.toMat4(Quat, QuatMat);
+   *     Mat4.multiply(dest, QuatMat);
+   *     Mat4.scale(dest, scale)
+   *     Mat4.translate(dest, negativeOrigin);
+   *
+   * @param {Mat4} out Mat4 receiving operation result
+   * @param {Quat} q Rotation Quaternion
+   * @param {Vec3} v Translation vector
+   * @param {Vec3} s Scaling vector
+   * @param {Vec3} o The origin vector around which to scale and rotate
+   * @returns {Mat4} out
+   */
+  public static fromRotationTranslationScaleOrigin(
+      out: Mat4, q: Quat, v: Vec3|number[], s: Vec3|number[], o: Vec3|number[]):
+      Mat4
+
+      /**
+       * Calculates a 4x4 matrix from the given Quaternion
+       *
+       * @param {Mat4} out Mat4 receiving operation result
+       * @param {Quat} q Quaternion to create matrix from
+       *
+       * @returns {Mat4} out
+       */
+      public static fromQuat(out: Mat4, q: Quat): Mat4
+
+      /**
+       * Generates a frustum matrix with the given bounds
+       *
+       * @param out Mat4 frustum matrix will be written into
+       * @param left Left bound of the frustum
+       * @param right Right bound of the frustum
+       * @param bottom Bottom bound of the frustum
+       * @param top Top bound of the frustum
+       * @param near Near bound of the frustum
+       * @param far Far bound of the frustum
+       * @returns out
+       */
+      public static frustum(
+          out: Mat4, left: number, right: number, bottom: number, top: number,
+          near: number, far: number): Mat4;
+
+  /**
+   * Generates a perspective projection matrix with the given bounds
+   *
+   * @param out Mat4 frustum matrix will be written into
+   * @param fovy Vertical field of view in radians
+   * @param aspect Aspect ratio. typically viewport width/height
+   * @param near Near bound of the frustum
+   * @param far Far bound of the frustum
+   * @returns out
+   */
+  public static perspective(
+      out: Mat4, fovy: number, aspect: number, near: number, far: number): Mat4;
+
+  /**
+   * Generates a perspective projection matrix with the given field of view.
+   * This is primarily useful for generating projection matrices to be used
+   * with the still experimental WebVR API.
+   *
+   * @param {Mat4} out Mat4 frustum matrix will be written into
+   * @param {Object} fov Object containing the following values: upDegrees,
+   *     downDegrees, leftDegrees, rightDegrees
+   * @param {number} near Near bound of the frustum
+   * @param {number} far Far bound of the frustum
+   * @returns {Mat4} out
+   */
+  public static perspectiveFromFieldOfView(
+      out: Mat4, fov: {
+        upDegrees: number,
+        downDegrees: number,
+        leftDegrees: number,
+        rightDegrees: number
+      },
+      near: number, far: number): Mat4
+
+      /**
+       * Generates a orthogonal projection matrix with the given bounds
+       *
+       * @param out Mat4 frustum matrix will be written into
+       * @param left Left bound of the frustum
+       * @param right Right bound of the frustum
+       * @param bottom Bottom bound of the frustum
+       * @param top Top bound of the frustum
+       * @param near Near bound of the frustum
+       * @param far Far bound of the frustum
+       * @returns out
+       */
+      public static ortho(
+          out: Mat4, left: number, right: number, bottom: number, top: number,
+          near: number, far: number): Mat4;
+
+  /**
+   * Generates a look-at matrix with the given eye position, focal point, and
+   * up axis
+   *
+   * @param out Mat4 frustum matrix will be written into
+   * @param eye Position of the viewer
+   * @param center Point the viewer is looking at
+   * @param up Vec3 pointing up
+   * @returns out
+   */
+  public static lookAt(
+      out: Mat4, eye: Vec3|number[], center: Vec3|number[],
+      up: Vec3|number[]): Mat4;
+
+  /**
+   * Returns a string representation of a Mat4
+   *
+   * @param mat matrix to represent as a string
+   * @returns string representation of the matrix
+   */
+  public static str(mat: Mat4): string;
+
+  /**
+   * Returns Frobenius norm of a Mat4
+   *
+   * @param a the matrix to calculate Frobenius norm of
+   * @returns Frobenius norm
+   */
+  public static frob(a: Mat4): number;
+
+  /**
+   * Adds two Mat4's
+   *
+   * @param {Mat4} out the receiving matrix
+   * @param {Mat4} a the first operand
+   * @param {Mat4} b the second operand
+   * @returns {Mat4} out
+   */
+  public static add(out: Mat4, a: Mat4, b: Mat4): Mat4
+
+      /**
+       * Subtracts matrix b from matrix a
+       *
+       * @param {Mat4} out the receiving matrix
+       * @param {Mat4} a the first operand
+       * @param {Mat4} b the second operand
+       * @returns {Mat4} out
+       */
+      public static subtract(out: Mat4, a: Mat4, b: Mat4): Mat4
+
+      /**
+       * Subtracts matrix b from matrix a
+       *
+       * @param {Mat4} out the receiving matrix
+       * @param {Mat4} a the first operand
+       * @param {Mat4} b the second operand
+       * @returns {Mat4} out
+       */
+      public static sub(out: Mat4, a: Mat4, b: Mat4): Mat4
+
+      /**
+       * Multiply each element of the matrix by a scalar.
+       *
+       * @param {Mat4} out the receiving matrix
+       * @param {Mat4} a the matrix to scale
+       * @param {number} b amount to scale the matrix's elements by
+       * @returns {Mat4} out
+       */
+      public static multiplyScalar(out: Mat4, a: Mat4, b: number): Mat4
+
+      /**
+       * Adds two Mat4's after multiplying each element of the second operand
+       * by a scalar value.
+       *
+       * @param {Mat4} out the receiving vector
+       * @param {Mat4} a the first operand
+       * @param {Mat4} b the second operand
+       * @param {number} scale the amount to scale b's elements by before
+       *     adding
+       * @returns {Mat4} out
+       */
+      public static multiplyScalarAndAdd(
+          out: Mat4, a: Mat4, b: Mat4, scale: number): Mat4
+
+      /**
+       * Returns whether or not the matrices have exactly the same elements in
+       * the same position (when compared with ===)
+       *
+       * @param {Mat4} a The first matrix.
+       * @param {Mat4} b The second matrix.
+       * @returns {boolean} True if the matrices are equal, false otherwise.
+       */
+      public static exactEquals(a: Mat4, b: Mat4): boolean
+
+      /**
+       * Returns whether or not the matrices have approximately the same
+       * elements in the same position.
+       *
+       * @param {Mat4} a The first matrix.
+       * @param {Mat4} b The second matrix.
+       * @returns {boolean} True if the matrices are equal, false otherwise.
+       */
+      public static equals(a: Mat4, b: Mat4): boolean
+}
+
+// Quat
+interface Quat extends Float32Array {
+  private typeQuat: number;
+
+  /**
+   * Creates a new identity Quat
+   *
+   * @returns a new Quaternion
+   */
+  public static create(): Quat;
+
+  /**
+   * Creates a new Quat initialized with values from an existing Quaternion
+   *
+   * @param a Quaternion to clone
+   * @returns a new Quaternion
+   * @function
+   */
+  public static clone(a: Quat): Quat;
+
+  /**
+   * Creates a new Quat initialized with the given values
+   *
+   * @param x X component
+   * @param y Y component
+   * @param z Z component
+   * @param w W component
+   * @returns a new Quaternion
+   * @function
+   */
+  public static fromValues(x: number, y: number, z: number, w: number): Quat;
+
+  /**
+   * Copy the values from one Quat to another
+   *
+   * @param out the receiving Quaternion
+   * @param a the source Quaternion
+   * @returns out
+   * @function
+   */
+  public static copy(out: Quat, a: Quat): Quat;
+
+  /**
+   * Set the components of a Quat to the given values
+   *
+   * @param out the receiving Quaternion
+   * @param x X component
+   * @param y Y component
+   * @param z Z component
+   * @param w W component
+   * @returns out
+   * @function
+   */
+  public static set(out: Quat, x: number, y: number, z: number, w: number):
+      Quat;
+
+  /**
+   * Set a Quat to the identity Quaternion
+   *
+   * @param out the receiving Quaternion
+   * @returns out
+   */
+  public static identity(out: Quat): Quat;
+
+  /**
+   * Sets a Quaternion to represent the shortest rotation from one
+   * vector to another.
+   *
+   * Both vectors are assumed to be unit length.
+   *
+   * @param {Quat} out the receiving Quaternion.
+   * @param {Vec3} a the initial vector
+   * @param {Vec3} b the destination vector
+   * @returns {Quat} out
+   */
+  public static rotationTo(out: Quat, a: Vec3|number[], b: Vec3|number[]): Quat;
+
+  /**
+   * Sets the specified Quaternion with values corresponding to the given
+   * axes. Each axis is a Vec3 and is expected to be unit length and
+   * perpendicular to all other specified axes.
+   *
+   * @param {Vec3} view  the vector representing the viewing direction
+   * @param {Vec3} right the vector representing the local "right" direction
+   * @param {Vec3} up    the vector representing the local "up" direction
+   * @returns {Quat} out
+   */
+  public static setAxes(
+      out: Quat, view: Vec3|number[], right: Vec3|number[], up: Vec3|number[]):
+      Quat
+
+
+
+      /**
+       * Sets a Quat from the given angle and rotation axis,
+       * then returns it.
+       *
+       * @param out the receiving Quaternion
+       * @param axis the axis around which to rotate
+       * @param rad the angle in radians
+       * @returns out
+       **/
+      public static setAxisAngle(out: Quat, axis: Vec3|number[], rad: number):
+          Quat;
+
+  /**
+   * Gets the rotation axis and angle for a given
+   *  Quaternion. If a Quaternion is created with
+   *  setAxisAngle, this method will return the same
+   *  values as providied in the original parameter list
+   *  OR functionally equivalent values.
+   * Example: The Quaternion formed by axis [0, 0, 1] and
+   *  angle -90 is the same as the Quaternion formed by
+   *  [0, 0, 1] and 270. This method favors the latter.
+   * @param  {Vec3} out_axis  Vector receiving the axis of rotation
+   * @param  {Quat} q     Quaternion to be decomposed
+   * @return {number}     Angle, in radians, of the rotation
+   */
+  public static getAxisAngle(out_axis: Vec3|number[], q: Quat): number
+
+      /**
+       * Adds two Quat's
+       *
+       * @param out the receiving Quaternion
+       * @param a the first operand
+       * @param b the second operand
+       * @returns out
+       * @function
+       */
+      public static add(out: Quat, a: Quat, b: Quat): Quat;
+
+  /**
+   * Multiplies two Quat's
+   *
+   * @param out the receiving Quaternion
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static multiply(out: Quat, a: Quat, b: Quat): Quat;
+
+  /**
+   * Multiplies two Quat's
+   *
+   * @param out the receiving Quaternion
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  public static mul(out: Quat, a: Quat, b: Quat): Quat;
+
+  /**
+   * Scales a Quat by a scalar number
+   *
+   * @param out the receiving vector
+   * @param a the vector to scale
+   * @param b amount to scale the vector by
+   * @returns out
+   * @function
+   */
+  public static scale(out: Quat, a: Quat, b: number): Quat;
+
+  /**
+   * Calculates the length of a Quat
+   *
+   * @param a vector to calculate length of
+   * @returns length of a
+   * @function
+   */
+  public static length(a: Quat): number;
+
+  /**
+   * Calculates the length of a Quat
+   *
+   * @param a vector to calculate length of
+   * @returns length of a
+   * @function
+   */
+  public static len(a: Quat): number;
+
+  /**
+   * Calculates the squared length of a Quat
+   *
+   * @param a vector to calculate squared length of
+   * @returns squared length of a
+   * @function
+   */
+  public static squaredLength(a: Quat): number;
+
+  /**
+   * Calculates the squared length of a Quat
+   *
+   * @param a vector to calculate squared length of
+   * @returns squared length of a
+   * @function
+   */
+  public static sqrLen(a: Quat): number;
+
+  /**
+   * Normalize a Quat
+   *
+   * @param out the receiving Quaternion
+   * @param a Quaternion to normalize
+   * @returns out
+   * @function
+   */
+  public static normalize(out: Quat, a: Quat): Quat;
+
+  /**
+   * Calculates the dot product of two Quat's
+   *
+   * @param a the first operand
+   * @param b the second operand
+   * @returns dot product of a and b
+   * @function
+   */
+  public static dot(a: Quat, b: Quat): number;
+
+  /**
+   * Performs a linear interpolation between two Quat's
+   *
+   * @param out the receiving Quaternion
+   * @param a the first operand
+   * @param b the second operand
+   * @param t interpolation amount between the two inputs
+   * @returns out
+   * @function
+   */
+  public static lerp(out: Quat, a: Quat, b: Quat, t: number): Quat;
+
+  /**
+   * Performs a spherical linear interpolation between two Quat
+   *
+   * @param out the receiving Quaternion
+   * @param a the first operand
+   * @param b the second operand
+   * @param t interpolation amount between the two inputs
+   * @returns out
+   */
+  public static slerp(out: Quat, a: Quat, b: Quat, t: number): Quat;
+
+  /**
+   * Performs a spherical linear interpolation with two control points
+   *
+   * @param {Quat} out the receiving Quaternion
+   * @param {Quat} a the first operand
+   * @param {Quat} b the second operand
+   * @param {Quat} c the third operand
+   * @param {Quat} d the fourth operand
+   * @param {number} t interpolation amount
+   * @returns {Quat} out
+   */
+  public static sqlerp(
+      out: Quat, a: Quat, b: Quat, c: Quat, d: Quat, t: number): Quat;
+
+  /**
+   * Calculates the inverse of a Quat
+   *
+   * @param out the receiving Quaternion
+   * @param a Quat to calculate inverse of
+   * @returns out
+   */
+  public static invert(out: Quat, a: Quat): Quat;
+
+  /**
+   * Calculates the conjugate of a Quat
+   * If the Quaternion is normalized, this function is faster than
+   * Quat.inverse and produces the same result.
+   *
+   * @param out the receiving Quaternion
+   * @param a Quat to calculate conjugate of
+   * @returns out
+   */
+  public static conjugate(out: Quat, a: Quat): Quat;
+
+  /**
+   * Returns a string representation of a Quaternion
+   *
+   * @param a Quat to represent as a string
+   * @returns string representation of the Quat
+   */
+  public static str(a: Quat): string;
+
+  /**
+   * Rotates a Quaternion by the given angle about the X axis
+   *
+   * @param out Quat receiving operation result
+   * @param a Quat to rotate
+   * @param rad angle (in radians) to rotate
+   * @returns out
+   */
+  public static rotateX(out: Quat, a: Quat, rad: number): Quat;
+
+  /**
+   * Rotates a Quaternion by the given angle about the Y axis
+   *
+   * @param out Quat receiving operation result
+   * @param a Quat to rotate
+   * @param rad angle (in radians) to rotate
+   * @returns out
+   */
+  public static rotateY(out: Quat, a: Quat, rad: number): Quat;
+
+  /**
+   * Rotates a Quaternion by the given angle about the Z axis
+   *
+   * @param out Quat receiving operation result
+   * @param a Quat to rotate
+   * @param rad angle (in radians) to rotate
+   * @returns out
+   */
+  public static rotateZ(out: Quat, a: Quat, rad: number): Quat;
+
+  /**
+   * Creates a Quaternion from the given 3x3 rotation matrix.
+   *
+   * NOTE: The resultant Quaternion is not normalized, so you should be sure
+   * to renormalize the Quaternion yourself where necessary.
+   *
+   * @param out the receiving Quaternion
+   * @param m rotation matrix
+   * @returns out
+   * @function
+   */
+  public static fromMat3(out: Quat, m: Mat3): Quat;
+
+  /**
+   * Sets the specified Quaternion with values corresponding to the given
+   * axes. Each axis is a Vec3 and is expected to be unit length and
+   * perpendicular to all other specified axes.
+   *
+   * @param out the receiving Quat
+   * @param view  the vector representing the viewing direction
+   * @param right the vector representing the local "right" direction
+   * @param up    the vector representing the local "up" direction
+   * @returns out
+   */
+  public static setAxes(
+      out: Quat, view: Vec3|number[], right: Vec3|number[],
+      up: Vec3|number[]): Quat;
+
+  /**
+   * Sets a Quaternion to represent the shortest rotation from one
+   * vector to another.
+   *
+   * Both vectors are assumed to be unit length.
+   *
+   * @param out the receiving Quaternion.
+   * @param a the initial vector
+   * @param b the destination vector
+   * @returns out
+   */
+  public static rotationTo(out: Quat, a: Vec3|number[], b: Vec3|number[]): Quat;
+
+  /**
+   * Calculates the W component of a Quat from the X, Y, and Z components.
+   * Assumes that Quaternion is 1 unit in length.
+   * Any existing W component will be ignored.
+   *
+   * @param out the receiving Quaternion
+   * @param a Quat to calculate W component of
+   * @returns out
+   */
+  public static calculateW(out: Quat, a: Quat): Quat;
+
+  /**
+   * Returns whether or not the Quaternions have exactly the same elements in
+   * the same position (when compared with ===)
+   *
+   * @param {Quat} a The first vector.
+   * @param {Quat} b The second vector.
+   * @returns {boolean} True if the Quaternions are equal, false otherwise.
+   */
+  public static exactEquals(a: Quat, b: Quat): boolean;
+
+  /**
+   * Returns whether or not the Quaternions have approximately the same
+   * elements in the same position.
+   *
+   * @param {Quat} a The first vector.
+   * @param {Quat} b The second vector.
+   * @returns {boolean} True if the Quaternions are equal, false otherwise.
+   */
+  public static equals(a: Quat, b: Quat): boolean;
+}

--- a/bindings/wasm/examples/editor.d.ts
+++ b/bindings/wasm/examples/editor.d.ts
@@ -23,32 +23,32 @@ declare function show(manifold: Manifold): Manifold;
 //
 // Definitions by: Nikolay Babanov <https://github.com/nbabanov>
 
-declare glMatrix as GLMatrix;
+declare const glMatrix: GLMatrix;
 
 interface GLMatrix {
   // Configuration constants
-  static EPSILON: number;
-  static ARRAY_TYPE: any;
-  static RANDOM(): number;
-  static ENABLE_SIMD: boolean;
+  EPSILON: number;
+  ARRAY_TYPE: any;
+  RANDOM(): number;
+  ENABLE_SIMD: boolean;
 
   // Compatibility detection
-  static SIMD_AVAILABLE: boolean;
-  static USE_SIMD: boolean;
+  SIMD_AVAILABLE: boolean;
+  USE_SIMD: boolean;
 
   /**
    * Sets the type of array used when creating new vectors and matrices
    *
    * @param {any} type - Array type, such as Float32Array or Array
    */
-  static setMatrixArrayType(type: any): void;
+  setMatrixArrayType(type: any): void;
 
   /**
    * Convert Degree To Radian
    *
    * @param {number} a - Angle in Degrees
    */
-  static toRadian(a: number): number;
+  toRadian(a: number): number;
 
   /**
    * Tests whether or not the arguments have approximately the same value,
@@ -61,27 +61,25 @@ interface GLMatrix {
    * @returns {boolean} True if the numbers are approximately equal, false
    *     otherwise.
    */
-  static equals(a: number, b: number): boolean;
+  equals(a: number, b: number): boolean;
 
-  static vec2: Vec2;
-  static vec3: Vec3;
-  static vec4: Vec4;
-  static mat2: Mat2;
-  static mat2d: Mat2d;
-  static mat3: Mat3;
-  static mat4: Mat4;
-  static quat: Quat;
+  vec2: Vec2;
+  vec3: Vec3;
+  vec4: Vec4;
+  mat2: Mat2;
+  mat2d: Mat2d;
+  mat3: Mat3;
+  mat4: Mat4;
+  quat: Quat;
 }
 
 interface Vec2 extends Float32Array {
-  private typeVec2: number;
-
   /**
    * Creates a new, empty Vec2
    *
    * @returns a new 2D vector
    */
-  public static create(): Vec2;
+  create(): Vec2;
 
   /**
    * Creates a new Vec2 initialized with values from an existing vector
@@ -89,7 +87,7 @@ interface Vec2 extends Float32Array {
    * @param a a vector to clone
    * @returns a new 2D vector
    */
-  public static clone(a: Vec2|number[]): Vec2;
+  clone(a: Vec2|number[]): Vec2;
 
   /**
    * Creates a new Vec2 initialized with the given values
@@ -98,7 +96,7 @@ interface Vec2 extends Float32Array {
    * @param y Y component
    * @returns a new 2D vector
    */
-  public static fromValues(x: number, y: number): Vec2;
+  fromValues(x: number, y: number): Vec2;
 
   /**
    * Copy the values from one Vec2 to another
@@ -107,7 +105,7 @@ interface Vec2 extends Float32Array {
    * @param a the source vector
    * @returns out
    */
-  public static copy(out: Vec2, a: Vec2|number[]): Vec2;
+  copy(out: Vec2, a: Vec2|number[]): Vec2;
 
   /**
    * Set the components of a Vec2 to the given values
@@ -117,7 +115,7 @@ interface Vec2 extends Float32Array {
    * @param y Y component
    * @returns out
    */
-  public static set(out: Vec2, x: number, y: number): Vec2;
+  set(out: Vec2, x: number, y: number): Vec2;
 
   /**
    * Adds two Vec2's
@@ -127,7 +125,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static add(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  add(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
 
   /**
    * Subtracts vector b from vector a
@@ -137,7 +135,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static subtract(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  subtract(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
 
   /**
    * Subtracts vector b from vector a
@@ -147,7 +145,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static sub(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  sub(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
 
   /**
    * Multiplies two Vec2's
@@ -157,7 +155,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static multiply(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  multiply(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
 
   /**
    * Multiplies two Vec2's
@@ -167,7 +165,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static mul(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  mul(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
 
   /**
    * Divides two Vec2's
@@ -177,7 +175,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static divide(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  divide(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
 
   /**
    * Divides two Vec2's
@@ -187,7 +185,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static div(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  div(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
 
   /**
    * Math.ceil the components of a Vec2
@@ -196,7 +194,7 @@ interface Vec2 extends Float32Array {
    * @param {Vec2} a vector to ceil
    * @returns {Vec2} out
    */
-  public static ceil(out: Vec2, a: Vec2|number[]): Vec2;
+  ceil(out: Vec2, a: Vec2|number[]): Vec2;
 
   /**
    * Math.floor the components of a Vec2
@@ -205,7 +203,7 @@ interface Vec2 extends Float32Array {
    * @param {Vec2} a vector to floor
    * @returns {Vec2} out
    */
-  public static floor(out: Vec2, a: Vec2|number[]): Vec2;
+  floor(out: Vec2, a: Vec2|number[]): Vec2;
 
   /**
    * Returns the minimum of two Vec2's
@@ -215,7 +213,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static min(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  min(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
 
   /**
    * Returns the maximum of two Vec2's
@@ -225,7 +223,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static max(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  max(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
 
   /**
    * Math.round the components of a Vec2
@@ -234,7 +232,7 @@ interface Vec2 extends Float32Array {
    * @param {Vec2} a vector to round
    * @returns {Vec2} out
    */
-  public static round(out: Vec2, a: Vec2|number[]): Vec2;
+  round(out: Vec2, a: Vec2|number[]): Vec2;
 
 
   /**
@@ -245,7 +243,7 @@ interface Vec2 extends Float32Array {
    * @param b amount to scale the vector by
    * @returns out
    */
-  public static scale(out: Vec2, a: Vec2|number[], b: number): Vec2;
+  scale(out: Vec2, a: Vec2|number[], b: number): Vec2;
 
   /**
    * Adds two Vec2's after scaling the second operand by a scalar value
@@ -256,8 +254,8 @@ interface Vec2 extends Float32Array {
    * @param scale the amount to scale b by before adding
    * @returns out
    */
-  public static scaleAndAdd(
-      out: Vec2, a: Vec2|number[], b: Vec2|number[], scale: number): Vec2;
+  scaleAndAdd(out: Vec2, a: Vec2|number[], b: Vec2|number[], scale: number):
+      Vec2;
 
   /**
    * Calculates the euclidian distance between two Vec2's
@@ -266,7 +264,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns distance between a and b
    */
-  public static distance(a: Vec2|number[], b: Vec2|number[]): number;
+  distance(a: Vec2|number[], b: Vec2|number[]): number;
 
   /**
    * Calculates the euclidian distance between two Vec2's
@@ -275,7 +273,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns distance between a and b
    */
-  public static dist(a: Vec2|number[], b: Vec2|number[]): number;
+  dist(a: Vec2|number[], b: Vec2|number[]): number;
 
   /**
    * Calculates the squared euclidian distance between two Vec2's
@@ -284,7 +282,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  public static squaredDistance(a: Vec2|number[], b: Vec2|number[]): number;
+  squaredDistance(a: Vec2|number[], b: Vec2|number[]): number;
 
   /**
    * Calculates the squared euclidian distance between two Vec2's
@@ -293,7 +291,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  public static sqrDist(a: Vec2|number[], b: Vec2|number[]): number;
+  sqrDist(a: Vec2|number[], b: Vec2|number[]): number;
 
   /**
    * Calculates the length of a Vec2
@@ -301,7 +299,7 @@ interface Vec2 extends Float32Array {
    * @param a vector to calculate length of
    * @returns length of a
    */
-  public static length(a: Vec2|number[]): number;
+  length(a: Vec2|number[]): number;
 
   /**
    * Calculates the length of a Vec2
@@ -309,7 +307,7 @@ interface Vec2 extends Float32Array {
    * @param a vector to calculate length of
    * @returns length of a
    */
-  public static len(a: Vec2|number[]): number;
+  len(a: Vec2|number[]): number;
 
   /**
    * Calculates the squared length of a Vec2
@@ -317,7 +315,7 @@ interface Vec2 extends Float32Array {
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  public static squaredLength(a: Vec2|number[]): number;
+  squaredLength(a: Vec2|number[]): number;
 
   /**
    * Calculates the squared length of a Vec2
@@ -325,7 +323,7 @@ interface Vec2 extends Float32Array {
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  public static sqrLen(a: Vec2|number[]): number;
+  sqrLen(a: Vec2|number[]): number;
 
   /**
    * Negates the components of a Vec2
@@ -334,7 +332,7 @@ interface Vec2 extends Float32Array {
    * @param a vector to negate
    * @returns out
    */
-  public static negate(out: Vec2, a: Vec2|number[]): Vec2;
+  negate(out: Vec2, a: Vec2|number[]): Vec2;
 
   /**
    * Returns the inverse of the components of a Vec2
@@ -343,7 +341,7 @@ interface Vec2 extends Float32Array {
    * @param a vector to invert
    * @returns out
    */
-  public static inverse(out: Vec2, a: Vec2|number[]): Vec2;
+  inverse(out: Vec2, a: Vec2|number[]): Vec2;
 
   /**
    * Normalize a Vec2
@@ -352,7 +350,7 @@ interface Vec2 extends Float32Array {
    * @param a vector to normalize
    * @returns out
    */
-  public static normalize(out: Vec2, a: Vec2|number[]): Vec2;
+  normalize(out: Vec2, a: Vec2|number[]): Vec2;
 
   /**
    * Calculates the dot product of two Vec2's
@@ -361,7 +359,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns dot product of a and b
    */
-  public static dot(a: Vec2|number[], b: Vec2|number[]): number;
+  dot(a: Vec2|number[], b: Vec2|number[]): number;
 
   /**
    * Computes the cross product of two Vec2's
@@ -372,7 +370,7 @@ interface Vec2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static cross(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
+  cross(out: Vec2, a: Vec2|number[], b: Vec2|number[]): Vec2;
 
   /**
    * Performs a linear interpolation between two Vec2's
@@ -383,8 +381,7 @@ interface Vec2 extends Float32Array {
    * @param t interpolation amount between the two inputs
    * @returns out
    */
-  public static lerp(out: Vec2, a: Vec2|number[], b: Vec2|number[], t: number):
-      Vec2;
+  lerp(out: Vec2, a: Vec2|number[], b: Vec2|number[], t: number): Vec2;
 
   /**
    * Generates a random unit vector
@@ -392,7 +389,7 @@ interface Vec2 extends Float32Array {
    * @param out the receiving vector
    * @returns out
    */
-  public static random(out: Vec2): Vec2;
+  random(out: Vec2): Vec2;
 
   /**
    * Generates a random vector with the given scale
@@ -402,7 +399,7 @@ interface Vec2 extends Float32Array {
    *     will be returned
    * @returns out
    */
-  public static random(out: Vec2, scale: number): Vec2;
+  random(out: Vec2, scale: number): Vec2;
 
   /**
    * Transforms the Vec2 with a Mat2
@@ -412,7 +409,7 @@ interface Vec2 extends Float32Array {
    * @param m matrix to transform with
    * @returns out
    */
-  public static transformMat2(out: Vec2, a: Vec2|number[], m: Mat2): Vec2;
+  transformMat2(out: Vec2, a: Vec2|number[], m: Mat2): Vec2;
 
   /**
    * Transforms the Vec2 with a Mat2d
@@ -422,7 +419,7 @@ interface Vec2 extends Float32Array {
    * @param m matrix to transform with
    * @returns out
    */
-  public static transformMat2d(out: Vec2, a: Vec2|number[], m: Mat2d): Vec2;
+  transformMat2d(out: Vec2, a: Vec2|number[], m: Mat2d): Vec2;
 
   /**
    * Transforms the Vec2 with a Mat3
@@ -433,7 +430,7 @@ interface Vec2 extends Float32Array {
    * @param m matrix to transform with
    * @returns out
    */
-  public static transformMat3(out: Vec2, a: Vec2|number[], m: Mat3): Vec2;
+  transformMat3(out: Vec2, a: Vec2|number[], m: Mat3): Vec2;
 
   /**
    * Transforms the Vec2 with a Mat4
@@ -445,7 +442,7 @@ interface Vec2 extends Float32Array {
    * @param m matrix to transform with
    * @returns out
    */
-  public static transformMat4(out: Vec2, a: Vec2|number[], m: Mat4): Vec2;
+  transformMat4(out: Vec2, a: Vec2|number[], m: Mat4): Vec2;
 
   /**
    * Perform some operation over an array of vec2s.
@@ -460,7 +457,7 @@ interface Vec2 extends Float32Array {
    * @param arg additional argument to pass to fn
    * @returns a
    */
-  public static forEach(
+  forEach(
       a: Float32Array, stride: number, offset: number, count: number,
       fn: (a: Vec2|number[], b: Vec2|number[], arg: any) => void,
       arg: any): Float32Array;
@@ -477,7 +474,7 @@ interface Vec2 extends Float32Array {
    * @param fn Function to call for each vector in the array
    * @returns a
    */
-  public static forEach(
+  forEach(
       a: Float32Array, stride: number, offset: number, count: number,
       fn: (a: Vec2|number[], b: Vec2|number[]) => void): Float32Array;
 
@@ -487,7 +484,7 @@ interface Vec2 extends Float32Array {
    * @param a vector to represent as a string
    * @returns string representation of the vector
    */
-  public static str(a: Vec2|number[]): string;
+  str(a: Vec2|number[]): string;
 
   /**
    * Returns whether or not the vectors exactly have the same elements in the
@@ -497,7 +494,7 @@ interface Vec2 extends Float32Array {
    * @param {Vec2} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  public static exactEquals(a: Vec2|number[], b: Vec2|number[]): boolean;
+  exactEquals(a: Vec2|number[], b: Vec2|number[]): boolean;
 
   /**
    * Returns whether or not the vectors have approximately the same elements
@@ -507,19 +504,17 @@ interface Vec2 extends Float32Array {
    * @param {Vec2} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  public static equals(a: Vec2|number[], b: Vec2|number[]): boolean;
+  equals(a: Vec2|number[], b: Vec2|number[]): boolean;
 }
 
 // Vec3
 interface Vec3 extends Float32Array {
-  private typeVec3: number;
-
   /**
    * Creates a new, empty Vec3
    *
    * @returns a new 3D vector
    */
-  public static create(): Vec3;
+  create(): Vec3;
 
   /**
    * Creates a new Vec3 initialized with values from an existing vector
@@ -527,7 +522,7 @@ interface Vec3 extends Float32Array {
    * @param a vector to clone
    * @returns a new 3D vector
    */
-  public static clone(a: Vec3|number[]): Vec3;
+  clone(a: Vec3|number[]): Vec3;
 
   /**
    * Creates a new Vec3 initialized with the given values
@@ -537,7 +532,7 @@ interface Vec3 extends Float32Array {
    * @param z Z component
    * @returns a new 3D vector
    */
-  public static fromValues(x: number, y: number, z: number): Vec3;
+  fromValues(x: number, y: number, z: number): Vec3;
 
   /**
    * Copy the values from one Vec3 to another
@@ -546,7 +541,7 @@ interface Vec3 extends Float32Array {
    * @param a the source vector
    * @returns out
    */
-  public static copy(out: Vec3, a: Vec3|number[]): Vec3;
+  copy(out: Vec3, a: Vec3|number[]): Vec3;
 
   /**
    * Set the components of a Vec3 to the given values
@@ -557,7 +552,7 @@ interface Vec3 extends Float32Array {
    * @param z Z component
    * @returns out
    */
-  public static set(out: Vec3, x: number, y: number, z: number): Vec3;
+  set(out: Vec3, x: number, y: number, z: number): Vec3;
 
   /**
    * Adds two Vec3's
@@ -567,7 +562,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static add(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  add(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
 
   /**
    * Subtracts vector b from vector a
@@ -577,7 +572,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static subtract(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  subtract(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
 
   /**
    * Subtracts vector b from vector a
@@ -587,18 +582,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static sub(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3
-
-      /**
-       * Multiplies two Vec3's
-       *
-       * @param out the receiving vector
-       * @param a the first operand
-       * @param b the second operand
-       * @returns out
-       */
-      public static multiply(out: Vec3, a: Vec3|number[], b: Vec3|number[]):
-          Vec3;
+  sub(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3
 
   /**
    * Multiplies two Vec3's
@@ -608,7 +592,17 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static mul(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  multiply(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+
+  /**
+   * Multiplies two Vec3's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  mul(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
 
   /**
    * Divides two Vec3's
@@ -618,7 +612,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static divide(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  divide(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
 
   /**
    * Divides two Vec3's
@@ -628,7 +622,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static div(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  div(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
 
   /**
    * Math.ceil the components of a Vec3
@@ -637,7 +631,7 @@ interface Vec3 extends Float32Array {
    * @param {Vec3} a vector to ceil
    * @returns {Vec3} out
    */
-  public static ceil(out: Vec3, a: Vec3|number[]): Vec3;
+  ceil(out: Vec3, a: Vec3|number[]): Vec3;
 
   /**
    * Math.floor the components of a Vec3
@@ -646,7 +640,7 @@ interface Vec3 extends Float32Array {
    * @param {Vec3} a vector to floor
    * @returns {Vec3} out
    */
-  public static floor(out: Vec3, a: Vec3|number[]): Vec3;
+  floor(out: Vec3, a: Vec3|number[]): Vec3;
 
   /**
    * Returns the minimum of two Vec3's
@@ -656,7 +650,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static min(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  min(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
 
   /**
    * Returns the maximum of two Vec3's
@@ -666,7 +660,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static max(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  max(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
 
   /**
    * Math.round the components of a Vec3
@@ -675,17 +669,17 @@ interface Vec3 extends Float32Array {
    * @param {Vec3} a vector to round
    * @returns {Vec3} out
    */
-  public static round(out: Vec3, a: Vec3|number[]): Vec3
+  round(out: Vec3, a: Vec3|number[]): Vec3
 
-      /**
-       * Scales a Vec3 by a scalar number
-       *
-       * @param out the receiving vector
-       * @param a the vector to scale
-       * @param b amount to scale the vector by
-       * @returns out
-       */
-      public static scale(out: Vec3, a: Vec3|number[], b: number): Vec3;
+  /**
+   * Scales a Vec3 by a scalar number
+   *
+   * @param out the receiving vector
+   * @param a the vector to scale
+   * @param b amount to scale the vector by
+   * @returns out
+   */
+  scale(out: Vec3, a: Vec3|number[], b: number): Vec3;
 
   /**
    * Adds two Vec3's after scaling the second operand by a scalar value
@@ -696,8 +690,8 @@ interface Vec3 extends Float32Array {
    * @param scale the amount to scale b by before adding
    * @returns out
    */
-  public static scaleAndAdd(
-      out: Vec3, a: Vec3|number[], b: Vec3|number[], scale: number): Vec3;
+  scaleAndAdd(out: Vec3, a: Vec3|number[], b: Vec3|number[], scale: number):
+      Vec3;
 
   /**
    * Calculates the euclidian distance between two Vec3's
@@ -706,7 +700,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns distance between a and b
    */
-  public static distance(a: Vec3|number[], b: Vec3|number[]): number;
+  distance(a: Vec3|number[], b: Vec3|number[]): number;
 
   /**
    * Calculates the euclidian distance between two Vec3's
@@ -715,7 +709,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns distance between a and b
    */
-  public static dist(a: Vec3|number[], b: Vec3|number[]): number;
+  dist(a: Vec3|number[], b: Vec3|number[]): number;
 
   /**
    * Calculates the squared euclidian distance between two Vec3's
@@ -724,7 +718,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  public static squaredDistance(a: Vec3|number[], b: Vec3|number[]): number;
+  squaredDistance(a: Vec3|number[], b: Vec3|number[]): number;
 
   /**
    * Calculates the squared euclidian distance between two Vec3's
@@ -733,7 +727,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  public static sqrDist(a: Vec3|number[], b: Vec3|number[]): number;
+  sqrDist(a: Vec3|number[], b: Vec3|number[]): number;
 
   /**
    * Calculates the length of a Vec3
@@ -741,7 +735,7 @@ interface Vec3 extends Float32Array {
    * @param a vector to calculate length of
    * @returns length of a
    */
-  public static length(a: Vec3|number[]): number;
+  length(a: Vec3|number[]): number;
 
   /**
    * Calculates the length of a Vec3
@@ -749,7 +743,7 @@ interface Vec3 extends Float32Array {
    * @param a vector to calculate length of
    * @returns length of a
    */
-  public static len(a: Vec3|number[]): number;
+  len(a: Vec3|number[]): number;
 
   /**
    * Calculates the squared length of a Vec3
@@ -757,7 +751,7 @@ interface Vec3 extends Float32Array {
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  public static squaredLength(a: Vec3|number[]): number;
+  squaredLength(a: Vec3|number[]): number;
 
   /**
    * Calculates the squared length of a Vec3
@@ -765,7 +759,7 @@ interface Vec3 extends Float32Array {
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  public static sqrLen(a: Vec3|number[]): number;
+  sqrLen(a: Vec3|number[]): number;
 
   /**
    * Negates the components of a Vec3
@@ -774,7 +768,7 @@ interface Vec3 extends Float32Array {
    * @param a vector to negate
    * @returns out
    */
-  public static negate(out: Vec3, a: Vec3|number[]): Vec3;
+  negate(out: Vec3, a: Vec3|number[]): Vec3;
 
   /**
    * Returns the inverse of the components of a Vec3
@@ -783,7 +777,7 @@ interface Vec3 extends Float32Array {
    * @param a vector to invert
    * @returns out
    */
-  public static inverse(out: Vec3, a: Vec3|number[]): Vec3;
+  inverse(out: Vec3, a: Vec3|number[]): Vec3;
 
   /**
    * Normalize a Vec3
@@ -792,7 +786,7 @@ interface Vec3 extends Float32Array {
    * @param a vector to normalize
    * @returns out
    */
-  public static normalize(out: Vec3, a: Vec3|number[]): Vec3;
+  normalize(out: Vec3, a: Vec3|number[]): Vec3;
 
   /**
    * Calculates the dot product of two Vec3's
@@ -801,7 +795,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns dot product of a and b
    */
-  public static dot(a: Vec3|number[], b: Vec3|number[]): number;
+  dot(a: Vec3|number[], b: Vec3|number[]): number;
 
   /**
    * Computes the cross product of two Vec3's
@@ -811,7 +805,7 @@ interface Vec3 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static cross(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
+  cross(out: Vec3, a: Vec3|number[], b: Vec3|number[]): Vec3;
 
   /**
    * Performs a linear interpolation between two Vec3's
@@ -822,8 +816,7 @@ interface Vec3 extends Float32Array {
    * @param t interpolation amount between the two inputs
    * @returns out
    */
-  public static lerp(out: Vec3, a: Vec3|number[], b: Vec3|number[], t: number):
-      Vec3;
+  lerp(out: Vec3, a: Vec3|number[], b: Vec3|number[], t: number): Vec3;
 
   /**
    * Performs a hermite interpolation with two control points
@@ -836,7 +829,7 @@ interface Vec3 extends Float32Array {
    * @param {number} t interpolation amount between the two inputs
    * @returns {Vec3} out
    */
-  public static hermite(
+  hermite(
       out: Vec3, a: Vec3|number[], b: Vec3|number[], c: Vec3|number[],
       d: Vec3|number[], t: number): Vec3;
 
@@ -851,7 +844,7 @@ interface Vec3 extends Float32Array {
    * @param {number} t interpolation amount between the two inputs
    * @returns {Vec3} out
    */
-  public static bezier(
+  bezier(
       out: Vec3, a: Vec3|number[], b: Vec3|number[], c: Vec3|number[],
       d: Vec3|number[], t: number): Vec3;
 
@@ -861,7 +854,7 @@ interface Vec3 extends Float32Array {
    * @param out the receiving vector
    * @returns out
    */
-  public static random(out: Vec3): Vec3;
+  random(out: Vec3): Vec3;
 
   /**
    * Generates a random vector with the given scale
@@ -871,7 +864,7 @@ interface Vec3 extends Float32Array {
    *     will be returned
    * @returns out
    */
-  public static random(out: Vec3, scale: number): Vec3;
+  random(out: Vec3, scale: number): Vec3;
 
   /**
    * Transforms the Vec3 with a Mat3.
@@ -881,7 +874,7 @@ interface Vec3 extends Float32Array {
    * @param m the 3x3 matrix to transform with
    * @returns out
    */
-  public static transformMat3(out: Vec3, a: Vec3|number[], m: Mat3): Vec3;
+  transformMat3(out: Vec3, a: Vec3|number[], m: Mat3): Vec3;
 
   /**
    * Transforms the Vec3 with a Mat4.
@@ -892,7 +885,7 @@ interface Vec3 extends Float32Array {
    * @param m matrix to transform with
    * @returns out
    */
-  public static transformMat4(out: Vec3, a: Vec3|number[], m: Mat4): Vec3;
+  transformMat4(out: Vec3, a: Vec3|number[], m: Mat4): Vec3;
 
   /**
    * Transforms the Vec3 with a Quat
@@ -902,7 +895,7 @@ interface Vec3 extends Float32Array {
    * @param q Quaternion to transform with
    * @returns out
    */
-  public static transformQuat(out: Vec3, a: Vec3|number[], q: Quat): Vec3;
+  transformQuat(out: Vec3, a: Vec3|number[], q: Quat): Vec3;
 
 
   /**
@@ -913,8 +906,7 @@ interface Vec3 extends Float32Array {
    * @param c The angle of rotation
    * @returns out
    */
-  public static rotateX(
-      out: Vec3, a: Vec3|number[], b: Vec3|number[], c: number): Vec3;
+  rotateX(out: Vec3, a: Vec3|number[], b: Vec3|number[], c: number): Vec3;
 
   /**
    * Rotate a 3D vector around the y-axis
@@ -924,8 +916,7 @@ interface Vec3 extends Float32Array {
    * @param c The angle of rotation
    * @returns out
    */
-  public static rotateY(
-      out: Vec3, a: Vec3|number[], b: Vec3|number[], c: number): Vec3;
+  rotateY(out: Vec3, a: Vec3|number[], b: Vec3|number[], c: number): Vec3;
 
   /**
    * Rotate a 3D vector around the z-axis
@@ -935,8 +926,7 @@ interface Vec3 extends Float32Array {
    * @param c The angle of rotation
    * @returns out
    */
-  public static rotateZ(
-      out: Vec3, a: Vec3|number[], b: Vec3|number[], c: number): Vec3;
+  rotateZ(out: Vec3, a: Vec3|number[], b: Vec3|number[], c: number): Vec3;
 
   /**
    * Perform some operation over an array of vec3s.
@@ -952,7 +942,7 @@ interface Vec3 extends Float32Array {
    * @returns a
    * @function
    */
-  public static forEach(
+  forEach(
       a: Float32Array, stride: number, offset: number, count: number,
       fn: (a: Vec3|number[], b: Vec3|number[], arg: any) => void,
       arg: any): Float32Array;
@@ -970,7 +960,7 @@ interface Vec3 extends Float32Array {
    * @returns a
    * @function
    */
-  public static forEach(
+  forEach(
       a: Float32Array, stride: number, offset: number, count: number,
       fn: (a: Vec3|number[], b: Vec3|number[]) => void): Float32Array;
 
@@ -980,7 +970,7 @@ interface Vec3 extends Float32Array {
    * @param b The second operand
    * @returns The angle in radians
    */
-  public static angle(a: Vec3|number[], b: Vec3|number[]): number;
+  angle(a: Vec3|number[], b: Vec3|number[]): number;
 
   /**
    * Returns a string representation of a vector
@@ -988,7 +978,7 @@ interface Vec3 extends Float32Array {
    * @param a vector to represent as a string
    * @returns string representation of the vector
    */
-  public static str(a: Vec3|number[]): string;
+  str(a: Vec3|number[]): string;
 
   /**
    * Returns whether or not the vectors have exactly the same elements in the
@@ -998,29 +988,27 @@ interface Vec3 extends Float32Array {
    * @param {Vec3} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  public static exactEquals(a: Vec3|number[], b: Vec3|number[]): boolean
+  exactEquals(a: Vec3|number[], b: Vec3|number[]): boolean
 
-      /**
-       * Returns whether or not the vectors have approximately the same
-       * elements in the same position.
-       *
-       * @param {Vec3} a The first vector.
-       * @param {Vec3} b The second vector.
-       * @returns {boolean} True if the vectors are equal, false otherwise.
-       */
-      public static equals(a: Vec3|number[], b: Vec3|number[]): boolean
+  /**
+   * Returns whether or not the vectors have approximately the same
+   * elements in the same position.
+   *
+   * @param {Vec3} a The first vector.
+   * @param {Vec3} b The second vector.
+   * @returns {boolean} True if the vectors are equal, false otherwise.
+   */
+  equals(a: Vec3|number[], b: Vec3|number[]): boolean
 }
 
 // Vec4
 interface Vec4 extends Float32Array {
-  private typeVec3: number;
-
   /**
    * Creates a new, empty Vec4
    *
    * @returns a new 4D vector
    */
-  public static create(): Vec4;
+  create(): Vec4;
 
   /**
    * Creates a new Vec4 initialized with values from an existing vector
@@ -1028,7 +1016,7 @@ interface Vec4 extends Float32Array {
    * @param a vector to clone
    * @returns a new 4D vector
    */
-  public static clone(a: Vec4|number[]): Vec4;
+  clone(a: Vec4|number[]): Vec4;
 
   /**
    * Creates a new Vec4 initialized with the given values
@@ -1039,7 +1027,7 @@ interface Vec4 extends Float32Array {
    * @param w W component
    * @returns a new 4D vector
    */
-  public static fromValues(x: number, y: number, z: number, w: number): Vec4;
+  fromValues(x: number, y: number, z: number, w: number): Vec4;
 
   /**
    * Copy the values from one Vec4 to another
@@ -1048,7 +1036,7 @@ interface Vec4 extends Float32Array {
    * @param a the source vector
    * @returns out
    */
-  public static copy(out: Vec4, a: Vec4|number[]): Vec4;
+  copy(out: Vec4, a: Vec4|number[]): Vec4;
 
   /**
    * Set the components of a Vec4 to the given values
@@ -1060,8 +1048,7 @@ interface Vec4 extends Float32Array {
    * @param w W component
    * @returns out
    */
-  public static set(out: Vec4, x: number, y: number, z: number, w: number):
-      Vec4;
+  set(out: Vec4, x: number, y: number, z: number, w: number): Vec4;
 
   /**
    * Adds two Vec4's
@@ -1071,7 +1058,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static add(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  add(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
 
   /**
    * Subtracts vector b from vector a
@@ -1081,7 +1068,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static subtract(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  subtract(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
 
   /**
    * Subtracts vector b from vector a
@@ -1091,7 +1078,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static sub(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  sub(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
 
   /**
    * Multiplies two Vec4's
@@ -1101,7 +1088,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static multiply(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  multiply(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
 
   /**
    * Multiplies two Vec4's
@@ -1111,7 +1098,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static mul(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  mul(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
 
   /**
    * Divides two Vec4's
@@ -1121,7 +1108,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static divide(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  divide(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
 
   /**
    * Divides two Vec4's
@@ -1131,7 +1118,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static div(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  div(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
 
   /**
    * Math.ceil the components of a Vec4
@@ -1140,7 +1127,7 @@ interface Vec4 extends Float32Array {
    * @param {Vec4} a vector to ceil
    * @returns {Vec4} out
    */
-  public static ceil(out: Vec4, a: Vec4|number[]): Vec4;
+  ceil(out: Vec4, a: Vec4|number[]): Vec4;
 
   /**
    * Math.floor the components of a Vec4
@@ -1149,7 +1136,7 @@ interface Vec4 extends Float32Array {
    * @param {Vec4} a vector to floor
    * @returns {Vec4} out
    */
-  public static floor(out: Vec4, a: Vec4|number[]): Vec4;
+  floor(out: Vec4, a: Vec4|number[]): Vec4;
 
   /**
    * Returns the minimum of two Vec4's
@@ -1159,7 +1146,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static min(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  min(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
 
   /**
    * Returns the maximum of two Vec4's
@@ -1169,7 +1156,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static max(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
+  max(out: Vec4, a: Vec4|number[], b: Vec4|number[]): Vec4;
 
   /**
    * Math.round the components of a Vec4
@@ -1178,7 +1165,7 @@ interface Vec4 extends Float32Array {
    * @param {Vec4} a vector to round
    * @returns {Vec4} out
    */
-  public static round(out: Vec4, a: Vec4|number[]): Vec4;
+  round(out: Vec4, a: Vec4|number[]): Vec4;
 
   /**
    * Scales a Vec4 by a scalar number
@@ -1188,7 +1175,7 @@ interface Vec4 extends Float32Array {
    * @param b amount to scale the vector by
    * @returns out
    */
-  public static scale(out: Vec4, a: Vec4|number[], b: number): Vec4;
+  scale(out: Vec4, a: Vec4|number[], b: number): Vec4;
 
   /**
    * Adds two Vec4's after scaling the second operand by a scalar value
@@ -1199,8 +1186,8 @@ interface Vec4 extends Float32Array {
    * @param scale the amount to scale b by before adding
    * @returns out
    */
-  public static scaleAndAdd(
-      out: Vec4, a: Vec4|number[], b: Vec4|number[], scale: number): Vec4;
+  scaleAndAdd(out: Vec4, a: Vec4|number[], b: Vec4|number[], scale: number):
+      Vec4;
 
   /**
    * Calculates the euclidian distance between two Vec4's
@@ -1209,7 +1196,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns distance between a and b
    */
-  public static distance(a: Vec4|number[], b: Vec4|number[]): number;
+  distance(a: Vec4|number[], b: Vec4|number[]): number;
 
   /**
    * Calculates the euclidian distance between two Vec4's
@@ -1218,7 +1205,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns distance between a and b
    */
-  public static dist(a: Vec4|number[], b: Vec4|number[]): number;
+  dist(a: Vec4|number[], b: Vec4|number[]): number;
 
   /**
    * Calculates the squared euclidian distance between two Vec4's
@@ -1227,7 +1214,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  public static squaredDistance(a: Vec4|number[], b: Vec4|number[]): number;
+  squaredDistance(a: Vec4|number[], b: Vec4|number[]): number;
 
   /**
    * Calculates the squared euclidian distance between two Vec4's
@@ -1236,7 +1223,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  public static sqrDist(a: Vec4|number[], b: Vec4|number[]): number;
+  sqrDist(a: Vec4|number[], b: Vec4|number[]): number;
 
   /**
    * Calculates the length of a Vec4
@@ -1244,7 +1231,7 @@ interface Vec4 extends Float32Array {
    * @param a vector to calculate length of
    * @returns length of a
    */
-  public static length(a: Vec4|number[]): number;
+  length(a: Vec4|number[]): number;
 
   /**
    * Calculates the length of a Vec4
@@ -1252,7 +1239,7 @@ interface Vec4 extends Float32Array {
    * @param a vector to calculate length of
    * @returns length of a
    */
-  public static len(a: Vec4|number[]): number;
+  len(a: Vec4|number[]): number;
 
   /**
    * Calculates the squared length of a Vec4
@@ -1260,7 +1247,7 @@ interface Vec4 extends Float32Array {
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  public static squaredLength(a: Vec4|number[]): number;
+  squaredLength(a: Vec4|number[]): number;
 
   /**
    * Calculates the squared length of a Vec4
@@ -1268,7 +1255,7 @@ interface Vec4 extends Float32Array {
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  public static sqrLen(a: Vec4|number[]): number;
+  sqrLen(a: Vec4|number[]): number;
 
   /**
    * Negates the components of a Vec4
@@ -1277,7 +1264,7 @@ interface Vec4 extends Float32Array {
    * @param a vector to negate
    * @returns out
    */
-  public static negate(out: Vec4, a: Vec4|number[]): Vec4;
+  negate(out: Vec4, a: Vec4|number[]): Vec4;
 
   /**
    * Returns the inverse of the components of a Vec4
@@ -1286,7 +1273,7 @@ interface Vec4 extends Float32Array {
    * @param a vector to invert
    * @returns out
    */
-  public static inverse(out: Vec4, a: Vec4|number[]): Vec4;
+  inverse(out: Vec4, a: Vec4|number[]): Vec4;
 
   /**
    * Normalize a Vec4
@@ -1295,7 +1282,7 @@ interface Vec4 extends Float32Array {
    * @param a vector to normalize
    * @returns out
    */
-  public static normalize(out: Vec4, a: Vec4|number[]): Vec4;
+  normalize(out: Vec4, a: Vec4|number[]): Vec4;
 
   /**
    * Calculates the dot product of two Vec4's
@@ -1304,7 +1291,7 @@ interface Vec4 extends Float32Array {
    * @param b the second operand
    * @returns dot product of a and b
    */
-  public static dot(a: Vec4|number[], b: Vec4|number[]): number;
+  dot(a: Vec4|number[], b: Vec4|number[]): number;
 
   /**
    * Performs a linear interpolation between two Vec4's
@@ -1315,8 +1302,7 @@ interface Vec4 extends Float32Array {
    * @param t interpolation amount between the two inputs
    * @returns out
    */
-  public static lerp(out: Vec4, a: Vec4|number[], b: Vec4|number[], t: number):
-      Vec4;
+  lerp(out: Vec4, a: Vec4|number[], b: Vec4|number[], t: number): Vec4;
 
   /**
    * Generates a random unit vector
@@ -1324,7 +1310,7 @@ interface Vec4 extends Float32Array {
    * @param out the receiving vector
    * @returns out
    */
-  public static random(out: Vec4): Vec4;
+  random(out: Vec4): Vec4;
 
   /**
    * Generates a random vector with the given scale
@@ -1334,7 +1320,7 @@ interface Vec4 extends Float32Array {
    *     will be returned
    * @returns out
    */
-  public static random(out: Vec4, scale: number): Vec4;
+  random(out: Vec4, scale: number): Vec4;
 
   /**
    * Transforms the Vec4 with a Mat4.
@@ -1344,7 +1330,7 @@ interface Vec4 extends Float32Array {
    * @param m matrix to transform with
    * @returns out
    */
-  public static transformMat4(out: Vec4, a: Vec4|number[], m: Mat4): Vec4;
+  transformMat4(out: Vec4, a: Vec4|number[], m: Mat4): Vec4;
 
   /**
    * Transforms the Vec4 with a Quat
@@ -1355,7 +1341,7 @@ interface Vec4 extends Float32Array {
    * @returns out
    */
 
-  public static transformQuat(out: Vec4, a: Vec4|number[], q: Quat): Vec4;
+  transformQuat(out: Vec4, a: Vec4|number[], q: Quat): Vec4;
 
   /**
    * Perform some operation over an array of Vec4s.
@@ -1371,7 +1357,7 @@ interface Vec4 extends Float32Array {
    * @returns a
    * @function
    */
-  public static forEach(
+  forEach(
       a: Float32Array, stride: number, offset: number, count: number,
       fn: (a: Vec4|number[], b: Vec4|number[], arg: any) => void,
       arg: any): Float32Array;
@@ -1389,7 +1375,7 @@ interface Vec4 extends Float32Array {
    * @returns a
    * @function
    */
-  public static forEach(
+  forEach(
       a: Float32Array, stride: number, offset: number, count: number,
       fn: (a: Vec4|number[], b: Vec4|number[]) => void): Float32Array;
 
@@ -1399,7 +1385,7 @@ interface Vec4 extends Float32Array {
    * @param a vector to represent as a string
    * @returns string representation of the vector
    */
-  public static str(a: Vec4|number[]): string;
+  str(a: Vec4|number[]): string;
 
   /**
    * Returns whether or not the vectors have exactly the same elements in the
@@ -1409,7 +1395,7 @@ interface Vec4 extends Float32Array {
    * @param {Vec4} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  public static exactEquals(a: Vec4|number[], b: Vec4|number[]): boolean;
+  exactEquals(a: Vec4|number[], b: Vec4|number[]): boolean;
 
   /**
    * Returns whether or not the vectors have approximately the same elements
@@ -1419,19 +1405,17 @@ interface Vec4 extends Float32Array {
    * @param {Vec4} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  public static equals(a: Vec4|number[], b: Vec4|number[]): boolean;
+  equals(a: Vec4|number[], b: Vec4|number[]): boolean;
 }
 
 // Mat2
 interface Mat2 extends Float32Array {
-  private typeMat2: number;
-
   /**
    * Creates a new identity Mat2
    *
    * @returns a new 2x2 matrix
    */
-  public static create(): Mat2;
+  create(): Mat2;
 
   /**
    * Creates a new Mat2 initialized with values from an existing matrix
@@ -1439,7 +1423,7 @@ interface Mat2 extends Float32Array {
    * @param a matrix to clone
    * @returns a new 2x2 matrix
    */
-  public static clone(a: Mat2): Mat2;
+  clone(a: Mat2): Mat2;
 
   /**
    * Copy the values from one Mat2 to another
@@ -1448,7 +1432,7 @@ interface Mat2 extends Float32Array {
    * @param a the source matrix
    * @returns out
    */
-  public static copy(out: Mat2, a: Mat2): Mat2;
+  copy(out: Mat2, a: Mat2): Mat2;
 
   /**
    * Set a Mat2 to the identity matrix
@@ -1456,7 +1440,7 @@ interface Mat2 extends Float32Array {
    * @param out the receiving matrix
    * @returns out
    */
-  public static identity(out: Mat2): Mat2;
+  identity(out: Mat2): Mat2;
 
   /**
    * Create a new Mat2 with the given values
@@ -1467,8 +1451,7 @@ interface Mat2 extends Float32Array {
    * @param {number} m11 Component in column 1, row 1 position (index 3)
    * @returns {Mat2} out A new 2x2 matrix
    */
-  public static fromValues(m00: number, m01: number, m10: number, m11: number):
-      Mat2;
+  fromValues(m00: number, m01: number, m10: number, m11: number): Mat2;
 
   /**
    * Set the components of a Mat2 to the given values
@@ -1480,8 +1463,7 @@ interface Mat2 extends Float32Array {
    * @param {number} m11 Component in column 1, row 1 position (index 3)
    * @returns {Mat2} out
    */
-  public static set(
-      out: Mat2, m00: number, m01: number, m10: number, m11: number): Mat2;
+  set(out: Mat2, m00: number, m01: number, m10: number, m11: number): Mat2;
 
   /**
    * Transpose the values of a Mat2
@@ -1490,7 +1472,7 @@ interface Mat2 extends Float32Array {
    * @param a the source matrix
    * @returns out
    */
-  public static transpose(out: Mat2, a: Mat2): Mat2;
+  transpose(out: Mat2, a: Mat2): Mat2;
 
   /**
    * Inverts a Mat2
@@ -1499,7 +1481,7 @@ interface Mat2 extends Float32Array {
    * @param a the source matrix
    * @returns out
    */
-  public static invert(out: Mat2, a: Mat2): Mat2|null;
+  invert(out: Mat2, a: Mat2): Mat2|null;
 
   /**
    * Calculates the adjugate of a Mat2
@@ -1508,7 +1490,7 @@ interface Mat2 extends Float32Array {
    * @param a the source matrix
    * @returns out
    */
-  public static adjoint(out: Mat2, a: Mat2): Mat2;
+  adjoint(out: Mat2, a: Mat2): Mat2;
 
   /**
    * Calculates the determinant of a Mat2
@@ -1516,7 +1498,7 @@ interface Mat2 extends Float32Array {
    * @param a the source matrix
    * @returns determinant of a
    */
-  public static determinant(a: Mat2): number;
+  determinant(a: Mat2): number;
 
   /**
    * Multiplies two Mat2's
@@ -1526,7 +1508,7 @@ interface Mat2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static multiply(out: Mat2, a: Mat2, b: Mat2): Mat2;
+  multiply(out: Mat2, a: Mat2, b: Mat2): Mat2;
 
   /**
    * Multiplies two Mat2's
@@ -1536,7 +1518,7 @@ interface Mat2 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static mul(out: Mat2, a: Mat2, b: Mat2): Mat2;
+  mul(out: Mat2, a: Mat2, b: Mat2): Mat2;
 
   /**
    * Rotates a Mat2 by the given angle
@@ -1546,7 +1528,7 @@ interface Mat2 extends Float32Array {
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  public static rotate(out: Mat2, a: Mat2, rad: number): Mat2;
+  rotate(out: Mat2, a: Mat2, rad: number): Mat2;
 
   /**
    * Scales the Mat2 by the dimensions in the given Vec2
@@ -1556,7 +1538,7 @@ interface Mat2 extends Float32Array {
    * @param v the Vec2 to scale the matrix by
    * @returns out
    **/
-  public static scale(out: Mat2, a: Mat2, v: Vec2|number[]): Mat2;
+  scale(out: Mat2, a: Mat2, v: Vec2|number[]): Mat2;
 
   /**
    * Creates a matrix from a given angle
@@ -1569,7 +1551,7 @@ interface Mat2 extends Float32Array {
    * @param {number} rad the angle to rotate the matrix by
    * @returns {Mat2} out
    */
-  public static fromRotation(out: Mat2, rad: number): Mat2;
+  fromRotation(out: Mat2, rad: number): Mat2;
 
   /**
    * Creates a matrix from a vector scaling
@@ -1582,7 +1564,7 @@ interface Mat2 extends Float32Array {
    * @param {Vec2} v Scaling vector
    * @returns {Mat2} out
    */
-  public static fromScaling(out: Mat2, v: Vec2|number[]): Mat2;
+  fromScaling(out: Mat2, v: Vec2|number[]): Mat2;
 
   /**
    * Returns a string representation of a Mat2
@@ -1590,7 +1572,7 @@ interface Mat2 extends Float32Array {
    * @param a matrix to represent as a string
    * @returns string representation of the matrix
    */
-  public static str(a: Mat2): string;
+  str(a: Mat2): string;
 
   /**
    * Returns Frobenius norm of a Mat2
@@ -1598,7 +1580,7 @@ interface Mat2 extends Float32Array {
    * @param a the matrix to calculate Frobenius norm of
    * @returns Frobenius norm
    */
-  public static frob(a: Mat2): number;
+  frob(a: Mat2): number;
 
   /**
    * Returns L, D and U matrices (Lower triangular, Diagonal and Upper
@@ -1608,7 +1590,7 @@ interface Mat2 extends Float32Array {
    * @param U the upper triangular matrix
    * @param a the input matrix to factorize
    */
-  public static LDU(L: Mat2, D: Mat2, U: Mat2, a: Mat2): Mat2;
+  LDU(L: Mat2, D: Mat2, U: Mat2, a: Mat2): Mat2;
 
   /**
    * Adds two Mat2's
@@ -1618,7 +1600,7 @@ interface Mat2 extends Float32Array {
    * @param {Mat2} b the second operand
    * @returns {Mat2} out
    */
-  public static add(out: Mat2, a: Mat2, b: Mat2): Mat2;
+  add(out: Mat2, a: Mat2, b: Mat2): Mat2;
 
   /**
    * Subtracts matrix b from matrix a
@@ -1628,7 +1610,7 @@ interface Mat2 extends Float32Array {
    * @param {Mat2} b the second operand
    * @returns {Mat2} out
    */
-  public static subtract(out: Mat2, a: Mat2, b: Mat2): Mat2;
+  subtract(out: Mat2, a: Mat2, b: Mat2): Mat2;
 
   /**
    * Subtracts matrix b from matrix a
@@ -1638,7 +1620,7 @@ interface Mat2 extends Float32Array {
    * @param {Mat2} b the second operand
    * @returns {Mat2} out
    */
-  public static sub(out: Mat2, a: Mat2, b: Mat2): Mat2;
+  sub(out: Mat2, a: Mat2, b: Mat2): Mat2;
 
   /**
    * Returns whether or not the matrices have exactly the same elements in the
@@ -1648,7 +1630,7 @@ interface Mat2 extends Float32Array {
    * @param {Mat2} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  public static exactEquals(a: Mat2, b: Mat2): boolean;
+  exactEquals(a: Mat2, b: Mat2): boolean;
 
   /**
    * Returns whether or not the matrices have approximately the same elements
@@ -1658,7 +1640,7 @@ interface Mat2 extends Float32Array {
    * @param {Mat2} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  public static equals(a: Mat2, b: Mat2): boolean;
+  equals(a: Mat2, b: Mat2): boolean;
 
   /**
    * Multiply each element of the matrix by a scalar.
@@ -1668,33 +1650,30 @@ interface Mat2 extends Float32Array {
    * @param {number} b amount to scale the matrix's elements by
    * @returns {Mat2} out
    */
-  public static multiplyScalar(out: Mat2, a: Mat2, b: number): Mat2
+  multiplyScalar(out: Mat2, a: Mat2, b: number): Mat2
 
-      /**
-       * Adds two Mat2's after multiplying each element of the second operand
-       * by a scalar value.
-       *
-       * @param {Mat2} out the receiving vector
-       * @param {Mat2} a the first operand
-       * @param {Mat2} b the second operand
-       * @param {number} scale the amount to scale b's elements by before
-       *     adding
-       * @returns {Mat2} out
-       */
-      public static multiplyScalarAndAdd(
-          out: Mat2, a: Mat2, b: Mat2, scale: number): Mat2
+  /**
+   * Adds two Mat2's after multiplying each element of the second operand
+   * by a scalar value.
+   *
+   * @param {Mat2} out the receiving vector
+   * @param {Mat2} a the first operand
+   * @param {Mat2} b the second operand
+   * @param {number} scale the amount to scale b's elements by before
+   *     adding
+   * @returns {Mat2} out
+   */
+  multiplyScalarAndAdd(out: Mat2, a: Mat2, b: Mat2, scale: number): Mat2
 }
 
 // Mat2d
 interface Mat2d extends Float32Array {
-  private typeMat2d: number;
-
   /**
    * Creates a new identity Mat2d
    *
    * @returns a new 2x3 matrix
    */
-  public static create(): Mat2d;
+  create(): Mat2d;
 
   /**
    * Creates a new Mat2d initialized with values from an existing matrix
@@ -1702,7 +1681,7 @@ interface Mat2d extends Float32Array {
    * @param a matrix to clone
    * @returns a new 2x3 matrix
    */
-  public static clone(a: Mat2d): Mat2d;
+  clone(a: Mat2d): Mat2d;
 
   /**
    * Copy the values from one Mat2d to another
@@ -1711,7 +1690,7 @@ interface Mat2d extends Float32Array {
    * @param a the source matrix
    * @returns out
    */
-  public static copy(out: Mat2d, a: Mat2d): Mat2d;
+  copy(out: Mat2d, a: Mat2d): Mat2d;
 
   /**
    * Set a Mat2d to the identity matrix
@@ -1719,7 +1698,7 @@ interface Mat2d extends Float32Array {
    * @param out the receiving matrix
    * @returns out
    */
-  public static identity(out: Mat2d): Mat2d;
+  identity(out: Mat2d): Mat2d;
 
   /**
    * Create a new Mat2d with the given values
@@ -1732,34 +1711,33 @@ interface Mat2d extends Float32Array {
    * @param {number} ty Component TY (index 5)
    * @returns {Mat2d} A new Mat2d
    */
-  public static fromValues(
+  fromValues(
       a: number, b: number, c: number, d: number, tx: number, ty: number): Mat2d
 
 
-      /**
-       * Set the components of a Mat2d to the given values
-       *
-       * @param {Mat2d} out the receiving matrix
-       * @param {number} a Component A (index 0)
-       * @param {number} b Component B (index 1)
-       * @param {number} c Component C (index 2)
-       * @param {number} d Component D (index 3)
-       * @param {number} tx Component TX (index 4)
-       * @param {number} ty Component TY (index 5)
-       * @returns {Mat2d} out
-       */
-      public static set(
-          out: Mat2d, a: number, b: number, c: number, d: number, tx: number,
-          ty: number): Mat2d
+  /**
+   * Set the components of a Mat2d to the given values
+   *
+   * @param {Mat2d} out the receiving matrix
+   * @param {number} a Component A (index 0)
+   * @param {number} b Component B (index 1)
+   * @param {number} c Component C (index 2)
+   * @param {number} d Component D (index 3)
+   * @param {number} tx Component TX (index 4)
+   * @param {number} ty Component TY (index 5)
+   * @returns {Mat2d} out
+   */
+  set(out: Mat2d, a: number, b: number, c: number, d: number, tx: number,
+      ty: number): Mat2d
 
-      /**
-       * Inverts a Mat2d
-       *
-       * @param out the receiving matrix
-       * @param a the source matrix
-       * @returns out
-       */
-      public static invert(out: Mat2d, a: Mat2d): Mat2d|null;
+  /**
+   * Inverts a Mat2d
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  invert(out: Mat2d, a: Mat2d): Mat2d|null;
 
   /**
    * Calculates the determinant of a Mat2d
@@ -1767,7 +1745,7 @@ interface Mat2d extends Float32Array {
    * @param a the source matrix
    * @returns determinant of a
    */
-  public static determinant(a: Mat2d): number;
+  determinant(a: Mat2d): number;
 
   /**
    * Multiplies two Mat2d's
@@ -1777,7 +1755,7 @@ interface Mat2d extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static multiply(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d;
+  multiply(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d;
 
   /**
    * Multiplies two Mat2d's
@@ -1787,7 +1765,7 @@ interface Mat2d extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static mul(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d;
+  mul(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d;
 
   /**
    * Rotates a Mat2d by the given angle
@@ -1797,7 +1775,7 @@ interface Mat2d extends Float32Array {
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  public static rotate(out: Mat2d, a: Mat2d, rad: number): Mat2d;
+  rotate(out: Mat2d, a: Mat2d, rad: number): Mat2d;
 
   /**
    * Scales the Mat2d by the dimensions in the given Vec2
@@ -1807,7 +1785,7 @@ interface Mat2d extends Float32Array {
    * @param v the Vec2 to scale the matrix by
    * @returns out
    **/
-  public static scale(out: Mat2d, a: Mat2d, v: Vec2|number[]): Mat2d;
+  scale(out: Mat2d, a: Mat2d, v: Vec2|number[]): Mat2d;
 
   /**
    * Translates the Mat2d by the dimensions in the given Vec2
@@ -1817,7 +1795,7 @@ interface Mat2d extends Float32Array {
    * @param v the Vec2 to translate the matrix by
    * @returns out
    **/
-  public static translate(out: Mat2d, a: Mat2d, v: Vec2|number[]): Mat2d;
+  translate(out: Mat2d, a: Mat2d, v: Vec2|number[]): Mat2d;
 
   /**
    * Creates a matrix from a given angle
@@ -1830,7 +1808,7 @@ interface Mat2d extends Float32Array {
    * @param {number} rad the angle to rotate the matrix by
    * @returns {Mat2d} out
    */
-  public static fromRotation(out: Mat2d, rad: number): Mat2d;
+  fromRotation(out: Mat2d, rad: number): Mat2d;
 
   /**
    * Creates a matrix from a vector scaling
@@ -1843,7 +1821,7 @@ interface Mat2d extends Float32Array {
    * @param {Vec2} v Scaling vector
    * @returns {Mat2d} out
    */
-  public static fromScaling(out: Mat2d, v: Vec2|number[]): Mat2d;
+  fromScaling(out: Mat2d, v: Vec2|number[]): Mat2d;
 
   /**
    * Creates a matrix from a vector translation
@@ -1856,15 +1834,15 @@ interface Mat2d extends Float32Array {
    * @param {Vec2} v Translation vector
    * @returns {Mat2d} out
    */
-  public static fromTranslation(out: Mat2d, v: Vec2|number[]): Mat2d
+  fromTranslation(out: Mat2d, v: Vec2|number[]): Mat2d
 
-      /**
-       * Returns a string representation of a Mat2d
-       *
-       * @param a matrix to represent as a string
-       * @returns string representation of the matrix
-       */
-      public static str(a: Mat2d): string;
+  /**
+   * Returns a string representation of a Mat2d
+   *
+   * @param a matrix to represent as a string
+   * @returns string representation of the matrix
+   */
+  str(a: Mat2d): string;
 
   /**
    * Returns Frobenius norm of a Mat2d
@@ -1872,7 +1850,7 @@ interface Mat2d extends Float32Array {
    * @param a the matrix to calculate Frobenius norm of
    * @returns Frobenius norm
    */
-  public static frob(a: Mat2d): number;
+  frob(a: Mat2d): number;
 
   /**
    * Adds two Mat2d's
@@ -1882,37 +1860,37 @@ interface Mat2d extends Float32Array {
    * @param {Mat2d} b the second operand
    * @returns {Mat2d} out
    */
-  public static add(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
+  add(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
 
-      /**
-       * Subtracts matrix b from matrix a
-       *
-       * @param {Mat2d} out the receiving matrix
-       * @param {Mat2d} a the first operand
-       * @param {Mat2d} b the second operand
-       * @returns {Mat2d} out
-       */
-      public static subtract(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat2d} out the receiving matrix
+   * @param {Mat2d} a the first operand
+   * @param {Mat2d} b the second operand
+   * @returns {Mat2d} out
+   */
+  subtract(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
 
-      /**
-       * Subtracts matrix b from matrix a
-       *
-       * @param {Mat2d} out the receiving matrix
-       * @param {Mat2d} a the first operand
-       * @param {Mat2d} b the second operand
-       * @returns {Mat2d} out
-       */
-      public static sub(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat2d} out the receiving matrix
+   * @param {Mat2d} a the first operand
+   * @param {Mat2d} b the second operand
+   * @returns {Mat2d} out
+   */
+  sub(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
 
-      /**
-       * Multiply each element of the matrix by a scalar.
-       *
-       * @param {Mat2d} out the receiving matrix
-       * @param {Mat2d} a the matrix to scale
-       * @param {number} b amount to scale the matrix's elements by
-       * @returns {Mat2d} out
-       */
-      public static multiplyScalar(out: Mat2d, a: Mat2d, b: number): Mat2d;
+  /**
+   * Multiply each element of the matrix by a scalar.
+   *
+   * @param {Mat2d} out the receiving matrix
+   * @param {Mat2d} a the matrix to scale
+   * @param {number} b amount to scale the matrix's elements by
+   * @returns {Mat2d} out
+   */
+  multiplyScalar(out: Mat2d, a: Mat2d, b: number): Mat2d;
 
   /**
    * Adds two Mat2d's after multiplying each element of the second operand by
@@ -1924,18 +1902,17 @@ interface Mat2d extends Float32Array {
    * @param {number} scale the amount to scale b's elements by before adding
    * @returns {Mat2d} out
    */
-  public static multiplyScalarAndAdd(
-      out: Mat2d, a: Mat2d, b: Mat2d, scale: number): Mat2d
+  multiplyScalarAndAdd(out: Mat2d, a: Mat2d, b: Mat2d, scale: number): Mat2d
 
-      /**
-       * Returns whether or not the matrices have exactly the same elements in
-       * the same position (when compared with ===)
-       *
-       * @param {Mat2d} a The first matrix.
-       * @param {Mat2d} b The second matrix.
-       * @returns {boolean} True if the matrices are equal, false otherwise.
-       */
-      public static exactEquals(a: Mat2d, b: Mat2d): boolean;
+  /**
+   * Returns whether or not the matrices have exactly the same elements in
+   * the same position (when compared with ===)
+   *
+   * @param {Mat2d} a The first matrix.
+   * @param {Mat2d} b The second matrix.
+   * @returns {boolean} True if the matrices are equal, false otherwise.
+   */
+  exactEquals(a: Mat2d, b: Mat2d): boolean;
 
   /**
    * Returns whether or not the matrices have approximately the same elements
@@ -1945,19 +1922,17 @@ interface Mat2d extends Float32Array {
    * @param {Mat2d} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  public static equals(a: Mat2d, b: Mat2d): boolean
+  equals(a: Mat2d, b: Mat2d): boolean
 }
 
 // Mat3
 interface Mat3 extends Float32Array {
-  private typeMat3: number;
-
   /**
    * Creates a new identity Mat3
    *
    * @returns a new 3x3 matrix
    */
-  public static create(): Mat3;
+  create(): Mat3;
 
   /**
    * Copies the upper-left 3x3 values into the given Mat3.
@@ -1966,15 +1941,15 @@ interface Mat3 extends Float32Array {
    * @param {Mat4} a   the source 4x4 matrix
    * @returns {Mat3} out
    */
-  public static fromMat4(out: Mat3, a: Mat4): Mat3
+  fromMat4(out: Mat3, a: Mat4): Mat3
 
-      /**
-       * Creates a new Mat3 initialized with values from an existing matrix
-       *
-       * @param a matrix to clone
-       * @returns a new 3x3 matrix
-       */
-      public static clone(a: Mat3): Mat3;
+  /**
+   * Creates a new Mat3 initialized with values from an existing matrix
+   *
+   * @param a matrix to clone
+   * @returns a new 3x3 matrix
+   */
+  clone(a: Mat3): Mat3;
 
   /**
    * Copy the values from one Mat3 to another
@@ -1983,7 +1958,7 @@ interface Mat3 extends Float32Array {
    * @param a the source matrix
    * @returns out
    */
-  public static copy(out: Mat3, a: Mat3): Mat3;
+  copy(out: Mat3, a: Mat3): Mat3;
 
   /**
    * Create a new Mat3 with the given values
@@ -1999,7 +1974,7 @@ interface Mat3 extends Float32Array {
    * @param {number} m22 Component in column 2, row 2 position (index 8)
    * @returns {Mat3} A new Mat3
    */
-  public static fromValues(
+  fromValues(
       m00: number, m01: number, m02: number, m10: number, m11: number,
       m12: number, m20: number, m21: number, m22: number): Mat3;
 
@@ -2019,17 +1994,16 @@ interface Mat3 extends Float32Array {
    * @param {number} m22 Component in column 2, row 2 position (index 8)
    * @returns {Mat3} out
    */
-  public static set(
-      out: Mat3, m00: number, m01: number, m02: number, m10: number,
+  set(out: Mat3, m00: number, m01: number, m02: number, m10: number,
       m11: number, m12: number, m20: number, m21: number, m22: number): Mat3
 
-      /**
-       * Set a Mat3 to the identity matrix
-       *
-       * @param out the receiving matrix
-       * @returns out
-       */
-      public static identity(out: Mat3): Mat3;
+  /**
+   * Set a Mat3 to the identity matrix
+   *
+   * @param out the receiving matrix
+   * @returns out
+   */
+  identity(out: Mat3): Mat3;
 
   /**
    * Transpose the values of a Mat3
@@ -2038,7 +2012,7 @@ interface Mat3 extends Float32Array {
    * @param a the source matrix
    * @returns out
    */
-  public static transpose(out: Mat3, a: Mat3): Mat3;
+  transpose(out: Mat3, a: Mat3): Mat3;
 
   /**
    * Inverts a Mat3
@@ -2047,7 +2021,7 @@ interface Mat3 extends Float32Array {
    * @param a the source matrix
    * @returns out
    */
-  public static invert(out: Mat3, a: Mat3): Mat3|null;
+  invert(out: Mat3, a: Mat3): Mat3|null;
 
   /**
    * Calculates the adjugate of a Mat3
@@ -2056,7 +2030,7 @@ interface Mat3 extends Float32Array {
    * @param a the source matrix
    * @returns out
    */
-  public static adjoint(out: Mat3, a: Mat3): Mat3;
+  adjoint(out: Mat3, a: Mat3): Mat3;
 
   /**
    * Calculates the determinant of a Mat3
@@ -2064,7 +2038,7 @@ interface Mat3 extends Float32Array {
    * @param a the source matrix
    * @returns determinant of a
    */
-  public static determinant(a: Mat3): number;
+  determinant(a: Mat3): number;
 
   /**
    * Multiplies two Mat3's
@@ -2074,7 +2048,7 @@ interface Mat3 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static multiply(out: Mat3, a: Mat3, b: Mat3): Mat3;
+  multiply(out: Mat3, a: Mat3, b: Mat3): Mat3;
 
   /**
    * Multiplies two Mat3's
@@ -2084,7 +2058,7 @@ interface Mat3 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static mul(out: Mat3, a: Mat3, b: Mat3): Mat3;
+  mul(out: Mat3, a: Mat3, b: Mat3): Mat3;
 
 
   /**
@@ -2095,7 +2069,7 @@ interface Mat3 extends Float32Array {
    * @param v vector to translate by
    * @returns out
    */
-  public static translate(out: Mat3, a: Mat3, v: Vec3|number[]): Mat3;
+  translate(out: Mat3, a: Mat3, v: Vec3|number[]): Mat3;
 
   /**
    * Rotates a Mat3 by the given angle
@@ -2105,7 +2079,7 @@ interface Mat3 extends Float32Array {
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  public static rotate(out: Mat3, a: Mat3, rad: number): Mat3;
+  rotate(out: Mat3, a: Mat3, rad: number): Mat3;
 
   /**
    * Scales the Mat3 by the dimensions in the given Vec2
@@ -2115,7 +2089,7 @@ interface Mat3 extends Float32Array {
    * @param v the Vec2 to scale the matrix by
    * @returns out
    **/
-  public static scale(out: Mat3, a: Mat3, v: Vec2|number[]): Mat3;
+  scale(out: Mat3, a: Mat3, v: Vec2|number[]): Mat3;
 
   /**
    * Creates a matrix from a vector translation
@@ -2128,42 +2102,42 @@ interface Mat3 extends Float32Array {
    * @param {Vec2} v Translation vector
    * @returns {Mat3} out
    */
-  public static fromTranslation(out: Mat3, v: Vec2|number[]): Mat3
+  fromTranslation(out: Mat3, v: Vec2|number[]): Mat3
 
-      /**
-       * Creates a matrix from a given angle
-       * This is equivalent to (but much faster than):
-       *
-       *     Mat3.identity(dest);
-       *     Mat3.rotate(dest, dest, rad);
-       *
-       * @param {Mat3} out Mat3 receiving operation result
-       * @param {number} rad the angle to rotate the matrix by
-       * @returns {Mat3} out
-       */
-      public static fromRotation(out: Mat3, rad: number): Mat3
+  /**
+   * Creates a matrix from a given angle
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat3.identity(dest);
+   *     Mat3.rotate(dest, dest, rad);
+   *
+   * @param {Mat3} out Mat3 receiving operation result
+   * @param {number} rad the angle to rotate the matrix by
+   * @returns {Mat3} out
+   */
+  fromRotation(out: Mat3, rad: number): Mat3
 
-      /**
-       * Creates a matrix from a vector scaling
-       * This is equivalent to (but much faster than):
-       *
-       *     Mat3.identity(dest);
-       *     Mat3.scale(dest, dest, vec);
-       *
-       * @param {Mat3} out Mat3 receiving operation result
-       * @param {Vec2} v Scaling vector
-       * @returns {Mat3} out
-       */
-      public static fromScaling(out: Mat3, v: Vec2|number[]): Mat3
+  /**
+   * Creates a matrix from a vector scaling
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat3.identity(dest);
+   *     Mat3.scale(dest, dest, vec);
+   *
+   * @param {Mat3} out Mat3 receiving operation result
+   * @param {Vec2} v Scaling vector
+   * @returns {Mat3} out
+   */
+  fromScaling(out: Mat3, v: Vec2|number[]): Mat3
 
-      /**
-       * Copies the values from a Mat2d into a Mat3
-       *
-       * @param out the receiving matrix
-       * @param {Mat2d} a the matrix to copy
-       * @returns out
-       **/
-      public static fromMat2d(out: Mat3, a: Mat2d): Mat3;
+  /**
+   * Copies the values from a Mat2d into a Mat3
+   *
+   * @param out the receiving matrix
+   * @param {Mat2d} a the matrix to copy
+   * @returns out
+   **/
+  fromMat2d(out: Mat3, a: Mat2d): Mat3;
 
   /**
    * Calculates a 3x3 matrix from the given Quaternion
@@ -2173,7 +2147,7 @@ interface Mat3 extends Float32Array {
    *
    * @returns out
    */
-  public static fromQuat(out: Mat3, q: Quat): Mat3;
+  fromQuat(out: Mat3, q: Quat): Mat3;
 
   /**
    * Calculates a 3x3 normal matrix (transpose inverse) from the 4x4 matrix
@@ -2183,7 +2157,7 @@ interface Mat3 extends Float32Array {
    *
    * @returns out
    */
-  public static normalFromMat4(out: Mat3, a: Mat4): Mat3|null;
+  normalFromMat4(out: Mat3, a: Mat4): Mat3|null;
 
   /**
    * Returns a string representation of a Mat3
@@ -2191,7 +2165,7 @@ interface Mat3 extends Float32Array {
    * @param mat matrix to represent as a string
    * @returns string representation of the matrix
    */
-  public static str(mat: Mat3): string;
+  str(mat: Mat3): string;
 
   /**
    * Returns Frobenius norm of a Mat3
@@ -2199,7 +2173,7 @@ interface Mat3 extends Float32Array {
    * @param a the matrix to calculate Frobenius norm of
    * @returns Frobenius norm
    */
-  public static frob(a: Mat3): number;
+  frob(a: Mat3): number;
 
   /**
    * Adds two Mat3's
@@ -2209,61 +2183,60 @@ interface Mat3 extends Float32Array {
    * @param {Mat3} b the second operand
    * @returns {Mat3} out
    */
-  public static add(out: Mat3, a: Mat3, b: Mat3): Mat3
+  add(out: Mat3, a: Mat3, b: Mat3): Mat3
 
-      /**
-       * Subtracts matrix b from matrix a
-       *
-       * @param {Mat3} out the receiving matrix
-       * @param {Mat3} a the first operand
-       * @param {Mat3} b the second operand
-       * @returns {Mat3} out
-       */
-      public static subtract(out: Mat3, a: Mat3, b: Mat3): Mat3
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat3} out the receiving matrix
+   * @param {Mat3} a the first operand
+   * @param {Mat3} b the second operand
+   * @returns {Mat3} out
+   */
+  subtract(out: Mat3, a: Mat3, b: Mat3): Mat3
 
-      /**
-       * Subtracts matrix b from matrix a
-       *
-       * @param {Mat3} out the receiving matrix
-       * @param {Mat3} a the first operand
-       * @param {Mat3} b the second operand
-       * @returns {Mat3} out
-       */
-      public static sub(out: Mat3, a: Mat3, b: Mat3): Mat3
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat3} out the receiving matrix
+   * @param {Mat3} a the first operand
+   * @param {Mat3} b the second operand
+   * @returns {Mat3} out
+   */
+  sub(out: Mat3, a: Mat3, b: Mat3): Mat3
 
-      /**
-       * Multiply each element of the matrix by a scalar.
-       *
-       * @param {Mat3} out the receiving matrix
-       * @param {Mat3} a the matrix to scale
-       * @param {number} b amount to scale the matrix's elements by
-       * @returns {Mat3} out
-       */
-      public static multiplyScalar(out: Mat3, a: Mat3, b: number): Mat3
+  /**
+   * Multiply each element of the matrix by a scalar.
+   *
+   * @param {Mat3} out the receiving matrix
+   * @param {Mat3} a the matrix to scale
+   * @param {number} b amount to scale the matrix's elements by
+   * @returns {Mat3} out
+   */
+  multiplyScalar(out: Mat3, a: Mat3, b: number): Mat3
 
-      /**
-       * Adds two Mat3's after multiplying each element of the second operand
-       * by a scalar value.
-       *
-       * @param {Mat3} out the receiving vector
-       * @param {Mat3} a the first operand
-       * @param {Mat3} b the second operand
-       * @param {number} scale the amount to scale b's elements by before
-       *     adding
-       * @returns {Mat3} out
-       */
-      public static multiplyScalarAndAdd(
-          out: Mat3, a: Mat3, b: Mat3, scale: number): Mat3
+  /**
+   * Adds two Mat3's after multiplying each element of the second operand
+   * by a scalar value.
+   *
+   * @param {Mat3} out the receiving vector
+   * @param {Mat3} a the first operand
+   * @param {Mat3} b the second operand
+   * @param {number} scale the amount to scale b's elements by before
+   *     adding
+   * @returns {Mat3} out
+   */
+  multiplyScalarAndAdd(out: Mat3, a: Mat3, b: Mat3, scale: number): Mat3
 
-      /**
-       * Returns whether or not the matrices have exactly the same elements in
-       * the same position (when compared with ===)
-       *
-       * @param {Mat3} a The first matrix.
-       * @param {Mat3} b The second matrix.
-       * @returns {boolean} True if the matrices are equal, false otherwise.
-       */
-      public static exactEquals(a: Mat3, b: Mat3): boolean;
+  /**
+   * Returns whether or not the matrices have exactly the same elements in
+   * the same position (when compared with ===)
+   *
+   * @param {Mat3} a The first matrix.
+   * @param {Mat3} b The second matrix.
+   * @returns {boolean} True if the matrices are equal, false otherwise.
+   */
+  exactEquals(a: Mat3, b: Mat3): boolean;
 
   /**
    * Returns whether or not the matrices have approximately the same elements
@@ -2273,19 +2246,17 @@ interface Mat3 extends Float32Array {
    * @param {Mat3} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  public static equals(a: Mat3, b: Mat3): boolean
+  equals(a: Mat3, b: Mat3): boolean
 }
 
 // Mat4
 interface Mat4 extends Float32Array {
-  private typeMat4: number;
-
   /**
    * Creates a new identity Mat4
    *
    * @returns a new 4x4 matrix
    */
-  public static create(): Mat4;
+  create(): Mat4;
 
   /**
    * Creates a new Mat4 initialized with values from an existing matrix
@@ -2293,7 +2264,7 @@ interface Mat4 extends Float32Array {
    * @param a matrix to clone
    * @returns a new 4x4 matrix
    */
-  public static clone(a: Mat4): Mat4;
+  clone(a: Mat4): Mat4;
 
   /**
    * Copy the values from one Mat4 to another
@@ -2302,7 +2273,7 @@ interface Mat4 extends Float32Array {
    * @param a the source matrix
    * @returns out
    */
-  public static copy(out: Mat4, a: Mat4): Mat4;
+  copy(out: Mat4, a: Mat4): Mat4;
 
 
   /**
@@ -2326,7 +2297,7 @@ interface Mat4 extends Float32Array {
    * @param {number} m33 Component in column 3, row 3 position (index 15)
    * @returns {Mat4} A new Mat4
    */
-  public static fromValues(
+  fromValues(
       m00: number, m01: number, m02: number, m03: number, m10: number,
       m11: number, m12: number, m13: number, m20: number, m21: number,
       m22: number, m23: number, m30: number, m31: number, m32: number,
@@ -2354,8 +2325,7 @@ interface Mat4 extends Float32Array {
    * @param {number} m33 Component in column 3, row 3 position (index 15)
    * @returns {Mat4} out
    */
-  public static set(
-      out: Mat4, m00: number, m01: number, m02: number, m03: number,
+  set(out: Mat4, m00: number, m01: number, m02: number, m03: number,
       m10: number, m11: number, m12: number, m13: number, m20: number,
       m21: number, m22: number, m23: number, m30: number, m31: number,
       m32: number, m33: number): Mat4;
@@ -2366,7 +2336,7 @@ interface Mat4 extends Float32Array {
    * @param out the receiving matrix
    * @returns out
    */
-  public static identity(out: Mat4): Mat4;
+  identity(out: Mat4): Mat4;
 
   /**
    * Transpose the values of a Mat4
@@ -2375,7 +2345,7 @@ interface Mat4 extends Float32Array {
    * @param a the source matrix
    * @returns out
    */
-  public static transpose(out: Mat4, a: Mat4): Mat4;
+  transpose(out: Mat4, a: Mat4): Mat4;
 
   /**
    * Inverts a Mat4
@@ -2384,7 +2354,7 @@ interface Mat4 extends Float32Array {
    * @param a the source matrix
    * @returns out
    */
-  public static invert(out: Mat4, a: Mat4): Mat4|null;
+  invert(out: Mat4, a: Mat4): Mat4|null;
 
   /**
    * Calculates the adjugate of a Mat4
@@ -2393,7 +2363,7 @@ interface Mat4 extends Float32Array {
    * @param a the source matrix
    * @returns out
    */
-  public static adjoint(out: Mat4, a: Mat4): Mat4;
+  adjoint(out: Mat4, a: Mat4): Mat4;
 
   /**
    * Calculates the determinant of a Mat4
@@ -2401,7 +2371,7 @@ interface Mat4 extends Float32Array {
    * @param a the source matrix
    * @returns determinant of a
    */
-  public static determinant(a: Mat4): number;
+  determinant(a: Mat4): number;
 
   /**
    * Multiplies two Mat4's
@@ -2411,7 +2381,7 @@ interface Mat4 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static multiply(out: Mat4, a: Mat4, b: Mat4): Mat4;
+  multiply(out: Mat4, a: Mat4, b: Mat4): Mat4;
 
   /**
    * Multiplies two Mat4's
@@ -2421,7 +2391,7 @@ interface Mat4 extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static mul(out: Mat4, a: Mat4, b: Mat4): Mat4;
+  mul(out: Mat4, a: Mat4, b: Mat4): Mat4;
 
   /**
    * Translate a Mat4 by the given vector
@@ -2431,7 +2401,7 @@ interface Mat4 extends Float32Array {
    * @param v vector to translate by
    * @returns out
    */
-  public static translate(out: Mat4, a: Mat4, v: Vec3|number[]): Mat4;
+  translate(out: Mat4, a: Mat4, v: Vec3|number[]): Mat4;
 
   /**
    * Scales the Mat4 by the dimensions in the given Vec3
@@ -2441,7 +2411,7 @@ interface Mat4 extends Float32Array {
    * @param v the Vec3 to scale the matrix by
    * @returns out
    **/
-  public static scale(out: Mat4, a: Mat4, v: Vec3|number[]): Mat4;
+  scale(out: Mat4, a: Mat4, v: Vec3|number[]): Mat4;
 
   /**
    * Rotates a Mat4 by the given angle
@@ -2452,8 +2422,7 @@ interface Mat4 extends Float32Array {
    * @param axis the axis to rotate around
    * @returns out
    */
-  public static rotate(out: Mat4, a: Mat4, rad: number, axis: Vec3|number[]):
-      Mat4;
+  rotate(out: Mat4, a: Mat4, rad: number, axis: Vec3|number[]): Mat4;
 
   /**
    * Rotates a matrix by the given angle around the X axis
@@ -2463,7 +2432,7 @@ interface Mat4 extends Float32Array {
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  public static rotateX(out: Mat4, a: Mat4, rad: number): Mat4;
+  rotateX(out: Mat4, a: Mat4, rad: number): Mat4;
 
   /**
    * Rotates a matrix by the given angle around the Y axis
@@ -2473,7 +2442,7 @@ interface Mat4 extends Float32Array {
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  public static rotateY(out: Mat4, a: Mat4, rad: number): Mat4;
+  rotateY(out: Mat4, a: Mat4, rad: number): Mat4;
 
   /**
    * Rotates a matrix by the given angle around the Z axis
@@ -2483,7 +2452,7 @@ interface Mat4 extends Float32Array {
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  public static rotateZ(out: Mat4, a: Mat4, rad: number): Mat4;
+  rotateZ(out: Mat4, a: Mat4, rad: number): Mat4;
 
   /**
    * Creates a matrix from a vector translation
@@ -2496,93 +2465,91 @@ interface Mat4 extends Float32Array {
    * @param {Vec3} v Translation vector
    * @returns {Mat4} out
    */
-  public static fromTranslation(out: Mat4, v: Vec3|number[]): Mat4
+  fromTranslation(out: Mat4, v: Vec3|number[]): Mat4
 
-      /**
-       * Creates a matrix from a vector scaling
-       * This is equivalent to (but much faster than):
-       *
-       *     Mat4.identity(dest);
-       *     Mat4.scale(dest, dest, vec);
-       *
-       * @param {Mat4} out Mat4 receiving operation result
-       * @param {Vec3} v Scaling vector
-       * @returns {Mat4} out
-       */
-      public static fromScaling(out: Mat4, v: Vec3|number[]): Mat4
+  /**
+   * Creates a matrix from a vector scaling
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat4.identity(dest);
+   *     Mat4.scale(dest, dest, vec);
+   *
+   * @param {Mat4} out Mat4 receiving operation result
+   * @param {Vec3} v Scaling vector
+   * @returns {Mat4} out
+   */
+  fromScaling(out: Mat4, v: Vec3|number[]): Mat4
 
-      /**
-       * Creates a matrix from a given angle around a given axis
-       * This is equivalent to (but much faster than):
-       *
-       *     Mat4.identity(dest);
-       *     Mat4.rotate(dest, dest, rad, axis);
-       *
-       * @param {Mat4} out Mat4 receiving operation result
-       * @param {number} rad the angle to rotate the matrix by
-       * @param {Vec3} axis the axis to rotate around
-       * @returns {Mat4} out
-       */
-      public static fromRotation(out: Mat4, rad: number, axis: Vec3|number[]):
-          Mat4
+  /**
+   * Creates a matrix from a given angle around a given axis
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat4.identity(dest);
+   *     Mat4.rotate(dest, dest, rad, axis);
+   *
+   * @param {Mat4} out Mat4 receiving operation result
+   * @param {number} rad the angle to rotate the matrix by
+   * @param {Vec3} axis the axis to rotate around
+   * @returns {Mat4} out
+   */
+  fromRotation(out: Mat4, rad: number, axis: Vec3|number[]): Mat4
 
-      /**
-       * Creates a matrix from the given angle around the X axis
-       * This is equivalent to (but much faster than):
-       *
-       *     Mat4.identity(dest);
-       *     Mat4.rotateX(dest, dest, rad);
-       *
-       * @param {Mat4} out Mat4 receiving operation result
-       * @param {number} rad the angle to rotate the matrix by
-       * @returns {Mat4} out
-       */
-      public static fromXRotation(out: Mat4, rad: number): Mat4
+  /**
+   * Creates a matrix from the given angle around the X axis
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat4.identity(dest);
+   *     Mat4.rotateX(dest, dest, rad);
+   *
+   * @param {Mat4} out Mat4 receiving operation result
+   * @param {number} rad the angle to rotate the matrix by
+   * @returns {Mat4} out
+   */
+  fromXRotation(out: Mat4, rad: number): Mat4
 
-      /**
-       * Creates a matrix from the given angle around the Y axis
-       * This is equivalent to (but much faster than):
-       *
-       *     Mat4.identity(dest);
-       *     Mat4.rotateY(dest, dest, rad);
-       *
-       * @param {Mat4} out Mat4 receiving operation result
-       * @param {number} rad the angle to rotate the matrix by
-       * @returns {Mat4} out
-       */
-      public static fromYRotation(out: Mat4, rad: number): Mat4
+  /**
+   * Creates a matrix from the given angle around the Y axis
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat4.identity(dest);
+   *     Mat4.rotateY(dest, dest, rad);
+   *
+   * @param {Mat4} out Mat4 receiving operation result
+   * @param {number} rad the angle to rotate the matrix by
+   * @returns {Mat4} out
+   */
+  fromYRotation(out: Mat4, rad: number): Mat4
 
 
-      /**
-       * Creates a matrix from the given angle around the Z axis
-       * This is equivalent to (but much faster than):
-       *
-       *     Mat4.identity(dest);
-       *     Mat4.rotateZ(dest, dest, rad);
-       *
-       * @param {Mat4} out Mat4 receiving operation result
-       * @param {number} rad the angle to rotate the matrix by
-       * @returns {Mat4} out
-       */
-      public static fromZRotation(out: Mat4, rad: number): Mat4
+  /**
+   * Creates a matrix from the given angle around the Z axis
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat4.identity(dest);
+   *     Mat4.rotateZ(dest, dest, rad);
+   *
+   * @param {Mat4} out Mat4 receiving operation result
+   * @param {number} rad the angle to rotate the matrix by
+   * @returns {Mat4} out
+   */
+  fromZRotation(out: Mat4, rad: number): Mat4
 
-      /**
-       * Creates a matrix from a Quaternion rotation and vector translation
-       * This is equivalent to (but much faster than):
-       *
-       *     Mat4.identity(dest);
-       *     Mat4.translate(dest, vec);
-       *     var QuatMat = Mat4.create();
-       *     Quat4.toMat4(Quat, QuatMat);
-       *     Mat4.multiply(dest, QuatMat);
-       *
-       * @param out Mat4 receiving operation result
-       * @param q Rotation Quaternion
-       * @param v Translation vector
-       * @returns out
-       */
-      public static fromRotationTranslation(
-          out: Mat4, q: Quat, v: Vec3|number[]): Mat4;
+  /**
+   * Creates a matrix from a Quaternion rotation and vector translation
+   * This is equivalent to (but much faster than):
+   *
+   *     Mat4.identity(dest);
+   *     Mat4.translate(dest, vec);
+   *     var QuatMat = Mat4.create();
+   *     Quat4.toMat4(Quat, QuatMat);
+   *     Mat4.multiply(dest, QuatMat);
+   *
+   * @param out Mat4 receiving operation result
+   * @param q Rotation Quaternion
+   * @param v Translation vector
+   * @returns out
+   */
+  fromRotationTranslation(out: Mat4, q: Quat, v: Vec3|number[]): Mat4;
 
   /**
    * Returns the translation vector component of a transformation
@@ -2593,7 +2560,7 @@ interface Mat4 extends Float32Array {
    * @param  {Mat4} mat Matrix to be decomposed (input)
    * @return {Vec3} out
    */
-  public static getTranslation(out: Vec3, mat: Mat4): Vec3;
+  getTranslation(out: Vec3, mat: Mat4): Vec3;
 
   /**
    * Returns a Quaternion representing the rotational component
@@ -2604,7 +2571,7 @@ interface Mat4 extends Float32Array {
    * @param {Mat4} mat Matrix to be decomposed (input)
    * @return {Quat} out
    */
-  public static getRotation(out: Quat, mat: Mat4): Quat;
+  getRotation(out: Quat, mat: Mat4): Quat;
 
   /**
    * Creates a matrix from a Quaternion rotation, vector translation and
@@ -2623,7 +2590,7 @@ interface Mat4 extends Float32Array {
    * @param s Scaling vector
    * @returns out
    */
-  public static fromRotationTranslationScale(
+  fromRotationTranslationScale(
       out: Mat4, q: Quat, v: Vec3|number[], s: Vec3|number[]): Mat4;
 
   /**
@@ -2647,35 +2614,35 @@ interface Mat4 extends Float32Array {
    * @param {Vec3} o The origin vector around which to scale and rotate
    * @returns {Mat4} out
    */
-  public static fromRotationTranslationScaleOrigin(
-      out: Mat4, q: Quat, v: Vec3|number[], s: Vec3|number[], o: Vec3|number[]):
-      Mat4
+  fromRotationTranslationScaleOrigin(
+      out: Mat4, q: Quat, v: Vec3|number[], s: Vec3|number[],
+      o: Vec3|number[]): Mat4
 
-      /**
-       * Calculates a 4x4 matrix from the given Quaternion
-       *
-       * @param {Mat4} out Mat4 receiving operation result
-       * @param {Quat} q Quaternion to create matrix from
-       *
-       * @returns {Mat4} out
-       */
-      public static fromQuat(out: Mat4, q: Quat): Mat4
+  /**
+   * Calculates a 4x4 matrix from the given Quaternion
+   *
+   * @param {Mat4} out Mat4 receiving operation result
+   * @param {Quat} q Quaternion to create matrix from
+   *
+   * @returns {Mat4} out
+   */
+  fromQuat(out: Mat4, q: Quat): Mat4
 
-      /**
-       * Generates a frustum matrix with the given bounds
-       *
-       * @param out Mat4 frustum matrix will be written into
-       * @param left Left bound of the frustum
-       * @param right Right bound of the frustum
-       * @param bottom Bottom bound of the frustum
-       * @param top Top bound of the frustum
-       * @param near Near bound of the frustum
-       * @param far Far bound of the frustum
-       * @returns out
-       */
-      public static frustum(
-          out: Mat4, left: number, right: number, bottom: number, top: number,
-          near: number, far: number): Mat4;
+  /**
+   * Generates a frustum matrix with the given bounds
+   *
+   * @param out Mat4 frustum matrix will be written into
+   * @param left Left bound of the frustum
+   * @param right Right bound of the frustum
+   * @param bottom Bottom bound of the frustum
+   * @param top Top bound of the frustum
+   * @param near Near bound of the frustum
+   * @param far Far bound of the frustum
+   * @returns out
+   */
+  frustum(
+      out: Mat4, left: number, right: number, bottom: number, top: number,
+      near: number, far: number): Mat4;
 
   /**
    * Generates a perspective projection matrix with the given bounds
@@ -2687,7 +2654,7 @@ interface Mat4 extends Float32Array {
    * @param far Far bound of the frustum
    * @returns out
    */
-  public static perspective(
+  perspective(
       out: Mat4, fovy: number, aspect: number, near: number, far: number): Mat4;
 
   /**
@@ -2702,7 +2669,7 @@ interface Mat4 extends Float32Array {
    * @param {number} far Far bound of the frustum
    * @returns {Mat4} out
    */
-  public static perspectiveFromFieldOfView(
+  perspectiveFromFieldOfView(
       out: Mat4, fov: {
         upDegrees: number,
         downDegrees: number,
@@ -2711,21 +2678,21 @@ interface Mat4 extends Float32Array {
       },
       near: number, far: number): Mat4
 
-      /**
-       * Generates a orthogonal projection matrix with the given bounds
-       *
-       * @param out Mat4 frustum matrix will be written into
-       * @param left Left bound of the frustum
-       * @param right Right bound of the frustum
-       * @param bottom Bottom bound of the frustum
-       * @param top Top bound of the frustum
-       * @param near Near bound of the frustum
-       * @param far Far bound of the frustum
-       * @returns out
-       */
-      public static ortho(
-          out: Mat4, left: number, right: number, bottom: number, top: number,
-          near: number, far: number): Mat4;
+  /**
+   * Generates a orthogonal projection matrix with the given bounds
+   *
+   * @param out Mat4 frustum matrix will be written into
+   * @param left Left bound of the frustum
+   * @param right Right bound of the frustum
+   * @param bottom Bottom bound of the frustum
+   * @param top Top bound of the frustum
+   * @param near Near bound of the frustum
+   * @param far Far bound of the frustum
+   * @returns out
+   */
+  ortho(
+      out: Mat4, left: number, right: number, bottom: number, top: number,
+      near: number, far: number): Mat4;
 
   /**
    * Generates a look-at matrix with the given eye position, focal point, and
@@ -2737,7 +2704,7 @@ interface Mat4 extends Float32Array {
    * @param up Vec3 pointing up
    * @returns out
    */
-  public static lookAt(
+  lookAt(
       out: Mat4, eye: Vec3|number[], center: Vec3|number[],
       up: Vec3|number[]): Mat4;
 
@@ -2747,7 +2714,7 @@ interface Mat4 extends Float32Array {
    * @param mat matrix to represent as a string
    * @returns string representation of the matrix
    */
-  public static str(mat: Mat4): string;
+  str(mat: Mat4): string;
 
   /**
    * Returns Frobenius norm of a Mat4
@@ -2755,7 +2722,7 @@ interface Mat4 extends Float32Array {
    * @param a the matrix to calculate Frobenius norm of
    * @returns Frobenius norm
    */
-  public static frob(a: Mat4): number;
+  frob(a: Mat4): number;
 
   /**
    * Adds two Mat4's
@@ -2765,83 +2732,80 @@ interface Mat4 extends Float32Array {
    * @param {Mat4} b the second operand
    * @returns {Mat4} out
    */
-  public static add(out: Mat4, a: Mat4, b: Mat4): Mat4
+  add(out: Mat4, a: Mat4, b: Mat4): Mat4
 
-      /**
-       * Subtracts matrix b from matrix a
-       *
-       * @param {Mat4} out the receiving matrix
-       * @param {Mat4} a the first operand
-       * @param {Mat4} b the second operand
-       * @returns {Mat4} out
-       */
-      public static subtract(out: Mat4, a: Mat4, b: Mat4): Mat4
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat4} out the receiving matrix
+   * @param {Mat4} a the first operand
+   * @param {Mat4} b the second operand
+   * @returns {Mat4} out
+   */
+  subtract(out: Mat4, a: Mat4, b: Mat4): Mat4
 
-      /**
-       * Subtracts matrix b from matrix a
-       *
-       * @param {Mat4} out the receiving matrix
-       * @param {Mat4} a the first operand
-       * @param {Mat4} b the second operand
-       * @returns {Mat4} out
-       */
-      public static sub(out: Mat4, a: Mat4, b: Mat4): Mat4
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat4} out the receiving matrix
+   * @param {Mat4} a the first operand
+   * @param {Mat4} b the second operand
+   * @returns {Mat4} out
+   */
+  sub(out: Mat4, a: Mat4, b: Mat4): Mat4
 
-      /**
-       * Multiply each element of the matrix by a scalar.
-       *
-       * @param {Mat4} out the receiving matrix
-       * @param {Mat4} a the matrix to scale
-       * @param {number} b amount to scale the matrix's elements by
-       * @returns {Mat4} out
-       */
-      public static multiplyScalar(out: Mat4, a: Mat4, b: number): Mat4
+  /**
+   * Multiply each element of the matrix by a scalar.
+   *
+   * @param {Mat4} out the receiving matrix
+   * @param {Mat4} a the matrix to scale
+   * @param {number} b amount to scale the matrix's elements by
+   * @returns {Mat4} out
+   */
+  multiplyScalar(out: Mat4, a: Mat4, b: number): Mat4
 
-      /**
-       * Adds two Mat4's after multiplying each element of the second operand
-       * by a scalar value.
-       *
-       * @param {Mat4} out the receiving vector
-       * @param {Mat4} a the first operand
-       * @param {Mat4} b the second operand
-       * @param {number} scale the amount to scale b's elements by before
-       *     adding
-       * @returns {Mat4} out
-       */
-      public static multiplyScalarAndAdd(
-          out: Mat4, a: Mat4, b: Mat4, scale: number): Mat4
+  /**
+   * Adds two Mat4's after multiplying each element of the second operand
+   * by a scalar value.
+   *
+   * @param {Mat4} out the receiving vector
+   * @param {Mat4} a the first operand
+   * @param {Mat4} b the second operand
+   * @param {number} scale the amount to scale b's elements by before
+   *     adding
+   * @returns {Mat4} out
+   */
+  multiplyScalarAndAdd(out: Mat4, a: Mat4, b: Mat4, scale: number): Mat4
 
-      /**
-       * Returns whether or not the matrices have exactly the same elements in
-       * the same position (when compared with ===)
-       *
-       * @param {Mat4} a The first matrix.
-       * @param {Mat4} b The second matrix.
-       * @returns {boolean} True if the matrices are equal, false otherwise.
-       */
-      public static exactEquals(a: Mat4, b: Mat4): boolean
+  /**
+   * Returns whether or not the matrices have exactly the same elements in
+   * the same position (when compared with ===)
+   *
+   * @param {Mat4} a The first matrix.
+   * @param {Mat4} b The second matrix.
+   * @returns {boolean} True if the matrices are equal, false otherwise.
+   */
+  exactEquals(a: Mat4, b: Mat4): boolean
 
-      /**
-       * Returns whether or not the matrices have approximately the same
-       * elements in the same position.
-       *
-       * @param {Mat4} a The first matrix.
-       * @param {Mat4} b The second matrix.
-       * @returns {boolean} True if the matrices are equal, false otherwise.
-       */
-      public static equals(a: Mat4, b: Mat4): boolean
+  /**
+   * Returns whether or not the matrices have approximately the same
+   * elements in the same position.
+   *
+   * @param {Mat4} a The first matrix.
+   * @param {Mat4} b The second matrix.
+   * @returns {boolean} True if the matrices are equal, false otherwise.
+   */
+  equals(a: Mat4, b: Mat4): boolean
 }
 
 // Quat
 interface Quat extends Float32Array {
-  private typeQuat: number;
-
   /**
    * Creates a new identity Quat
    *
    * @returns a new Quaternion
    */
-  public static create(): Quat;
+  create(): Quat;
 
   /**
    * Creates a new Quat initialized with values from an existing Quaternion
@@ -2850,7 +2814,7 @@ interface Quat extends Float32Array {
    * @returns a new Quaternion
    * @function
    */
-  public static clone(a: Quat): Quat;
+  clone(a: Quat): Quat;
 
   /**
    * Creates a new Quat initialized with the given values
@@ -2862,7 +2826,7 @@ interface Quat extends Float32Array {
    * @returns a new Quaternion
    * @function
    */
-  public static fromValues(x: number, y: number, z: number, w: number): Quat;
+  fromValues(x: number, y: number, z: number, w: number): Quat;
 
   /**
    * Copy the values from one Quat to another
@@ -2872,7 +2836,7 @@ interface Quat extends Float32Array {
    * @returns out
    * @function
    */
-  public static copy(out: Quat, a: Quat): Quat;
+  copy(out: Quat, a: Quat): Quat;
 
   /**
    * Set the components of a Quat to the given values
@@ -2885,8 +2849,7 @@ interface Quat extends Float32Array {
    * @returns out
    * @function
    */
-  public static set(out: Quat, x: number, y: number, z: number, w: number):
-      Quat;
+  set(out: Quat, x: number, y: number, z: number, w: number): Quat;
 
   /**
    * Set a Quat to the identity Quaternion
@@ -2894,7 +2857,7 @@ interface Quat extends Float32Array {
    * @param out the receiving Quaternion
    * @returns out
    */
-  public static identity(out: Quat): Quat;
+  identity(out: Quat): Quat;
 
   /**
    * Sets a Quaternion to represent the shortest rotation from one
@@ -2907,7 +2870,7 @@ interface Quat extends Float32Array {
    * @param {Vec3} b the destination vector
    * @returns {Quat} out
    */
-  public static rotationTo(out: Quat, a: Vec3|number[], b: Vec3|number[]): Quat;
+  rotationTo(out: Quat, a: Vec3|number[], b: Vec3|number[]): Quat;
 
   /**
    * Sets the specified Quaternion with values corresponding to the given
@@ -2919,23 +2882,22 @@ interface Quat extends Float32Array {
    * @param {Vec3} up    the vector representing the local "up" direction
    * @returns {Quat} out
    */
-  public static setAxes(
-      out: Quat, view: Vec3|number[], right: Vec3|number[], up: Vec3|number[]):
-      Quat
+  setAxes(
+      out: Quat, view: Vec3|number[], right: Vec3|number[],
+      up: Vec3|number[]): Quat
 
 
 
-      /**
-       * Sets a Quat from the given angle and rotation axis,
-       * then returns it.
-       *
-       * @param out the receiving Quaternion
-       * @param axis the axis around which to rotate
-       * @param rad the angle in radians
-       * @returns out
-       **/
-      public static setAxisAngle(out: Quat, axis: Vec3|number[], rad: number):
-          Quat;
+  /**
+   * Sets a Quat from the given angle and rotation axis,
+   * then returns it.
+   *
+   * @param out the receiving Quaternion
+   * @param axis the axis around which to rotate
+   * @param rad the angle in radians
+   * @returns out
+   **/
+  setAxisAngle(out: Quat, axis: Vec3|number[], rad: number): Quat;
 
   /**
    * Gets the rotation axis and angle for a given
@@ -2950,18 +2912,18 @@ interface Quat extends Float32Array {
    * @param  {Quat} q     Quaternion to be decomposed
    * @return {number}     Angle, in radians, of the rotation
    */
-  public static getAxisAngle(out_axis: Vec3|number[], q: Quat): number
+  getAxisAngle(out_axis: Vec3|number[], q: Quat): number
 
-      /**
-       * Adds two Quat's
-       *
-       * @param out the receiving Quaternion
-       * @param a the first operand
-       * @param b the second operand
-       * @returns out
-       * @function
-       */
-      public static add(out: Quat, a: Quat, b: Quat): Quat;
+  /**
+   * Adds two Quat's
+   *
+   * @param out the receiving Quaternion
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   * @function
+   */
+  add(out: Quat, a: Quat, b: Quat): Quat;
 
   /**
    * Multiplies two Quat's
@@ -2971,7 +2933,7 @@ interface Quat extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static multiply(out: Quat, a: Quat, b: Quat): Quat;
+  multiply(out: Quat, a: Quat, b: Quat): Quat;
 
   /**
    * Multiplies two Quat's
@@ -2981,7 +2943,7 @@ interface Quat extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  public static mul(out: Quat, a: Quat, b: Quat): Quat;
+  mul(out: Quat, a: Quat, b: Quat): Quat;
 
   /**
    * Scales a Quat by a scalar number
@@ -2992,7 +2954,7 @@ interface Quat extends Float32Array {
    * @returns out
    * @function
    */
-  public static scale(out: Quat, a: Quat, b: number): Quat;
+  scale(out: Quat, a: Quat, b: number): Quat;
 
   /**
    * Calculates the length of a Quat
@@ -3001,7 +2963,7 @@ interface Quat extends Float32Array {
    * @returns length of a
    * @function
    */
-  public static length(a: Quat): number;
+  length(a: Quat): number;
 
   /**
    * Calculates the length of a Quat
@@ -3010,7 +2972,7 @@ interface Quat extends Float32Array {
    * @returns length of a
    * @function
    */
-  public static len(a: Quat): number;
+  len(a: Quat): number;
 
   /**
    * Calculates the squared length of a Quat
@@ -3019,7 +2981,7 @@ interface Quat extends Float32Array {
    * @returns squared length of a
    * @function
    */
-  public static squaredLength(a: Quat): number;
+  squaredLength(a: Quat): number;
 
   /**
    * Calculates the squared length of a Quat
@@ -3028,7 +2990,7 @@ interface Quat extends Float32Array {
    * @returns squared length of a
    * @function
    */
-  public static sqrLen(a: Quat): number;
+  sqrLen(a: Quat): number;
 
   /**
    * Normalize a Quat
@@ -3038,7 +3000,7 @@ interface Quat extends Float32Array {
    * @returns out
    * @function
    */
-  public static normalize(out: Quat, a: Quat): Quat;
+  normalize(out: Quat, a: Quat): Quat;
 
   /**
    * Calculates the dot product of two Quat's
@@ -3048,7 +3010,7 @@ interface Quat extends Float32Array {
    * @returns dot product of a and b
    * @function
    */
-  public static dot(a: Quat, b: Quat): number;
+  dot(a: Quat, b: Quat): number;
 
   /**
    * Performs a linear interpolation between two Quat's
@@ -3060,7 +3022,7 @@ interface Quat extends Float32Array {
    * @returns out
    * @function
    */
-  public static lerp(out: Quat, a: Quat, b: Quat, t: number): Quat;
+  lerp(out: Quat, a: Quat, b: Quat, t: number): Quat;
 
   /**
    * Performs a spherical linear interpolation between two Quat
@@ -3071,7 +3033,7 @@ interface Quat extends Float32Array {
    * @param t interpolation amount between the two inputs
    * @returns out
    */
-  public static slerp(out: Quat, a: Quat, b: Quat, t: number): Quat;
+  slerp(out: Quat, a: Quat, b: Quat, t: number): Quat;
 
   /**
    * Performs a spherical linear interpolation with two control points
@@ -3084,8 +3046,7 @@ interface Quat extends Float32Array {
    * @param {number} t interpolation amount
    * @returns {Quat} out
    */
-  public static sqlerp(
-      out: Quat, a: Quat, b: Quat, c: Quat, d: Quat, t: number): Quat;
+  sqlerp(out: Quat, a: Quat, b: Quat, c: Quat, d: Quat, t: number): Quat;
 
   /**
    * Calculates the inverse of a Quat
@@ -3094,7 +3055,7 @@ interface Quat extends Float32Array {
    * @param a Quat to calculate inverse of
    * @returns out
    */
-  public static invert(out: Quat, a: Quat): Quat;
+  invert(out: Quat, a: Quat): Quat;
 
   /**
    * Calculates the conjugate of a Quat
@@ -3105,7 +3066,7 @@ interface Quat extends Float32Array {
    * @param a Quat to calculate conjugate of
    * @returns out
    */
-  public static conjugate(out: Quat, a: Quat): Quat;
+  conjugate(out: Quat, a: Quat): Quat;
 
   /**
    * Returns a string representation of a Quaternion
@@ -3113,7 +3074,7 @@ interface Quat extends Float32Array {
    * @param a Quat to represent as a string
    * @returns string representation of the Quat
    */
-  public static str(a: Quat): string;
+  str(a: Quat): string;
 
   /**
    * Rotates a Quaternion by the given angle about the X axis
@@ -3123,7 +3084,7 @@ interface Quat extends Float32Array {
    * @param rad angle (in radians) to rotate
    * @returns out
    */
-  public static rotateX(out: Quat, a: Quat, rad: number): Quat;
+  rotateX(out: Quat, a: Quat, rad: number): Quat;
 
   /**
    * Rotates a Quaternion by the given angle about the Y axis
@@ -3133,7 +3094,7 @@ interface Quat extends Float32Array {
    * @param rad angle (in radians) to rotate
    * @returns out
    */
-  public static rotateY(out: Quat, a: Quat, rad: number): Quat;
+  rotateY(out: Quat, a: Quat, rad: number): Quat;
 
   /**
    * Rotates a Quaternion by the given angle about the Z axis
@@ -3143,7 +3104,7 @@ interface Quat extends Float32Array {
    * @param rad angle (in radians) to rotate
    * @returns out
    */
-  public static rotateZ(out: Quat, a: Quat, rad: number): Quat;
+  rotateZ(out: Quat, a: Quat, rad: number): Quat;
 
   /**
    * Creates a Quaternion from the given 3x3 rotation matrix.
@@ -3156,7 +3117,7 @@ interface Quat extends Float32Array {
    * @returns out
    * @function
    */
-  public static fromMat3(out: Quat, m: Mat3): Quat;
+  fromMat3(out: Quat, m: Mat3): Quat;
 
   /**
    * Sets the specified Quaternion with values corresponding to the given
@@ -3169,7 +3130,7 @@ interface Quat extends Float32Array {
    * @param up    the vector representing the local "up" direction
    * @returns out
    */
-  public static setAxes(
+  setAxes(
       out: Quat, view: Vec3|number[], right: Vec3|number[],
       up: Vec3|number[]): Quat;
 
@@ -3184,7 +3145,7 @@ interface Quat extends Float32Array {
    * @param b the destination vector
    * @returns out
    */
-  public static rotationTo(out: Quat, a: Vec3|number[], b: Vec3|number[]): Quat;
+  rotationTo(out: Quat, a: Vec3|number[], b: Vec3|number[]): Quat;
 
   /**
    * Calculates the W component of a Quat from the X, Y, and Z components.
@@ -3195,7 +3156,7 @@ interface Quat extends Float32Array {
    * @param a Quat to calculate W component of
    * @returns out
    */
-  public static calculateW(out: Quat, a: Quat): Quat;
+  calculateW(out: Quat, a: Quat): Quat;
 
   /**
    * Returns whether or not the Quaternions have exactly the same elements in
@@ -3205,7 +3166,7 @@ interface Quat extends Float32Array {
    * @param {Quat} b The second vector.
    * @returns {boolean} True if the Quaternions are equal, false otherwise.
    */
-  public static exactEquals(a: Quat, b: Quat): boolean;
+  exactEquals(a: Quat, b: Quat): boolean;
 
   /**
    * Returns whether or not the Quaternions have approximately the same
@@ -3215,5 +3176,5 @@ interface Quat extends Float32Array {
    * @param {Quat} b The second vector.
    * @returns {boolean} True if the Quaternions are equal, false otherwise.
    */
-  public static equals(a: Quat, b: Quat): boolean;
+  equals(a: Quat, b: Quat): boolean;
 }

--- a/bindings/wasm/examples/editor.d.ts
+++ b/bindings/wasm/examples/editor.d.ts
@@ -26,6 +26,18 @@ declare function show(manifold: Manifold): Manifold;
 declare const glMatrix: GLMatrix;
 
 interface GLMatrix {
+  glMatrix: TopAPI;
+  vec2: Vec2API;
+  vec3: Vec3API;
+  vec4: Vec4API;
+  mat2: Mat2API;
+  mat2d: Mat2dAPI;
+  mat3: Mat3API;
+  mat4: Mat4API;
+  quat: QuatAPI;
+}
+
+interface TopAPI {
   // Configuration constants
   EPSILON: number;
   ARRAY_TYPE: any;
@@ -62,70 +74,89 @@ interface GLMatrix {
    *     otherwise.
    */
   equals(a: number, b: number): boolean;
-
-  vec2: Vec2Type;
-  vec3: Vec3Type;
-  vec4: Vec4Type;
-  mat2: Mat2Type;
-  mat2d: Mat2dType;
-  mat3: Mat3Type;
-  mat4: Mat4Type;
-  quat: QuatType;
 }
 
-interface Vec2Type extends Float32Array {
+type Vec4 = [number, number, number, number];
+type Mat2 = [
+  number,
+  number,
+  number,
+  number,
+];
+type Mat2d = [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+];
+type Mat3 = [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+];
+type Quat = [number, number, number, number];
+
+interface Vec2API {
   /**
-   * Creates a new, empty Vec2Type
+   * Creates a new, empty Vec2
    *
    * @returns a new 2D vector
    */
-  create(): Vec2Type;
+  create(): Vec2;
 
   /**
-   * Creates a new Vec2Type initialized with values from an existing vector
+   * Creates a new Vec2 initialized with values from an existing vector
    *
    * @param a a vector to clone
    * @returns a new 2D vector
    */
-  clone(a: Vec2Type|number[]): Vec2Type;
+  clone(a: Vec2): Vec2;
 
   /**
-   * Creates a new Vec2Type initialized with the given values
+   * Creates a new Vec2 initialized with the given values
    *
    * @param x X component
    * @param y Y component
    * @returns a new 2D vector
    */
-  fromValues(x: number, y: number): Vec2Type;
+  fromValues(x: number, y: number): Vec2;
 
   /**
-   * Copy the values from one Vec2Type to another
+   * Copy the values from one Vec2 to another
    *
    * @param out the receiving vector
    * @param a the source vector
    * @returns out
    */
-  copy(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
+  copy(out: Vec2, a: Vec2): Vec2;
 
   /**
-   * Set the components of a Vec2Type to the given values
+   * Set the components of a Vec2 to the given values
    *
    * @param out the receiving vector
    * @param x X component
    * @param y Y component
    * @returns out
    */
-  set(out: Vec2Type, x: number, y: number): Vec2Type;
+  set(out: Vec2, x: number, y: number): Vec2;
 
   /**
-   * Adds two Vec2Type's
+   * Adds two Vec2's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  add(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
+  add(out: Vec2, a: Vec2, b: Vec2): Vec2;
 
   /**
    * Subtracts vector b from vector a
@@ -135,7 +166,7 @@ interface Vec2Type extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  subtract(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
+  subtract(out: Vec2, a: Vec2, b: Vec2): Vec2;
 
   /**
    * Subtracts vector b from vector a
@@ -145,120 +176,118 @@ interface Vec2Type extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  sub(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
+  sub(out: Vec2, a: Vec2, b: Vec2): Vec2;
 
   /**
-   * Multiplies two Vec2Type's
+   * Multiplies two Vec2's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
+  multiply(out: Vec2, a: Vec2, b: Vec2): Vec2;
 
   /**
-   * Multiplies two Vec2Type's
+   * Multiplies two Vec2's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
+  mul(out: Vec2, a: Vec2, b: Vec2): Vec2;
 
   /**
-   * Divides two Vec2Type's
+   * Divides two Vec2's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  divide(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
+  divide(out: Vec2, a: Vec2, b: Vec2): Vec2;
 
   /**
-   * Divides two Vec2Type's
+   * Divides two Vec2's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  div(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
+  div(out: Vec2, a: Vec2, b: Vec2): Vec2;
 
   /**
-   * Math.ceil the components of a Vec2Type
+   * Math.ceil the components of a Vec2
    *
-   * @param {Vec2Type} out the receiving vector
-   * @param {Vec2Type} a vector to ceil
-   * @returns {Vec2Type} out
+   * @param {Vec2} out the receiving vector
+   * @param {Vec2} a vector to ceil
+   * @returns {Vec2} out
    */
-  ceil(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
+  ceil(out: Vec2, a: Vec2): Vec2;
 
   /**
-   * Math.floor the components of a Vec2Type
+   * Math.floor the components of a Vec2
    *
-   * @param {Vec2Type} out the receiving vector
-   * @param {Vec2Type} a vector to floor
-   * @returns {Vec2Type} out
+   * @param {Vec2} out the receiving vector
+   * @param {Vec2} a vector to floor
+   * @returns {Vec2} out
    */
-  floor(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
+  floor(out: Vec2, a: Vec2): Vec2;
 
   /**
-   * Returns the minimum of two Vec2Type's
-   *
-   * @param out the receiving vector
-   * @param a the first operand
-   * @param b the second operand
-   * @returns out
-   */
-  min(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
-
-  /**
-   * Returns the maximum of two Vec2Type's
+   * Returns the minimum of two Vec2's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  max(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
+  min(out: Vec2, a: Vec2, b: Vec2): Vec2;
+
+  /**
+   * Returns the maximum of two Vec2's
+   *
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
+   */
+  max(out: Vec2, a: Vec2, b: Vec2): Vec2;
 
   /**
    * Rotates the 2D vector.
    *
-   * @param {Vec2Type} out the receiving vector
-   * @param {Vec2Type} a vector to rotate
-   * @param {Vec2Type} b origin of the rotation
+   * @param {Vec2} out the receiving vector
+   * @param {Vec2} a vector to rotate
+   * @param {Vec2} b origin of the rotation
    * @param {number} rad angle of rotation in radians
-   * @returns {Vec2Type} out
+   * @returns {Vec2} out
    */
-  rotate(
-      out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[],
-      rad: number): Vec2Type;
+  rotate(out: Vec2, a: Vec2, b: Vec2, rad: number): Vec2;
 
   /**
-   * Math.round the components of a Vec2Type
+   * Math.round the components of a Vec2
    *
-   * @param {Vec2Type} out the receiving vector
-   * @param {Vec2Type} a vector to round
-   * @returns {Vec2Type} out
+   * @param {Vec2} out the receiving vector
+   * @param {Vec2} a vector to round
+   * @returns {Vec2} out
    */
-  round(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
+  round(out: Vec2, a: Vec2): Vec2;
 
   /**
-   * Scales a Vec2Type by a scalar number
+   * Scales a Vec2 by a scalar number
    *
    * @param out the receiving vector
    * @param a the vector to scale
    * @param b amount to scale the vector by
    * @returns out
    */
-  scale(out: Vec2Type, a: Vec2Type|number[], b: number): Vec2Type;
+  scale(out: Vec2, a: Vec2, b: number): Vec2;
 
   /**
-   * Adds two Vec2Type's after scaling the second operand by a scalar value
+   * Adds two Vec2's after scaling the second operand by a scalar value
    *
    * @param out the receiving vector
    * @param a the first operand
@@ -266,116 +295,114 @@ interface Vec2Type extends Float32Array {
    * @param scale the amount to scale b by before adding
    * @returns out
    */
-  scaleAndAdd(
-      out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[],
-      scale: number): Vec2Type;
+  scaleAndAdd(out: Vec2, a: Vec2, b: Vec2, scale: number): Vec2;
 
   /**
-   * Calculates the euclidian distance between two Vec2Type's
+   * Calculates the euclidian distance between two Vec2's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns distance between a and b
    */
-  distance(a: Vec2Type|number[], b: Vec2Type|number[]): number;
+  distance(a: Vec2, b: Vec2): number;
 
   /**
-   * Calculates the euclidian distance between two Vec2Type's
+   * Calculates the euclidian distance between two Vec2's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns distance between a and b
    */
-  dist(a: Vec2Type|number[], b: Vec2Type|number[]): number;
+  dist(a: Vec2, b: Vec2): number;
 
   /**
-   * Calculates the squared euclidian distance between two Vec2Type's
+   * Calculates the squared euclidian distance between two Vec2's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  squaredDistance(a: Vec2Type|number[], b: Vec2Type|number[]): number;
+  squaredDistance(a: Vec2, b: Vec2): number;
 
   /**
-   * Calculates the squared euclidian distance between two Vec2Type's
+   * Calculates the squared euclidian distance between two Vec2's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  sqrDist(a: Vec2Type|number[], b: Vec2Type|number[]): number;
+  sqrDist(a: Vec2, b: Vec2): number;
 
   /**
-   * Calculates the length of a Vec2Type
+   * Calculates the length of a Vec2
    *
    * @param a vector to calculate length of
    * @returns length of a
    */
-  length(a: Vec2Type|number[]): number;
+  length(a: Vec2): number;
 
   /**
-   * Calculates the length of a Vec2Type
+   * Calculates the length of a Vec2
    *
    * @param a vector to calculate length of
    * @returns length of a
    */
-  len(a: Vec2Type|number[]): number;
+  len(a: Vec2): number;
 
   /**
-   * Calculates the squared length of a Vec2Type
+   * Calculates the squared length of a Vec2
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  squaredLength(a: Vec2Type|number[]): number;
+  squaredLength(a: Vec2): number;
 
   /**
-   * Calculates the squared length of a Vec2Type
+   * Calculates the squared length of a Vec2
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  sqrLen(a: Vec2Type|number[]): number;
+  sqrLen(a: Vec2): number;
 
   /**
-   * Negates the components of a Vec2Type
+   * Negates the components of a Vec2
    *
    * @param out the receiving vector
    * @param a vector to negate
    * @returns out
    */
-  negate(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
+  negate(out: Vec2, a: Vec2): Vec2;
 
   /**
-   * Returns the inverse of the components of a Vec2Type
+   * Returns the inverse of the components of a Vec2
    *
    * @param out the receiving vector
    * @param a vector to invert
    * @returns out
    */
-  inverse(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
+  inverse(out: Vec2, a: Vec2): Vec2;
 
   /**
-   * Normalize a Vec2Type
+   * Normalize a Vec2
    *
    * @param out the receiving vector
    * @param a vector to normalize
    * @returns out
    */
-  normalize(out: Vec2Type, a: Vec2Type|number[]): Vec2Type;
+  normalize(out: Vec2, a: Vec2): Vec2;
 
   /**
-   * Calculates the dot product of two Vec2Type's
+   * Calculates the dot product of two Vec2's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns dot product of a and b
    */
-  dot(a: Vec2Type|number[], b: Vec2Type|number[]): number;
+  dot(a: Vec2, b: Vec2): number;
 
   /**
-   * Computes the cross product of two Vec2Type's
+   * Computes the cross product of two Vec2's
    * Note that the cross product must by definition produce a 3D vector
    *
    * @param out the receiving vector
@@ -383,10 +410,10 @@ interface Vec2Type extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  cross(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[]): Vec2Type;
+  cross(out: Vec2, a: Vec2, b: Vec2): Vec2;
 
   /**
-   * Performs a linear interpolation between two Vec2Type's
+   * Performs a linear interpolation between two Vec2's
    *
    * @param out the receiving vector
    * @param a the first operand
@@ -394,8 +421,7 @@ interface Vec2Type extends Float32Array {
    * @param t interpolation amount between the two inputs
    * @returns out
    */
-  lerp(out: Vec2Type, a: Vec2Type|number[], b: Vec2Type|number[], t: number):
-      Vec2Type;
+  lerp(out: Vec2, a: Vec2, b: Vec2, t: number): Vec2;
 
   /**
    * Generates a random unit vector
@@ -403,7 +429,7 @@ interface Vec2Type extends Float32Array {
    * @param out the receiving vector
    * @returns out
    */
-  random(out: Vec2Type): Vec2Type;
+  random(out: Vec2): Vec2;
 
   /**
    * Generates a random vector with the given scale
@@ -413,30 +439,30 @@ interface Vec2Type extends Float32Array {
    *     will be returned
    * @returns out
    */
-  random(out: Vec2Type, scale: number): Vec2Type;
+  random(out: Vec2, scale: number): Vec2;
 
   /**
-   * Transforms the Vec2Type with a Mat2Type
+   * Transforms the Vec2 with a Mat2
    *
    * @param out the receiving vector
    * @param a the vector to transform
    * @param m matrix to transform with
    * @returns out
    */
-  transformMat2(out: Vec2Type, a: Vec2Type|number[], m: Mat2Type): Vec2Type;
+  transformMat2(out: Vec2, a: Vec2, m: Mat2): Vec2;
 
   /**
-   * Transforms the Vec2Type with a Mat2dType
+   * Transforms the Vec2 with a Mat2d
    *
    * @param out the receiving vector
    * @param a the vector to transform
    * @param m matrix to transform with
    * @returns out
    */
-  transformMat2d(out: Vec2Type, a: Vec2Type|number[], m: Mat2dType): Vec2Type;
+  transformMat2d(out: Vec2, a: Vec2, m: Mat2d): Vec2;
 
   /**
-   * Transforms the Vec2Type with a Mat3Type
+   * Transforms the Vec2 with a Mat3
    * 3rd vector component is implicitly '1'
    *
    * @param out the receiving vector
@@ -444,10 +470,10 @@ interface Vec2Type extends Float32Array {
    * @param m matrix to transform with
    * @returns out
    */
-  transformMat3(out: Vec2Type, a: Vec2Type|number[], m: Mat3Type): Vec2Type;
+  transformMat3(out: Vec2, a: Vec2, m: Mat3): Vec2;
 
   /**
-   * Transforms the Vec2Type with a Mat4Type
+   * Transforms the Vec2 with a Mat4
    * 3rd vector component is implicitly '0'
    * 4th vector component is implicitly '1'
    *
@@ -456,13 +482,13 @@ interface Vec2Type extends Float32Array {
    * @param m matrix to transform with
    * @returns out
    */
-  transformMat4(out: Vec2Type, a: Vec2Type|number[], m: Mat4Type): Vec2Type;
+  transformMat4(out: Vec2, a: Vec2, m: Mat4): Vec2;
 
   /**
    * Perform some operation over an array of vec2Types.
    *
    * @param a the array of vectors to iterate over
-   * @param stride Number of elements between the start of each Vec2Type. If 0
+   * @param stride Number of elements between the start of each Vec2. If 0
    *     assumes tightly packed
    * @param offset Number of elements to skip at the beginning of the array
    * @param count Number of vec2Types to iterate over. If 0 iterates over entire
@@ -473,14 +499,13 @@ interface Vec2Type extends Float32Array {
    */
   forEach(
       a: Float32Array, stride: number, offset: number, count: number,
-      fn: (a: Vec2Type|number[], b: Vec2Type|number[], arg: any) => void,
-      arg: any): Float32Array;
+      fn: (a: Vec2, b: Vec2, arg: any) => void, arg: any): Float32Array;
 
   /**
    * Perform some operation over an array of vec2Types.
    *
    * @param a the array of vectors to iterate over
-   * @param stride Number of elements between the start of each Vec2Type. If 0
+   * @param stride Number of elements between the start of each Vec2. If 0
    *     assumes tightly packed
    * @param offset Number of elements to skip at the beginning of the array
    * @param count Number of vec2Types to iterate over. If 0 iterates over entire
@@ -490,7 +515,7 @@ interface Vec2Type extends Float32Array {
    */
   forEach(
       a: Float32Array, stride: number, offset: number, count: number,
-      fn: (a: Vec2Type|number[], b: Vec2Type|number[]) => void): Float32Array;
+      fn: (a: Vec2, b: Vec2) => void): Float32Array;
 
   /**
    * Returns a string representation of a vector
@@ -498,67 +523,67 @@ interface Vec2Type extends Float32Array {
    * @param a vector to represent as a string
    * @returns string representation of the vector
    */
-  str(a: Vec2Type|number[]): string;
+  str(a: Vec2): string;
 
   /**
    * Returns whether or not the vectors exactly have the same elements in the
    * same position (when compared with ===)
    *
-   * @param {Vec2Type} a The first vector.
-   * @param {Vec2Type} b The second vector.
+   * @param {Vec2} a The first vector.
+   * @param {Vec2} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  exactEquals(a: Vec2Type|number[], b: Vec2Type|number[]): boolean;
+  exactEquals(a: Vec2, b: Vec2): boolean;
 
   /**
    * Returns whether or not the vectors have approximately the same elements
    * in the same position.
    *
-   * @param {Vec2Type} a The first vector.
-   * @param {Vec2Type} b The second vector.
+   * @param {Vec2} a The first vector.
+   * @param {Vec2} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  equals(a: Vec2Type|number[], b: Vec2Type|number[]): boolean;
+  equals(a: Vec2, b: Vec2): boolean;
 }
 
-// Vec3Type
-interface Vec3Type extends Float32Array {
+// Vec3
+interface Vec3API {
   /**
-   * Creates a new, empty Vec3Type
+   * Creates a new, empty Vec3
    *
    * @returns a new 3D vector
    */
-  create(): Vec3Type;
+  create(): Vec3;
 
   /**
-   * Creates a new Vec3Type initialized with values from an existing vector
+   * Creates a new Vec3 initialized with values from an existing vector
    *
    * @param a vector to clone
    * @returns a new 3D vector
    */
-  clone(a: Vec3Type|number[]): Vec3Type;
+  clone(a: Vec3): Vec3;
 
   /**
-   * Creates a new Vec3Type initialized with the given values
+   * Creates a new Vec3 initialized with the given values
    *
    * @param x X component
    * @param y Y component
    * @param z Z component
    * @returns a new 3D vector
    */
-  fromValues(x: number, y: number, z: number): Vec3Type;
+  fromValues(x: number, y: number, z: number): Vec3;
 
   /**
-   * Copy the values from one Vec3Type to another
+   * Copy the values from one Vec3 to another
    *
    * @param out the receiving vector
    * @param a the source vector
    * @returns out
    */
-  copy(out: Vec3Type, a: Vec3Type|number[]): Vec3Type;
+  copy(out: Vec3, a: Vec3): Vec3;
 
   /**
-   * Set the components of a Vec3Type to the given values
+   * Set the components of a Vec3 to the given values
    *
    * @param out the receiving vector
    * @param x X component
@@ -566,17 +591,17 @@ interface Vec3Type extends Float32Array {
    * @param z Z component
    * @returns out
    */
-  set(out: Vec3Type, x: number, y: number, z: number): Vec3Type;
+  set(out: Vec3, x: number, y: number, z: number): Vec3;
 
   /**
-   * Adds two Vec3Type's
+   * Adds two Vec3's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  add(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
+  add(out: Vec3, a: Vec3, b: Vec3): Vec3;
 
   /**
    * Subtracts vector b from vector a
@@ -586,7 +611,7 @@ interface Vec3Type extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  subtract(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
+  subtract(out: Vec3, a: Vec3, b: Vec3): Vec3;
 
   /**
    * Subtracts vector b from vector a
@@ -596,107 +621,107 @@ interface Vec3Type extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  sub(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type
+  sub(out: Vec3, a: Vec3, b: Vec3): Vec3
 
   /**
-   * Multiplies two Vec3Type's
+   * Multiplies two Vec3's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
+  multiply(out: Vec3, a: Vec3, b: Vec3): Vec3;
 
   /**
-   * Multiplies two Vec3Type's
+   * Multiplies two Vec3's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
+  mul(out: Vec3, a: Vec3, b: Vec3): Vec3;
 
   /**
-   * Divides two Vec3Type's
+   * Divides two Vec3's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  divide(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
+  divide(out: Vec3, a: Vec3, b: Vec3): Vec3;
 
   /**
-   * Divides two Vec3Type's
+   * Divides two Vec3's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  div(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
+  div(out: Vec3, a: Vec3, b: Vec3): Vec3;
 
   /**
-   * Math.ceil the components of a Vec3Type
+   * Math.ceil the components of a Vec3
    *
-   * @param {Vec3Type} out the receiving vector
-   * @param {Vec3Type} a vector to ceil
-   * @returns {Vec3Type} out
+   * @param {Vec3} out the receiving vector
+   * @param {Vec3} a vector to ceil
+   * @returns {Vec3} out
    */
-  ceil(out: Vec3Type, a: Vec3Type|number[]): Vec3Type;
+  ceil(out: Vec3, a: Vec3): Vec3;
 
   /**
-   * Math.floor the components of a Vec3Type
+   * Math.floor the components of a Vec3
    *
-   * @param {Vec3Type} out the receiving vector
-   * @param {Vec3Type} a vector to floor
-   * @returns {Vec3Type} out
+   * @param {Vec3} out the receiving vector
+   * @param {Vec3} a vector to floor
+   * @returns {Vec3} out
    */
-  floor(out: Vec3Type, a: Vec3Type|number[]): Vec3Type;
+  floor(out: Vec3, a: Vec3): Vec3;
 
   /**
-   * Returns the minimum of two Vec3Type's
-   *
-   * @param out the receiving vector
-   * @param a the first operand
-   * @param b the second operand
-   * @returns out
-   */
-  min(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
-
-  /**
-   * Returns the maximum of two Vec3Type's
+   * Returns the minimum of two Vec3's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  max(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
+  min(out: Vec3, a: Vec3, b: Vec3): Vec3;
 
   /**
-   * Math.round the components of a Vec3Type
+   * Returns the maximum of two Vec3's
    *
-   * @param {Vec3Type} out the receiving vector
-   * @param {Vec3Type} a vector to round
-   * @returns {Vec3Type} out
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
    */
-  round(out: Vec3Type, a: Vec3Type|number[]): Vec3Type
+  max(out: Vec3, a: Vec3, b: Vec3): Vec3;
 
   /**
-   * Scales a Vec3Type by a scalar number
+   * Math.round the components of a Vec3
+   *
+   * @param {Vec3} out the receiving vector
+   * @param {Vec3} a vector to round
+   * @returns {Vec3} out
+   */
+  round(out: Vec3, a: Vec3): Vec3
+
+  /**
+   * Scales a Vec3 by a scalar number
    *
    * @param out the receiving vector
    * @param a the vector to scale
    * @param b amount to scale the vector by
    * @returns out
    */
-  scale(out: Vec3Type, a: Vec3Type|number[], b: number): Vec3Type;
+  scale(out: Vec3, a: Vec3, b: number): Vec3;
 
   /**
-   * Adds two Vec3Type's after scaling the second operand by a scalar value
+   * Adds two Vec3's after scaling the second operand by a scalar value
    *
    * @param out the receiving vector
    * @param a the first operand
@@ -704,126 +729,124 @@ interface Vec3Type extends Float32Array {
    * @param scale the amount to scale b by before adding
    * @returns out
    */
-  scaleAndAdd(
-      out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[],
-      scale: number): Vec3Type;
+  scaleAndAdd(out: Vec3, a: Vec3, b: Vec3, scale: number): Vec3;
 
   /**
-   * Calculates the euclidian distance between two Vec3Type's
+   * Calculates the euclidian distance between two Vec3's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns distance between a and b
    */
-  distance(a: Vec3Type|number[], b: Vec3Type|number[]): number;
+  distance(a: Vec3, b: Vec3): number;
 
   /**
-   * Calculates the euclidian distance between two Vec3Type's
+   * Calculates the euclidian distance between two Vec3's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns distance between a and b
    */
-  dist(a: Vec3Type|number[], b: Vec3Type|number[]): number;
+  dist(a: Vec3, b: Vec3): number;
 
   /**
-   * Calculates the squared euclidian distance between two Vec3Type's
+   * Calculates the squared euclidian distance between two Vec3's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  squaredDistance(a: Vec3Type|number[], b: Vec3Type|number[]): number;
+  squaredDistance(a: Vec3, b: Vec3): number;
 
   /**
-   * Calculates the squared euclidian distance between two Vec3Type's
+   * Calculates the squared euclidian distance between two Vec3's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  sqrDist(a: Vec3Type|number[], b: Vec3Type|number[]): number;
+  sqrDist(a: Vec3, b: Vec3): number;
 
   /**
-   * Calculates the length of a Vec3Type
+   * Calculates the length of a Vec3
    *
    * @param a vector to calculate length of
    * @returns length of a
    */
-  length(a: Vec3Type|number[]): number;
+  length(a: Vec3): number;
 
   /**
-   * Calculates the length of a Vec3Type
+   * Calculates the length of a Vec3
    *
    * @param a vector to calculate length of
    * @returns length of a
    */
-  len(a: Vec3Type|number[]): number;
+  len(a: Vec3): number;
 
   /**
-   * Calculates the squared length of a Vec3Type
+   * Calculates the squared length of a Vec3
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  squaredLength(a: Vec3Type|number[]): number;
+  squaredLength(a: Vec3): number;
 
   /**
-   * Calculates the squared length of a Vec3Type
+   * Calculates the squared length of a Vec3
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  sqrLen(a: Vec3Type|number[]): number;
+  sqrLen(a: Vec3): number;
 
   /**
-   * Negates the components of a Vec3Type
+   * Negates the components of a Vec3
    *
    * @param out the receiving vector
    * @param a vector to negate
    * @returns out
    */
-  negate(out: Vec3Type, a: Vec3Type|number[]): Vec3Type;
+  negate(out: Vec3, a: Vec3): Vec3;
 
   /**
-   * Returns the inverse of the components of a Vec3Type
+   * Returns the inverse of the components of a Vec3
    *
    * @param out the receiving vector
    * @param a vector to invert
    * @returns out
    */
-  inverse(out: Vec3Type, a: Vec3Type|number[]): Vec3Type;
+  inverse(out: Vec3, a: Vec3): Vec3;
 
   /**
-   * Normalize a Vec3Type
+   * Normalize a Vec3
    *
    * @param out the receiving vector
    * @param a vector to normalize
    * @returns out
    */
-  normalize(out: Vec3Type, a: Vec3Type|number[]): Vec3Type;
+  normalize(out: Vec3, a: Vec3): Vec3;
 
   /**
-   * Calculates the dot product of two Vec3Type's
+   * Calculates the dot product of two Vec3's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns dot product of a and b
    */
-  dot(a: Vec3Type|number[], b: Vec3Type|number[]): number;
+  dot(a: Vec3, b: Vec3): number;
 
   /**
-   * Computes the cross product of two Vec3Type's
+   * Computes the cross product of two Vec3's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  cross(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[]): Vec3Type;
+  cross(out: Vec3, a: Vec3, b: Vec3): Vec3;
 
   /**
-   * Performs a linear interpolation between two Vec3Type's
+   * Performs a linear interpolation between two Vec3's
    *
    * @param out the receiving vector
    * @param a the first operand
@@ -831,38 +854,33 @@ interface Vec3Type extends Float32Array {
    * @param t interpolation amount between the two inputs
    * @returns out
    */
-  lerp(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[], t: number):
-      Vec3Type;
+  lerp(out: Vec3, a: Vec3, b: Vec3, t: number): Vec3;
 
   /**
    * Performs a hermite interpolation with two control points
    *
-   * @param {Vec3Type} out the receiving vector
-   * @param {Vec3Type} a the first operand
-   * @param {Vec3Type} b the second operand
-   * @param {Vec3Type} c the third operand
-   * @param {Vec3Type} d the fourth operand
+   * @param {Vec3} out the receiving vector
+   * @param {Vec3} a the first operand
+   * @param {Vec3} b the second operand
+   * @param {Vec3} c the third operand
+   * @param {Vec3} d the fourth operand
    * @param {number} t interpolation amount between the two inputs
-   * @returns {Vec3Type} out
+   * @returns {Vec3} out
    */
-  hermite(
-      out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[],
-      c: Vec3Type|number[], d: Vec3Type|number[], t: number): Vec3Type;
+  hermite(out: Vec3, a: Vec3, b: Vec3, c: Vec3, d: Vec3, t: number): Vec3;
 
   /**
    * Performs a bezier interpolation with two control points
    *
-   * @param {Vec3Type} out the receiving vector
-   * @param {Vec3Type} a the first operand
-   * @param {Vec3Type} b the second operand
-   * @param {Vec3Type} c the third operand
-   * @param {Vec3Type} d the fourth operand
+   * @param {Vec3} out the receiving vector
+   * @param {Vec3} a the first operand
+   * @param {Vec3} b the second operand
+   * @param {Vec3} c the third operand
+   * @param {Vec3} d the fourth operand
    * @param {number} t interpolation amount between the two inputs
-   * @returns {Vec3Type} out
+   * @returns {Vec3} out
    */
-  bezier(
-      out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[],
-      c: Vec3Type|number[], d: Vec3Type|number[], t: number): Vec3Type;
+  bezier(out: Vec3, a: Vec3, b: Vec3, c: Vec3, d: Vec3, t: number): Vec3;
 
   /**
    * Generates a random unit vector
@@ -870,7 +888,7 @@ interface Vec3Type extends Float32Array {
    * @param out the receiving vector
    * @returns out
    */
-  random(out: Vec3Type): Vec3Type;
+  random(out: Vec3): Vec3;
 
   /**
    * Generates a random vector with the given scale
@@ -880,20 +898,20 @@ interface Vec3Type extends Float32Array {
    *     will be returned
    * @returns out
    */
-  random(out: Vec3Type, scale: number): Vec3Type;
+  random(out: Vec3, scale: number): Vec3;
 
   /**
-   * Transforms the Vec3Type with a Mat3Type.
+   * Transforms the Vec3 with a Mat3.
    *
    * @param out the receiving vector
    * @param a the vector to transform
    * @param m the 3x3 matrix to transform with
    * @returns out
    */
-  transformMat3(out: Vec3Type, a: Vec3Type|number[], m: Mat3Type): Vec3Type;
+  transformMat3(out: Vec3, a: Vec3, m: Mat3): Vec3;
 
   /**
-   * Transforms the Vec3Type with a Mat4Type.
+   * Transforms the Vec3 with a Mat4.
    * 4th vector component is implicitly '1'
    *
    * @param out the receiving vector
@@ -901,57 +919,54 @@ interface Vec3Type extends Float32Array {
    * @param m matrix to transform with
    * @returns out
    */
-  transformMat4(out: Vec3Type, a: Vec3Type|number[], m: Mat4Type): Vec3Type;
+  transformMat4(out: Vec3, a: Vec3, m: Mat4): Vec3;
 
   /**
-   * Transforms the Vec3Type with a QuatType
+   * Transforms the Vec3 with a Quat
    *
    * @param out the receiving vector
    * @param a the vector to transform
    * @param q Quaternion to transform with
    * @returns out
    */
-  transformQuat(out: Vec3Type, a: Vec3Type|number[], q: QuatType): Vec3Type;
+  transformQuat(out: Vec3, a: Vec3, q: Quat): Vec3;
 
 
   /**
    * Rotate a 3D vector around the x-axis
-   * @param out The receiving Vec3Type
-   * @param a The Vec3Type point to rotate
+   * @param out The receiving Vec3
+   * @param a The Vec3 point to rotate
    * @param b The origin of the rotation
    * @param c The angle of rotation
    * @returns out
    */
-  rotateX(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[], c: number):
-      Vec3Type;
+  rotateX(out: Vec3, a: Vec3, b: Vec3, c: number): Vec3;
 
   /**
    * Rotate a 3D vector around the y-axis
-   * @param out The receiving Vec3Type
-   * @param a The Vec3Type point to rotate
+   * @param out The receiving Vec3
+   * @param a The Vec3 point to rotate
    * @param b The origin of the rotation
    * @param c The angle of rotation
    * @returns out
    */
-  rotateY(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[], c: number):
-      Vec3Type;
+  rotateY(out: Vec3, a: Vec3, b: Vec3, c: number): Vec3;
 
   /**
    * Rotate a 3D vector around the z-axis
-   * @param out The receiving Vec3Type
-   * @param a The Vec3Type point to rotate
+   * @param out The receiving Vec3
+   * @param a The Vec3 point to rotate
    * @param b The origin of the rotation
    * @param c The angle of rotation
    * @returns out
    */
-  rotateZ(out: Vec3Type, a: Vec3Type|number[], b: Vec3Type|number[], c: number):
-      Vec3Type;
+  rotateZ(out: Vec3, a: Vec3, b: Vec3, c: number): Vec3;
 
   /**
    * Perform some operation over an array of vec3s.
    *
    * @param a the array of vectors to iterate over
-   * @param stride Number of elements between the start of each Vec3Type. If 0
+   * @param stride Number of elements between the start of each Vec3. If 0
    *     assumes tightly packed
    * @param offset Number of elements to skip at the beginning of the array
    * @param count Number of vec3s to iterate over. If 0 iterates over entire
@@ -963,14 +978,13 @@ interface Vec3Type extends Float32Array {
    */
   forEach(
       a: Float32Array, stride: number, offset: number, count: number,
-      fn: (a: Vec3Type|number[], b: Vec3Type|number[], arg: any) => void,
-      arg: any): Float32Array;
+      fn: (a: Vec3, b: Vec3, arg: any) => void, arg: any): Float32Array;
 
   /**
    * Perform some operation over an array of vec3s.
    *
    * @param a the array of vectors to iterate over
-   * @param stride Number of elements between the start of each Vec3Type. If 0
+   * @param stride Number of elements between the start of each Vec3. If 0
    *     assumes tightly packed
    * @param offset Number of elements to skip at the beginning of the array
    * @param count Number of vec3s to iterate over. If 0 iterates over entire
@@ -981,7 +995,7 @@ interface Vec3Type extends Float32Array {
    */
   forEach(
       a: Float32Array, stride: number, offset: number, count: number,
-      fn: (a: Vec3Type|number[], b: Vec3Type|number[]) => void): Float32Array;
+      fn: (a: Vec3, b: Vec3) => void): Float32Array;
 
   /**
    * Get the angle between two 3D vectors
@@ -989,7 +1003,7 @@ interface Vec3Type extends Float32Array {
    * @param b The second operand
    * @returns The angle in radians
    */
-  angle(a: Vec3Type|number[], b: Vec3Type|number[]): number;
+  angle(a: Vec3, b: Vec3): number;
 
   /**
    * Returns a string representation of a vector
@@ -997,48 +1011,48 @@ interface Vec3Type extends Float32Array {
    * @param a vector to represent as a string
    * @returns string representation of the vector
    */
-  str(a: Vec3Type|number[]): string;
+  str(a: Vec3): string;
 
   /**
    * Returns whether or not the vectors have exactly the same elements in the
    * same position (when compared with ===)
    *
-   * @param {Vec3Type} a The first vector.
-   * @param {Vec3Type} b The second vector.
+   * @param {Vec3} a The first vector.
+   * @param {Vec3} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  exactEquals(a: Vec3Type|number[], b: Vec3Type|number[]): boolean
+  exactEquals(a: Vec3, b: Vec3): boolean
 
   /**
    * Returns whether or not the vectors have approximately the same
    * elements in the same position.
    *
-   * @param {Vec3Type} a The first vector.
-   * @param {Vec3Type} b The second vector.
+   * @param {Vec3} a The first vector.
+   * @param {Vec3} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  equals(a: Vec3Type|number[], b: Vec3Type|number[]): boolean
+  equals(a: Vec3, b: Vec3): boolean
 }
 
-// Vec4Type
-interface Vec4Type extends Float32Array {
+// Vec4
+interface Vec4API {
   /**
-   * Creates a new, empty Vec4Type
+   * Creates a new, empty Vec4
    *
    * @returns a new 4D vector
    */
-  create(): Vec4Type;
+  create(): Vec4;
 
   /**
-   * Creates a new Vec4Type initialized with values from an existing vector
+   * Creates a new Vec4 initialized with values from an existing vector
    *
    * @param a vector to clone
    * @returns a new 4D vector
    */
-  clone(a: Vec4Type|number[]): Vec4Type;
+  clone(a: Vec4): Vec4;
 
   /**
-   * Creates a new Vec4Type initialized with the given values
+   * Creates a new Vec4 initialized with the given values
    *
    * @param x X component
    * @param y Y component
@@ -1046,19 +1060,19 @@ interface Vec4Type extends Float32Array {
    * @param w W component
    * @returns a new 4D vector
    */
-  fromValues(x: number, y: number, z: number, w: number): Vec4Type;
+  fromValues(x: number, y: number, z: number, w: number): Vec4;
 
   /**
-   * Copy the values from one Vec4Type to another
+   * Copy the values from one Vec4 to another
    *
    * @param out the receiving vector
    * @param a the source vector
    * @returns out
    */
-  copy(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
+  copy(out: Vec4, a: Vec4): Vec4;
 
   /**
-   * Set the components of a Vec4Type to the given values
+   * Set the components of a Vec4 to the given values
    *
    * @param out the receiving vector
    * @param x X component
@@ -1067,17 +1081,17 @@ interface Vec4Type extends Float32Array {
    * @param w W component
    * @returns out
    */
-  set(out: Vec4Type, x: number, y: number, z: number, w: number): Vec4Type;
+  set(out: Vec4, x: number, y: number, z: number, w: number): Vec4;
 
   /**
-   * Adds two Vec4Type's
+   * Adds two Vec4's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  add(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
+  add(out: Vec4, a: Vec4, b: Vec4): Vec4;
 
   /**
    * Subtracts vector b from vector a
@@ -1087,7 +1101,7 @@ interface Vec4Type extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  subtract(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
+  subtract(out: Vec4, a: Vec4, b: Vec4): Vec4;
 
   /**
    * Subtracts vector b from vector a
@@ -1097,107 +1111,107 @@ interface Vec4Type extends Float32Array {
    * @param b the second operand
    * @returns out
    */
-  sub(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
+  sub(out: Vec4, a: Vec4, b: Vec4): Vec4;
 
   /**
-   * Multiplies two Vec4Type's
+   * Multiplies two Vec4's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
+  multiply(out: Vec4, a: Vec4, b: Vec4): Vec4;
 
   /**
-   * Multiplies two Vec4Type's
+   * Multiplies two Vec4's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
+  mul(out: Vec4, a: Vec4, b: Vec4): Vec4;
 
   /**
-   * Divides two Vec4Type's
+   * Divides two Vec4's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  divide(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
+  divide(out: Vec4, a: Vec4, b: Vec4): Vec4;
 
   /**
-   * Divides two Vec4Type's
+   * Divides two Vec4's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  div(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
+  div(out: Vec4, a: Vec4, b: Vec4): Vec4;
 
   /**
-   * Math.ceil the components of a Vec4Type
+   * Math.ceil the components of a Vec4
    *
-   * @param {Vec4Type} out the receiving vector
-   * @param {Vec4Type} a vector to ceil
-   * @returns {Vec4Type} out
+   * @param {Vec4} out the receiving vector
+   * @param {Vec4} a vector to ceil
+   * @returns {Vec4} out
    */
-  ceil(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
+  ceil(out: Vec4, a: Vec4): Vec4;
 
   /**
-   * Math.floor the components of a Vec4Type
+   * Math.floor the components of a Vec4
    *
-   * @param {Vec4Type} out the receiving vector
-   * @param {Vec4Type} a vector to floor
-   * @returns {Vec4Type} out
+   * @param {Vec4} out the receiving vector
+   * @param {Vec4} a vector to floor
+   * @returns {Vec4} out
    */
-  floor(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
+  floor(out: Vec4, a: Vec4): Vec4;
 
   /**
-   * Returns the minimum of two Vec4Type's
-   *
-   * @param out the receiving vector
-   * @param a the first operand
-   * @param b the second operand
-   * @returns out
-   */
-  min(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
-
-  /**
-   * Returns the maximum of two Vec4Type's
+   * Returns the minimum of two Vec4's
    *
    * @param out the receiving vector
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  max(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[]): Vec4Type;
+  min(out: Vec4, a: Vec4, b: Vec4): Vec4;
 
   /**
-   * Math.round the components of a Vec4Type
+   * Returns the maximum of two Vec4's
    *
-   * @param {Vec4Type} out the receiving vector
-   * @param {Vec4Type} a vector to round
-   * @returns {Vec4Type} out
+   * @param out the receiving vector
+   * @param a the first operand
+   * @param b the second operand
+   * @returns out
    */
-  round(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
+  max(out: Vec4, a: Vec4, b: Vec4): Vec4;
 
   /**
-   * Scales a Vec4Type by a scalar number
+   * Math.round the components of a Vec4
+   *
+   * @param {Vec4} out the receiving vector
+   * @param {Vec4} a vector to round
+   * @returns {Vec4} out
+   */
+  round(out: Vec4, a: Vec4): Vec4;
+
+  /**
+   * Scales a Vec4 by a scalar number
    *
    * @param out the receiving vector
    * @param a the vector to scale
    * @param b amount to scale the vector by
    * @returns out
    */
-  scale(out: Vec4Type, a: Vec4Type|number[], b: number): Vec4Type;
+  scale(out: Vec4, a: Vec4, b: number): Vec4;
 
   /**
-   * Adds two Vec4Type's after scaling the second operand by a scalar value
+   * Adds two Vec4's after scaling the second operand by a scalar value
    *
    * @param out the receiving vector
    * @param a the first operand
@@ -1205,116 +1219,114 @@ interface Vec4Type extends Float32Array {
    * @param scale the amount to scale b by before adding
    * @returns out
    */
-  scaleAndAdd(
-      out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[],
-      scale: number): Vec4Type;
+  scaleAndAdd(out: Vec4, a: Vec4, b: Vec4, scale: number): Vec4;
 
   /**
-   * Calculates the euclidian distance between two Vec4Type's
+   * Calculates the euclidian distance between two Vec4's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns distance between a and b
    */
-  distance(a: Vec4Type|number[], b: Vec4Type|number[]): number;
+  distance(a: Vec4, b: Vec4): number;
 
   /**
-   * Calculates the euclidian distance between two Vec4Type's
+   * Calculates the euclidian distance between two Vec4's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns distance between a and b
    */
-  dist(a: Vec4Type|number[], b: Vec4Type|number[]): number;
+  dist(a: Vec4, b: Vec4): number;
 
   /**
-   * Calculates the squared euclidian distance between two Vec4Type's
+   * Calculates the squared euclidian distance between two Vec4's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  squaredDistance(a: Vec4Type|number[], b: Vec4Type|number[]): number;
+  squaredDistance(a: Vec4, b: Vec4): number;
 
   /**
-   * Calculates the squared euclidian distance between two Vec4Type's
+   * Calculates the squared euclidian distance between two Vec4's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns squared distance between a and b
    */
-  sqrDist(a: Vec4Type|number[], b: Vec4Type|number[]): number;
+  sqrDist(a: Vec4, b: Vec4): number;
 
   /**
-   * Calculates the length of a Vec4Type
+   * Calculates the length of a Vec4
    *
    * @param a vector to calculate length of
    * @returns length of a
    */
-  length(a: Vec4Type|number[]): number;
+  length(a: Vec4): number;
 
   /**
-   * Calculates the length of a Vec4Type
+   * Calculates the length of a Vec4
    *
    * @param a vector to calculate length of
    * @returns length of a
    */
-  len(a: Vec4Type|number[]): number;
+  len(a: Vec4): number;
 
   /**
-   * Calculates the squared length of a Vec4Type
+   * Calculates the squared length of a Vec4
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  squaredLength(a: Vec4Type|number[]): number;
+  squaredLength(a: Vec4): number;
 
   /**
-   * Calculates the squared length of a Vec4Type
+   * Calculates the squared length of a Vec4
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    */
-  sqrLen(a: Vec4Type|number[]): number;
+  sqrLen(a: Vec4): number;
 
   /**
-   * Negates the components of a Vec4Type
+   * Negates the components of a Vec4
    *
    * @param out the receiving vector
    * @param a vector to negate
    * @returns out
    */
-  negate(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
+  negate(out: Vec4, a: Vec4): Vec4;
 
   /**
-   * Returns the inverse of the components of a Vec4Type
+   * Returns the inverse of the components of a Vec4
    *
    * @param out the receiving vector
    * @param a vector to invert
    * @returns out
    */
-  inverse(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
+  inverse(out: Vec4, a: Vec4): Vec4;
 
   /**
-   * Normalize a Vec4Type
+   * Normalize a Vec4
    *
    * @param out the receiving vector
    * @param a vector to normalize
    * @returns out
    */
-  normalize(out: Vec4Type, a: Vec4Type|number[]): Vec4Type;
+  normalize(out: Vec4, a: Vec4): Vec4;
 
   /**
-   * Calculates the dot product of two Vec4Type's
+   * Calculates the dot product of two Vec4's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns dot product of a and b
    */
-  dot(a: Vec4Type|number[], b: Vec4Type|number[]): number;
+  dot(a: Vec4, b: Vec4): number;
 
   /**
-   * Performs a linear interpolation between two Vec4Type's
+   * Performs a linear interpolation between two Vec4's
    *
    * @param out the receiving vector
    * @param a the first operand
@@ -1322,8 +1334,7 @@ interface Vec4Type extends Float32Array {
    * @param t interpolation amount between the two inputs
    * @returns out
    */
-  lerp(out: Vec4Type, a: Vec4Type|number[], b: Vec4Type|number[], t: number):
-      Vec4Type;
+  lerp(out: Vec4, a: Vec4, b: Vec4, t: number): Vec4;
 
   /**
    * Generates a random unit vector
@@ -1331,7 +1342,7 @@ interface Vec4Type extends Float32Array {
    * @param out the receiving vector
    * @returns out
    */
-  random(out: Vec4Type): Vec4Type;
+  random(out: Vec4): Vec4;
 
   /**
    * Generates a random vector with the given scale
@@ -1341,20 +1352,20 @@ interface Vec4Type extends Float32Array {
    *     will be returned
    * @returns out
    */
-  random(out: Vec4Type, scale: number): Vec4Type;
+  random(out: Vec4, scale: number): Vec4;
 
   /**
-   * Transforms the Vec4Type with a Mat4Type.
+   * Transforms the Vec4 with a Mat4.
    *
    * @param out the receiving vector
    * @param a the vector to transform
    * @param m matrix to transform with
    * @returns out
    */
-  transformMat4(out: Vec4Type, a: Vec4Type|number[], m: Mat4Type): Vec4Type;
+  transformMat4(out: Vec4, a: Vec4, m: Mat4): Vec4;
 
   /**
-   * Transforms the Vec4Type with a QuatType
+   * Transforms the Vec4 with a Quat
    *
    * @param out the receiving vector
    * @param a the vector to transform
@@ -1362,13 +1373,13 @@ interface Vec4Type extends Float32Array {
    * @returns out
    */
 
-  transformQuat(out: Vec4Type, a: Vec4Type|number[], q: QuatType): Vec4Type;
+  transformQuat(out: Vec4, a: Vec4, q: Quat): Vec4;
 
   /**
    * Perform some operation over an array of Vec4s.
    *
    * @param a the array of vectors to iterate over
-   * @param stride Number of elements between the start of each Vec4Type. If 0
+   * @param stride Number of elements between the start of each Vec4. If 0
    *     assumes tightly packed
    * @param offset Number of elements to skip at the beginning of the array
    * @param count Number of Vec4s to iterate over. If 0 iterates over entire
@@ -1380,14 +1391,13 @@ interface Vec4Type extends Float32Array {
    */
   forEach(
       a: Float32Array, stride: number, offset: number, count: number,
-      fn: (a: Vec4Type|number[], b: Vec4Type|number[], arg: any) => void,
-      arg: any): Float32Array;
+      fn: (a: Vec4, b: Vec4, arg: any) => void, arg: any): Float32Array;
 
   /**
    * Perform some operation over an array of Vec4s.
    *
    * @param a the array of vectors to iterate over
-   * @param stride Number of elements between the start of each Vec4Type. If 0
+   * @param stride Number of elements between the start of each Vec4. If 0
    *     assumes tightly packed
    * @param offset Number of elements to skip at the beginning of the array
    * @param count Number of Vec4s to iterate over. If 0 iterates over entire
@@ -1398,7 +1408,7 @@ interface Vec4Type extends Float32Array {
    */
   forEach(
       a: Float32Array, stride: number, offset: number, count: number,
-      fn: (a: Vec4Type|number[], b: Vec4Type|number[]) => void): Float32Array;
+      fn: (a: Vec4, b: Vec4) => void): Float32Array;
 
   /**
    * Returns a string representation of a vector
@@ -1406,203 +1416,202 @@ interface Vec4Type extends Float32Array {
    * @param a vector to represent as a string
    * @returns string representation of the vector
    */
-  str(a: Vec4Type|number[]): string;
+  str(a: Vec4): string;
 
   /**
    * Returns whether or not the vectors have exactly the same elements in the
    * same position (when compared with ===)
    *
-   * @param {Vec4Type} a The first vector.
-   * @param {Vec4Type} b The second vector.
+   * @param {Vec4} a The first vector.
+   * @param {Vec4} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  exactEquals(a: Vec4Type|number[], b: Vec4Type|number[]): boolean;
+  exactEquals(a: Vec4, b: Vec4): boolean;
 
   /**
    * Returns whether or not the vectors have approximately the same elements
    * in the same position.
    *
-   * @param {Vec4Type} a The first vector.
-   * @param {Vec4Type} b The second vector.
+   * @param {Vec4} a The first vector.
+   * @param {Vec4} b The second vector.
    * @returns {boolean} True if the vectors are equal, false otherwise.
    */
-  equals(a: Vec4Type|number[], b: Vec4Type|number[]): boolean;
+  equals(a: Vec4, b: Vec4): boolean;
 }
 
-// Mat2Type
-interface Mat2Type extends Float32Array {
+// Mat2
+interface Mat2API {
   /**
-   * Creates a new identity Mat2Type
+   * Creates a new identity Mat2
    *
    * @returns a new 2x2 matrix
    */
-  create(): Mat2Type;
+  create(): Mat2;
 
   /**
-   * Creates a new Mat2Type initialized with values from an existing matrix
+   * Creates a new Mat2 initialized with values from an existing matrix
    *
    * @param a matrix to clone
    * @returns a new 2x2 matrix
    */
-  clone(a: Mat2Type): Mat2Type;
+  clone(a: Mat2): Mat2;
 
   /**
-   * Copy the values from one Mat2Type to another
+   * Copy the values from one Mat2 to another
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  copy(out: Mat2Type, a: Mat2Type): Mat2Type;
+  copy(out: Mat2, a: Mat2): Mat2;
 
   /**
-   * Set a Mat2Type to the identity matrix
+   * Set a Mat2 to the identity matrix
    *
    * @param out the receiving matrix
    * @returns out
    */
-  identity(out: Mat2Type): Mat2Type;
+  identity(out: Mat2): Mat2;
 
   /**
-   * Create a new Mat2Type with the given values
+   * Create a new Mat2 with the given values
    *
    * @param {number} m00 Component in column 0, row 0 position (index 0)
    * @param {number} m01 Component in column 0, row 1 position (index 1)
    * @param {number} m10 Component in column 1, row 0 position (index 2)
    * @param {number} m11 Component in column 1, row 1 position (index 3)
-   * @returns {Mat2Type} out A new 2x2 matrix
+   * @returns {Mat2} out A new 2x2 matrix
    */
-  fromValues(m00: number, m01: number, m10: number, m11: number): Mat2Type;
+  fromValues(m00: number, m01: number, m10: number, m11: number): Mat2;
 
   /**
-   * Set the components of a Mat2Type to the given values
+   * Set the components of a Mat2 to the given values
    *
-   * @param {Mat2Type} out the receiving matrix
+   * @param {Mat2} out the receiving matrix
    * @param {number} m00 Component in column 0, row 0 position (index 0)
    * @param {number} m01 Component in column 0, row 1 position (index 1)
    * @param {number} m10 Component in column 1, row 0 position (index 2)
    * @param {number} m11 Component in column 1, row 1 position (index 3)
-   * @returns {Mat2Type} out
+   * @returns {Mat2} out
    */
-  set(out: Mat2Type, m00: number, m01: number, m10: number,
-      m11: number): Mat2Type;
+  set(out: Mat2, m00: number, m01: number, m10: number, m11: number): Mat2;
 
   /**
-   * Transpose the values of a Mat2Type
+   * Transpose the values of a Mat2
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  transpose(out: Mat2Type, a: Mat2Type): Mat2Type;
+  transpose(out: Mat2, a: Mat2): Mat2;
 
   /**
-   * Inverts a Mat2Type
+   * Inverts a Mat2
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  invert(out: Mat2Type, a: Mat2Type): Mat2Type|null;
+  invert(out: Mat2, a: Mat2): Mat2|null;
 
   /**
-   * Calculates the adjugate of a Mat2Type
+   * Calculates the adjugate of a Mat2
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  adjoint(out: Mat2Type, a: Mat2Type): Mat2Type;
+  adjoint(out: Mat2, a: Mat2): Mat2;
 
   /**
-   * Calculates the determinant of a Mat2Type
+   * Calculates the determinant of a Mat2
    *
    * @param a the source matrix
    * @returns determinant of a
    */
-  determinant(a: Mat2Type): number;
+  determinant(a: Mat2): number;
 
   /**
-   * Multiplies two Mat2Type's
+   * Multiplies two Mat2's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Mat2Type, a: Mat2Type, b: Mat2Type): Mat2Type;
+  multiply(out: Mat2, a: Mat2, b: Mat2): Mat2;
 
   /**
-   * Multiplies two Mat2Type's
+   * Multiplies two Mat2's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Mat2Type, a: Mat2Type, b: Mat2Type): Mat2Type;
+  mul(out: Mat2, a: Mat2, b: Mat2): Mat2;
 
   /**
-   * Rotates a Mat2Type by the given angle
+   * Rotates a Mat2 by the given angle
    *
    * @param out the receiving matrix
    * @param a the matrix to rotate
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  rotate(out: Mat2Type, a: Mat2Type, rad: number): Mat2Type;
+  rotate(out: Mat2, a: Mat2, rad: number): Mat2;
 
   /**
-   * Scales the Mat2Type by the dimensions in the given Vec2Type
+   * Scales the Mat2 by the dimensions in the given Vec2
    *
    * @param out the receiving matrix
    * @param a the matrix to rotate
-   * @param v the Vec2Type to scale the matrix by
+   * @param v the Vec2 to scale the matrix by
    * @returns out
    **/
-  scale(out: Mat2Type, a: Mat2Type, v: Vec2Type|number[]): Mat2Type;
+  scale(out: Mat2, a: Mat2, v: Vec2): Mat2;
 
   /**
    * Creates a matrix from a given angle
    * This is equivalent to (but much faster than):
    *
-   *     Mat2Type.identity(dest);
-   *     Mat2Type.rotate(dest, dest, rad);
+   *     Mat2.identity(dest);
+   *     Mat2.rotate(dest, dest, rad);
    *
-   * @param {Mat2Type} out Mat2Type receiving operation result
+   * @param {Mat2} out Mat2 receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @returns {Mat2Type} out
+   * @returns {Mat2} out
    */
-  fromRotation(out: Mat2Type, rad: number): Mat2Type;
+  fromRotation(out: Mat2, rad: number): Mat2;
 
   /**
    * Creates a matrix from a vector scaling
    * This is equivalent to (but much faster than):
    *
-   *     Mat2Type.identity(dest);
-   *     Mat2Type.scale(dest, dest, vec);
+   *     Mat2.identity(dest);
+   *     Mat2.scale(dest, dest, vec);
    *
-   * @param {Mat2Type} out Mat2Type receiving operation result
-   * @param {Vec2Type} v Scaling vector
-   * @returns {Mat2Type} out
+   * @param {Mat2} out Mat2 receiving operation result
+   * @param {Vec2} v Scaling vector
+   * @returns {Mat2} out
    */
-  fromScaling(out: Mat2Type, v: Vec2Type|number[]): Mat2Type;
+  fromScaling(out: Mat2, v: Vec2): Mat2;
 
   /**
-   * Returns a string representation of a Mat2Type
+   * Returns a string representation of a Mat2
    *
    * @param a matrix to represent as a string
    * @returns string representation of the matrix
    */
-  str(a: Mat2Type): string;
+  str(a: Mat2): string;
 
   /**
-   * Returns Frobenius norm of a Mat2Type
+   * Returns Frobenius norm of a Mat2
    *
    * @param a the matrix to calculate Frobenius norm of
    * @returns Frobenius norm
    */
-  frob(a: Mat2Type): number;
+  frob(a: Mat2): number;
 
   /**
    * Returns L, D and U matrices (Lower triangular, Diagonal and Upper
@@ -1612,119 +1621,118 @@ interface Mat2Type extends Float32Array {
    * @param U the upper triangular matrix
    * @param a the input matrix to factorize
    */
-  LDU(L: Mat2Type, D: Mat2Type, U: Mat2Type, a: Mat2Type): Mat2Type;
+  LDU(L: Mat2, D: Mat2, U: Mat2, a: Mat2): Mat2;
 
   /**
-   * Adds two Mat2Type's
+   * Adds two Mat2's
    *
-   * @param {Mat2Type} out the receiving matrix
-   * @param {Mat2Type} a the first operand
-   * @param {Mat2Type} b the second operand
-   * @returns {Mat2Type} out
+   * @param {Mat2} out the receiving matrix
+   * @param {Mat2} a the first operand
+   * @param {Mat2} b the second operand
+   * @returns {Mat2} out
    */
-  add(out: Mat2Type, a: Mat2Type, b: Mat2Type): Mat2Type;
-
-  /**
-   * Subtracts matrix b from matrix a
-   *
-   * @param {Mat2Type} out the receiving matrix
-   * @param {Mat2Type} a the first operand
-   * @param {Mat2Type} b the second operand
-   * @returns {Mat2Type} out
-   */
-  subtract(out: Mat2Type, a: Mat2Type, b: Mat2Type): Mat2Type;
+  add(out: Mat2, a: Mat2, b: Mat2): Mat2;
 
   /**
    * Subtracts matrix b from matrix a
    *
-   * @param {Mat2Type} out the receiving matrix
-   * @param {Mat2Type} a the first operand
-   * @param {Mat2Type} b the second operand
-   * @returns {Mat2Type} out
+   * @param {Mat2} out the receiving matrix
+   * @param {Mat2} a the first operand
+   * @param {Mat2} b the second operand
+   * @returns {Mat2} out
    */
-  sub(out: Mat2Type, a: Mat2Type, b: Mat2Type): Mat2Type;
+  subtract(out: Mat2, a: Mat2, b: Mat2): Mat2;
+
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat2} out the receiving matrix
+   * @param {Mat2} a the first operand
+   * @param {Mat2} b the second operand
+   * @returns {Mat2} out
+   */
+  sub(out: Mat2, a: Mat2, b: Mat2): Mat2;
 
   /**
    * Returns whether or not the matrices have exactly the same elements in the
    * same position (when compared with ===)
    *
-   * @param {Mat2Type} a The first matrix.
-   * @param {Mat2Type} b The second matrix.
+   * @param {Mat2} a The first matrix.
+   * @param {Mat2} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  exactEquals(a: Mat2Type, b: Mat2Type): boolean;
+  exactEquals(a: Mat2, b: Mat2): boolean;
 
   /**
    * Returns whether or not the matrices have approximately the same elements
    * in the same position.
    *
-   * @param {Mat2Type} a The first matrix.
-   * @param {Mat2Type} b The second matrix.
+   * @param {Mat2} a The first matrix.
+   * @param {Mat2} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  equals(a: Mat2Type, b: Mat2Type): boolean;
+  equals(a: Mat2, b: Mat2): boolean;
 
   /**
    * Multiply each element of the matrix by a scalar.
    *
-   * @param {Mat2Type} out the receiving matrix
-   * @param {Mat2Type} a the matrix to scale
+   * @param {Mat2} out the receiving matrix
+   * @param {Mat2} a the matrix to scale
    * @param {number} b amount to scale the matrix's elements by
-   * @returns {Mat2Type} out
+   * @returns {Mat2} out
    */
-  multiplyScalar(out: Mat2Type, a: Mat2Type, b: number): Mat2Type
+  multiplyScalar(out: Mat2, a: Mat2, b: number): Mat2
 
   /**
-   * Adds two Mat2Type's after multiplying each element of the second operand
+   * Adds two Mat2's after multiplying each element of the second operand
    * by a scalar value.
    *
-   * @param {Mat2Type} out the receiving vector
-   * @param {Mat2Type} a the first operand
-   * @param {Mat2Type} b the second operand
+   * @param {Mat2} out the receiving vector
+   * @param {Mat2} a the first operand
+   * @param {Mat2} b the second operand
    * @param {number} scale the amount to scale b's elements by before
    *     adding
-   * @returns {Mat2Type} out
+   * @returns {Mat2} out
    */
-  multiplyScalarAndAdd(out: Mat2Type, a: Mat2Type, b: Mat2Type, scale: number):
-      Mat2Type
+  multiplyScalarAndAdd(out: Mat2, a: Mat2, b: Mat2, scale: number): Mat2
 }
 
-// Mat2dType
-interface Mat2dType extends Float32Array {
+// Mat2d
+interface Mat2dAPI {
   /**
-   * Creates a new identity Mat2dType
+   * Creates a new identity Mat2d
    *
    * @returns a new 2x3 matrix
    */
-  create(): Mat2dType;
+  create(): Mat2d;
 
   /**
-   * Creates a new Mat2dType initialized with values from an existing matrix
+   * Creates a new Mat2d initialized with values from an existing matrix
    *
    * @param a matrix to clone
    * @returns a new 2x3 matrix
    */
-  clone(a: Mat2dType): Mat2dType;
+  clone(a: Mat2d): Mat2d;
 
   /**
-   * Copy the values from one Mat2dType to another
+   * Copy the values from one Mat2d to another
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  copy(out: Mat2dType, a: Mat2dType): Mat2dType;
+  copy(out: Mat2d, a: Mat2d): Mat2d;
 
   /**
-   * Set a Mat2dType to the identity matrix
+   * Set a Mat2d to the identity matrix
    *
    * @param out the receiving matrix
    * @returns out
    */
-  identity(out: Mat2dType): Mat2dType;
+  identity(out: Mat2d): Mat2d;
 
   /**
-   * Create a new Mat2dType with the given values
+   * Create a new Mat2d with the given values
    *
    * @param {number} a Component A (index 0)
    * @param {number} b Component B (index 1)
@@ -1732,261 +1740,259 @@ interface Mat2dType extends Float32Array {
    * @param {number} d Component D (index 3)
    * @param {number} tx Component TX (index 4)
    * @param {number} ty Component TY (index 5)
-   * @returns {Mat2dType} A new Mat2dType
+   * @returns {Mat2d} A new Mat2d
    */
   fromValues(
-      a: number, b: number, c: number, d: number, tx: number,
-      ty: number): Mat2dType
+      a: number, b: number, c: number, d: number, tx: number, ty: number): Mat2d
 
 
   /**
-   * Set the components of a Mat2dType to the given values
+   * Set the components of a Mat2d to the given values
    *
-   * @param {Mat2dType} out the receiving matrix
+   * @param {Mat2d} out the receiving matrix
    * @param {number} a Component A (index 0)
    * @param {number} b Component B (index 1)
    * @param {number} c Component C (index 2)
    * @param {number} d Component D (index 3)
    * @param {number} tx Component TX (index 4)
    * @param {number} ty Component TY (index 5)
-   * @returns {Mat2dType} out
+   * @returns {Mat2d} out
    */
-  set(out: Mat2dType, a: number, b: number, c: number, d: number, tx: number,
-      ty: number): Mat2dType
+  set(out: Mat2d, a: number, b: number, c: number, d: number, tx: number,
+      ty: number): Mat2d
 
   /**
-   * Inverts a Mat2dType
+   * Inverts a Mat2d
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  invert(out: Mat2dType, a: Mat2dType): Mat2dType|null;
+  invert(out: Mat2d, a: Mat2d): Mat2d|null;
 
   /**
-   * Calculates the determinant of a Mat2dType
+   * Calculates the determinant of a Mat2d
    *
    * @param a the source matrix
    * @returns determinant of a
    */
-  determinant(a: Mat2dType): number;
+  determinant(a: Mat2d): number;
 
   /**
-   * Multiplies two Mat2dType's
+   * Multiplies two Mat2d's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Mat2dType, a: Mat2dType, b: Mat2dType): Mat2dType;
+  multiply(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d;
 
   /**
-   * Multiplies two Mat2dType's
+   * Multiplies two Mat2d's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Mat2dType, a: Mat2dType, b: Mat2dType): Mat2dType;
+  mul(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d;
 
   /**
-   * Rotates a Mat2dType by the given angle
+   * Rotates a Mat2d by the given angle
    *
    * @param out the receiving matrix
    * @param a the matrix to rotate
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  rotate(out: Mat2dType, a: Mat2dType, rad: number): Mat2dType;
+  rotate(out: Mat2d, a: Mat2d, rad: number): Mat2d;
 
   /**
-   * Scales the Mat2dType by the dimensions in the given Vec2Type
+   * Scales the Mat2d by the dimensions in the given Vec2
    *
    * @param out the receiving matrix
    * @param a the matrix to translate
-   * @param v the Vec2Type to scale the matrix by
+   * @param v the Vec2 to scale the matrix by
    * @returns out
    **/
-  scale(out: Mat2dType, a: Mat2dType, v: Vec2Type|number[]): Mat2dType;
+  scale(out: Mat2d, a: Mat2d, v: Vec2): Mat2d;
 
   /**
-   * Translates the Mat2dType by the dimensions in the given Vec2Type
+   * Translates the Mat2d by the dimensions in the given Vec2
    *
    * @param out the receiving matrix
    * @param a the matrix to translate
-   * @param v the Vec2Type to translate the matrix by
+   * @param v the Vec2 to translate the matrix by
    * @returns out
    **/
-  translate(out: Mat2dType, a: Mat2dType, v: Vec2Type|number[]): Mat2dType;
+  translate(out: Mat2d, a: Mat2d, v: Vec2): Mat2d;
 
   /**
    * Creates a matrix from a given angle
    * This is equivalent to (but much faster than):
    *
-   *     Mat2dType.identity(dest);
-   *     Mat2dType.rotate(dest, dest, rad);
+   *     Mat2d.identity(dest);
+   *     Mat2d.rotate(dest, dest, rad);
    *
-   * @param {Mat2dType} out Mat2dType receiving operation result
+   * @param {Mat2d} out Mat2d receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @returns {Mat2dType} out
+   * @returns {Mat2d} out
    */
-  fromRotation(out: Mat2dType, rad: number): Mat2dType;
+  fromRotation(out: Mat2d, rad: number): Mat2d;
 
   /**
    * Creates a matrix from a vector scaling
    * This is equivalent to (but much faster than):
    *
-   *     Mat2dType.identity(dest);
-   *     Mat2dType.scale(dest, dest, vec);
+   *     Mat2d.identity(dest);
+   *     Mat2d.scale(dest, dest, vec);
    *
-   * @param {Mat2dType} out Mat2dType receiving operation result
-   * @param {Vec2Type} v Scaling vector
-   * @returns {Mat2dType} out
+   * @param {Mat2d} out Mat2d receiving operation result
+   * @param {Vec2} v Scaling vector
+   * @returns {Mat2d} out
    */
-  fromScaling(out: Mat2dType, v: Vec2Type|number[]): Mat2dType;
+  fromScaling(out: Mat2d, v: Vec2): Mat2d;
 
   /**
    * Creates a matrix from a vector translation
    * This is equivalent to (but much faster than):
    *
-   *     Mat2dType.identity(dest);
-   *     Mat2dType.translate(dest, dest, vec);
+   *     Mat2d.identity(dest);
+   *     Mat2d.translate(dest, dest, vec);
    *
-   * @param {Mat2dType} out Mat2dType receiving operation result
-   * @param {Vec2Type} v Translation vector
-   * @returns {Mat2dType} out
+   * @param {Mat2d} out Mat2d receiving operation result
+   * @param {Vec2} v Translation vector
+   * @returns {Mat2d} out
    */
-  fromTranslation(out: Mat2dType, v: Vec2Type|number[]): Mat2dType
+  fromTranslation(out: Mat2d, v: Vec2): Mat2d
 
   /**
-   * Returns a string representation of a Mat2dType
+   * Returns a string representation of a Mat2d
    *
    * @param a matrix to represent as a string
    * @returns string representation of the matrix
    */
-  str(a: Mat2dType): string;
+  str(a: Mat2d): string;
 
   /**
-   * Returns Frobenius norm of a Mat2dType
+   * Returns Frobenius norm of a Mat2d
    *
    * @param a the matrix to calculate Frobenius norm of
    * @returns Frobenius norm
    */
-  frob(a: Mat2dType): number;
+  frob(a: Mat2d): number;
 
   /**
-   * Adds two Mat2dType's
+   * Adds two Mat2d's
    *
-   * @param {Mat2dType} out the receiving matrix
-   * @param {Mat2dType} a the first operand
-   * @param {Mat2dType} b the second operand
-   * @returns {Mat2dType} out
+   * @param {Mat2d} out the receiving matrix
+   * @param {Mat2d} a the first operand
+   * @param {Mat2d} b the second operand
+   * @returns {Mat2d} out
    */
-  add(out: Mat2dType, a: Mat2dType, b: Mat2dType): Mat2dType
-
-  /**
-   * Subtracts matrix b from matrix a
-   *
-   * @param {Mat2dType} out the receiving matrix
-   * @param {Mat2dType} a the first operand
-   * @param {Mat2dType} b the second operand
-   * @returns {Mat2dType} out
-   */
-  subtract(out: Mat2dType, a: Mat2dType, b: Mat2dType): Mat2dType
+  add(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
 
   /**
    * Subtracts matrix b from matrix a
    *
-   * @param {Mat2dType} out the receiving matrix
-   * @param {Mat2dType} a the first operand
-   * @param {Mat2dType} b the second operand
-   * @returns {Mat2dType} out
+   * @param {Mat2d} out the receiving matrix
+   * @param {Mat2d} a the first operand
+   * @param {Mat2d} b the second operand
+   * @returns {Mat2d} out
    */
-  sub(out: Mat2dType, a: Mat2dType, b: Mat2dType): Mat2dType
+  subtract(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
+
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat2d} out the receiving matrix
+   * @param {Mat2d} a the first operand
+   * @param {Mat2d} b the second operand
+   * @returns {Mat2d} out
+   */
+  sub(out: Mat2d, a: Mat2d, b: Mat2d): Mat2d
 
   /**
    * Multiply each element of the matrix by a scalar.
    *
-   * @param {Mat2dType} out the receiving matrix
-   * @param {Mat2dType} a the matrix to scale
+   * @param {Mat2d} out the receiving matrix
+   * @param {Mat2d} a the matrix to scale
    * @param {number} b amount to scale the matrix's elements by
-   * @returns {Mat2dType} out
+   * @returns {Mat2d} out
    */
-  multiplyScalar(out: Mat2dType, a: Mat2dType, b: number): Mat2dType;
+  multiplyScalar(out: Mat2d, a: Mat2d, b: number): Mat2d;
 
   /**
-   * Adds two Mat2dType's after multiplying each element of the second operand
+   * Adds two Mat2d's after multiplying each element of the second operand
    * by a scalar value.
    *
-   * @param {Mat2dType} out the receiving vector
-   * @param {Mat2dType} a the first operand
-   * @param {Mat2dType} b the second operand
+   * @param {Mat2d} out the receiving vector
+   * @param {Mat2d} a the first operand
+   * @param {Mat2d} b the second operand
    * @param {number} scale the amount to scale b's elements by before adding
-   * @returns {Mat2dType} out
+   * @returns {Mat2d} out
    */
-  multiplyScalarAndAdd(
-      out: Mat2dType, a: Mat2dType, b: Mat2dType, scale: number): Mat2dType
+  multiplyScalarAndAdd(out: Mat2d, a: Mat2d, b: Mat2d, scale: number): Mat2d
 
   /**
    * Returns whether or not the matrices have exactly the same elements in
    * the same position (when compared with ===)
    *
-   * @param {Mat2dType} a The first matrix.
-   * @param {Mat2dType} b The second matrix.
+   * @param {Mat2d} a The first matrix.
+   * @param {Mat2d} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  exactEquals(a: Mat2dType, b: Mat2dType): boolean;
+  exactEquals(a: Mat2d, b: Mat2d): boolean;
 
   /**
    * Returns whether or not the matrices have approximately the same elements
    * in the same position.
    *
-   * @param {Mat2dType} a The first matrix.
-   * @param {Mat2dType} b The second matrix.
+   * @param {Mat2d} a The first matrix.
+   * @param {Mat2d} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  equals(a: Mat2dType, b: Mat2dType): boolean
+  equals(a: Mat2d, b: Mat2d): boolean
 }
 
-// Mat3Type
-interface Mat3Type extends Float32Array {
+// Mat3
+interface Mat3API {
   /**
-   * Creates a new identity Mat3Type
+   * Creates a new identity Mat3
    *
    * @returns a new 3x3 matrix
    */
-  create(): Mat3Type;
+  create(): Mat3;
 
   /**
-   * Copies the upper-left 3x3 values into the given Mat3Type.
+   * Copies the upper-left 3x3 values into the given Mat3.
    *
-   * @param {Mat3Type} out the receiving 3x3 matrix
-   * @param {Mat4Type} a   the source 4x4 matrix
-   * @returns {Mat3Type} out
+   * @param {Mat3} out the receiving 3x3 matrix
+   * @param {Mat4} a   the source 4x4 matrix
+   * @returns {Mat3} out
    */
-  fromMat4(out: Mat3Type, a: Mat4Type): Mat3Type
+  fromMat4(out: Mat3, a: Mat4): Mat3
 
   /**
-   * Creates a new Mat3Type initialized with values from an existing matrix
+   * Creates a new Mat3 initialized with values from an existing matrix
    *
    * @param a matrix to clone
    * @returns a new 3x3 matrix
    */
-  clone(a: Mat3Type): Mat3Type;
+  clone(a: Mat3): Mat3;
 
   /**
-   * Copy the values from one Mat3Type to another
+   * Copy the values from one Mat3 to another
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  copy(out: Mat3Type, a: Mat3Type): Mat3Type;
+  copy(out: Mat3, a: Mat3): Mat3;
 
   /**
-   * Create a new Mat3Type with the given values
+   * Create a new Mat3 with the given values
    *
    * @param {number} m00 Component in column 0, row 0 position (index 0)
    * @param {number} m01 Component in column 0, row 1 position (index 1)
@@ -1997,17 +2003,17 @@ interface Mat3Type extends Float32Array {
    * @param {number} m20 Component in column 2, row 0 position (index 6)
    * @param {number} m21 Component in column 2, row 1 position (index 7)
    * @param {number} m22 Component in column 2, row 2 position (index 8)
-   * @returns {Mat3Type} A new Mat3Type
+   * @returns {Mat3} A new Mat3
    */
   fromValues(
       m00: number, m01: number, m02: number, m10: number, m11: number,
-      m12: number, m20: number, m21: number, m22: number): Mat3Type;
+      m12: number, m20: number, m21: number, m22: number): Mat3;
 
 
   /**
-   * Set the components of a Mat3Type to the given values
+   * Set the components of a Mat3 to the given values
    *
-   * @param {Mat3Type} out the receiving matrix
+   * @param {Mat3} out the receiving matrix
    * @param {number} m00 Component in column 0, row 0 position (index 0)
    * @param {number} m01 Component in column 0, row 1 position (index 1)
    * @param {number} m02 Component in column 0, row 2 position (index 2)
@@ -2017,293 +2023,292 @@ interface Mat3Type extends Float32Array {
    * @param {number} m20 Component in column 2, row 0 position (index 6)
    * @param {number} m21 Component in column 2, row 1 position (index 7)
    * @param {number} m22 Component in column 2, row 2 position (index 8)
-   * @returns {Mat3Type} out
+   * @returns {Mat3} out
    */
-  set(out: Mat3Type, m00: number, m01: number, m02: number, m10: number,
-      m11: number, m12: number, m20: number, m21: number, m22: number): Mat3Type
+  set(out: Mat3, m00: number, m01: number, m02: number, m10: number,
+      m11: number, m12: number, m20: number, m21: number, m22: number): Mat3
 
   /**
-   * Set a Mat3Type to the identity matrix
+   * Set a Mat3 to the identity matrix
    *
    * @param out the receiving matrix
    * @returns out
    */
-  identity(out: Mat3Type): Mat3Type;
+  identity(out: Mat3): Mat3;
 
   /**
-   * Transpose the values of a Mat3Type
-   *
-   * @param out the receiving matrix
-   * @param a the source matrix
-   * @returns out
-   */
-  transpose(out: Mat3Type, a: Mat3Type): Mat3Type;
-
-  /**
-   * Inverts a Mat3Type
+   * Transpose the values of a Mat3
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  invert(out: Mat3Type, a: Mat3Type): Mat3Type|null;
+  transpose(out: Mat3, a: Mat3): Mat3;
 
   /**
-   * Calculates the adjugate of a Mat3Type
+   * Inverts a Mat3
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  adjoint(out: Mat3Type, a: Mat3Type): Mat3Type;
+  invert(out: Mat3, a: Mat3): Mat3|null;
 
   /**
-   * Calculates the determinant of a Mat3Type
+   * Calculates the adjugate of a Mat3
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  adjoint(out: Mat3, a: Mat3): Mat3;
+
+  /**
+   * Calculates the determinant of a Mat3
    *
    * @param a the source matrix
    * @returns determinant of a
    */
-  determinant(a: Mat3Type): number;
+  determinant(a: Mat3): number;
 
   /**
-   * Multiplies two Mat3Type's
+   * Multiplies two Mat3's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Mat3Type, a: Mat3Type, b: Mat3Type): Mat3Type;
+  multiply(out: Mat3, a: Mat3, b: Mat3): Mat3;
 
   /**
-   * Multiplies two Mat3Type's
+   * Multiplies two Mat3's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Mat3Type, a: Mat3Type, b: Mat3Type): Mat3Type;
+  mul(out: Mat3, a: Mat3, b: Mat3): Mat3;
 
 
   /**
-   * Translate a Mat3Type by the given vector
+   * Translate a Mat3 by the given vector
    *
    * @param out the receiving matrix
    * @param a the matrix to translate
    * @param v vector to translate by
    * @returns out
    */
-  translate(out: Mat3Type, a: Mat3Type, v: Vec3Type|number[]): Mat3Type;
+  translate(out: Mat3, a: Mat3, v: Vec3): Mat3;
 
   /**
-   * Rotates a Mat3Type by the given angle
+   * Rotates a Mat3 by the given angle
    *
    * @param out the receiving matrix
    * @param a the matrix to rotate
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  rotate(out: Mat3Type, a: Mat3Type, rad: number): Mat3Type;
+  rotate(out: Mat3, a: Mat3, rad: number): Mat3;
 
   /**
-   * Scales the Mat3Type by the dimensions in the given Vec2Type
+   * Scales the Mat3 by the dimensions in the given Vec2
    *
    * @param out the receiving matrix
    * @param a the matrix to rotate
-   * @param v the Vec2Type to scale the matrix by
+   * @param v the Vec2 to scale the matrix by
    * @returns out
    **/
-  scale(out: Mat3Type, a: Mat3Type, v: Vec2Type|number[]): Mat3Type;
+  scale(out: Mat3, a: Mat3, v: Vec2): Mat3;
 
   /**
    * Creates a matrix from a vector translation
    * This is equivalent to (but much faster than):
    *
-   *     Mat3Type.identity(dest);
-   *     Mat3Type.translate(dest, dest, vec);
+   *     Mat3.identity(dest);
+   *     Mat3.translate(dest, dest, vec);
    *
-   * @param {Mat3Type} out Mat3Type receiving operation result
-   * @param {Vec2Type} v Translation vector
-   * @returns {Mat3Type} out
+   * @param {Mat3} out Mat3 receiving operation result
+   * @param {Vec2} v Translation vector
+   * @returns {Mat3} out
    */
-  fromTranslation(out: Mat3Type, v: Vec2Type|number[]): Mat3Type
+  fromTranslation(out: Mat3, v: Vec2): Mat3
 
   /**
    * Creates a matrix from a given angle
    * This is equivalent to (but much faster than):
    *
-   *     Mat3Type.identity(dest);
-   *     Mat3Type.rotate(dest, dest, rad);
+   *     Mat3.identity(dest);
+   *     Mat3.rotate(dest, dest, rad);
    *
-   * @param {Mat3Type} out Mat3Type receiving operation result
+   * @param {Mat3} out Mat3 receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @returns {Mat3Type} out
+   * @returns {Mat3} out
    */
-  fromRotation(out: Mat3Type, rad: number): Mat3Type
+  fromRotation(out: Mat3, rad: number): Mat3
 
   /**
    * Creates a matrix from a vector scaling
    * This is equivalent to (but much faster than):
    *
-   *     Mat3Type.identity(dest);
-   *     Mat3Type.scale(dest, dest, vec);
+   *     Mat3.identity(dest);
+   *     Mat3.scale(dest, dest, vec);
    *
-   * @param {Mat3Type} out Mat3Type receiving operation result
-   * @param {Vec2Type} v Scaling vector
-   * @returns {Mat3Type} out
+   * @param {Mat3} out Mat3 receiving operation result
+   * @param {Vec2} v Scaling vector
+   * @returns {Mat3} out
    */
-  fromScaling(out: Mat3Type, v: Vec2Type|number[]): Mat3Type
+  fromScaling(out: Mat3, v: Vec2): Mat3
 
   /**
-   * Copies the values from a Mat2dType into a Mat3Type
+   * Copies the values from a Mat2d into a Mat3
    *
    * @param out the receiving matrix
-   * @param {Mat2dType} a the matrix to copy
+   * @param {Mat2d} a the matrix to copy
    * @returns out
    **/
-  fromMat2d(out: Mat3Type, a: Mat2dType): Mat3Type;
+  fromMat2d(out: Mat3, a: Mat2d): Mat3;
 
   /**
    * Calculates a 3x3 matrix from the given Quaternion
    *
-   * @param out Mat3Type receiving operation result
+   * @param out Mat3 receiving operation result
    * @param q Quaternion to create matrix from
    *
    * @returns out
    */
-  fromQuat(out: Mat3Type, q: QuatType): Mat3Type;
+  fromQuat(out: Mat3, q: Quat): Mat3;
 
   /**
    * Calculates a 3x3 normal matrix (transpose inverse) from the 4x4 matrix
    *
-   * @param out Mat3Type receiving operation result
-   * @param a Mat4Type to derive the normal matrix from
+   * @param out Mat3 receiving operation result
+   * @param a Mat4 to derive the normal matrix from
    *
    * @returns out
    */
-  normalFromMat4(out: Mat3Type, a: Mat4Type): Mat3Type|null;
+  normalFromMat4(out: Mat3, a: Mat4): Mat3|null;
 
   /**
-   * Returns a string representation of a Mat3Type
+   * Returns a string representation of a Mat3
    *
    * @param mat matrix to represent as a string
    * @returns string representation of the matrix
    */
-  str(mat: Mat3Type): string;
+  str(mat: Mat3): string;
 
   /**
-   * Returns Frobenius norm of a Mat3Type
+   * Returns Frobenius norm of a Mat3
    *
    * @param a the matrix to calculate Frobenius norm of
    * @returns Frobenius norm
    */
-  frob(a: Mat3Type): number;
+  frob(a: Mat3): number;
 
   /**
-   * Adds two Mat3Type's
+   * Adds two Mat3's
    *
-   * @param {Mat3Type} out the receiving matrix
-   * @param {Mat3Type} a the first operand
-   * @param {Mat3Type} b the second operand
-   * @returns {Mat3Type} out
+   * @param {Mat3} out the receiving matrix
+   * @param {Mat3} a the first operand
+   * @param {Mat3} b the second operand
+   * @returns {Mat3} out
    */
-  add(out: Mat3Type, a: Mat3Type, b: Mat3Type): Mat3Type
-
-  /**
-   * Subtracts matrix b from matrix a
-   *
-   * @param {Mat3Type} out the receiving matrix
-   * @param {Mat3Type} a the first operand
-   * @param {Mat3Type} b the second operand
-   * @returns {Mat3Type} out
-   */
-  subtract(out: Mat3Type, a: Mat3Type, b: Mat3Type): Mat3Type
+  add(out: Mat3, a: Mat3, b: Mat3): Mat3
 
   /**
    * Subtracts matrix b from matrix a
    *
-   * @param {Mat3Type} out the receiving matrix
-   * @param {Mat3Type} a the first operand
-   * @param {Mat3Type} b the second operand
-   * @returns {Mat3Type} out
+   * @param {Mat3} out the receiving matrix
+   * @param {Mat3} a the first operand
+   * @param {Mat3} b the second operand
+   * @returns {Mat3} out
    */
-  sub(out: Mat3Type, a: Mat3Type, b: Mat3Type): Mat3Type
+  subtract(out: Mat3, a: Mat3, b: Mat3): Mat3
+
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat3} out the receiving matrix
+   * @param {Mat3} a the first operand
+   * @param {Mat3} b the second operand
+   * @returns {Mat3} out
+   */
+  sub(out: Mat3, a: Mat3, b: Mat3): Mat3
 
   /**
    * Multiply each element of the matrix by a scalar.
    *
-   * @param {Mat3Type} out the receiving matrix
-   * @param {Mat3Type} a the matrix to scale
+   * @param {Mat3} out the receiving matrix
+   * @param {Mat3} a the matrix to scale
    * @param {number} b amount to scale the matrix's elements by
-   * @returns {Mat3Type} out
+   * @returns {Mat3} out
    */
-  multiplyScalar(out: Mat3Type, a: Mat3Type, b: number): Mat3Type
+  multiplyScalar(out: Mat3, a: Mat3, b: number): Mat3
 
   /**
-   * Adds two Mat3Type's after multiplying each element of the second operand
+   * Adds two Mat3's after multiplying each element of the second operand
    * by a scalar value.
    *
-   * @param {Mat3Type} out the receiving vector
-   * @param {Mat3Type} a the first operand
-   * @param {Mat3Type} b the second operand
+   * @param {Mat3} out the receiving vector
+   * @param {Mat3} a the first operand
+   * @param {Mat3} b the second operand
    * @param {number} scale the amount to scale b's elements by before
    *     adding
-   * @returns {Mat3Type} out
+   * @returns {Mat3} out
    */
-  multiplyScalarAndAdd(out: Mat3Type, a: Mat3Type, b: Mat3Type, scale: number):
-      Mat3Type
+  multiplyScalarAndAdd(out: Mat3, a: Mat3, b: Mat3, scale: number): Mat3
 
   /**
    * Returns whether or not the matrices have exactly the same elements in
    * the same position (when compared with ===)
    *
-   * @param {Mat3Type} a The first matrix.
-   * @param {Mat3Type} b The second matrix.
+   * @param {Mat3} a The first matrix.
+   * @param {Mat3} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  exactEquals(a: Mat3Type, b: Mat3Type): boolean;
+  exactEquals(a: Mat3, b: Mat3): boolean;
 
   /**
    * Returns whether or not the matrices have approximately the same elements
    * in the same position.
    *
-   * @param {Mat3Type} a The first matrix.
-   * @param {Mat3Type} b The second matrix.
+   * @param {Mat3} a The first matrix.
+   * @param {Mat3} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  equals(a: Mat3Type, b: Mat3Type): boolean
+  equals(a: Mat3, b: Mat3): boolean
 }
 
-// Mat4Type
-interface Mat4Type extends Float32Array {
+// Mat4
+interface Mat4API {
   /**
-   * Creates a new identity Mat4Type
+   * Creates a new identity Mat4
    *
    * @returns a new 4x4 matrix
    */
-  create(): Mat4Type;
+  create(): Mat4;
 
   /**
-   * Creates a new Mat4Type initialized with values from an existing matrix
+   * Creates a new Mat4 initialized with values from an existing matrix
    *
    * @param a matrix to clone
    * @returns a new 4x4 matrix
    */
-  clone(a: Mat4Type): Mat4Type;
+  clone(a: Mat4): Mat4;
 
   /**
-   * Copy the values from one Mat4Type to another
+   * Copy the values from one Mat4 to another
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  copy(out: Mat4Type, a: Mat4Type): Mat4Type;
+  copy(out: Mat4, a: Mat4): Mat4;
 
 
   /**
-   * Create a new Mat4Type with the given values
+   * Create a new Mat4 with the given values
    *
    * @param {number} m00 Component in column 0, row 0 position (index 0)
    * @param {number} m01 Component in column 0, row 1 position (index 1)
@@ -2321,18 +2326,18 @@ interface Mat4Type extends Float32Array {
    * @param {number} m31 Component in column 3, row 1 position (index 13)
    * @param {number} m32 Component in column 3, row 2 position (index 14)
    * @param {number} m33 Component in column 3, row 3 position (index 15)
-   * @returns {Mat4Type} A new Mat4Type
+   * @returns {Mat4} A new Mat4
    */
   fromValues(
       m00: number, m01: number, m02: number, m03: number, m10: number,
       m11: number, m12: number, m13: number, m20: number, m21: number,
       m22: number, m23: number, m30: number, m31: number, m32: number,
-      m33: number): Mat4Type;
+      m33: number): Mat4;
 
   /**
-   * Set the components of a Mat4Type to the given values
+   * Set the components of a Mat4 to the given values
    *
-   * @param {Mat4Type} out the receiving matrix
+   * @param {Mat4} out the receiving matrix
    * @param {number} m00 Component in column 0, row 0 position (index 0)
    * @param {number} m01 Component in column 0, row 1 position (index 1)
    * @param {number} m02 Component in column 0, row 2 position (index 2)
@@ -2349,98 +2354,98 @@ interface Mat4Type extends Float32Array {
    * @param {number} m31 Component in column 3, row 1 position (index 13)
    * @param {number} m32 Component in column 3, row 2 position (index 14)
    * @param {number} m33 Component in column 3, row 3 position (index 15)
-   * @returns {Mat4Type} out
+   * @returns {Mat4} out
    */
-  set(out: Mat4Type, m00: number, m01: number, m02: number, m03: number,
+  set(out: Mat4, m00: number, m01: number, m02: number, m03: number,
       m10: number, m11: number, m12: number, m13: number, m20: number,
       m21: number, m22: number, m23: number, m30: number, m31: number,
-      m32: number, m33: number): Mat4Type;
+      m32: number, m33: number): Mat4;
 
   /**
-   * Set a Mat4Type to the identity matrix
+   * Set a Mat4 to the identity matrix
    *
    * @param out the receiving matrix
    * @returns out
    */
-  identity(out: Mat4Type): Mat4Type;
+  identity(out: Mat4): Mat4;
 
   /**
-   * Transpose the values of a Mat4Type
-   *
-   * @param out the receiving matrix
-   * @param a the source matrix
-   * @returns out
-   */
-  transpose(out: Mat4Type, a: Mat4Type): Mat4Type;
-
-  /**
-   * Inverts a Mat4Type
+   * Transpose the values of a Mat4
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  invert(out: Mat4Type, a: Mat4Type): Mat4Type|null;
+  transpose(out: Mat4, a: Mat4): Mat4;
 
   /**
-   * Calculates the adjugate of a Mat4Type
+   * Inverts a Mat4
    *
    * @param out the receiving matrix
    * @param a the source matrix
    * @returns out
    */
-  adjoint(out: Mat4Type, a: Mat4Type): Mat4Type;
+  invert(out: Mat4, a: Mat4): Mat4|null;
 
   /**
-   * Calculates the determinant of a Mat4Type
+   * Calculates the adjugate of a Mat4
+   *
+   * @param out the receiving matrix
+   * @param a the source matrix
+   * @returns out
+   */
+  adjoint(out: Mat4, a: Mat4): Mat4;
+
+  /**
+   * Calculates the determinant of a Mat4
    *
    * @param a the source matrix
    * @returns determinant of a
    */
-  determinant(a: Mat4Type): number;
+  determinant(a: Mat4): number;
 
   /**
-   * Multiplies two Mat4Type's
+   * Multiplies two Mat4's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: Mat4Type, a: Mat4Type, b: Mat4Type): Mat4Type;
+  multiply(out: Mat4, a: Mat4, b: Mat4): Mat4;
 
   /**
-   * Multiplies two Mat4Type's
+   * Multiplies two Mat4's
    *
    * @param out the receiving matrix
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: Mat4Type, a: Mat4Type, b: Mat4Type): Mat4Type;
+  mul(out: Mat4, a: Mat4, b: Mat4): Mat4;
 
   /**
-   * Translate a Mat4Type by the given vector
+   * Translate a Mat4 by the given vector
    *
    * @param out the receiving matrix
    * @param a the matrix to translate
    * @param v vector to translate by
    * @returns out
    */
-  translate(out: Mat4Type, a: Mat4Type, v: Vec3Type|number[]): Mat4Type;
+  translate(out: Mat4, a: Mat4, v: Vec3): Mat4;
 
   /**
-   * Scales the Mat4Type by the dimensions in the given Vec3Type
+   * Scales the Mat4 by the dimensions in the given Vec3
    *
    * @param out the receiving matrix
    * @param a the matrix to scale
-   * @param v the Vec3Type to scale the matrix by
+   * @param v the Vec3 to scale the matrix by
    * @returns out
    **/
-  scale(out: Mat4Type, a: Mat4Type, v: Vec3Type|number[]): Mat4Type;
+  scale(out: Mat4, a: Mat4, v: Vec3): Mat4;
 
   /**
-   * Rotates a Mat4Type by the given angle
+   * Rotates a Mat4 by the given angle
    *
    * @param out the receiving matrix
    * @param a the matrix to rotate
@@ -2448,8 +2453,7 @@ interface Mat4Type extends Float32Array {
    * @param axis the axis to rotate around
    * @returns out
    */
-  rotate(out: Mat4Type, a: Mat4Type, rad: number, axis: Vec3Type|number[]):
-      Mat4Type;
+  rotate(out: Mat4, a: Mat4, rad: number, axis: Vec3): Mat4;
 
   /**
    * Rotates a matrix by the given angle around the X axis
@@ -2459,7 +2463,7 @@ interface Mat4Type extends Float32Array {
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  rotateX(out: Mat4Type, a: Mat4Type, rad: number): Mat4Type;
+  rotateX(out: Mat4, a: Mat4, rad: number): Mat4;
 
   /**
    * Rotates a matrix by the given angle around the Y axis
@@ -2469,7 +2473,7 @@ interface Mat4Type extends Float32Array {
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  rotateY(out: Mat4Type, a: Mat4Type, rad: number): Mat4Type;
+  rotateY(out: Mat4, a: Mat4, rad: number): Mat4;
 
   /**
    * Rotates a matrix by the given angle around the Z axis
@@ -2479,188 +2483,184 @@ interface Mat4Type extends Float32Array {
    * @param rad the angle to rotate the matrix by
    * @returns out
    */
-  rotateZ(out: Mat4Type, a: Mat4Type, rad: number): Mat4Type;
+  rotateZ(out: Mat4, a: Mat4, rad: number): Mat4;
 
   /**
    * Creates a matrix from a vector translation
    * This is equivalent to (but much faster than):
    *
-   *     Mat4Type.identity(dest);
-   *     Mat4Type.translate(dest, dest, vec);
+   *     Mat4.identity(dest);
+   *     Mat4.translate(dest, dest, vec);
    *
-   * @param {Mat4Type} out Mat4Type receiving operation result
-   * @param {Vec3Type} v Translation vector
-   * @returns {Mat4Type} out
+   * @param {Mat4} out Mat4 receiving operation result
+   * @param {Vec3} v Translation vector
+   * @returns {Mat4} out
    */
-  fromTranslation(out: Mat4Type, v: Vec3Type|number[]): Mat4Type
+  fromTranslation(out: Mat4, v: Vec3): Mat4
 
   /**
    * Creates a matrix from a vector scaling
    * This is equivalent to (but much faster than):
    *
-   *     Mat4Type.identity(dest);
-   *     Mat4Type.scale(dest, dest, vec);
+   *     Mat4.identity(dest);
+   *     Mat4.scale(dest, dest, vec);
    *
-   * @param {Mat4Type} out Mat4Type receiving operation result
-   * @param {Vec3Type} v Scaling vector
-   * @returns {Mat4Type} out
+   * @param {Mat4} out Mat4 receiving operation result
+   * @param {Vec3} v Scaling vector
+   * @returns {Mat4} out
    */
-  fromScaling(out: Mat4Type, v: Vec3Type|number[]): Mat4Type
+  fromScaling(out: Mat4, v: Vec3): Mat4
 
   /**
    * Creates a matrix from a given angle around a given axis
    * This is equivalent to (but much faster than):
    *
-   *     Mat4Type.identity(dest);
-   *     Mat4Type.rotate(dest, dest, rad, axis);
+   *     Mat4.identity(dest);
+   *     Mat4.rotate(dest, dest, rad, axis);
    *
-   * @param {Mat4Type} out Mat4Type receiving operation result
+   * @param {Mat4} out Mat4 receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @param {Vec3Type} axis the axis to rotate around
-   * @returns {Mat4Type} out
+   * @param {Vec3} axis the axis to rotate around
+   * @returns {Mat4} out
    */
-  fromRotation(out: Mat4Type, rad: number, axis: Vec3Type|number[]): Mat4Type
+  fromRotation(out: Mat4, rad: number, axis: Vec3): Mat4
 
   /**
    * Creates a matrix from the given angle around the X axis
    * This is equivalent to (but much faster than):
    *
-   *     Mat4Type.identity(dest);
-   *     Mat4Type.rotateX(dest, dest, rad);
+   *     Mat4.identity(dest);
+   *     Mat4.rotateX(dest, dest, rad);
    *
-   * @param {Mat4Type} out Mat4Type receiving operation result
+   * @param {Mat4} out Mat4 receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @returns {Mat4Type} out
+   * @returns {Mat4} out
    */
-  fromXRotation(out: Mat4Type, rad: number): Mat4Type
+  fromXRotation(out: Mat4, rad: number): Mat4
 
   /**
    * Creates a matrix from the given angle around the Y axis
    * This is equivalent to (but much faster than):
    *
-   *     Mat4Type.identity(dest);
-   *     Mat4Type.rotateY(dest, dest, rad);
+   *     Mat4.identity(dest);
+   *     Mat4.rotateY(dest, dest, rad);
    *
-   * @param {Mat4Type} out Mat4Type receiving operation result
+   * @param {Mat4} out Mat4 receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @returns {Mat4Type} out
+   * @returns {Mat4} out
    */
-  fromYRotation(out: Mat4Type, rad: number): Mat4Type
+  fromYRotation(out: Mat4, rad: number): Mat4
 
 
   /**
    * Creates a matrix from the given angle around the Z axis
    * This is equivalent to (but much faster than):
    *
-   *     Mat4Type.identity(dest);
-   *     Mat4Type.rotateZ(dest, dest, rad);
+   *     Mat4.identity(dest);
+   *     Mat4.rotateZ(dest, dest, rad);
    *
-   * @param {Mat4Type} out Mat4Type receiving operation result
+   * @param {Mat4} out Mat4 receiving operation result
    * @param {number} rad the angle to rotate the matrix by
-   * @returns {Mat4Type} out
+   * @returns {Mat4} out
    */
-  fromZRotation(out: Mat4Type, rad: number): Mat4Type
+  fromZRotation(out: Mat4, rad: number): Mat4
 
   /**
    * Creates a matrix from a Quaternion rotation and vector translation
    * This is equivalent to (but much faster than):
    *
-   *     Mat4Type.identity(dest);
-   *     Mat4Type.translate(dest, vec);
-   *     var QuatMat = Mat4Type.create();
-   *     Quat4.toMat4(QuatType, QuatMat);
-   *     Mat4Type.multiply(dest, QuatMat);
+   *     Mat4.identity(dest);
+   *     Mat4.translate(dest, vec);
+   *     var QuatMat = Mat4.create();
+   *     Quat4.toMat4(Quat, QuatMat);
+   *     Mat4.multiply(dest, QuatMat);
    *
-   * @param out Mat4Type receiving operation result
+   * @param out Mat4 receiving operation result
    * @param q Rotation Quaternion
    * @param v Translation vector
    * @returns out
    */
-  fromRotationTranslation(out: Mat4Type, q: QuatType, v: Vec3Type|number[]):
-      Mat4Type;
+  fromRotationTranslation(out: Mat4, q: Quat, v: Vec3): Mat4;
 
   /**
    * Returns the translation vector component of a transformation
    *  matrix. If a matrix is built with fromRotationTranslation,
    *  the returned vector will be the same as the translation vector
    *  originally supplied.
-   * @param  {Vec3Type} out Vector to receive translation component
-   * @param  {Mat4Type} mat Matrix to be decomposed (input)
-   * @return {Vec3Type} out
+   * @param  {Vec3} out Vector to receive translation component
+   * @param  {Mat4} mat Matrix to be decomposed (input)
+   * @return {Vec3} out
    */
-  getTranslation(out: Vec3Type, mat: Mat4Type): Vec3Type;
+  getTranslation(out: Vec3, mat: Mat4): Vec3;
 
   /**
    * Returns a Quaternion representing the rotational component
    *  of a transformation matrix. If a matrix is built with
    *  fromRotationTranslation, the returned Quaternion will be the
    *  same as the Quaternion originally supplied.
-   * @param {QuatType} out Quaternion to receive the rotation component
-   * @param {Mat4Type} mat Matrix to be decomposed (input)
-   * @return {QuatType} out
+   * @param {Quat} out Quaternion to receive the rotation component
+   * @param {Mat4} mat Matrix to be decomposed (input)
+   * @return {Quat} out
    */
-  getRotation(out: QuatType, mat: Mat4Type): QuatType;
+  getRotation(out: Quat, mat: Mat4): Quat;
 
   /**
    * Creates a matrix from a Quaternion rotation, vector translation and
    * vector scale This is equivalent to (but much faster than):
    *
-   *     Mat4Type.identity(dest);
-   *     Mat4Type.translate(dest, vec);
-   *     var QuatMat = Mat4Type.create();
-   *     Quat4.toMat4(QuatType, QuatMat);
-   *     Mat4Type.multiply(dest, QuatMat);
-   *     Mat4Type.scale(dest, scale)
+   *     Mat4.identity(dest);
+   *     Mat4.translate(dest, vec);
+   *     var QuatMat = Mat4.create();
+   *     Quat4.toMat4(Quat, QuatMat);
+   *     Mat4.multiply(dest, QuatMat);
+   *     Mat4.scale(dest, scale)
    *
-   * @param out Mat4Type receiving operation result
+   * @param out Mat4 receiving operation result
    * @param q Rotation Quaternion
    * @param v Translation vector
    * @param s Scaling vector
    * @returns out
    */
-  fromRotationTranslationScale(
-      out: Mat4Type, q: QuatType, v: Vec3Type|number[],
-      s: Vec3Type|number[]): Mat4Type;
+  fromRotationTranslationScale(out: Mat4, q: Quat, v: Vec3, s: Vec3): Mat4;
 
   /**
    * Creates a matrix from a Quaternion rotation, vector translation and
    * vector scale, rotating and scaling around the given origin This is
    * equivalent to (but much faster than):
    *
-   *     Mat4Type.identity(dest);
-   *     Mat4Type.translate(dest, vec);
-   *     Mat4Type.translate(dest, origin);
-   *     var QuatMat = Mat4Type.create();
-   *     Quat4.toMat4(QuatType, QuatMat);
-   *     Mat4Type.multiply(dest, QuatMat);
-   *     Mat4Type.scale(dest, scale)
-   *     Mat4Type.translate(dest, negativeOrigin);
+   *     Mat4.identity(dest);
+   *     Mat4.translate(dest, vec);
+   *     Mat4.translate(dest, origin);
+   *     var QuatMat = Mat4.create();
+   *     Quat4.toMat4(Quat, QuatMat);
+   *     Mat4.multiply(dest, QuatMat);
+   *     Mat4.scale(dest, scale)
+   *     Mat4.translate(dest, negativeOrigin);
    *
-   * @param {Mat4Type} out Mat4Type receiving operation result
-   * @param {QuatType} q Rotation Quaternion
-   * @param {Vec3Type} v Translation vector
-   * @param {Vec3Type} s Scaling vector
-   * @param {Vec3Type} o The origin vector around which to scale and rotate
-   * @returns {Mat4Type} out
+   * @param {Mat4} out Mat4 receiving operation result
+   * @param {Quat} q Rotation Quaternion
+   * @param {Vec3} v Translation vector
+   * @param {Vec3} s Scaling vector
+   * @param {Vec3} o The origin vector around which to scale and rotate
+   * @returns {Mat4} out
    */
   fromRotationTranslationScaleOrigin(
-      out: Mat4Type, q: QuatType, v: Vec3Type|number[], s: Vec3Type|number[],
-      o: Vec3Type|number[]): Mat4Type
+      out: Mat4, q: Quat, v: Vec3, s: Vec3, o: Vec3): Mat4
 
   /**
    * Calculates a 4x4 matrix from the given Quaternion
    *
-   * @param {Mat4Type} out Mat4Type receiving operation result
-   * @param {QuatType} q Quaternion to create matrix from
+   * @param {Mat4} out Mat4 receiving operation result
+   * @param {Quat} q Quaternion to create matrix from
    *
-   * @returns {Mat4Type} out
+   * @returns {Mat4} out
    */
-  fromQuat(out: Mat4Type, q: QuatType): Mat4Type
+  fromQuat(out: Mat4, q: Quat): Mat4
 
   /**
    * Generates a frustum matrix with the given bounds
    *
-   * @param out Mat4Type frustum matrix will be written into
+   * @param out Mat4 frustum matrix will be written into
    * @param left Left bound of the frustum
    * @param right Right bound of the frustum
    * @param bottom Bottom bound of the frustum
@@ -2670,13 +2670,13 @@ interface Mat4Type extends Float32Array {
    * @returns out
    */
   frustum(
-      out: Mat4Type, left: number, right: number, bottom: number, top: number,
-      near: number, far: number): Mat4Type;
+      out: Mat4, left: number, right: number, bottom: number, top: number,
+      near: number, far: number): Mat4;
 
   /**
    * Generates a perspective projection matrix with the given bounds
    *
-   * @param out Mat4Type frustum matrix will be written into
+   * @param out Mat4 frustum matrix will be written into
    * @param fovy Vertical field of view in radians
    * @param aspect Aspect ratio. typically viewport width/height
    * @param near Near bound of the frustum
@@ -2684,34 +2684,33 @@ interface Mat4Type extends Float32Array {
    * @returns out
    */
   perspective(
-      out: Mat4Type, fovy: number, aspect: number, near: number,
-      far: number): Mat4Type;
+      out: Mat4, fovy: number, aspect: number, near: number, far: number): Mat4;
 
   /**
    * Generates a perspective projection matrix with the given field of view.
    * This is primarily useful for generating projection matrices to be used
    * with the still experimental WebVR API.
    *
-   * @param {Mat4Type} out Mat4Type frustum matrix will be written into
+   * @param {Mat4} out Mat4 frustum matrix will be written into
    * @param {Object} fov Object containing the following values: upDegrees,
    *     downDegrees, leftDegrees, rightDegrees
    * @param {number} near Near bound of the frustum
    * @param {number} far Far bound of the frustum
-   * @returns {Mat4Type} out
+   * @returns {Mat4} out
    */
   perspectiveFromFieldOfView(
-      out: Mat4Type, fov: {
+      out: Mat4, fov: {
         upDegrees: number,
         downDegrees: number,
         leftDegrees: number,
         rightDegrees: number
       },
-      near: number, far: number): Mat4Type
+      near: number, far: number): Mat4
 
   /**
    * Generates a orthogonal projection matrix with the given bounds
    *
-   * @param out Mat4Type frustum matrix will be written into
+   * @param out Mat4 frustum matrix will be written into
    * @param left Left bound of the frustum
    * @param right Right bound of the frustum
    * @param bottom Bottom bound of the frustum
@@ -2721,134 +2720,131 @@ interface Mat4Type extends Float32Array {
    * @returns out
    */
   ortho(
-      out: Mat4Type, left: number, right: number, bottom: number, top: number,
-      near: number, far: number): Mat4Type;
+      out: Mat4, left: number, right: number, bottom: number, top: number,
+      near: number, far: number): Mat4;
 
   /**
    * Generates a look-at matrix with the given eye position, focal point, and
    * up axis
    *
-   * @param out Mat4Type frustum matrix will be written into
+   * @param out Mat4 frustum matrix will be written into
    * @param eye Position of the viewer
    * @param center Point the viewer is looking at
-   * @param up Vec3Type pointing up
+   * @param up Vec3 pointing up
    * @returns out
    */
-  lookAt(
-      out: Mat4Type, eye: Vec3Type|number[], center: Vec3Type|number[],
-      up: Vec3Type|number[]): Mat4Type;
+  lookAt(out: Mat4, eye: Vec3, center: Vec3, up: Vec3): Mat4;
 
   /**
-   * Returns a string representation of a Mat4Type
+   * Returns a string representation of a Mat4
    *
    * @param mat matrix to represent as a string
    * @returns string representation of the matrix
    */
-  str(mat: Mat4Type): string;
+  str(mat: Mat4): string;
 
   /**
-   * Returns Frobenius norm of a Mat4Type
+   * Returns Frobenius norm of a Mat4
    *
    * @param a the matrix to calculate Frobenius norm of
    * @returns Frobenius norm
    */
-  frob(a: Mat4Type): number;
+  frob(a: Mat4): number;
 
   /**
-   * Adds two Mat4Type's
+   * Adds two Mat4's
    *
-   * @param {Mat4Type} out the receiving matrix
-   * @param {Mat4Type} a the first operand
-   * @param {Mat4Type} b the second operand
-   * @returns {Mat4Type} out
+   * @param {Mat4} out the receiving matrix
+   * @param {Mat4} a the first operand
+   * @param {Mat4} b the second operand
+   * @returns {Mat4} out
    */
-  add(out: Mat4Type, a: Mat4Type, b: Mat4Type): Mat4Type
-
-  /**
-   * Subtracts matrix b from matrix a
-   *
-   * @param {Mat4Type} out the receiving matrix
-   * @param {Mat4Type} a the first operand
-   * @param {Mat4Type} b the second operand
-   * @returns {Mat4Type} out
-   */
-  subtract(out: Mat4Type, a: Mat4Type, b: Mat4Type): Mat4Type
+  add(out: Mat4, a: Mat4, b: Mat4): Mat4
 
   /**
    * Subtracts matrix b from matrix a
    *
-   * @param {Mat4Type} out the receiving matrix
-   * @param {Mat4Type} a the first operand
-   * @param {Mat4Type} b the second operand
-   * @returns {Mat4Type} out
+   * @param {Mat4} out the receiving matrix
+   * @param {Mat4} a the first operand
+   * @param {Mat4} b the second operand
+   * @returns {Mat4} out
    */
-  sub(out: Mat4Type, a: Mat4Type, b: Mat4Type): Mat4Type
+  subtract(out: Mat4, a: Mat4, b: Mat4): Mat4
+
+  /**
+   * Subtracts matrix b from matrix a
+   *
+   * @param {Mat4} out the receiving matrix
+   * @param {Mat4} a the first operand
+   * @param {Mat4} b the second operand
+   * @returns {Mat4} out
+   */
+  sub(out: Mat4, a: Mat4, b: Mat4): Mat4
 
   /**
    * Multiply each element of the matrix by a scalar.
    *
-   * @param {Mat4Type} out the receiving matrix
-   * @param {Mat4Type} a the matrix to scale
+   * @param {Mat4} out the receiving matrix
+   * @param {Mat4} a the matrix to scale
    * @param {number} b amount to scale the matrix's elements by
-   * @returns {Mat4Type} out
+   * @returns {Mat4} out
    */
-  multiplyScalar(out: Mat4Type, a: Mat4Type, b: number): Mat4Type
+  multiplyScalar(out: Mat4, a: Mat4, b: number): Mat4
 
   /**
-   * Adds two Mat4Type's after multiplying each element of the second operand
+   * Adds two Mat4's after multiplying each element of the second operand
    * by a scalar value.
    *
-   * @param {Mat4Type} out the receiving vector
-   * @param {Mat4Type} a the first operand
-   * @param {Mat4Type} b the second operand
+   * @param {Mat4} out the receiving vector
+   * @param {Mat4} a the first operand
+   * @param {Mat4} b the second operand
    * @param {number} scale the amount to scale b's elements by before
    *     adding
-   * @returns {Mat4Type} out
+   * @returns {Mat4} out
    */
-  multiplyScalarAndAdd(out: Mat4Type, a: Mat4Type, b: Mat4Type, scale: number):
-      Mat4Type
+  multiplyScalarAndAdd(out: Mat4, a: Mat4, b: Mat4, scale: number): Mat4
 
   /**
    * Returns whether or not the matrices have exactly the same elements in
    * the same position (when compared with ===)
    *
-   * @param {Mat4Type} a The first matrix.
-   * @param {Mat4Type} b The second matrix.
+   * @param {Mat4} a The first matrix.
+   * @param {Mat4} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  exactEquals(a: Mat4Type, b: Mat4Type): boolean
+  exactEquals(a: Mat4, b: Mat4): boolean
 
   /**
    * Returns whether or not the matrices have approximately the same
    * elements in the same position.
    *
-   * @param {Mat4Type} a The first matrix.
-   * @param {Mat4Type} b The second matrix.
+   * @param {Mat4} a The first matrix.
+   * @param {Mat4} b The second matrix.
    * @returns {boolean} True if the matrices are equal, false otherwise.
    */
-  equals(a: Mat4Type, b: Mat4Type): boolean
+  equals(a: Mat4, b: Mat4): boolean
 }
 
-// QuatType
-interface QuatType extends Float32Array {
+// Quat
+interface QuatAPI {
   /**
-   * Creates a new identity QuatType
+   * Creates a new identity Quat
    *
    * @returns a new Quaternion
    */
-  create(): QuatType;
+  create(): Quat;
 
   /**
-   * Creates a new QuatType initialized with values from an existing Quaternion
+   * Creates a new Quat initialized with values from an existing Quaternion
    *
    * @param a Quaternion to clone
    * @returns a new Quaternion
    * @function
    */
-  clone(a: QuatType): QuatType;
+  clone(a: Quat): Quat;
 
   /**
-   * Creates a new QuatType initialized with the given values
+   * Creates a new Quat initialized with the given values
    *
    * @param x X component
    * @param y Y component
@@ -2857,20 +2853,20 @@ interface QuatType extends Float32Array {
    * @returns a new Quaternion
    * @function
    */
-  fromValues(x: number, y: number, z: number, w: number): QuatType;
+  fromValues(x: number, y: number, z: number, w: number): Quat;
 
   /**
-   * Copy the values from one QuatType to another
+   * Copy the values from one Quat to another
    *
    * @param out the receiving Quaternion
    * @param a the source Quaternion
    * @returns out
    * @function
    */
-  copy(out: QuatType, a: QuatType): QuatType;
+  copy(out: Quat, a: Quat): Quat;
 
   /**
-   * Set the components of a QuatType to the given values
+   * Set the components of a Quat to the given values
    *
    * @param out the receiving Quaternion
    * @param x X component
@@ -2880,15 +2876,15 @@ interface QuatType extends Float32Array {
    * @returns out
    * @function
    */
-  set(out: QuatType, x: number, y: number, z: number, w: number): QuatType;
+  set(out: Quat, x: number, y: number, z: number, w: number): Quat;
 
   /**
-   * Set a QuatType to the identity Quaternion
+   * Set a Quat to the identity Quaternion
    *
    * @param out the receiving Quaternion
    * @returns out
    */
-  identity(out: QuatType): QuatType;
+  identity(out: Quat): Quat;
 
   /**
    * Sets a Quaternion to represent the shortest rotation from one
@@ -2896,32 +2892,29 @@ interface QuatType extends Float32Array {
    *
    * Both vectors are assumed to be unit length.
    *
-   * @param {QuatType} out the receiving Quaternion.
-   * @param {Vec3Type} a the initial vector
-   * @param {Vec3Type} b the destination vector
-   * @returns {QuatType} out
+   * @param {Quat} out the receiving Quaternion.
+   * @param {Vec3} a the initial vector
+   * @param {Vec3} b the destination vector
+   * @returns {Quat} out
    */
-  rotationTo(out: QuatType, a: Vec3Type|number[], b: Vec3Type|number[]):
-      QuatType;
+  rotationTo(out: Quat, a: Vec3, b: Vec3): Quat;
 
   /**
    * Sets the specified Quaternion with values corresponding to the given
-   * axes. Each axis is a Vec3Type and is expected to be unit length and
+   * axes. Each axis is a Vec3 and is expected to be unit length and
    * perpendicular to all other specified axes.
    *
-   * @param {Vec3Type} view  the vector representing the viewing direction
-   * @param {Vec3Type} right the vector representing the local "right" direction
-   * @param {Vec3Type} up    the vector representing the local "up" direction
-   * @returns {QuatType} out
+   * @param {Vec3} view  the vector representing the viewing direction
+   * @param {Vec3} right the vector representing the local "right" direction
+   * @param {Vec3} up    the vector representing the local "up" direction
+   * @returns {Quat} out
    */
-  setAxes(
-      out: QuatType, view: Vec3Type|number[], right: Vec3Type|number[],
-      up: Vec3Type|number[]): QuatType
+  setAxes(out: Quat, view: Vec3, right: Vec3, up: Vec3): Quat
 
 
 
   /**
-   * Sets a QuatType from the given angle and rotation axis,
+   * Sets a Quat from the given angle and rotation axis,
    * then returns it.
    *
    * @param out the receiving Quaternion
@@ -2929,7 +2922,7 @@ interface QuatType extends Float32Array {
    * @param rad the angle in radians
    * @returns out
    **/
-  setAxisAngle(out: QuatType, axis: Vec3Type|number[], rad: number): QuatType;
+  setAxisAngle(out: Quat, axis: Vec3, rad: number): Quat;
 
   /**
    * Gets the rotation axis and angle for a given
@@ -2940,14 +2933,14 @@ interface QuatType extends Float32Array {
    * Example: The Quaternion formed by axis [0, 0, 1] and
    *  angle -90 is the same as the Quaternion formed by
    *  [0, 0, 1] and 270. This method favors the latter.
-   * @param  {Vec3Type} out_axis  Vector receiving the axis of rotation
-   * @param  {QuatType} q     Quaternion to be decomposed
+   * @param  {Vec3} out_axis  Vector receiving the axis of rotation
+   * @param  {Quat} q     Quaternion to be decomposed
    * @return {number}     Angle, in radians, of the rotation
    */
-  getAxisAngle(out_axis: Vec3Type|number[], q: QuatType): number
+  getAxisAngle(out_axis: Vec3, q: Quat): number
 
   /**
-   * Adds two QuatType's
+   * Adds two Quat's
    *
    * @param out the receiving Quaternion
    * @param a the first operand
@@ -2955,30 +2948,30 @@ interface QuatType extends Float32Array {
    * @returns out
    * @function
    */
-  add(out: QuatType, a: QuatType, b: QuatType): QuatType;
+  add(out: Quat, a: Quat, b: Quat): Quat;
 
   /**
-   * Multiplies two QuatType's
+   * Multiplies two Quat's
    *
    * @param out the receiving Quaternion
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  multiply(out: QuatType, a: QuatType, b: QuatType): QuatType;
+  multiply(out: Quat, a: Quat, b: Quat): Quat;
 
   /**
-   * Multiplies two QuatType's
+   * Multiplies two Quat's
    *
    * @param out the receiving Quaternion
    * @param a the first operand
    * @param b the second operand
    * @returns out
    */
-  mul(out: QuatType, a: QuatType, b: QuatType): QuatType;
+  mul(out: Quat, a: Quat, b: Quat): Quat;
 
   /**
-   * Scales a QuatType by a scalar number
+   * Scales a Quat by a scalar number
    *
    * @param out the receiving vector
    * @param a the vector to scale
@@ -2986,66 +2979,66 @@ interface QuatType extends Float32Array {
    * @returns out
    * @function
    */
-  scale(out: QuatType, a: QuatType, b: number): QuatType;
+  scale(out: Quat, a: Quat, b: number): Quat;
 
   /**
-   * Calculates the length of a QuatType
+   * Calculates the length of a Quat
    *
    * @param a vector to calculate length of
    * @returns length of a
    * @function
    */
-  length(a: QuatType): number;
+  length(a: Quat): number;
 
   /**
-   * Calculates the length of a QuatType
+   * Calculates the length of a Quat
    *
    * @param a vector to calculate length of
    * @returns length of a
    * @function
    */
-  len(a: QuatType): number;
+  len(a: Quat): number;
 
   /**
-   * Calculates the squared length of a QuatType
+   * Calculates the squared length of a Quat
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    * @function
    */
-  squaredLength(a: QuatType): number;
+  squaredLength(a: Quat): number;
 
   /**
-   * Calculates the squared length of a QuatType
+   * Calculates the squared length of a Quat
    *
    * @param a vector to calculate squared length of
    * @returns squared length of a
    * @function
    */
-  sqrLen(a: QuatType): number;
+  sqrLen(a: Quat): number;
 
   /**
-   * Normalize a QuatType
+   * Normalize a Quat
    *
    * @param out the receiving Quaternion
    * @param a Quaternion to normalize
    * @returns out
    * @function
    */
-  normalize(out: QuatType, a: QuatType): QuatType;
+  normalize(out: Quat, a: Quat): Quat;
 
   /**
-   * Calculates the dot product of two QuatType's
+   * Calculates the dot product of two Quat's
    *
    * @param a the first operand
    * @param b the second operand
    * @returns dot product of a and b
    * @function
    */
-  dot(a: QuatType, b: QuatType): number;
+  dot(a: Quat, b: Quat): number;
 
   /**
-   * Performs a linear interpolation between two QuatType's
+   * Performs a linear interpolation between two Quat's
    *
    * @param out the receiving Quaternion
    * @param a the first operand
@@ -3054,10 +3047,10 @@ interface QuatType extends Float32Array {
    * @returns out
    * @function
    */
-  lerp(out: QuatType, a: QuatType, b: QuatType, t: number): QuatType;
+  lerp(out: Quat, a: Quat, b: Quat, t: number): Quat;
 
   /**
-   * Performs a spherical linear interpolation between two QuatType
+   * Performs a spherical linear interpolation between two Quat
    *
    * @param out the receiving Quaternion
    * @param a the first operand
@@ -3065,80 +3058,78 @@ interface QuatType extends Float32Array {
    * @param t interpolation amount between the two inputs
    * @returns out
    */
-  slerp(out: QuatType, a: QuatType, b: QuatType, t: number): QuatType;
+  slerp(out: Quat, a: Quat, b: Quat, t: number): Quat;
 
   /**
    * Performs a spherical linear interpolation with two control points
    *
-   * @param {QuatType} out the receiving Quaternion
-   * @param {QuatType} a the first operand
-   * @param {QuatType} b the second operand
-   * @param {QuatType} c the third operand
-   * @param {QuatType} d the fourth operand
+   * @param {Quat} out the receiving Quaternion
+   * @param {Quat} a the first operand
+   * @param {Quat} b the second operand
+   * @param {Quat} c the third operand
+   * @param {Quat} d the fourth operand
    * @param {number} t interpolation amount
-   * @returns {QuatType} out
+   * @returns {Quat} out
    */
-  sqlerp(
-      out: QuatType, a: QuatType, b: QuatType, c: QuatType, d: QuatType,
-      t: number): QuatType;
+  sqlerp(out: Quat, a: Quat, b: Quat, c: Quat, d: Quat, t: number): Quat;
 
   /**
-   * Calculates the inverse of a QuatType
+   * Calculates the inverse of a Quat
    *
    * @param out the receiving Quaternion
-   * @param a QuatType to calculate inverse of
+   * @param a Quat to calculate inverse of
    * @returns out
    */
-  invert(out: QuatType, a: QuatType): QuatType;
+  invert(out: Quat, a: Quat): Quat;
 
   /**
-   * Calculates the conjugate of a QuatType
+   * Calculates the conjugate of a Quat
    * If the Quaternion is normalized, this function is faster than
-   * QuatType.inverse and produces the same result.
+   * Quat.inverse and produces the same result.
    *
    * @param out the receiving Quaternion
-   * @param a QuatType to calculate conjugate of
+   * @param a Quat to calculate conjugate of
    * @returns out
    */
-  conjugate(out: QuatType, a: QuatType): QuatType;
+  conjugate(out: Quat, a: Quat): Quat;
 
   /**
    * Returns a string representation of a Quaternion
    *
-   * @param a QuatType to represent as a string
-   * @returns string representation of the QuatType
+   * @param a Quat to represent as a string
+   * @returns string representation of the Quat
    */
-  str(a: QuatType): string;
+  str(a: Quat): string;
 
   /**
    * Rotates a Quaternion by the given angle about the X axis
    *
-   * @param out QuatType receiving operation result
-   * @param a QuatType to rotate
+   * @param out Quat receiving operation result
+   * @param a Quat to rotate
    * @param rad angle (in radians) to rotate
    * @returns out
    */
-  rotateX(out: QuatType, a: QuatType, rad: number): QuatType;
+  rotateX(out: Quat, a: Quat, rad: number): Quat;
 
   /**
    * Rotates a Quaternion by the given angle about the Y axis
    *
-   * @param out QuatType receiving operation result
-   * @param a QuatType to rotate
+   * @param out Quat receiving operation result
+   * @param a Quat to rotate
    * @param rad angle (in radians) to rotate
    * @returns out
    */
-  rotateY(out: QuatType, a: QuatType, rad: number): QuatType;
+  rotateY(out: Quat, a: Quat, rad: number): Quat;
 
   /**
    * Rotates a Quaternion by the given angle about the Z axis
    *
-   * @param out QuatType receiving operation result
-   * @param a QuatType to rotate
+   * @param out Quat receiving operation result
+   * @param a Quat to rotate
    * @param rad angle (in radians) to rotate
    * @returns out
    */
-  rotateZ(out: QuatType, a: QuatType, rad: number): QuatType;
+  rotateZ(out: Quat, a: Quat, rad: number): Quat;
 
   /**
    * Creates a Quaternion from the given 3x3 rotation matrix.
@@ -3151,22 +3142,20 @@ interface QuatType extends Float32Array {
    * @returns out
    * @function
    */
-  fromMat3(out: QuatType, m: Mat3Type): QuatType;
+  fromMat3(out: Quat, m: Mat3): Quat;
 
   /**
    * Sets the specified Quaternion with values corresponding to the given
-   * axes. Each axis is a Vec3Type and is expected to be unit length and
+   * axes. Each axis is a Vec3 and is expected to be unit length and
    * perpendicular to all other specified axes.
    *
-   * @param out the receiving QuatType
+   * @param out the receiving Quat
    * @param view  the vector representing the viewing direction
    * @param right the vector representing the local "right" direction
    * @param up    the vector representing the local "up" direction
    * @returns out
    */
-  setAxes(
-      out: QuatType, view: Vec3Type|number[], right: Vec3Type|number[],
-      up: Vec3Type|number[]): QuatType;
+  setAxes(out: Quat, view: Vec3, right: Vec3, up: Vec3): Quat;
 
   /**
    * Sets a Quaternion to represent the shortest rotation from one
@@ -3179,37 +3168,36 @@ interface QuatType extends Float32Array {
    * @param b the destination vector
    * @returns out
    */
-  rotationTo(out: QuatType, a: Vec3Type|number[], b: Vec3Type|number[]):
-      QuatType;
+  rotationTo(out: Quat, a: Vec3, b: Vec3): Quat;
 
   /**
-   * Calculates the W component of a QuatType from the X, Y, and Z components.
+   * Calculates the W component of a Quat from the X, Y, and Z components.
    * Assumes that Quaternion is 1 unit in length.
    * Any existing W component will be ignored.
    *
    * @param out the receiving Quaternion
-   * @param a QuatType to calculate W component of
+   * @param a Quat to calculate W component of
    * @returns out
    */
-  calculateW(out: QuatType, a: QuatType): QuatType;
+  calculateW(out: Quat, a: Quat): Quat;
 
   /**
    * Returns whether or not the Quaternions have exactly the same elements in
    * the same position (when compared with ===)
    *
-   * @param {QuatType} a The first vector.
-   * @param {QuatType} b The second vector.
+   * @param {Quat} a The first vector.
+   * @param {Quat} b The second vector.
    * @returns {boolean} True if the Quaternions are equal, false otherwise.
    */
-  exactEquals(a: QuatType, b: QuatType): boolean;
+  exactEquals(a: Quat, b: Quat): boolean;
 
   /**
    * Returns whether or not the Quaternions have approximately the same
    * elements in the same position.
    *
-   * @param {QuatType} a The first vector.
-   * @param {QuatType} b The second vector.
+   * @param {Quat} a The first vector.
+   * @param {Quat} b The second vector.
    * @returns {boolean} True if the Quaternions are equal, false otherwise.
    */
-  equals(a: QuatType, b: QuatType): boolean;
+  equals(a: Quat, b: Quat): boolean;
 }

--- a/bindings/wasm/examples/examples.js
+++ b/bindings/wasm/examples/examples.js
@@ -34,7 +34,9 @@ export const examples = {
       // To share your code with another browser/device, simply copy the text to
       // a file.
 
-      // See the script drop-down above ("Intro") for usage examples.
+      // See the script drop-down above ("Intro") for usage examples. The
+      // gl-matrix package from npm is automatically imported for convenience -
+      // its API is available in the top-level glMatrix object.
       return result;
     },
 
@@ -47,8 +49,7 @@ export const examples = {
 
       const edgeLength = 50;  // Length of each edge of the overall tetrahedron.
       const gap = 0.2;  // Spacing between the two halves to allow sliding.
-      const nDivisions =
-          50;  // Number of divisions (both ways) in the screw surface.
+      const nDivisions = 50;  // Divisions (both ways) in the screw surface.
 
       const scale = edgeLength / (2 * Math.sqrt(2));
 
@@ -78,23 +79,19 @@ export const examples = {
         const edge = cylinder(edgeLength, radius, -1, circularSegments);
         const corner = sphere(radius, circularSegments);
 
-        let edge1 = union(corner, edge);
-        edge1 = edge1.rotate([-90, 0, 0]).translate([
+        const edge1 = union(corner, edge).rotate([-90, 0, 0]).translate([
           -edgeLength / 2, -edgeLength / 2, 0
         ]);
 
-        let edge2 = edge1.rotate([0, 0, 180]);
-        edge2 = union(edge2, edge1);
-        edge2 =
-            union(edge2, edge.translate([-edgeLength / 2, -edgeLength / 2, 0]));
+        const edge2 = union(
+            union(edge1, edge1.rotate([0, 0, 180])),
+            edge.translate([-edgeLength / 2, -edgeLength / 2, 0]));
 
-        let edge4 = edge2.rotate([0, 0, 90]);
-        edge4 = union(edge4, edge2);
+        const edge4 = union(edge2, edge2.rotate([0, 0, 90])).translate([
+          0, 0, -edgeLength / 2
+        ]);
 
-        let frame = edge4.translate([0, 0, -edgeLength / 2]);
-        frame = union(frame, frame.rotate([180, 0, 0]));
-
-        return frame;
+        return union(edge4, edge4.rotate([180, 0, 0]));
       }
 
       setMinCircularAngle(3);
@@ -275,10 +272,7 @@ export const examples = {
     MengerSponge: function() {
       // This example demonstrates how symbolic perturbation correctly creates
       // holes even though the subtracted objects are exactly coplanar.
-
-      function vec2add(a, b) {
-        return [a[0] + b[0], a[1] + b[1]];
-      }
+      const {vec2} = glMatrix;
 
       function fractal(holes, hole, w, position, depth, maxDepth) {
         w /= 3;
@@ -291,7 +285,8 @@ export const examples = {
         ];
         for (let offset of offsets)
           fractal(
-              holes, hole, w, vec2add(position, offset), depth + 1, maxDepth);
+              holes, hole, w, vec2.add(offset, position, offset), depth + 1,
+              maxDepth);
       }
 
       function mengerSponge(n) {
@@ -315,17 +310,11 @@ export const examples = {
     StretchyBracelet: function() {
       // Recreates Stretchy Bracelet by Emmett Lalish:
       // https://www.thingiverse.com/thing:13505
+      const {vec2} = glMatrix;
 
       function base(
           width, radius, decorRadius, twistRadius, nDecor, innerRadius,
           outerRadius, cut, nCut, nDivision) {
-        function rotate(v, theta) {
-          return [
-            v[0] * Math.cos(theta) - v[1] * Math.sin(theta),
-            v[0] * Math.sin(theta) + v[1] * Math.cos(theta)
-          ];
-        }
-
         let b = cylinder(width, radius + twistRadius / 2);
         const circle = [];
         const dPhiDeg = 180 / nDivision;
@@ -343,14 +332,15 @@ export const examples = {
         const stretch = [];
         const dPhiRad = 2 * Math.PI / nCut;
 
+        const o = [0, 0];
         const p0 = [outerRadius, 0];
         const p1 = [innerRadius, -cut];
         const p2 = [innerRadius, cut];
         for (let i = 0; i < nCut; ++i) {
-          stretch.push(rotate(p0, dPhiRad * i));
-          stretch.push(rotate(p1, dPhiRad * i));
-          stretch.push(rotate(p2, dPhiRad * i));
-          stretch.push(rotate(p0, dPhiRad * i));
+          stretch.push(vec2.rotate([0, 0], p0, o, dPhiRad * i));
+          stretch.push(vec2.rotate([0, 0], p1, o, dPhiRad * i));
+          stretch.push(vec2.rotate([0, 0], p2, o, dPhiRad * i));
+          stretch.push(vec2.rotate([0, 0], p0, o, dPhiRad * i));
         }
         b = intersection(extrude(stretch, width), b);
         return b;

--- a/bindings/wasm/examples/examples.js
+++ b/bindings/wasm/examples/examples.js
@@ -215,6 +215,8 @@ export const examples = {
       function torusKnot(
           p, q, majorRadius, minorRadius, threadRadius, circularSegments = 0,
           linearSegments = 0) {
+        const {vec3} = glMatrix;
+
         function gcd(a, b) {
           return b == 0 ? a : gcd(b, a % b);
         }
@@ -234,42 +236,20 @@ export const examples = {
           circle.push([Math.cos(dPhi * i) + offset, Math.sin(dPhi * i)]);
         }
 
-        function rotateVector(v, axis, angle) {
-          const cos = Math.cos(angle);
-          const sin = Math.sin(angle);
-          const c = (1 - cos) * (v.x * axis.x + v.y * axis.y + v.z * axis.z);
-
-          const x =
-              cos * v.x + sin * (axis.y * v.z - axis.z * v.y) + c * axis.x;
-          const y =
-              cos * v.y + sin * (axis.z * v.x - axis.x * v.z) + c * axis.y;
-          const z =
-              cos * v.z + sin * (axis.x * v.y - axis.y * v.x) + c * axis.z;
-          v.x = x;
-          v.y = y;
-          v.z = z;
-        }
-
         const func = (v) => {
           const psi = q * Math.atan2(v[0], v[1]);
           const theta = psi * p / q;
           const x1 = Math.sqrt(v[0] * v[0] + v[1] * v[1]);
           const phi = Math.atan2(x1 - offset, v[2]);
-          const point = {
-            x: threadRadius * Math.cos(phi),
-            y: 0,
-            z: threadRadius * Math.sin(phi)
-          };
+          vec3.set(
+              v, threadRadius * Math.cos(phi), 0, threadRadius * Math.sin(phi));
+          const center = [0, 0, 0];
           const r = majorRadius + minorRadius * Math.cos(theta);
-          rotateVector(
-              point, {x: 1, y: 0, z: 0}, -Math.atan2(p * minorRadius, q * r));
-          point.x += minorRadius;
-          rotateVector(point, {x: 0, y: 1, z: 0}, theta);
-          point.x += majorRadius;
-          rotateVector(point, {x: 0, y: 0, z: 1}, psi);
-          v[0] = point.x;
-          v[1] = point.y;
-          v[2] = point.z;
+          vec3.rotateX(v, v, center, -Math.atan2(p * minorRadius, q * r));
+          v[0] += minorRadius;
+          vec3.rotateY(v, v, center, theta);
+          v[0] += majorRadius;
+          vec3.rotateZ(v, v, center, psi);
         };
 
         let knot = revolve(circle, m).warp(func);

--- a/bindings/wasm/examples/examples.js
+++ b/bindings/wasm/examples/examples.js
@@ -157,9 +157,9 @@ export const examples = {
       const sharpness = 0.8;
       const n = 50;
 
-      const vertPos = [];
-      const triVerts = [];
-      vertPos.push(-offset, 0, height, -offset, 0, -height);
+      const positions = [];
+      const triangles = [];
+      positions.push(-offset, 0, height, -offset, 0, -height);
       const sharpenedEdges = [];
 
       const delta = 3.14159 / wiggles;
@@ -167,25 +167,25 @@ export const examples = {
         const theta = (i - wiggles) * delta;
         const amp = 0.5 * height * Math.max(Math.cos(0.8 * theta), 0);
 
-        vertPos.push(
+        positions.push(
             radius * Math.cos(theta), radius * Math.sin(theta),
             amp * (i % 2 == 0 ? 1 : -1));
         let j = i + 1;
         if (j == 2 * wiggles) j = 0;
 
         const smoothness = 1 - sharpness * Math.cos((theta + delta / 2) / 2);
-        let halfedge = triVerts.length + 1;
+        let halfedge = triangles.length + 1;
         sharpenedEdges.push({halfedge, smoothness});
-        triVerts.push(0, 2 + i, 2 + j);
+        triangles.push(0, 2 + i, 2 + j);
 
-        halfedge = triVerts.length + 1;
+        halfedge = triangles.length + 1;
         sharpenedEdges.push({halfedge, smoothness});
-        triVerts.push(1, 2 + j, 2 + i);
+        triangles.push(1, 2 + j, 2 + i);
       }
 
-      const scallop = new Mesh();
-      scallop.triVerts = Uint32Array.from(triVerts);
-      scallop.vertProperties = Float32Array.from(vertPos);
+      const triVerts = Uint32Array.from(triangles);
+      const vertProperties = Float32Array.from(positions);
+      const scallop = new Mesh({numProp: 3, triVerts, vertProperties});
       const result = smooth(scallop, sharpenedEdges).refine(n);
       return result;
     },
@@ -240,7 +240,7 @@ export const examples = {
           const phi = Math.atan2(x1 - offset, v[2]);
           vec3.set(
               v, threadRadius * Math.cos(phi), 0, threadRadius * Math.sin(phi));
-          const center = [0, 0, 0];
+          const center = vec3.fromValues(0, 0, 0);
           const r = majorRadius + minorRadius * Math.cos(theta);
           vec3.rotateX(v, v, center, -Math.atan2(p * minorRadius, q * r));
           v[0] += minorRadius;
@@ -280,8 +280,10 @@ export const examples = {
             hole.scale([w, w, 1.0]).translate([position[0], position[1], 0.0]));
         if (depth == maxDepth) return;
         const offsets = [
-          [-w, -w], [-w, 0.0], [-w, w], [0.0, w], [w, w], [w, 0.0], [w, -w],
-          [0.0, -w]
+          vec2.fromValues(-w, -w), vec2.fromValues(-w, 0.0),
+          vec2.fromValues(-w, w), vec2.fromValues(0.0, w),
+          vec2.fromValues(w, w), vec2.fromValues(w, 0.0),
+          vec2.fromValues(w, -w), vec2.fromValues(0.0, -w)
         ];
         for (let offset of offsets)
           fractal(
@@ -332,10 +334,10 @@ export const examples = {
         const stretch = [];
         const dPhiRad = 2 * Math.PI / nCut;
 
-        const o = [0, 0];
-        const p0 = [outerRadius, 0];
-        const p1 = [innerRadius, -cut];
-        const p2 = [innerRadius, cut];
+        const o = vec2.fromValues(0, 0);
+        const p0 = vec2.fromValues(outerRadius, 0);
+        const p1 = vec2.fromValues(innerRadius, -cut);
+        const p2 = vec2.fromValues(innerRadius, cut);
         for (let i = 0; i < nCut; ++i) {
           stretch.push(vec2.rotate([0, 0], p0, o, dPhiRad * i));
           stretch.push(vec2.rotate([0, 0], p1, o, dPhiRad * i));
@@ -376,6 +378,7 @@ export const examples = {
       // https://www.thingiverse.com/thing:25477. This sample demonstrates the
       // use of a Signed Distance Function (SDF) to create smooth, complex
       // manifolds.
+      const {vec3} = glMatrix;
 
       const size = 20;
       const n = 20;
@@ -392,8 +395,8 @@ export const examples = {
       function gyroidOffset(level) {
         const period = 2 * pi;
         const box = {
-          min: [-period, -period, -period],
-          max: [period, period, period]
+          min: vec3.fromValues(-period, -period, -period),
+          max: vec3.fromValues(period, period, period)
         };
         return levelSet(gyroid, box, period / n, level).scale(size / period);
       };

--- a/bindings/wasm/examples/worker.js
+++ b/bindings/wasm/examples/worker.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as glMatrix from 'https://cdn.jsdelivr.net/npm/gl-matrix@3.4.3/+esm';
 import {Accessor, Document, Material, WebIO} from 'https://cdn.skypack.dev/pin/@gltf-transform/core@v3.0.0-SfbIFhNPTRdr1UE2VSan/mode=imports,min/optimized/@gltf-transform/core.js';
 
 import Module from '../manifold.js';
@@ -139,8 +140,9 @@ console.log = function(...args) {
 onmessage = async (e) => {
   const content = e.data + '\nreturn exportGLB(result);\n';
   try {
-    const f = new Function('exportGLB', ...exposedFunctions, content);
-    await f(exportGLB, ...exposedFunctions.map(name => wasm[name]));
+    const f =
+        new Function('exportGLB', 'glMatrix', ...exposedFunctions, content);
+    await f(exportGLB, glMatrix, ...exposedFunctions.map(name => wasm[name]));
   } catch (error) {
     console.log(error.toString());
     postMessage({objectURL: null});

--- a/bindings/wasm/examples/worker.js
+++ b/bindings/wasm/examples/worker.js
@@ -20,6 +20,9 @@ import Module from '../manifold.js';
 const wasm = await Module();
 wasm.setup();
 
+// Faster on modern browsers than Float32Array
+glMatrix.glMatrix.setMatrixArrayType(Array);
+
 // Scene setup
 const io = new WebIO();
 const doc = new Document();

--- a/bindings/wasm/examples/worker.js
+++ b/bindings/wasm/examples/worker.js
@@ -186,16 +186,8 @@ async function exportGLB(manifold) {
     if (outMesh == null) {
       continue;
     }
-
-    const transform = mesh.transform(run);
-    const mat4 = new Float32Array(16);
-    for (const col of [0, 1, 2, 3]) {
-      for (const row of [0, 1, 2]) {
-        mat4[4 * col + row] = transform[3 * col + row];
-      }
-    }
-    mat4[15] = 1;
-    const node = doc.createNode('debug').setMesh(outMesh).setMatrix(mat4);
+    const node =
+        doc.createNode('debug').setMesh(outMesh).setMatrix(mesh.transform(run));
     scene.addChild(node);
   }
 

--- a/bindings/wasm/manifold.d.ts
+++ b/bindings/wasm/manifold.d.ts
@@ -20,10 +20,9 @@ interface SealedFloat32Array<N extends number> extends Float32Array {
   length: N;
 }
 
-type Vec2 = [number, number];
-type Vec3 = [number, number, number];
-type Vec4 = [number, number, number, number];
-type Matrix3x4 = [Vec3, Vec3, Vec3, Vec3];
+type Vec2 = number[2];
+type Vec3 = number[3];
+type Mat4 = number[16];
 type SimplePolygon = Vec2[];
 type Polygons = SimplePolygon|SimplePolygon[];
 type Box = {
@@ -56,9 +55,9 @@ declare class Mesh {
     mergeToVert?: Uint32Array,
     runIndex?: Uint32Array,
     runOriginalID?: Uint32Array,
+    runTransform?: Float32Array,
     faceID?: Uint32Array,
-    halfedgeTangent?: Float32Array,
-    runTransform?: Float32Array
+    halfedgeTangent?: Float32Array
   });
   numProp: number;
   vertProperties: Float32Array;
@@ -67,9 +66,9 @@ declare class Mesh {
   mergeToVert?: Uint32Array;
   runIndex?: Uint32Array;
   runOriginalID?: Uint32Array;
+  runTransform?: Float32Array;
   faceID?: Uint32Array;
   halfedgeTangent?: Float32Array;
-  runTransform?: Float32Array;
   get numTri(): number;
   get numVert(): number;
   get numRun(): number;
@@ -77,7 +76,7 @@ declare class Mesh {
   position(vert: number): SealedFloat32Array<3>;
   extras(vert: number): Float32Array;
   tangent(halfedge: number): SealedFloat32Array<4>;
-  transform(run: number): SealedFloat32Array<12>;
+  transform(run: number): SealedFloat32Array<16>;
 }
 
 declare class Manifold {
@@ -86,13 +85,13 @@ declare class Manifold {
    */
   constructor(mesh: Mesh);
   /**
-   * Transform this Manifold in space. The first three columns form a 3x3 matrix
-   * transform and the last is a translation vector. This operation can be
-   * chained. Transforms are combined and applied lazily.
+   * Transform this Manifold in space. Stored in column-major order. This
+   * operation can be chained. Transforms are combined and applied lazily.
    *
-   * @param m The affine transform matrix to apply to all the vertices.
+   * @param m The affine transformation matrix to apply to all the vertices. The
+   *     last row is ignored.
    */
-  transform(m: Matrix3x4 | number[16]): Manifold;
+  transform(m: Mat4): Manifold;
 
   /**
    * Move this Manifold in space. This operation can be chained. Transforms are

--- a/bindings/wasm/manifold.d.ts
+++ b/bindings/wasm/manifold.d.ts
@@ -20,9 +20,26 @@ interface SealedFloat32Array<N extends number> extends Float32Array {
   length: N;
 }
 
-type Vec2 = number[2];
-type Vec3 = number[3];
-type Mat4 = number[16];
+type Vec2 = [number, number];
+type Vec3 = [number, number, number];
+type Mat4 = [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+];
 type SimplePolygon = Vec2[];
 type Polygons = SimplePolygon|SimplePolygon[];
 type Box = {
@@ -76,7 +93,7 @@ declare class Mesh {
   position(vert: number): SealedFloat32Array<3>;
   extras(vert: number): Float32Array;
   tangent(halfedge: number): SealedFloat32Array<4>;
-  transform(run: number): SealedFloat32Array<16>;
+  transform(run: number): Mat4;
 }
 
 declare class Manifold {

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "chai": "*",
-    "mocha": "*"
+    "mocha": "*",
+    "gl-matrix": "3.4.3"
   }
 }

--- a/bindings/wasm/test/test.js
+++ b/bindings/wasm/test/test.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {expect} from 'chai';
+import glMatrix from 'gl-matrix';
 
 import {examples} from '../examples/examples.js';
 import Module from '../manifold.js';
@@ -75,8 +76,8 @@ wasm.cleanup = function() {
 function runExample(name) {
   try {
     const content = examples.functionBodies.get(name) + '\nreturn result;\n';
-    const f = new Function(...exposedFunctions, content);
-    const manifold = f(...exposedFunctions.map(name => wasm[name]));
+    const f = new Function(...exposedFunctions, 'glMatrix', content);
+    const manifold = f(...exposedFunctions.map(name => wasm[name]), glMatrix);
 
     const mesh = manifold.getMesh();
     expect(mesh.mergeFromVert.length).to.equal(mesh.mergeToVert.length);

--- a/bindings/wasm/test/test.js
+++ b/bindings/wasm/test/test.js
@@ -21,6 +21,9 @@ import Module from '../manifold.js';
 const wasm = await Module();
 wasm.setup();
 
+// Faster on modern browsers than Float32Array
+glMatrix.glMatrix.setMatrixArrayType(Array);
+
 // manifold member functions that returns a new manifold
 const memberFunctions = [
   'add', 'subtract', 'intersect', 'refine', 'transform', 'translate', 'rotate',


### PR DESCRIPTION
Fixes #238 
Fixes #324 

This does simplify some of the examples nicely, and it feels pretty easy to use.

Also, I switched manifold.js from using 3x4 to 4x4 matrices, since that seems to be what all the other libraries use (we're still only using the affine portion). 