### PR TITLE
Update Clipper2 commit + avoid building Clipper2Z

### DIFF
--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -399,7 +399,7 @@ std::vector<CrossSection> CrossSection::Decompose() const {
  */
 CrossSection CrossSection::RectClip(const Rect& rect) const {
   auto r = C2::RectD(rect.min.x, rect.min.y, rect.max.x, rect.max.y);
-  auto ps = C2::RectClip(r, GetPaths(), false, precision_);
+  auto ps = C2::ExecuteRectClip(r, GetPaths(), false, precision_);
   return CrossSection(ps);
 }
 

--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(graphlite)
 set(CLIPPER2_UTILS OFF)
 set(CLIPPER2_EXAMPLES OFF)
 set(CLIPPER2_TESTS OFF)
+set(CLIPPER2_USINGZ "OFF" CACHE STRING "Preempt cache default of USINGZ (we only use 2d)")
 add_definitions(-D_HAS_EXCEPTIONS=0) # disable exceptions for STL
 
 add_subdirectory(clipper2/CPP)


### PR DESCRIPTION
I got a PR (https://github.com/AngusJohnson/Clipper2/pull/463) merged into Clipper2 making the build of **Clipper2Z** (which we do not use) optional. This update to that commit, turning USINGZ off, and fixing the one breaking change (rename of `RectClip` to `ExecuteRectClip`) that has happened since the last commit.