### PR TITLE
Added docs, refactored for single OpType

### DIFF
--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -31,15 +31,15 @@ Manifold Difference(const Manifold& a, const Manifold& b) { return a - b; }
 Manifold Intersection(const Manifold& a, const Manifold& b) { return a ^ b; }
 
 Manifold UnionN(const std::vector<Manifold>& manifolds) {
-  return Manifold::BatchBoolean(manifolds, Manifold::OpType::Add);
+  return Manifold::BatchBoolean(manifolds, OpType::Add);
 }
 
 Manifold DifferenceN(const std::vector<Manifold>& manifolds) {
-  return Manifold::BatchBoolean(manifolds, Manifold::OpType::Subtract);
+  return Manifold::BatchBoolean(manifolds, OpType::Subtract);
 }
 
 Manifold IntersectionN(const std::vector<Manifold>& manifolds) {
-  return Manifold::BatchBoolean(manifolds, Manifold::OpType::Intersect);
+  return Manifold::BatchBoolean(manifolds, OpType::Intersect);
 }
 
 std::vector<SimplePolygon> ToPolygon(

--- a/src/cross_section/include/cross_section.h
+++ b/src/cross_section/include/cross_section.h
@@ -27,8 +27,16 @@ namespace manifold {
 
 class Rect;
 
+/** @addtogroup Core
+ *  @{
+ */
+
 class CrossSection {
  public:
+  /** @name Creation
+   *  Constructors
+   */
+  ///@{
   CrossSection();
   ~CrossSection();
   CrossSection(const CrossSection& other);
@@ -36,19 +44,45 @@ class CrossSection {
   CrossSection(CrossSection&&) noexcept;
   CrossSection& operator=(CrossSection&&) noexcept;
 
-  // Construction from arbitrary contours
   enum class FillRule { EvenOdd, NonZero, Positive, Negative };
   CrossSection(const SimplePolygon& contour,
                FillRule fillrule = FillRule::Positive);
   CrossSection(const Polygons& contours,
                FillRule fillrule = FillRule::Positive);
 
-  // Shapes
   static CrossSection Square(const glm::vec2 dims, bool center = false);
   static CrossSection Circle(float radius, int circularSegments = 0);
+  ///@}
 
-  // Booleans
-  enum class OpType { Add, Subtract, Intersect, Xor };
+  /** @name Information
+   *  Details of the cross-section
+   */
+  ///@{
+  // Output
+  Polygons ToPolygons() const;
+  double Area() const;
+  bool IsEmpty() const;
+  Rect Bounds() const;
+  ///@}
+
+  /** @name Modification
+   */
+  ///@{
+  CrossSection Translate(const glm::vec2 v) const;
+  CrossSection Rotate(float degrees) const;
+  CrossSection Scale(const glm::vec2 s) const;
+  CrossSection Mirror(const glm::vec2 ax) const;
+  CrossSection Transform(const glm::mat3x2& m) const;
+  CrossSection Simplify(double epsilon = 1e-6) const;
+  enum class JoinType { Square, Round, Miter };
+  CrossSection Offset(double delta, JoinType jt, double miter_limit = 2.0,
+                      double arc_tolerance = 0.0) const;
+  ///@}
+
+  /** @name Boolean
+   *  Combine two manifolds
+   */
+  ///@{
   CrossSection Boolean(const CrossSection& second, OpType op) const;
   static CrossSection BatchBoolean(
       const std::vector<CrossSection>& crossSections, OpType op);
@@ -59,34 +93,17 @@ class CrossSection {
   CrossSection operator^(const CrossSection&) const;  // Intersect
   CrossSection& operator^=(const CrossSection&);
   CrossSection RectClip(const Rect& rect) const;
-
-  // Transformations
-  CrossSection Translate(const glm::vec2 v) const;
-  CrossSection Rotate(float degrees) const;
-  CrossSection Scale(const glm::vec2 s) const;
-  CrossSection Mirror(const glm::vec2 ax) const;
-  CrossSection Transform(const glm::mat3x2& m) const;
-
-  // Path Simplification
-  CrossSection Simplify(double epsilon = 1e-6) const;
-
-  // Offsetting
-  enum class JoinType { Square, Round, Miter };
-  CrossSection Offset(double delta, JoinType jt, double miter_limit = 2.0,
-                      double arc_tolerance = 0.0) const;
-
-  // Geometry
-  double Area() const;
-  bool IsEmpty() const;
-  Rect Bounds() const;
-
-  // Output
-  Polygons ToPolygons() const;
+  ///@}
 
  private:
   C2::PathsD paths_;
   CrossSection(C2::PathsD paths);
 };
+/** @} */
+
+/** @addtogroup Connections
+ *  @{
+ */
 
 class Rect {
  public:
@@ -164,4 +181,5 @@ class Rect {
 
   CrossSection AsCrossSection() const;
 };
+/** @} */
 }  // namespace manifold

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -31,19 +31,16 @@ using namespace manifold;
 namespace {
 const int precision_ = 8;
 
-C2::ClipType cliptype_of_op(CrossSection::OpType op) {
+C2::ClipType cliptype_of_op(OpType op) {
   C2::ClipType ct = C2::ClipType::Union;
   switch (op) {
-    case CrossSection::OpType::Add:
+    case OpType::Add:
       break;
-    case CrossSection::OpType::Subtract:
+    case OpType::Subtract:
       ct = C2::ClipType::Difference;
       break;
-    case CrossSection::OpType::Intersect:
+    case OpType::Intersect:
       ct = C2::ClipType::Intersection;
-      break;
-    case CrossSection::OpType::Xor:
-      ct = C2::ClipType::Xor;
       break;
   };
   return ct;

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -142,10 +142,6 @@ class Manifold {
    *  Combine two manifolds
    */
   ///@{
-  /**
-   * Boolean operation type: Add (Union), Subtract (Difference), and Intersect.
-   */
-  enum class OpType { Add, Subtract, Intersect };
   Manifold Boolean(const Manifold& second, OpType op) const;
   static Manifold BatchBoolean(const std::vector<Manifold>& manifolds,
                                OpType op);

--- a/src/manifold/src/boolean3.cpp
+++ b/src/manifold/src/boolean3.cpp
@@ -512,10 +512,10 @@ VecDH<int> Winding03(const Manifold::Impl &inP, SparseIndices &p0q2,
 
 namespace manifold {
 Boolean3::Boolean3(const Manifold::Impl &inP, const Manifold::Impl &inQ,
-                   Manifold::OpType op)
+                   OpType op)
     : inP_(inP),
       inQ_(inQ),
-      expandP_(op == Manifold::OpType::Add ? 1.0 : -1.0),
+      expandP_(op == OpType::Add ? 1.0 : -1.0),
       policy_(autoPolicy(glm::max(inP.NumEdge(), inQ.NumEdge()))) {
   // Symbolic perturbation:
   // Union -> expand inP

--- a/src/manifold/src/boolean3.h
+++ b/src/manifold/src/boolean3.h
@@ -47,9 +47,8 @@ namespace manifold {
 /** @ingroup Private */
 class Boolean3 {
  public:
-  Boolean3(const Manifold::Impl& inP, const Manifold::Impl& inQ,
-           Manifold::OpType op);
-  Manifold::Impl Result(Manifold::OpType op) const;
+  Boolean3(const Manifold::Impl& inP, const Manifold::Impl& inQ, OpType op);
+  Manifold::Impl Result(OpType op) const;
 
  private:
   const Manifold::Impl &inP_, &inQ_;

--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -539,31 +539,31 @@ void CreateProperties(Manifold::Impl &outR, const VecDH<TriRef> &refPQ,
 
 namespace manifold {
 
-Manifold::Impl Boolean3::Result(Manifold::OpType op) const {
+Manifold::Impl Boolean3::Result(OpType op) const {
 #ifdef MANIFOLD_DEBUG
   Timer assemble;
   assemble.Start();
 #endif
 
-  ASSERT((expandP_ > 0) == (op == Manifold::OpType::Add), logicErr,
+  ASSERT((expandP_ > 0) == (op == OpType::Add), logicErr,
          "Result op type not compatible with constructor op type.");
-  const int c1 = op == Manifold::OpType::Intersect ? 0 : 1;
-  const int c2 = op == Manifold::OpType::Add ? 1 : 0;
-  const int c3 = op == Manifold::OpType::Intersect ? 1 : -1;
+  const int c1 = op == OpType::Intersect ? 0 : 1;
+  const int c2 = op == OpType::Add ? 1 : 0;
+  const int c3 = op == OpType::Intersect ? 1 : -1;
 
   if (w03_.size() == 0) {
-    if (w30_.size() != 0 && op == Manifold::OpType::Add) {
+    if (w30_.size() != 0 && op == OpType::Add) {
       return inQ_;
     }
     return Manifold::Impl();
   } else if (w30_.size() == 0) {
-    if (op == Manifold::OpType::Intersect) {
+    if (op == OpType::Intersect) {
       return Manifold::Impl();
     }
     return inP_;
   }
 
-  const bool invertQ = op == Manifold::OpType::Subtract;
+  const bool invertQ = op == OpType::Subtract;
 
   // Convert winding numbers to inclusion values based on operation type.
   VecDH<int> i12(x12_.size());

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -222,7 +222,7 @@ Manifold::Impl CsgLeafNode::Compose(
 CsgOpNode::CsgOpNode() {}
 
 CsgOpNode::CsgOpNode(const std::vector<std::shared_ptr<CsgNode>> &children,
-                     Manifold::OpType op)
+                     OpType op)
     : impl_(std::make_shared<Impl>()) {
   impl_->children_ = children;
   SetOp(op);
@@ -231,7 +231,7 @@ CsgOpNode::CsgOpNode(const std::vector<std::shared_ptr<CsgNode>> &children,
 }
 
 CsgOpNode::CsgOpNode(std::vector<std::shared_ptr<CsgNode>> &&children,
-                     Manifold::OpType op)
+                     OpType op)
     : impl_(std::make_shared<Impl>()) {
   impl_->children_ = children;
   SetOp(op);
@@ -263,7 +263,7 @@ std::shared_ptr<CsgLeafNode> CsgOpNode::ToLeafNode() const {
           impls.push_back(
               std::dynamic_pointer_cast<CsgLeafNode>(child)->GetImpl());
         }
-        BatchBoolean(Manifold::OpType::Intersect, impls);
+        BatchBoolean(OpType::Intersect, impls);
         children_.clear();
         children_.push_back(std::make_shared<CsgLeafNode>(impls.front()));
         break;
@@ -276,11 +276,10 @@ std::shared_ptr<CsgLeafNode> CsgOpNode::ToLeafNode() const {
         BatchUnion();
         auto rhs = std::dynamic_pointer_cast<CsgLeafNode>(children_.front());
         children_.clear();
-        Boolean3 boolean(*lhs->GetImpl(), *rhs->GetImpl(),
-                         Manifold::OpType::Subtract);
+        Boolean3 boolean(*lhs->GetImpl(), *rhs->GetImpl(), OpType::Subtract);
         children_.push_back(
             std::make_shared<CsgLeafNode>(std::make_shared<Manifold::Impl>(
-                boolean.Result(Manifold::OpType::Subtract))));
+                boolean.Result(OpType::Subtract))));
       };
       case CsgNodeType::Leaf:
         // unreachable
@@ -299,9 +298,9 @@ std::shared_ptr<CsgLeafNode> CsgOpNode::ToLeafNode() const {
  * operation. Only supports union and intersection.
  */
 void CsgOpNode::BatchBoolean(
-    Manifold::OpType operation,
+    OpType operation,
     std::vector<std::shared_ptr<const Manifold::Impl>> &results) {
-  ASSERT(operation != Manifold::OpType::Subtract, logicErr,
+  ASSERT(operation != OpType::Subtract, logicErr,
          "BatchBoolean doesn't support Difference.");
   auto cmpFn = [](std::shared_ptr<const Manifold::Impl> a,
                   std::shared_ptr<const Manifold::Impl> b) {
@@ -387,7 +386,7 @@ void CsgOpNode::BatchUnion() const {
             std::make_shared<const Manifold::Impl>(CsgLeafNode::Compose(tmp)));
       }
     }
-    BatchBoolean(Manifold::OpType::Add, impls);
+    BatchBoolean(OpType::Add, impls);
     children_.erase(children_.begin() + start, children_.end());
     children_.push_back(std::make_shared<CsgLeafNode>(impls.back()));
     // move it to the front as we process from the back, and the newly added
@@ -438,15 +437,15 @@ std::vector<std::shared_ptr<CsgNode>> &CsgOpNode::GetChildren(
   return children_;
 }
 
-void CsgOpNode::SetOp(Manifold::OpType op) {
+void CsgOpNode::SetOp(OpType op) {
   switch (op) {
-    case Manifold::OpType::Add:
+    case OpType::Add:
       impl_->op_ = CsgNodeType::Union;
       break;
-    case Manifold::OpType::Subtract:
+    case OpType::Subtract:
       impl_->op_ = CsgNodeType::Difference;
       break;
-    case Manifold::OpType::Intersect:
+    case OpType::Intersect:
       impl_->op_ = CsgNodeType::Intersection;
       break;
   }

--- a/src/manifold/src/csg_tree.h
+++ b/src/manifold/src/csg_tree.h
@@ -63,11 +63,9 @@ class CsgOpNode final : public CsgNode {
  public:
   CsgOpNode();
 
-  CsgOpNode(const std::vector<std::shared_ptr<CsgNode>> &children,
-            Manifold::OpType op);
+  CsgOpNode(const std::vector<std::shared_ptr<CsgNode>> &children, OpType op);
 
-  CsgOpNode(std::vector<std::shared_ptr<CsgNode>> &&children,
-            Manifold::OpType op);
+  CsgOpNode(std::vector<std::shared_ptr<CsgNode>> &&children, OpType op);
 
   std::shared_ptr<CsgNode> Transform(const glm::mat4x3 &m) const override;
 
@@ -89,10 +87,10 @@ class CsgOpNode final : public CsgNode {
   // the following fields are for lazy evaluation, so they are mutable
   mutable std::shared_ptr<CsgLeafNode> cache_ = nullptr;
 
-  void SetOp(Manifold::OpType);
+  void SetOp(OpType);
 
   static void BatchBoolean(
-      Manifold::OpType operation,
+      OpType operation,
       std::vector<std::shared_ptr<const Manifold::Impl>> &results);
 
   void BatchUnion() const;

--- a/src/utilities/include/public.h
+++ b/src/utilities/include/public.h
@@ -112,11 +112,6 @@ inline HOST_DEVICE int CCW(glm::vec2 p0, glm::vec2 p1, glm::vec2 p2,
     return area > 0 ? 1 : -1;
 }
 
-/** @defgroup Polygon
- *  @brief Polygon data structures
- * @{
- */
-
 /**
  * Single polygon contour, wound CCW. First and last point are implicitly
  * connected. Should ensure all input is
@@ -131,8 +126,6 @@ using SimplePolygon = std::vector<glm::vec2>;
  * [&epsilon;-valid](https://github.com/elalish/manifold/wiki/Manifold-Library#definition-of-%CE%B5-valid).
  */
 using Polygons = std::vector<SimplePolygon>;
-// };
-/** @} */
 
 /**
  * The triangle-mesh input and output of this library.
@@ -269,12 +262,7 @@ struct Components {
   std::vector<int> indices;
   int numComponents;
 };
-/** @} */
 
-/**
- * @ingroup Connections
- * Axis-aligned bounding box
- */
 struct Box {
   glm::vec3 min = glm::vec3(std::numeric_limits<float>::infinity());
   glm::vec3 max = glm::vec3(-std::numeric_limits<float>::infinity());
@@ -422,7 +410,25 @@ struct Box {
     return glm::all(glm::isfinite(min)) && glm::all(glm::isfinite(max));
   }
 };
+/** @} */
 
+/** @addtogroup Core
+ *  @{
+ */
+
+/**
+ * Boolean operation type: Add (Union), Subtract (Difference), and Intersect.
+ */
+enum class OpType { Add, Subtract, Intersect };
+
+/**
+ * These static properties control how circular shapes are quantized by
+ * default on construction. If circularSegments is specified, it takes
+ * precedence. If it is zero, then instead the minimum is used of the segments
+ * calculated based on edge length and angle, rounded up to the nearest
+ * multiple of four. To get numbers not divisible by four, circularSegments
+ * must be specified.
+ */
 class Quality {
  private:
   inline static int circularSegments_ = 0;
@@ -430,15 +436,6 @@ class Quality {
   inline static float circularEdgeLength_ = 1.0f;
 
  public:
-  /** @name Defaults
-   * These static properties control how circular shapes are quantized by
-   * default on construction. If circularSegments is specified, it takes
-   * precedence. If it is zero, then instead the minimum is used of the segments
-   * calculated based on edge length and angle, rounded up to the nearest
-   * multiple of four. To get numbers not divisible by four, circularSegments
-   * must be specified.
-   */
-  ///@{
   /**
    * Sets an angle constraint the default number of circular segments for the
    * CrossSection::Circle(), Manifold::Cylinder(), Manifold::Sphere(), and
@@ -497,8 +494,8 @@ class Quality {
     nSeg -= nSeg % 4;
     return nSeg;
   }
-  ///@}
 };
+/** @} */
 
 /** @defgroup Debug
  *  @brief Debugging features

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ add_subdirectory(third_party)
 
 enable_testing()
 
-set(SOURCE_FILES polygon_test.cpp manifold_test.cpp boolean_test.cpp sdf_test.cpp samples_test.cpp test_main.cpp cross_section_test.cpp)
+set(SOURCE_FILES polygon_test.cpp cross_section_test.cpp manifold_test.cpp boolean_test.cpp sdf_test.cpp samples_test.cpp test_main.cpp)
 
 if(MANIFOLD_CBIND)
   list(APPEND SOURCE_FILES manifoldc_test.cpp)


### PR DESCRIPTION
@geoffder This should add CrossSection to our [docs](https://manifoldcad.org/docs/html/modules.html). I also removed the `Xor` op type (since it creates corner-touching polygons, which we don't want to encourage, and since we don't have a Manifold equivalent) and combined the OpType definitions.  