### PR TITLE
Simplify the CsgOpNodes as we build them, rather than in GetChildren

### DIFF
--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -16,18 +16,20 @@ project(extras)
 
 add_executable(perfTest perf_test.cpp)
 target_link_libraries(perfTest manifold)
-
 target_compile_options(perfTest PRIVATE ${MANIFOLD_FLAGS})
 target_compile_features(perfTest PUBLIC cxx_std_17)
+
+add_executable(largeSceneTest large_scene_test.cpp)
+target_link_libraries(largeSceneTest manifold)
+target_compile_options(largeSceneTest PRIVATE ${MANIFOLD_FLAGS})
+target_compile_features(largeSceneTest PUBLIC cxx_std_17)
 
 if(BUILD_TEST_CGAL)
     add_executable(perfTestCGAL perf_test_cgal.cpp)
     find_package(CGAL REQUIRED COMPONENTS Core)
     target_compile_definitions(perfTestCGAL PRIVATE CGAL_USE_GMPXX)
-
     # target_compile_definitions(perfTestCGAL PRIVATE CGAL_DEBUG)
     target_link_libraries(perfTestCGAL manifold CGAL::CGAL CGAL::CGAL_Core)
-
     target_compile_options(perfTestCGAL PRIVATE ${MANIFOLD_FLAGS})
     target_compile_features(perfTestCGAL PUBLIC cxx_std_17)
 endif()

--- a/extras/large_scene_test.cpp
+++ b/extras/large_scene_test.cpp
@@ -23,11 +23,7 @@ using namespace manifold;
   Build & execute with the following command:
 
   ( mkdir -p build && cd build && \
-    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
-      -DMANIFOLD_PAR=TBB \
-      -DTHRUST_MULTICONFIG_ENABLE_SYSTEM_TBB=1 \
-      -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_TBB \
-      .. && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DMANIFOLD_PAR=TBB .. && \
     make -j && \
     time ./extras/largeSceneTest 50 )
 */

--- a/extras/large_scene_test.cpp
+++ b/extras/large_scene_test.cpp
@@ -1,0 +1,58 @@
+// Copyright 2020 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <iostream>
+
+#include "manifold.h"
+
+using namespace manifold;
+
+/*
+  Build & execute with the following command:
+
+  ( mkdir -p build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
+      -DMANIFOLD_PAR=TBB \
+      -DTHRUST_MULTICONFIG_ENABLE_SYSTEM_TBB=1 \
+      -DTHRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_TBB \
+      .. && \
+    make -j && \
+    time ./extras/largeSceneTest 50 )
+*/
+int main(int argc, char **argv) {
+  int n = 20;  // Crashes at n=50
+  if (argc == 2) n = atoi(argv[1]);
+
+  std::cout << "n = " << n << std::endl;
+
+  auto start = std::chrono::high_resolution_clock::now();
+  Manifold scene;
+
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < n; ++j) {
+      for (int k = 0; k < n; ++k) {
+        if (i == 0 && j == 0 && k == 0) continue;
+
+        Manifold sphere = Manifold::Sphere(1).Translate(glm::vec3(i, j, k));
+        scene = scene.Boolean(sphere, OpType::Add);
+      }
+    }
+  }
+  scene.NumTri();
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> elapsed = end - start;
+  std::cout << "nTri = " << scene.NumTri() << ", time = " << elapsed.count()
+            << " sec" << std::endl;
+}

