### PR TITLE
Add Mirror transformation method to Manifold

### DIFF
--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -67,6 +67,8 @@ ManifoldManifold *manifold_transform(void *mem, ManifoldManifold *m, float x1,
                                      float y1, float z1, float x2, float y2,
                                      float z2, float x3, float y3, float z3,
                                      float x4, float y4, float z4);
+ManifoldManifold *manifold_mirror(void *mem, ManifoldManifold *m, float nx,
+                                  float ny, float nz);
 ManifoldManifold *manifold_warp(void *mem, ManifoldManifold *m,
                                 ManifoldVec3 (*fun)(float, float, float));
 ManifoldManifold *manifold_refine(void *mem, ManifoldManifold *m, int refine);

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -126,6 +126,12 @@ ManifoldManifold *manifold_transform(void *mem, ManifoldManifold *m, float x1,
   return to_c(new (mem) Manifold(transformed));
 }
 
+ManifoldManifold *manifold_mirror(void *mem, ManifoldManifold *m, float nx,
+                                  float ny, float nz) {
+  auto mirrored = from_c(m)->Mirror({nx, ny, nz});
+  return to_c(new (mem) Manifold(mirrored));
+}
+
 ManifoldManifold *manifold_warp(void *mem, ManifoldManifold *m,
                                 ManifoldVec3 (*fun)(float, float, float)) {
   std::function<void(glm::vec3 & v)> warp = [fun](glm::vec3 &v) {

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -132,6 +132,7 @@ class Manifold {
   Manifold Rotate(float xDegrees, float yDegrees = 0.0f,
                   float zDegrees = 0.0f) const;
   Manifold Transform(const glm::mat4x3&) const;
+  Manifold Mirror(glm::vec3) const;
   Manifold Warp(std::function<void(glm::vec3&)>) const;
   Manifold Refine(int) const;
   // Manifold RefineToLength(float);

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -518,6 +518,30 @@ Manifold Manifold::Transform(const glm::mat4x3& m) const {
 }
 
 /**
+ * Mirror this Manifold over the plane described by the unit form of the given
+ * normal vector. If the length of the normal is zero, an empty Manifold is
+ * returned. This operation can be chained. Transforms are combined and applied
+ * lazily.
+ *
+ * @param normal The normal vector of the plane to be mirrored over
+ */
+Manifold Manifold::Mirror(glm::vec3 normal) const {
+  if (glm::length(normal) == 0.) {
+    return Manifold();
+  }
+  auto n = glm::normalize(normal);
+  glm::mat4x3 m(1.0f - 2.0f * n.x * n.x, -2.0f * n.x * n.y,
+                -2.0f * n.x * n.z,  //
+                -2.0f * n.x * n.y, 1.0f - 2.0f * n.y * n.y,
+                -2.0f * n.y * n.z,  //
+                -2.0f * n.x * n.z, -2.0f * n.y * n.z,
+                1.0f - 2.0f * n.z * n.z  //
+                ,
+                0.0f, 0.0f, 0.0f);
+  return Manifold(pNode_->Transform(m));
+}
+
+/**
  * This function does not change the topology, but allows the vertices to be
  * moved according to any arbitrary input function. It is easy to create a
  * function that warps a geometrically valid object into one which overlaps, but

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -530,14 +530,7 @@ Manifold Manifold::Mirror(glm::vec3 normal) const {
     return Manifold();
   }
   auto n = glm::normalize(normal);
-  glm::mat4x3 m(1.0f - 2.0f * n.x * n.x, -2.0f * n.x * n.y,
-                -2.0f * n.x * n.z,  //
-                -2.0f * n.x * n.y, 1.0f - 2.0f * n.y * n.y,
-                -2.0f * n.y * n.z,  //
-                -2.0f * n.x * n.z, -2.0f * n.y * n.z,
-                1.0f - 2.0f * n.z * n.z  //
-                ,
-                0.0f, 0.0f, 0.0f);
+  auto m = glm::mat4x3(glm::mat3(1.0f) - 2.0f * glm::outerProduct(n, n));
   return Manifold(pNode_->Transform(m));
 }
 

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -490,3 +490,18 @@ TEST(Manifold, FaceIDRoundTrip) {
   const MeshGL outGL = cube2.GetMeshGL();
   ASSERT_EQ(NumUnique(outGL.faceID), 12);
 }
+
+TEST(Manifold, MirrorUnion) {
+  auto a = Manifold::Cube({5., 5., 5.}, true);
+  auto b = a.Translate({2.5, 2.5, 2.5});
+  auto result = a + b + b.Mirror({1, 1, 0});
+
+#ifdef MANIFOLD_EXPORT
+  if (options.exportModels)
+    ExportMesh("manifold_mirror_union.glb", result.GetMesh(), {});
+#endif
+
+  auto vol_a = a.GetProperties().volume;
+  EXPECT_FLOAT_EQ(vol_a + 1.75 * vol_a, result.GetProperties().volume);
+  EXPECT_TRUE(a.Mirror(glm::vec3(0)).IsEmpty());
+}

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -502,6 +502,6 @@ TEST(Manifold, MirrorUnion) {
 #endif
 
   auto vol_a = a.GetProperties().volume;
-  EXPECT_FLOAT_EQ(vol_a + 1.75 * vol_a, result.GetProperties().volume);
+  EXPECT_FLOAT_EQ(vol_a * 2.75, result.GetProperties().volume);
   EXPECT_TRUE(a.Mirror(glm::vec3(0)).IsEmpty());
 }


### PR DESCRIPTION
At first I thought that additional lazy tracking of inversion would be required, but it seems like the `invert` check with `glm::determinant` in `Impl::Transform` is already taking care of it? The added test is a simple 3d adapted version of the one for `CrossSection`.