### PR TITLE
SimplePolygon/Polygons accessors for C bindings

### DIFF
--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -11,6 +11,16 @@ ManifoldSimplePolygon *manifold_simple_polygon(void *mem, ManifoldVec2 *ps,
                                                size_t length);
 ManifoldPolygons *manifold_polygons(void *mem, ManifoldSimplePolygon **ps,
                                     size_t length);
+size_t manifold_simple_polygon_length(ManifoldSimplePolygon *p);
+size_t manifold_polygons_length(ManifoldPolygons *ps);
+size_t manifold_polygons_simple_length(ManifoldPolygons *ps, int idx);
+ManifoldVec2 manifold_simple_polygon_get_point(ManifoldSimplePolygon *p,
+                                               int idx);
+ManifoldSimplePolygon *manifold_polygons_get_simple(void *mem,
+                                                    ManifoldPolygons *ps,
+                                                    int idx);
+ManifoldVec2 manifold_polygons_get_point(ManifoldPolygons *ps, int simple_idx,
+                                         int pt_idx);
 
 // Mesh Construction
 ManifoldMeshGL *manifold_meshgl(void *mem, float *vert_props, size_t n_verts,

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -88,11 +88,13 @@ ManifoldManifold *manifold_union(void *mem, ManifoldManifold *a,
   auto m = (*from_c(a)) + (*from_c(b));
   return to_c(new (mem) Manifold(m));
 }
+
 ManifoldManifold *manifold_difference(void *mem, ManifoldManifold *a,
                                       ManifoldManifold *b) {
   auto m = (*from_c(a)) - (*from_c(b));
   return to_c(new (mem) Manifold(m));
 }
+
 ManifoldManifold *manifold_intersection(void *mem, ManifoldManifold *a,
                                         ManifoldManifold *b) {
   auto m = (*from_c(a)) ^ (*from_c(b));

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -54,6 +54,35 @@ ManifoldPolygons *manifold_polygons(void *mem, ManifoldSimplePolygon **ps,
   return to_c(vec);
 }
 
+size_t manifold_simple_polygon_length(ManifoldSimplePolygon *p) {
+  return from_c(p)->size();
+}
+
+size_t manifold_polygons_length(ManifoldPolygons *ps) {
+  return from_c(ps)->size();
+}
+
+size_t manifold_polygons_simple_length(ManifoldPolygons *ps, int idx) {
+  return (*from_c(ps))[idx].size();
+}
+
+ManifoldVec2 manifold_simple_polygon_get_point(ManifoldSimplePolygon *p,
+                                               int idx) {
+  return to_c((*from_c(p))[idx]);
+}
+
+ManifoldSimplePolygon *manifold_polygons_get_simple(void *mem,
+                                                    ManifoldPolygons *ps,
+                                                    int idx) {
+  auto sp = (*from_c(ps))[idx];
+  return to_c(new (mem) SimplePolygon(sp));
+}
+
+ManifoldVec2 manifold_polygons_get_point(ManifoldPolygons *ps, int simple_idx,
+                                         int pt_idx) {
+  return to_c((*from_c(ps))[simple_idx][pt_idx]);
+}
+
 ManifoldManifold *manifold_union(void *mem, ManifoldManifold *a,
                                  ManifoldManifold *b) {
   auto m = (*from_c(a)) + (*from_c(b));

--- a/test/manifoldc_test.cpp
+++ b/test/manifoldc_test.cpp
@@ -156,3 +156,22 @@ TEST(CBIND, compose_decompose) {
     manifold_delete_manifold(decomposed[i]);
   }
 }
+
+TEST(CBIND, polygons) {
+  ManifoldVec2 vs[] = {{0, 0}, {1, 1}, {2, 2}};
+  ManifoldSimplePolygon *sp =
+      manifold_simple_polygon(malloc(manifold_simple_polygon_size()), vs, 3);
+  ManifoldSimplePolygon *sps[] = {sp};
+  ManifoldPolygons *ps =
+      manifold_polygons(malloc(manifold_polygons_size()), sps, 1);
+
+  EXPECT_EQ(vs[0].x, manifold_simple_polygon_get_point(sp, 0).x);
+  EXPECT_EQ(vs[1].x, manifold_simple_polygon_get_point(sp, 1).x);
+  EXPECT_EQ(vs[2].x, manifold_simple_polygon_get_point(sp, 2).x);
+  EXPECT_EQ(vs[0].x, manifold_polygons_get_point(ps, 0, 0).x);
+  EXPECT_EQ(vs[1].x, manifold_polygons_get_point(ps, 0, 1).x);
+  EXPECT_EQ(vs[2].x, manifold_polygons_get_point(ps, 0, 2).x);
+
+  manifold_delete_simple_polygon(sp);
+  manifold_delete_polygons(ps);
+}


### PR DESCRIPTION
These were left out before because they were only used for input to extrude/revolve, thus there was no reason to ever want to get points back out of the vectors. Now we have useful 2d operations that can create new Polygons worth extracting.