### PR TITLE
Add CrossSection decomposition

### DIFF
--- a/src/cross_section/include/cross_section.h
+++ b/src/cross_section/include/cross_section.h
@@ -149,17 +149,7 @@ class CrossSection {
   /** @name Topological
    */
   ///@{
-  /**
-   * Construct a CrossSection from a vector of other CrossSections (batch
-   * boolean union).
-   */
   static CrossSection Compose(std::vector<CrossSection>&);
-
-  /**
-   * This operation returns a vector of CrossSections that are topologically
-   * disconnected, each containing only one outline contour and zero or more
-   * holes.
-   */
   std::vector<CrossSection> Decompose() const;
   ///@}
 

--- a/src/cross_section/include/cross_section.h
+++ b/src/cross_section/include/cross_section.h
@@ -17,6 +17,7 @@
 #include <clipper2/clipper.h>
 
 #include <memory>
+#include <vector>
 
 #include "clipper2/clipper.core.h"
 #include "clipper2/clipper.offset.h"
@@ -84,7 +85,6 @@ class CrossSection {
    *  Details of the cross-section
    */
   ///@{
-  Polygons ToPolygons() const;
   double Area() const;
   int NumVert() const;
   int NumContour() const;
@@ -144,6 +144,29 @@ class CrossSection {
   CrossSection operator^(const CrossSection&) const;
   CrossSection& operator^=(const CrossSection&);
   CrossSection RectClip(const Rect& rect) const;
+  ///@}
+
+  /** @name Topological
+   */
+  ///@{
+  /**
+   * Construct a CrossSection from a vector of other CrossSections (batch
+   * boolean union).
+   */
+  static CrossSection Compose(std::vector<CrossSection>&);
+
+  /**
+   * This operation returns a vector of CrossSections that are topologically
+   * disconnected, each containing only one outline contour and zero or more
+   * holes.
+   */
+  std::vector<CrossSection> Decompose() const;
+  ///@}
+
+  /** @name Conversion
+   */
+  ///@{
+  Polygons ToPolygons() const;
   ///@}
 
  private:

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -363,10 +363,14 @@ CrossSection CrossSection::Compose(std::vector<CrossSection>& crossSections) {
 
 /**
  * This operation returns a vector of CrossSections that are topologically
- * disconnected, each containing only one outline contour and zero or more
+ * disconnected, each containing one outline contour with zero or more
  * holes.
  */
 std::vector<CrossSection> CrossSection::Decompose() const {
+  if (NumContour() < 2) {
+    return std::vector<CrossSection>{CrossSection(*this)};
+  }
+
   C2::PolyTreeD tree;
   C2::BooleanOp(C2::ClipType::Union, C2::FillRule::Positive, GetPaths(),
                 C2::PathsD(), tree, precision_);

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -372,7 +372,7 @@ std::vector<CrossSection> CrossSection::Decompose() const {
                 C2::PathsD(), tree, precision_);
 
   auto polys = std::vector<C2::PathsD>();
-  decompose_outline((C2::PolyTreeD*)(tree.Child(0)->Parent()), polys, 0);
+  decompose_outline(&tree, polys, 0);
 
   auto n_polys = polys.size();
   auto comps = std::vector<CrossSection>(n_polys);

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -111,3 +111,23 @@ TEST(CrossSection, Warp) {
   Identical(Manifold::Extrude(a, 1.).GetMesh(),
             Manifold::Extrude(b, 1.).GetMesh());
 }
+
+TEST(CrossSection, Decompose) {
+  auto a = CrossSection::Square({2., 2.}, true) -
+           CrossSection::Square({1., 1.}, true);
+  auto b = a.Translate({4, 4});
+  auto ab = a + b;
+  auto decomp = ab.Decompose();
+  auto recomp = CrossSection::Compose(decomp);
+
+  EXPECT_EQ(decomp.size(), 2);
+  EXPECT_EQ(decomp[0].NumContour(), 2);
+  EXPECT_EQ(decomp[1].NumContour(), 2);
+
+  Identical(Manifold::Extrude(a, 1.).GetMesh(),
+            Manifold::Extrude(decomp[0], 1.).GetMesh());
+  Identical(Manifold::Extrude(b, 1.).GetMesh(),
+            Manifold::Extrude(decomp[1], 1.).GetMesh());
+  Identical(Manifold::Extrude(ab, 1.).GetMesh(),
+            Manifold::Extrude(recomp, 1.).GetMesh());
+}


### PR DESCRIPTION
Add ability to decompose a `CrossSection` into a set of non-intersecting independent parts (much like `Manifold::Decompose`). Implemented using the Clipper2 tree boolean operation that tracks the nesting relationships of paths, and followed by unpacking the results into vectors of contours (with the outlines at their heads).