--- a/extras/large_scene_test.cpp
+++ b/extras/large_scene_test.cpp
@@ -32,7 +32,7 @@ using namespace manifold;
     time ./extras/largeSceneTest 50 )
 */
 int main(int argc, char **argv) {
-  int n = 20;  // Crashes at n=50
+  int n = 20;
   if (argc == 2) n = atoi(argv[1]);
 
   std::cout << "n = " << n << std::endl;

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -259,7 +259,8 @@ std::shared_ptr<CsgNode> CsgOpNode::Boolean(std::shared_ptr<CsgNode> second,
 
   auto handleOperand = [&](const std::shared_ptr<CsgNode> &operand) {
     if (auto opNode = std::dynamic_pointer_cast<CsgOpNode>(operand)) {
-      if (opNode->IsOp(op)) {
+      if (opNode->IsOp(op) && opNode.use_count() == 1 &&
+          opNode->impl_.UseCount() == 1) {
         for (auto &child : opNode->GetChildren(/* finalize= */ false)) {
           children.push_back(child);
         }

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -456,18 +456,16 @@ void CsgOpNode::BatchUnion() const {
 std::vector<std::shared_ptr<CsgNode>> &CsgOpNode::GetChildren(
     bool forceToLeafNodes) const {
   auto impl = impl_.GetGuard();
-  auto &children_ = impl->children_;
-  if (children_.empty() || impl->forcedToLeafNodes_) return children_;
-  impl->forcedToLeafNodes_ = forceToLeafNodes;
 
-  if (forceToLeafNodes) {
-    for (auto &child : children_) {
+  if (forceToLeafNodes && !impl->forcedToLeafNodes_) {
+    impl->forcedToLeafNodes_ = true;
+    for (auto &child : impl->children_) {
       if (child->GetNodeType() != CsgNodeType::Leaf) {
         child = child->ToLeafNode();
       }
     }
   }
-  return children_;
+  return impl->children_;
 }
 
 void CsgOpNode::SetOp(OpType op) {

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -241,8 +241,6 @@ CsgOpNode::CsgOpNode(const std::vector<std::shared_ptr<CsgNode>> &children,
   auto impl = impl_.GetGuard();
   impl->children_ = children;
   SetOp(op);
-  // opportunistically flatten the tree without costly evaluation
-  GetChildren(false);
 }
 
 CsgOpNode::CsgOpNode(std::vector<std::shared_ptr<CsgNode>> &&children,

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -82,8 +82,7 @@ std::shared_ptr<CsgNode> CsgNode::Boolean(std::shared_ptr<CsgNode> second,
       return opNode->Boolean(shared_from_this(), op);
     }
   }
-  std::vector<std::shared_ptr<CsgNode>> children(
-      {shared_from_this(), second->shared_from_this()});
+  std::vector<std::shared_ptr<CsgNode>> children({shared_from_this(), second});
   return std::make_shared<CsgOpNode>(children, op);
 }
 

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -458,9 +458,7 @@ std::vector<std::shared_ptr<CsgNode>> &CsgOpNode::GetChildren(
     bool finalize) const {
   auto impl = impl_.GetGuard();
   auto &children_ = impl->children_;
-  if (children_.empty() || (impl->simplified_ && !finalize) || impl->flattened_)
-    return children_;
-  impl->simplified_ = true;
+  if (children_.empty() || impl->flattened_) return children_;
   impl->flattened_ = finalize;
 
   if (finalize) {

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -256,8 +256,7 @@ std::shared_ptr<CsgNode> CsgOpNode::Boolean(std::shared_ptr<CsgNode> second,
 
   auto handleOperand = [&](const std::shared_ptr<CsgNode> &operand) {
     if (auto opNode = std::dynamic_pointer_cast<CsgOpNode>(operand)) {
-      if (opNode->IsOp(op) && opNode.use_count() == 1 &&
-          opNode->impl_.UseCount() == 1) {
+      if (opNode->IsOp(op) && opNode->impl_.UseCount() == 1) {
         for (auto &child : opNode->GetChildren(/* finalize= */ false)) {
           children.push_back(child);
         }

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -272,6 +272,14 @@ std::shared_ptr<CsgNode> CsgOpNode::Boolean(std::shared_ptr<CsgNode> second,
   handleOperand(shared_from_this());
   handleOperand(second);
 
+  if (op == OpType::Subtract && children.size() > 2) {
+    // special handling for difference: we treat it as first - (second + third +
+    // ...) so op = Union after the first node
+    std::vector<std::shared_ptr<CsgNode>> unionChildren(children.begin() + 1,
+                                                        children.end());
+    children.resize(1);
+    children.push_back(std::make_shared<CsgOpNode>(unionChildren, OpType::Add));
+  }
   return std::make_shared<CsgOpNode>(children, op);
 }
 

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -73,8 +73,8 @@ struct CheckOverlap {
 }  // namespace
 namespace manifold {
 
-std::shared_ptr<CsgNode> CsgNode::Boolean(std::shared_ptr<CsgNode> second,
-                                          OpType op) {
+std::shared_ptr<CsgNode> CsgNode::Boolean(
+    const std::shared_ptr<CsgNode> &second, OpType op) {
   if (auto opNode = std::dynamic_pointer_cast<CsgOpNode>(second)) {
     // "this" is not a CsgOpNode (which overrides Boolean), but if "second" is
     // and the operation is commutative, we let it built the tree.
@@ -250,8 +250,8 @@ CsgOpNode::CsgOpNode(std::vector<std::shared_ptr<CsgNode>> &&children,
   SetOp(op);
 }
 
-std::shared_ptr<CsgNode> CsgOpNode::Boolean(std::shared_ptr<CsgNode> second,
-                                            OpType op) {
+std::shared_ptr<CsgNode> CsgOpNode::Boolean(
+    const std::shared_ptr<CsgNode> &second, OpType op) {
   std::vector<std::shared_ptr<CsgNode>> children;
 
   auto handleOperand = [&](const std::shared_ptr<CsgNode> &operand) {

--- a/src/manifold/src/csg_tree.h
+++ b/src/manifold/src/csg_tree.h
@@ -29,8 +29,8 @@ class CsgNode : public std::enable_shared_from_this<CsgNode> {
   virtual CsgNodeType GetNodeType() const = 0;
   virtual glm::mat4x3 GetTransform() const = 0;
 
-  virtual std::shared_ptr<CsgNode> Boolean(std::shared_ptr<CsgNode> second,
-                                           OpType op);
+  virtual std::shared_ptr<CsgNode> Boolean(
+      const std::shared_ptr<CsgNode> &second, OpType op);
 
   std::shared_ptr<CsgNode> Translate(const glm::vec3 &t) const;
   std::shared_ptr<CsgNode> Scale(const glm::vec3 &s) const;
@@ -71,7 +71,7 @@ class CsgOpNode final : public CsgNode {
 
   CsgOpNode(std::vector<std::shared_ptr<CsgNode>> &&children, OpType op);
 
-  std::shared_ptr<CsgNode> Boolean(std::shared_ptr<CsgNode> second,
+  std::shared_ptr<CsgNode> Boolean(const std::shared_ptr<CsgNode> &second,
                                    OpType op) override;
 
   std::shared_ptr<CsgNode> Transform(const glm::mat4x3 &m) const override;

--- a/src/manifold/src/csg_tree.h
+++ b/src/manifold/src/csg_tree.h
@@ -85,7 +85,7 @@ class CsgOpNode final : public CsgNode {
  private:
   struct Impl {
     std::vector<std::shared_ptr<CsgNode>> children_;
-    bool flattened_ = false;
+    bool forcedToLeafNodes_ = false;
   };
   mutable ConcurrentSharedPtr<Impl> impl_ = ConcurrentSharedPtr<Impl>(Impl{});
   CsgNodeType op_;
@@ -103,7 +103,7 @@ class CsgOpNode final : public CsgNode {
   void BatchUnion() const;
 
   std::vector<std::shared_ptr<CsgNode>> &GetChildren(
-      bool finalize = true) const;
+      bool forceToLeafNodes = true) const;
 };
 
 }  // namespace manifold

--- a/src/manifold/src/csg_tree.h
+++ b/src/manifold/src/csg_tree.h
@@ -85,7 +85,6 @@ class CsgOpNode final : public CsgNode {
  private:
   struct Impl {
     std::vector<std::shared_ptr<CsgNode>> children_;
-    bool simplified_ = false;
     bool flattened_ = false;
   };
   mutable ConcurrentSharedPtr<Impl> impl_ = ConcurrentSharedPtr<Impl>(Impl{});

--- a/src/manifold/src/csg_tree.h
+++ b/src/manifold/src/csg_tree.h
@@ -22,12 +22,15 @@ enum class CsgNodeType { Union, Intersection, Difference, Leaf };
 
 class CsgLeafNode;
 
-class CsgNode {
+class CsgNode : public std::enable_shared_from_this<CsgNode> {
  public:
   virtual std::shared_ptr<CsgLeafNode> ToLeafNode() const = 0;
   virtual std::shared_ptr<CsgNode> Transform(const glm::mat4x3 &m) const = 0;
   virtual CsgNodeType GetNodeType() const = 0;
   virtual glm::mat4x3 GetTransform() const = 0;
+
+  virtual std::shared_ptr<CsgNode> Boolean(std::shared_ptr<CsgNode> second,
+                                           OpType op);
 
   std::shared_ptr<CsgNode> Translate(const glm::vec3 &t) const;
   std::shared_ptr<CsgNode> Scale(const glm::vec3 &s) const;
@@ -68,6 +71,9 @@ class CsgOpNode final : public CsgNode {
 
   CsgOpNode(std::vector<std::shared_ptr<CsgNode>> &&children, OpType op);
 
+  std::shared_ptr<CsgNode> Boolean(std::shared_ptr<CsgNode> second,
+                                   OpType op) override;
+
   std::shared_ptr<CsgNode> Transform(const glm::mat4x3 &m) const override;
 
   std::shared_ptr<CsgLeafNode> ToLeafNode() const override;
@@ -89,6 +95,7 @@ class CsgOpNode final : public CsgNode {
   mutable std::shared_ptr<CsgLeafNode> cache_ = nullptr;
 
   void SetOp(OpType);
+  bool IsOp(OpType op);
 
   static std::shared_ptr<Manifold::Impl> BatchBoolean(
       OpType operation,

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -585,8 +585,7 @@ Manifold Manifold::Refine(int n) const {
  * @param op The type of operation to perform.
  */
 Manifold Manifold::Boolean(const Manifold& second, OpType op) const {
-  std::vector<std::shared_ptr<CsgNode>> children({pNode_, second.pNode_});
-  return Manifold(std::make_shared<CsgOpNode>(children, op));
+  return Manifold(pNode_->Boolean(second.pNode_, op));
 }
 
 Manifold Manifold::BatchBoolean(const std::vector<Manifold>& manifolds,

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -589,3 +589,39 @@ TEST(Boolean, UnionDifference) {
   float blocksize = block.GetProperties().volume;
   EXPECT_NEAR(resultsize, blocksize * 2, 0.0001);
 }
+
+TEST(Boolean, BooleanVolumes) {
+  glm::mat4 m = glm::translate(glm::mat4(1.0f), glm::vec3(1.0f));
+
+  // Define solids which volumes are easy to compute w/ bit arithmetics:
+  // m1, m2, m4 are unique, non intersecting "bits" (of volume 1, 2, 4)
+  // m3 = m1 + m2
+  // m7 = m1 + m2 + m3
+  auto m1 = Manifold::Cube({1, 1, 1});
+  auto m2 = Manifold::Cube({2, 1, 1}).Transform(
+      glm::translate(glm::mat4(1.0f), glm::vec3(1.0f, 0, 0)));
+  auto m4 = Manifold::Cube({4, 1, 1}).Transform(
+      glm::translate(glm::mat4(1.0f), glm::vec3(3.0f, 0, 0)));
+  auto m3 = Manifold::Cube({3, 1, 1});
+  auto m7 = Manifold::Cube({7, 1, 1});
+
+  EXPECT_FLOAT_EQ((m1 ^ m2).GetProperties().volume, 0);
+  EXPECT_FLOAT_EQ((m1 + m2 + m4).GetProperties().volume, 7);
+  EXPECT_FLOAT_EQ((m1 + m2 - m4).GetProperties().volume, 3);
+  EXPECT_FLOAT_EQ((m1 + (m2 ^ m4)).GetProperties().volume, 1);
+  EXPECT_FLOAT_EQ((m7 ^ m4).GetProperties().volume, 4);
+  EXPECT_FLOAT_EQ((m7 ^ m3 ^ m1).GetProperties().volume, 1);
+  EXPECT_FLOAT_EQ((m7 ^ (m1 + m2)).GetProperties().volume, 3);
+  EXPECT_FLOAT_EQ((m7 - m4).GetProperties().volume, 3);
+  EXPECT_FLOAT_EQ((m7 - m4 - m2).GetProperties().volume, 1);
+  EXPECT_FLOAT_EQ((m7 - (m7 - m1)).GetProperties().volume, 1);
+  EXPECT_FLOAT_EQ((m7 - (m1 + m2)).GetProperties().volume, 4);
+}
+
+TEST(Boolean, TreeTransforms) {
+  auto a = (Manifold::Cube({1, 1, 1}) + Manifold::Cube({1, 1, 1}))
+               .Translate({1, 0, 0});
+  auto b = (Manifold::Cube({1, 1, 1}) + Manifold::Cube({1, 1, 1}));
+
+  EXPECT_FLOAT_EQ((a + b).GetProperties().volume, 2);
+}

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -505,39 +505,3 @@ TEST(Manifold, MirrorUnion) {
   EXPECT_FLOAT_EQ(vol_a * 2.75, result.GetProperties().volume);
   EXPECT_TRUE(a.Mirror(glm::vec3(0)).IsEmpty());
 }
-
-TEST(Manifold, BooleanVolumes) {
-  glm::mat4 m = glm::translate(glm::mat4(1.0f), glm::vec3(1.0f));
-
-  // Define solids which volumes are easy to compute w/ bit arithmetics:
-  // m1, m2, m4 are unique, non intersecting "bits" (of volume 1, 2, 4)
-  // m3 = m1 + m2
-  // m7 = m1 + m2 + m3
-  auto m1 = Manifold::Cube({1, 1, 1});
-  auto m2 = Manifold::Cube({2, 1, 1}).Transform(
-      glm::translate(glm::mat4(1.0f), glm::vec3(1.0f, 0, 0)));
-  auto m4 = Manifold::Cube({4, 1, 1}).Transform(
-      glm::translate(glm::mat4(1.0f), glm::vec3(3.0f, 0, 0)));
-  auto m3 = Manifold::Cube({3, 1, 1});
-  auto m7 = Manifold::Cube({7, 1, 1});
-
-  EXPECT_FLOAT_EQ((m1 ^ m2).GetProperties().volume, 0);
-  EXPECT_FLOAT_EQ((m1 + m2 + m4).GetProperties().volume, 7);
-  EXPECT_FLOAT_EQ((m1 + m2 - m4).GetProperties().volume, 3);
-  EXPECT_FLOAT_EQ((m1 + (m2 ^ m4)).GetProperties().volume, 1);
-  EXPECT_FLOAT_EQ((m7 ^ m4).GetProperties().volume, 4);
-  EXPECT_FLOAT_EQ((m7 ^ m3 ^ m1).GetProperties().volume, 1);
-  EXPECT_FLOAT_EQ((m7 ^ (m1 + m2)).GetProperties().volume, 3);
-  EXPECT_FLOAT_EQ((m7 - m4).GetProperties().volume, 3);
-  EXPECT_FLOAT_EQ((m7 - m4 - m2).GetProperties().volume, 1);
-  EXPECT_FLOAT_EQ((m7 - (m7 - m1)).GetProperties().volume, 1);
-  EXPECT_FLOAT_EQ((m7 - (m1 + m2)).GetProperties().volume, 4);
-}
-
-TEST(Manifold, TreeTransforms) {
-  auto a = (Manifold::Cube({1, 1, 1}) + Manifold::Cube({1, 1, 1}))
-               .Translate({1, 0, 0});
-  auto b = (Manifold::Cube({1, 1, 1}) + Manifold::Cube({1, 1, 1}));
-
-  EXPECT_FLOAT_EQ((a + b).GetProperties().volume, 2);
-}

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -505,3 +505,31 @@ TEST(Manifold, MirrorUnion) {
   EXPECT_FLOAT_EQ(vol_a * 2.75, result.GetProperties().volume);
   EXPECT_TRUE(a.Mirror(glm::vec3(0)).IsEmpty());
 }
+
+TEST(Manifold, BooleanVolumes) {
+  glm::mat4 m = glm::translate(glm::mat4(1.0f), glm::vec3(1.0f));
+
+  // Define solids which volumes are easy to compute w/ bit arithmetics:
+  // m1, m2, m4 are unique, non intersecting "bits" (of volume 1, 2, 4)
+  // m3 = m1 + m2
+  // m7 = m1 + m2 + m3
+  auto m1 = Manifold::Cube({1, 1, 1});
+  auto m2 = Manifold::Cube({2, 1, 1}).Transform(
+      glm::translate(glm::mat4(1.0f), glm::vec3(1.0f, 0, 0)));
+  auto m4 = Manifold::Cube({4, 1, 1}).Transform(
+      glm::translate(glm::mat4(1.0f), glm::vec3(3.0f, 0, 0)));
+  auto m3 = Manifold::Cube({3, 1, 1});
+  auto m7 = Manifold::Cube({7, 1, 1});
+
+  EXPECT_FLOAT_EQ((m1 ^ m2).GetProperties().volume, 0);
+  EXPECT_FLOAT_EQ((m1 + m2 + m4).GetProperties().volume, 7);
+  EXPECT_FLOAT_EQ((m1 + m2 - m4).GetProperties().volume, 3);
+  EXPECT_FLOAT_EQ((m1 + (m2 ^ m4)).GetProperties().volume, 1);
+  EXPECT_FLOAT_EQ((m7 ^ m4).GetProperties().volume, 4);
+  EXPECT_FLOAT_EQ((m7 ^ m3 ^ m1).GetProperties().volume, 1);
+  EXPECT_FLOAT_EQ((m7 ^ (m1 + m2)).GetProperties().volume, 3);
+  EXPECT_FLOAT_EQ((m7 - m4).GetProperties().volume, 3);
+  EXPECT_FLOAT_EQ((m7 - m4 - m2).GetProperties().volume, 1);
+  EXPECT_FLOAT_EQ((m7 - (m7 - m1)).GetProperties().volume, 1);
+  EXPECT_FLOAT_EQ((m7 - (m1 + m2)).GetProperties().volume, 4);
+}

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -533,3 +533,11 @@ TEST(Manifold, BooleanVolumes) {
   EXPECT_FLOAT_EQ((m7 - (m7 - m1)).GetProperties().volume, 1);
   EXPECT_FLOAT_EQ((m7 - (m1 + m2)).GetProperties().volume, 4);
 }
+
+TEST(Manifold, TreeTransforms) {
+  auto a = (Manifold::Cube({1, 1, 1}) + Manifold::Cube({1, 1, 1}))
+               .Translate({1, 0, 0});
+  auto b = (Manifold::Cube({1, 1, 1}) + Manifold::Cube({1, 1, 1}));
+
+  EXPECT_FLOAT_EQ((a + b).GetProperties().volume, 2);
+}


### PR DESCRIPTION
Early simplification (while building boolean op nodes) makes it easier to flatten the tree and avoids... stack overflows in GetChildren.

large_scene_test.cpp in this PR will just segfault without the flattening changes (and could potentially form the basis for some large scene benchmark so I thought it worth to check it in).

Found this crash while testing https://github.com/openscad/openscad/pull/4533 (segfaulted on issue2342.scad)