### PR TITLE
parallelize some csg operations

### DIFF
--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -122,6 +122,23 @@ inline ExecutionPolicy autoPolicy(int size) {
   }
 #endif
 
+#define THRUST_DYNAMIC_BACKEND_HOST_VOID(NAME)               \
+  template <typename... Args>                                \
+  void NAME##_host(ExecutionPolicy policy, Args... args) {   \
+    switch (policy) {                                        \
+      case ExecutionPolicy::ParUnseq:                        \
+      case ExecutionPolicy::Par:                             \
+        thrust::NAME(thrust::MANIFOLD_PAR_NS::par, args...); \
+        break;                                               \
+      case ExecutionPolicy::Seq:                             \
+        break;                                               \
+    }                                                        \
+    thrust::NAME(thrust::cpp::par, args...);                 \
+  }
+
+THRUST_DYNAMIC_BACKEND_HOST_VOID(for_each)
+THRUST_DYNAMIC_BACKEND_HOST_VOID(for_each_n)
+
 THRUST_DYNAMIC_BACKEND_VOID(gather)
 THRUST_DYNAMIC_BACKEND_VOID(scatter)
 THRUST_DYNAMIC_BACKEND_VOID(for_each)


### PR DESCRIPTION
Just some trivial parallelization, results in ~5% improvement for meshes with many unions. Just thought of this and this makes me unable to fall asleep...
`BatchBoolean` is not optimized yet, not sure if I should do parallelization as it will mess up with the mesh size and may end up being slower.