### PR TITLE
locateFile property in Module function

### DIFF
--- a/bindings/wasm/manifold.d.ts
+++ b/bindings/wasm/manifold.d.ts
@@ -41,4 +41,4 @@ export interface ManifoldStatic {
   setup: () => void;
 }
 
-export default function Module(): Promise<ManifoldStatic>;
+export default function Module(config: {locateFile: () => string}): Promise<ManifoldStatic>;


### PR DESCRIPTION
Allows to provide custom url of the manifold.wasm file. This is needed for Vite. Partial fix for #365