### PR TITLE
Add CrossSection and Rect to C bindings

### DIFF
--- a/bindings/c/box.cpp
+++ b/bindings/c/box.cpp
@@ -17,26 +17,20 @@ ManifoldVec3 manifold_box_min(ManifoldBox *b) { return to_c((*from_c(b)).min); }
 ManifoldVec3 manifold_box_max(ManifoldBox *b) { return to_c((*from_c(b)).max); }
 
 ManifoldVec3 manifold_box_dimensions(ManifoldBox *b) {
-  auto box = *from_c(b);
-  auto v = box.Size();
+  auto v = from_c(b)->Size();
   return {v.x, v.y, v.z};
 }
 
 ManifoldVec3 manifold_box_center(ManifoldBox *b) {
-  auto box = *from_c(b);
-  auto v = box.Center();
+  auto v = from_c(b)->Center();
   return {v.x, v.y, v.z};
 }
 
-float manifold_box_scale(ManifoldBox *b) {
-  auto box = *from_c(b);
-  return box.Scale();
-}
+float manifold_box_scale(ManifoldBox *b) { return from_c(b)->Scale(); }
 
 int manifold_box_contains_pt(ManifoldBox *b, float x, float y, float z) {
-  auto box = *from_c(b);
   auto p = glm::vec3(x, y, z);
-  return box.Contains(p);
+  return from_c(b)->Contains(p);
 }
 
 int manifold_box_contains_box(ManifoldBox *a, ManifoldBox *b) {
@@ -52,7 +46,7 @@ void manifold_box_include_pt(ManifoldBox *b, float x, float y, float z) {
 }
 
 ManifoldBox *manifold_box_union(void *mem, ManifoldBox *a, ManifoldBox *b) {
-  auto box = (*from_c(a)).Union(*from_c(b));
+  auto box = from_c(a)->Union(*from_c(b));
   return to_c(new (mem) Box(box));
 }
 
@@ -61,13 +55,12 @@ ManifoldBox *manifold_box_transform(void *mem, ManifoldBox *b, float x1,
                                     float z2, float x3, float y3, float z3,
                                     float x4, float y4, float z4) {
   auto mat = glm::mat4x3(x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4);
-  auto transformed = (*from_c(b)).Transform(mat);
+  auto transformed = from_c(b)->Transform(mat);
   return to_c(new (mem) Box(transformed));
 }
 
 ManifoldBox *manifold_box_translate(void *mem, ManifoldBox *b, float x, float y,
                                     float z) {
-  auto box = *from_c(b);
   auto p = glm::vec3(x, y, z);
   auto translated = (*from_c(b)) + p;
   return to_c(new (mem) Box(translated));
@@ -75,20 +68,18 @@ ManifoldBox *manifold_box_translate(void *mem, ManifoldBox *b, float x, float y,
 
 ManifoldBox *manifold_box_mul(void *mem, ManifoldBox *b, float x, float y,
                               float z) {
-  auto box = *from_c(b);
   auto p = glm::vec3(x, y, z);
   auto scaled = (*from_c(b)) * p;
   return to_c(new (mem) Box(scaled));
 }
 
 int manifold_box_does_overlap_pt(ManifoldBox *b, float x, float y, float z) {
-  auto box = *from_c(b);
   auto p = glm::vec3(x, y, z);
-  return box.DoesOverlap(p);
+  return from_c(b)->DoesOverlap(p);
 }
 
 int manifold_box_does_overlap_box(ManifoldBox *a, ManifoldBox *b) {
-  return (*from_c(a)).DoesOverlap(*from_c(b));
+  return from_c(a)->DoesOverlap(*from_c(b));
 }
 
-int manifold_box_is_finite(ManifoldBox *b) { return (*from_c(b)).IsFinite(); }
+int manifold_box_is_finite(ManifoldBox *b) { return from_c(b)->IsFinite(); }

--- a/bindings/c/conv.cpp
+++ b/bindings/c/conv.cpp
@@ -3,12 +3,17 @@
 #include <meshIO.h>
 #include <sdf.h>
 
+#include "cross_section.h"
 #include "include/types.h"
 #include "public.h"
 #include "types.h"
 
 ManifoldManifold *to_c(manifold::Manifold *m) {
   return reinterpret_cast<ManifoldManifold *>(m);
+}
+
+ManifoldCrossSection *to_c(manifold::CrossSection *cs) {
+  return reinterpret_cast<ManifoldCrossSection *>(cs);
 }
 
 ManifoldSimplePolygon *to_c(manifold::SimplePolygon *m) {
@@ -39,7 +44,6 @@ ManifoldError to_c(manifold::Manifold::Error error) {
   ManifoldError e = MANIFOLD_NO_ERROR;
   switch (error) {
     case Manifold::Error::NoError:
-      e = MANIFOLD_NO_ERROR;
       break;
     case Manifold::Error::NonFiniteVertex:
       e = MANIFOLD_NON_FINITE_VERTEX;
@@ -79,6 +83,10 @@ ManifoldBox *to_c(manifold::Box *m) {
   return reinterpret_cast<ManifoldBox *>(m);
 }
 
+ManifoldRect *to_c(manifold::Rect *m) {
+  return reinterpret_cast<ManifoldRect *>(m);
+}
+
 ManifoldMaterial *to_c(manifold::Material *m) {
   return reinterpret_cast<ManifoldMaterial *>(m);
 }
@@ -86,6 +94,8 @@ ManifoldMaterial *to_c(manifold::Material *m) {
 ManifoldExportOptions *to_c(manifold::ExportOptions *m) {
   return reinterpret_cast<ManifoldExportOptions *>(m);
 }
+
+ManifoldVec2 to_c(glm::vec2 v) { return {v.x, v.y}; }
 
 ManifoldVec3 to_c(glm::vec3 v) { return {v.x, v.y, v.z}; }
 
@@ -97,6 +107,10 @@ ManifoldProperties to_c(manifold::Properties p) {
 
 const manifold::Manifold *from_c(ManifoldManifold *m) {
   return reinterpret_cast<manifold::Manifold const *>(m);
+}
+
+const manifold::CrossSection *from_c(ManifoldCrossSection *m) {
+  return reinterpret_cast<manifold::CrossSection const *>(m);
 }
 
 const manifold::SimplePolygon *from_c(ManifoldSimplePolygon *m) {
@@ -123,8 +137,45 @@ const manifold::Components *from_c(ManifoldComponents *components) {
   return reinterpret_cast<manifold::Components *>(components);
 }
 
+CrossSection::FillRule from_c(ManifoldFillRule fillrule) {
+  auto fr = CrossSection::FillRule::EvenOdd;
+  switch (fillrule) {
+    case MANIFOLD_FILL_RULE_EVEN_ODD:
+      break;
+    case MANIFOLD_FILL_RULE_NON_ZERO:
+      fr = CrossSection::FillRule::NonZero;
+      break;
+    case MANIFOLD_FILL_RULE_POSITIVE:
+      fr = CrossSection::FillRule::Positive;
+      break;
+    case MANIFOLD_FILL_RULE_NEGATIVE:
+      fr = CrossSection::FillRule::Negative;
+      break;
+  };
+  return fr;
+}
+
+CrossSection::JoinType from_c(ManifoldJoinType join_type) {
+  auto jt = CrossSection::JoinType::Square;
+  switch (join_type) {
+    case MANIFOLD_JOIN_TYPE_SQUARE:
+      break;
+    case MANIFOLD_JOIN_TYPE_ROUND:
+      jt = CrossSection::JoinType::Round;
+      break;
+    case MANIFOLD_JOIN_TYPE_MITER:
+      jt = CrossSection::JoinType::Miter;
+      break;
+  };
+  return jt;
+}
+
 const manifold::Box *from_c(ManifoldBox *m) {
   return reinterpret_cast<manifold::Box const *>(m);
+}
+
+const manifold::Rect *from_c(ManifoldRect *m) {
+  return reinterpret_cast<manifold::Rect const *>(m);
 }
 
 manifold::Material *from_c(ManifoldMaterial *mat) {
@@ -134,6 +185,8 @@ manifold::Material *from_c(ManifoldMaterial *mat) {
 manifold::ExportOptions *from_c(ManifoldExportOptions *options) {
   return reinterpret_cast<manifold::ExportOptions *>(options);
 }
+
+glm::vec2 from_c(ManifoldVec2 v) { return glm::vec2(v.x, v.y); }
 
 glm::vec3 from_c(ManifoldVec3 v) { return glm::vec3(v.x, v.y, v.z); }
 

--- a/bindings/c/cross.cpp
+++ b/bindings/c/cross.cpp
@@ -1,0 +1,135 @@
+#include <conv.h>
+#include <manifold.h>
+#include <public.h>
+
+#include "cross_section.h"
+#include "types.h"
+
+ManifoldCrossSection *manifold_cross_section_of_simple_polygon(
+    void *mem, ManifoldSimplePolygon *p, ManifoldFillRule fr) {
+  return to_c(new (mem) CrossSection(*from_c(p), from_c(fr)));
+}
+
+ManifoldCrossSection *manifold_cross_section_of_polygons(void *mem,
+                                                         ManifoldPolygons *p,
+                                                         ManifoldFillRule fr) {
+  return to_c(new (mem) CrossSection(*from_c(p), from_c(fr)));
+}
+
+ManifoldCrossSection *manifold_cross_section_square(void *mem, float x, float y,
+                                                    int center) {
+  auto cs = CrossSection::Square(glm::vec2(x, y), center);
+  return to_c(new (mem) CrossSection(cs));
+}
+
+ManifoldCrossSection *manifold_cross_section_circle(void *mem, float radius,
+                                                    int circular_segments) {
+  auto cs = CrossSection::Circle(radius, circular_segments);
+  return to_c(new (mem) CrossSection(cs));
+}
+
+ManifoldCrossSection *manifold_cross_section_union(void *mem,
+                                                   ManifoldCrossSection *a,
+                                                   ManifoldCrossSection *b) {
+  auto cs = (*from_c(a)) + (*from_c(b));
+  return to_c(new (mem) CrossSection(cs));
+}
+
+ManifoldCrossSection *manifold_cross_section_difference(
+    void *mem, ManifoldCrossSection *a, ManifoldCrossSection *b) {
+  auto cs = (*from_c(a)) - (*from_c(b));
+  return to_c(new (mem) CrossSection(cs));
+}
+
+ManifoldCrossSection *manifold_cross_section_intersection(
+    void *mem, ManifoldCrossSection *a, ManifoldCrossSection *b) {
+  auto cs = (*from_c(a)) ^ (*from_c(b));
+  return to_c(new (mem) CrossSection(cs));
+}
+
+ManifoldCrossSection *manifold_cross_section_xor(void *mem,
+                                                 ManifoldCrossSection *a,
+                                                 ManifoldCrossSection *b) {
+  auto cs = from_c(a)->Boolean(*from_c(b), CrossSection::OpType::Xor);
+  return to_c(new (mem) CrossSection(cs));
+}
+
+ManifoldCrossSection *manifold_cross_section_rect_clip(void *mem,
+                                                       ManifoldCrossSection *cs,
+                                                       ManifoldRect *r) {
+  auto clipped = from_c(cs)->RectClip(*from_c(r));
+  return to_c(new (mem) CrossSection(clipped));
+}
+
+ManifoldCrossSection *manifold_cross_section_translate(void *mem,
+                                                       ManifoldCrossSection *cs,
+                                                       float x, float y) {
+  auto translated = from_c(cs)->Translate(glm::vec2(x, y));
+  return to_c(new (mem) CrossSection(translated));
+}
+
+ManifoldCrossSection *manifold_cross_section_rotate(void *mem,
+                                                    ManifoldCrossSection *cs,
+                                                    float deg) {
+  auto rotated = from_c(cs)->Rotate(deg);
+  return to_c(new (mem) CrossSection(rotated));
+}
+
+ManifoldCrossSection *manifold_cross_section_scale(void *mem,
+                                                   ManifoldCrossSection *cs,
+                                                   float x, float y) {
+  auto scaled = from_c(cs)->Scale(glm::vec2(x, y));
+  return to_c(new (mem) CrossSection(scaled));
+}
+
+ManifoldCrossSection *manifold_cross_section_mirror(void *mem,
+                                                    ManifoldCrossSection *cs,
+                                                    float ax_x, float ax_y) {
+  auto mirrored = from_c(cs)->Mirror(glm::vec2(ax_x, ax_y));
+  return to_c(new (mem) CrossSection(mirrored));
+}
+
+ManifoldCrossSection *manifold_cross_section_transform(void *mem,
+                                                       ManifoldCrossSection *cs,
+                                                       float x1, float y1,
+                                                       float x2, float y2,
+                                                       float x3, float y3) {
+  auto mat = glm::mat3x2(x1, y1, x2, y2, x3, y3);
+  auto transformed = from_c(cs)->Transform(mat);
+  return to_c(new (mem) CrossSection(transformed));
+}
+
+ManifoldCrossSection *manifold_cross_section_simplify(void *mem,
+                                                      ManifoldCrossSection *cs,
+                                                      double epsilon) {
+  auto simplified = from_c(cs)->Simplify(epsilon);
+  return to_c(new (mem) CrossSection(simplified));
+}
+
+ManifoldCrossSection *manifold_cross_section_offset(
+    void *mem, ManifoldCrossSection *cs, double delta, ManifoldJoinType jt,
+    double miter_limit, double arc_tolerance) {
+  auto offset =
+      from_c(cs)->Offset(delta, from_c(jt), miter_limit, arc_tolerance);
+  return to_c(new (mem) CrossSection(offset));
+}
+
+double manifold_cross_section_area(ManifoldCrossSection *cs) {
+  return from_c(cs)->Area();
+}
+
+int manifold_cross_section_is_empty(ManifoldCrossSection *cs) {
+  return from_c(cs)->IsEmpty();
+}
+
+ManifoldRect *manifold_cross_section_bounds(void *mem,
+                                            ManifoldCrossSection *cs) {
+  auto rect = from_c(cs)->Bounds();
+  return to_c(new (mem) Rect(rect));
+}
+
+ManifoldPolygons *manifold_cross_section_to_polygons(void *mem,
+                                                     ManifoldCrossSection *cs) {
+  auto ps = from_c(cs)->ToPolygons();
+  return to_c(new (mem) Polygons(ps));
+}

--- a/bindings/c/cross.cpp
+++ b/bindings/c/cross.cpp
@@ -57,13 +57,6 @@ ManifoldCrossSection *manifold_cross_section_intersection(
   return to_c(new (mem) CrossSection(cs));
 }
 
-ManifoldCrossSection *manifold_cross_section_xor(void *mem,
-                                                 ManifoldCrossSection *a,
-                                                 ManifoldCrossSection *b) {
-  auto cs = from_c(a)->Boolean(*from_c(b), CrossSection::OpType::Xor);
-  return to_c(new (mem) CrossSection(cs));
-}
-
 ManifoldCrossSection *manifold_cross_section_rect_clip(void *mem,
                                                        ManifoldCrossSection *cs,
                                                        ManifoldRect *r) {

--- a/bindings/c/cross.cpp
+++ b/bindings/c/cross.cpp
@@ -5,6 +5,16 @@
 #include "cross_section.h"
 #include "types.h"
 
+ManifoldCrossSection *manifold_cross_section_empty(void *mem) {
+  return to_c(new (mem) CrossSection());
+}
+
+ManifoldCrossSection *manifold_cross_section_copy(void *mem,
+                                                  ManifoldCrossSection *cs) {
+  auto cross = *from_c(cs);
+  return to_c(new (mem) CrossSection(cross));
+}
+
 ManifoldCrossSection *manifold_cross_section_of_simple_polygon(
     void *mem, ManifoldSimplePolygon *p, ManifoldFillRule fr) {
   return to_c(new (mem) CrossSection(*from_c(p), from_c(fr)));

--- a/bindings/c/include/conv.h
+++ b/bindings/c/include/conv.h
@@ -5,31 +5,43 @@
 #include <sdf.h>
 #include <types.h>
 
+#include "cross_section.h"
+
 ManifoldManifold *to_c(manifold::Manifold *m);
+ManifoldCrossSection *to_c(manifold::CrossSection *cr);
 ManifoldSimplePolygon *to_c(manifold::SimplePolygon *p);
 ManifoldPolygons *to_c(manifold::Polygons *ps);
 ManifoldMesh *to_c(manifold::Mesh *m);
 ManifoldMeshGL *to_c(manifold::MeshGL *m);
+ManifoldFillRule *to_c(manifold::CrossSection::FillRule *fr);
+ManifoldJoinType *to_c(manifold::CrossSection::JoinType *jt);
 ManifoldBox *to_c(manifold::Box *m);
+ManifoldRect *to_c(manifold::Rect *m);
 ManifoldCurvature *to_c(manifold::Curvature *m);
 ManifoldComponents *to_c(manifold::Components *components);
 ManifoldError to_c(manifold::Manifold::Error error);
 ManifoldMaterial *to_c(manifold::Material *m);
 ManifoldExportOptions *to_c(manifold::ExportOptions *m);
+ManifoldVec2 to_c(glm::vec2 v);
 ManifoldVec3 to_c(glm::vec3 v);
 ManifoldIVec3 to_c(glm::ivec3 v);
 ManifoldProperties to_c(manifold::Properties p);
 
 const manifold::Manifold *from_c(ManifoldManifold *m);
+const manifold::CrossSection *from_c(ManifoldCrossSection *cr);
 const manifold::SimplePolygon *from_c(ManifoldSimplePolygon *m);
 const manifold::Polygons *from_c(ManifoldPolygons *m);
 const manifold::Mesh *from_c(ManifoldMesh *m);
 const manifold::MeshGL *from_c(ManifoldMeshGL *m);
+CrossSection::FillRule from_c(ManifoldFillRule fillrule);
+CrossSection::JoinType from_c(ManifoldJoinType jt);
 const manifold::Box *from_c(ManifoldBox *m);
+const manifold::Rect *from_c(ManifoldRect *r);
 const manifold::Curvature *from_c(ManifoldCurvature *m);
 const manifold::Components *from_c(ManifoldComponents *components);
 manifold::Material *from_c(ManifoldMaterial *mat);
 manifold::ExportOptions *from_c(ManifoldExportOptions *options);
+glm::vec2 from_c(ManifoldVec2 v);
 glm::vec3 from_c(ManifoldVec3 v);
 glm::ivec3 from_c(ManifoldIVec3 v);
 glm::vec4 from_c(ManifoldVec4 v);

--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -121,6 +121,9 @@ int manifold_original_id(ManifoldManifold *m);
 
 // CrossSection
 
+ManifoldCrossSection *manifold_cross_section_empty(void *mem);
+ManifoldCrossSection *manifold_cross_section_copy(void *mem,
+                                                  ManifoldCrossSection *cs);
 ManifoldCrossSection *manifold_cross_section_of_simple_polygon(
     void *mem, ManifoldSimplePolygon *p, ManifoldFillRule fr);
 ManifoldCrossSection *manifold_cross_section_of_polygons(void *mem,
@@ -167,6 +170,7 @@ ManifoldCrossSection *manifold_cross_section_offset(
     void *mem, ManifoldCrossSection *cs, double delta, ManifoldJoinType jt,
     double miter_limit, double arc_tolerance);
 double manifold_cross_section_area(ManifoldCrossSection *cs);
+int manifold_cross_section_is_empty(ManifoldCrossSection *cs);
 ManifoldRect *manifold_cross_section_bounds(void *mem,
                                             ManifoldCrossSection *cs);
 ManifoldPolygons *manifold_cross_section_to_polygons(void *mem,

--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -119,6 +119,82 @@ float *manifold_curvature_vert_gaussian(void *mem, ManifoldCurvature *curv);
 int manifold_get_circular_segments(float radius);
 int manifold_original_id(ManifoldManifold *m);
 
+// CrossSection
+
+ManifoldCrossSection *manifold_cross_section_of_simple_polygon(
+    void *mem, ManifoldSimplePolygon *p, ManifoldFillRule fr);
+ManifoldCrossSection *manifold_cross_section_of_polygons(void *mem,
+                                                         ManifoldPolygons *p,
+                                                         ManifoldFillRule fr);
+ManifoldCrossSection *manifold_cross_section_square(void *mem, float x, float y,
+                                                    int center);
+ManifoldCrossSection *manifold_cross_section_circle(void *mem, float radius,
+                                                    int circular_segments);
+ManifoldCrossSection *manifold_cross_section_union(void *mem,
+                                                   ManifoldCrossSection *a,
+                                                   ManifoldCrossSection *b);
+ManifoldCrossSection *manifold_cross_section_difference(
+    void *mem, ManifoldCrossSection *a, ManifoldCrossSection *b);
+ManifoldCrossSection *manifold_cross_section_intersection(
+    void *mem, ManifoldCrossSection *a, ManifoldCrossSection *b);
+ManifoldCrossSection *manifold_cross_section_xor(void *mem,
+                                                 ManifoldCrossSection *a,
+                                                 ManifoldCrossSection *b);
+ManifoldCrossSection *manifold_cross_section_rect_clip(void *mem,
+                                                       ManifoldCrossSection *cs,
+                                                       ManifoldRect *r);
+ManifoldCrossSection *manifold_cross_section_translate(void *mem,
+                                                       ManifoldCrossSection *cs,
+                                                       float x, float y);
+ManifoldCrossSection *manifold_cross_section_rotate(void *mem,
+                                                    ManifoldCrossSection *cs,
+                                                    float deg);
+ManifoldCrossSection *manifold_cross_section_scale(void *mem,
+                                                   ManifoldCrossSection *cs,
+                                                   float x, float y);
+ManifoldCrossSection *manifold_cross_section_mirror(void *mem,
+                                                    ManifoldCrossSection *cs,
+                                                    float ax_x, float ax_y);
+ManifoldCrossSection *manifold_cross_section_transform(void *mem,
+                                                       ManifoldCrossSection *cs,
+                                                       float x1, float y1,
+                                                       float x2, float y2,
+                                                       float x3, float y3);
+ManifoldCrossSection *manifold_cross_section_simplify(void *mem,
+                                                      ManifoldCrossSection *cs,
+                                                      double epsilon);
+ManifoldCrossSection *manifold_cross_section_offset(
+    void *mem, ManifoldCrossSection *cs, double delta, ManifoldJoinType jt,
+    double miter_limit, double arc_tolerance);
+double manifold_cross_section_area(ManifoldCrossSection *cs);
+ManifoldRect *manifold_cross_section_bounds(void *mem,
+                                            ManifoldCrossSection *cs);
+ManifoldPolygons *manifold_cross_section_to_polygons(void *mem,
+                                                     ManifoldCrossSection *cs);
+
+// Rectangle
+ManifoldRect *manifold_rect(void *mem, float x1, float y1, float x2, float y2);
+ManifoldVec2 manifold_rect_min(ManifoldRect *r);
+ManifoldVec2 manifold_rect_max(ManifoldRect *r);
+ManifoldVec2 manifold_rect_dimensions(ManifoldRect *r);
+ManifoldVec2 manifold_rect_center(ManifoldRect *r);
+float manifold_rect_scale(ManifoldRect *r);
+int manifold_rect_contains_pt(ManifoldRect *r, float x, float y);
+int manifold_rect_contains_rect(ManifoldRect *a, ManifoldRect *b);
+void manifold_rect_include_pt(ManifoldRect *r, float x, float y);
+ManifoldRect *manifold_rect_union(void *mem, ManifoldRect *a, ManifoldRect *b);
+ManifoldRect *manifold_rect_transform(void *mem, ManifoldRect *r, float x1,
+                                      float y1, float x2, float y2, float x3,
+                                      float y3);
+ManifoldRect *manifold_rect_translate(void *mem, ManifoldRect *r, float x,
+                                      float y);
+ManifoldRect *manifold_rect_mul(void *mem, ManifoldRect *r, float x, float y);
+int manifold_rect_does_overlap_rect(ManifoldRect *a, ManifoldRect *r);
+int manifold_rect_is_empty(ManifoldRect *r);
+int manifold_rect_is_finite(ManifoldRect *r);
+ManifoldCrossSection *manifold_rect_as_cross_section(void *mem,
+                                                     ManifoldRect *r);
+
 // Bounding Box
 ManifoldBox *manifold_box(void *mem, float x1, float y1, float z1, float x2,
                           float y2, float z2);
@@ -186,34 +262,40 @@ void manifold_export_meshgl(const char *filename, ManifoldMeshGL *mesh,
                             ManifoldExportOptions *options);
 
 // memory size
+size_t manifold_manifold_size();
+size_t manifold_cross_section_size();
 size_t manifold_simple_polygon_size();
 size_t manifold_polygons_size();
-size_t manifold_manifold_size();
 size_t manifold_manifold_pair_size();
 size_t manifold_meshgl_size();
 size_t manifold_box_size();
+size_t manifold_rect_size();
 size_t manifold_curvature_size();
 size_t manifold_components_size();
 size_t manifold_material_size();
 size_t manifold_export_options_size();
 
 // destruction
+void manifold_destruct_manifold(ManifoldManifold *m);
+void manifold_destruct_cross_section(ManifoldCrossSection *m);
 void manifold_destruct_simple_polygon(ManifoldSimplePolygon *p);
 void manifold_destruct_polygons(ManifoldPolygons *p);
-void manifold_destruct_manifold(ManifoldManifold *m);
 void manifold_destruct_meshgl(ManifoldMeshGL *m);
 void manifold_destruct_box(ManifoldBox *b);
+void manifold_destruct_rect(ManifoldRect *b);
 void manifold_destruct_curvature(ManifoldCurvature *c);
 void manifold_destruct_components(ManifoldComponents *c);
 void manifold_destruct_material(ManifoldMaterial *m);
 void manifold_destruct_export_options(ManifoldExportOptions *options);
 
 // pointer free + destruction
+void manifold_delete_manifold(ManifoldManifold *m);
+void manifold_delete_cross_section(ManifoldCrossSection *m);
 void manifold_delete_simple_polygon(ManifoldSimplePolygon *p);
 void manifold_delete_polygons(ManifoldPolygons *p);
-void manifold_delete_manifold(ManifoldManifold *m);
 void manifold_delete_meshgl(ManifoldMeshGL *m);
 void manifold_delete_box(ManifoldBox *b);
+void manifold_delete_rect(ManifoldRect *b);
 void manifold_delete_curvature(ManifoldCurvature *c);
 void manifold_delete_components(ManifoldComponents *c);
 void manifold_delete_material(ManifoldMaterial *m);

--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -86,11 +86,11 @@ ManifoldManifold *manifold_of_meshgl(void *mem, ManifoldMeshGL *mesh);
 ManifoldManifold *manifold_smooth(void *mem, ManifoldMeshGL *mesh,
                                   int *half_edges, float *smoothness,
                                   int n_idxs);
-ManifoldManifold *manifold_extrude(void *mem, ManifoldPolygons *polygons,
+ManifoldManifold *manifold_extrude(void *mem, ManifoldCrossSection *cs,
                                    float height, int slices,
                                    float twist_degrees, float scale_x,
                                    float scale_y);
-ManifoldManifold *manifold_revolve(void *mem, ManifoldPolygons *polygons,
+ManifoldManifold *manifold_revolve(void *mem, ManifoldCrossSection *cs,
                                    int circular_segments);
 ManifoldManifold *manifold_compose(void *mem, ManifoldManifold **ms,
                                    size_t length);

--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -140,9 +140,6 @@ ManifoldCrossSection *manifold_cross_section_difference(
     void *mem, ManifoldCrossSection *a, ManifoldCrossSection *b);
 ManifoldCrossSection *manifold_cross_section_intersection(
     void *mem, ManifoldCrossSection *a, ManifoldCrossSection *b);
-ManifoldCrossSection *manifold_cross_section_xor(void *mem,
-                                                 ManifoldCrossSection *a,
-                                                 ManifoldCrossSection *b);
 ManifoldCrossSection *manifold_cross_section_rect_clip(void *mem,
                                                        ManifoldCrossSection *cs,
                                                        ManifoldRect *r);

--- a/bindings/c/include/types.h
+++ b/bindings/c/include/types.h
@@ -2,6 +2,7 @@
 #include <stddef.h>
 
 typedef struct ManifoldManifold ManifoldManifold;
+typedef struct ManifoldCrossSection ManifoldCrossSection;
 typedef struct ManifoldSimplePolygon ManifoldSimplePolygon;
 typedef struct ManifoldPolygons ManifoldPolygons;
 typedef struct ManifoldMesh ManifoldMesh;
@@ -9,6 +10,7 @@ typedef struct ManifoldMeshGL ManifoldMeshGL;
 typedef struct ManifoldCurvature ManifoldCurvature;
 typedef struct ManifoldComponents ManifoldComponents;
 typedef struct ManifoldBox ManifoldBox;
+typedef struct ManifoldRect ManifoldRect;
 typedef struct ManifoldMaterial ManifoldMaterial;
 typedef struct ManifoldExportOptions ManifoldExportOptions;
 
@@ -66,3 +68,16 @@ typedef enum ManifoldError {
   MANIFOLD_RUN_INDEX_WRONG_LENGTH,
   MANIFOLD_FACE_ID_WRONG_LENGTH,
 } ManifoldError;
+
+typedef enum ManifoldFillRule {
+  MANIFOLD_FILL_RULE_EVEN_ODD,
+  MANIFOLD_FILL_RULE_NON_ZERO,
+  MANIFOLD_FILL_RULE_POSITIVE,
+  MANIFOLD_FILL_RULE_NEGATIVE
+} ManifoldFillRule;
+
+typedef enum ManifoldJoinType {
+  MANIFOLD_JOIN_TYPE_SQUARE,
+  MANIFOLD_JOIN_TYPE_ROUND,
+  MANIFOLD_JOIN_TYPE_MITER,
+} ManifoldJoinType;

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -408,6 +408,7 @@ float *manifold_curvature_vert_gaussian(void *mem, ManifoldCurvature *curv) {
 }
 
 // Static Quality Globals
+
 void manifold_set_min_circular_angle(float degrees) {
   Quality::SetMinCircularAngle(degrees);
 }

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -7,9 +7,11 @@
 #include <sdf.h>
 
 #include "box.cpp"
+#include "cross.cpp"
 #include "include/conv.h"
 #include "include/types.h"
 #include "meshio.cpp"
+#include "rect.cpp"
 #include "types.h"
 
 using namespace manifold;
@@ -423,16 +425,21 @@ int manifold_get_circular_segments(float radius) {
 }
 
 // memory size
+size_t manifold_cross_section_size() { return sizeof(CrossSection); }
 size_t manifold_simple_polygon_size() { return sizeof(SimplePolygon); }
 size_t manifold_polygons_size() { return sizeof(Polygons); }
 size_t manifold_manifold_size() { return sizeof(Manifold); }
 size_t manifold_manifold_pair_size() { return sizeof(ManifoldManifoldPair); }
 size_t manifold_meshgl_size() { return sizeof(MeshGL); }
 size_t manifold_box_size() { return sizeof(Box); }
+size_t manifold_rect_size() { return sizeof(Rect); }
 size_t manifold_curvature_size() { return sizeof(Curvature); }
 size_t manifold_components_size() { return sizeof(Components); }
 
 // pointer free + destruction
+void manifold_delete_cross_section(ManifoldCrossSection *c) {
+  delete from_c(c);
+}
 void manifold_delete_simple_polygon(ManifoldSimplePolygon *p) {
   delete from_c(p);
 }
@@ -440,10 +447,14 @@ void manifold_delete_polygons(ManifoldPolygons *p) { delete from_c(p); }
 void manifold_delete_manifold(ManifoldManifold *m) { delete from_c(m); }
 void manifold_delete_meshgl(ManifoldMeshGL *m) { delete from_c(m); }
 void manifold_delete_box(ManifoldBox *b) { delete from_c(b); }
+void manifold_delete_rect(ManifoldRect *r) { delete from_c(r); }
 void manifold_delete_curvature(ManifoldCurvature *c) { delete from_c(c); }
 void manifold_delete_components(ManifoldComponents *c) { delete from_c(c); }
 
 // destruction
+void manifold_destruct_cross_section(ManifoldCrossSection *m) {
+  from_c(m)->~CrossSection();
+}
 void manifold_destruct_simple_polygon(ManifoldSimplePolygon *p) {
   from_c(p)->~SimplePolygon();
 }
@@ -451,6 +462,7 @@ void manifold_destruct_polygons(ManifoldPolygons *p) { from_c(p)->~Polygons(); }
 void manifold_destruct_manifold(ManifoldManifold *m) { from_c(m)->~Manifold(); }
 void manifold_destruct_meshgl(ManifoldMeshGL *m) { from_c(m)->~MeshGL(); }
 void manifold_destruct_box(ManifoldBox *b) { from_c(b)->~Box(); }
+void manifold_destruct_rect(ManifoldRect *r) { from_c(r)->~Rect(); }
 void manifold_destruct_curvature(ManifoldCurvature *c) {
   from_c(c)->~Curvature();
 }

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -225,20 +225,19 @@ ManifoldManifold *manifold_of_meshgl(void *mem, ManifoldMeshGL *mesh) {
   return to_c(new (mem) Manifold(m));
 }
 
-ManifoldManifold *manifold_extrude(void *mem, ManifoldPolygons *polygons,
+ManifoldManifold *manifold_extrude(void *mem, ManifoldCrossSection *cs,
                                    float height, int slices,
                                    float twist_degrees, float scale_x,
                                    float scale_y) {
   auto scale = glm::vec2(scale_x, scale_y);
-  auto m = Manifold::Extrude(*from_c(polygons), height, slices, twist_degrees,
-                             scale);
+  auto m = Manifold::Extrude(*from_c(cs), height, slices, twist_degrees, scale);
   return to_c(new (mem) Manifold(m));
 }
 
-ManifoldManifold *manifold_revolve(void *mem, ManifoldPolygons *polygons,
+ManifoldManifold *manifold_revolve(void *mem, ManifoldCrossSection *cs,
 
                                    int circular_segments) {
-  auto m = Manifold::Revolve(*from_c(polygons), circular_segments);
+  auto m = Manifold::Revolve(*from_c(cs), circular_segments);
   return to_c(new (mem) Manifold(m));
 }
 

--- a/bindings/c/rect.cpp
+++ b/bindings/c/rect.cpp
@@ -1,0 +1,93 @@
+#include <conv.h>
+#include <manifold.h>
+#include <public.h>
+
+#include "cross_section.h"
+#include "types.h"
+
+ManifoldRect *manifold_rect(void *mem, float x1, float y1, float x2, float y2) {
+  auto p1 = glm::vec2(x1, y1);
+  auto p2 = glm::vec2(x2, y2);
+  auto rect = new (mem) Rect(p1, p2);
+  return to_c(rect);
+}
+
+ManifoldVec2 manifold_rect_min(ManifoldRect *r) {
+  return to_c((*from_c(r)).min);
+}
+
+ManifoldVec2 manifold_rect_max(ManifoldRect *r) {
+  return to_c((*from_c(r)).max);
+}
+
+ManifoldVec2 manifold_rect_dimensions(ManifoldRect *r) {
+  auto v = from_c(r)->Size();
+  return {v.x, v.y};
+}
+
+ManifoldVec2 manifold_rect_center(ManifoldRect *r) {
+  auto v = from_c(r)->Center();
+  return {v.x, v.y};
+}
+
+float manifold_rect_scale(ManifoldRect *r) { return from_c(r)->Scale(); }
+
+int manifold_rect_contains_pt(ManifoldRect *r, float x, float y) {
+  auto rect = *from_c(r);
+  auto p = glm::vec2(x, y);
+  return rect.Contains(p);
+}
+
+int manifold_rect_contains_rect(ManifoldRect *a, ManifoldRect *b) {
+  auto outer = *from_c(a);
+  auto inner = *from_c(b);
+  return outer.Contains(inner);
+}
+
+void manifold_rect_include_pt(ManifoldRect *r, float x, float y) {
+  auto rect = *from_c(r);
+  auto p = glm::vec2(x, y);
+  rect.Union(p);
+}
+
+ManifoldRect *manifold_rect_union(void *mem, ManifoldRect *a, ManifoldRect *b) {
+  auto rect = from_c(a)->Union(*from_c(b));
+  return to_c(new (mem) Rect(rect));
+}
+
+ManifoldRect *manifold_rect_transform(void *mem, ManifoldRect *r, float x1,
+                                      float y1, float x2, float y2, float x3,
+                                      float y3) {
+  auto mat = glm::mat3x2(x1, y1, x2, y2, x3, y3);
+  auto transformed = from_c(r)->Transform(mat);
+  return to_c(new (mem) Rect(transformed));
+}
+
+ManifoldRect *manifold_rect_translate(void *mem, ManifoldRect *r, float x,
+                                      float y) {
+  auto rect = *from_c(r);
+  auto p = glm::vec2(x, y);
+  auto translated = (*from_c(r)) + p;
+  return to_c(new (mem) Rect(translated));
+}
+
+ManifoldRect *manifold_rect_mul(void *mem, ManifoldRect *r, float x, float y) {
+  auto rect = *from_c(r);
+  auto p = glm::vec2(x, y);
+  auto scaled = (*from_c(r)) * p;
+  return to_c(new (mem) Rect(scaled));
+}
+
+int manifold_rect_does_overlap_rect(ManifoldRect *a, ManifoldRect *r) {
+  return from_c(a)->DoesOverlap(*from_c(r));
+}
+
+int manifold_rect_is_empty(ManifoldRect *r) { return from_c(r)->IsEmpty(); }
+
+int manifold_rect_is_finite(ManifoldRect *r) { return from_c(r)->IsFinite(); }
+
+ManifoldCrossSection *manifold_rect_as_cross_section(void *mem,
+                                                     ManifoldRect *r) {
+  auto cs = from_c(r)->AsCrossSection();
+  return to_c(new (mem) CrossSection(cs));
+}

--- a/test/manifoldc_test.cpp
+++ b/test/manifoldc_test.cpp
@@ -4,6 +4,7 @@
 #include "manifold.h"
 #include "polygon.h"
 #include "sdf.h"
+#include "types.h"
 
 #ifdef MANIFOLD_EXPORT
 #include "meshIO.h"
@@ -108,10 +109,13 @@ TEST(CBIND, extrude) {
       malloc(manifold_simple_polygon_size()), &pts[0], 4)};
   ManifoldPolygons *polys =
       manifold_polygons(malloc(manifold_polygons_size()), sq, 1);
+  ManifoldCrossSection *cross =
+      manifold_cross_section_of_polygons(malloc(manifold_cross_section_size()),
+                                         polys, MANIFOLD_FILL_RULE_POSITIVE);
 
   ManifoldManifold *cube = manifold_cube(malloc(sz), 1., 1., 1., 0);
   ManifoldManifold *extrusion =
-      manifold_extrude(malloc(sz), polys, 1, 0, 0, 1, 1);
+      manifold_extrude(malloc(sz), cross, 1, 0, 0, 1, 1);
 
   ManifoldManifold *diff = manifold_difference(malloc(sz), cube, extrusion);
   ManifoldProperties props = manifold_get_properties(diff);


### PR DESCRIPTION
`ManifoldCrossSection` and `ManifoldRect` types and their associated methods have been added, along with switching over `extrude` and `revolve` to take `ManifoldCrossSection*` rather than `ManifoldPolygons*`