### PR TITLE
Add JS bindings for triangulation

### DIFF
--- a/bindings/wasm/CMakeLists.txt
+++ b/bindings/wasm/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(manifoldjs bindings.cpp)
 # make sure that we recompile the wasm when bindings.js is being modified
 set_source_files_properties(bindings.cpp OBJECT_DEPENDS
   ${CMAKE_CURRENT_SOURCE_DIR}/bindings.js)
-target_link_libraries(manifoldjs manifold sdf cross_section)
+target_link_libraries(manifoldjs manifold sdf cross_section polygon)
 target_compile_options(manifoldjs PRIVATE ${MANIFOLD_FLAGS} -fexceptions)
 target_link_options(manifoldjs PUBLIC --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/bindings.js --bind -sALLOW_TABLE_GROWTH=1
   -sEXPORTED_RUNTIME_METHODS=addFunction,removeFunction -sMODULARIZE=1 -sEXPORT_ES6=1)

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -142,21 +142,6 @@ Manifold Extrude(std::vector<std::vector<glm::vec2>>& polygons, float height,
                            twistDegrees, scaleTop);
 }
 
-std::vector<glm::ivec3> TriangulateJS(
-    std::vector<std::vector<glm::vec2>>& polygons) {
-  CrossSection crossSection(polygons);
-  int idx = 0;
-  PolygonsIdx polygonsIndexed;
-  for (auto& poly : polygons) {
-    SimplePolygonIdx simpleIndexed;
-    for (const glm::vec2& polyVert : poly) {
-      simpleIndexed.push_back({polyVert, idx++});
-    }
-    polygonsIndexed.push_back(simpleIndexed);
-  }
-  return Triangulate(polygonsIndexed);
-}
-
 Manifold Revolve(std::vector<std::vector<glm::vec2>>& polygons,
                  int circularSegments) {
   return Manifold::Revolve(ToPolygon(polygons), circularSegments);
@@ -282,7 +267,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
   function("tetrahedron", &Manifold::Tetrahedron);
   function("_Smooth", &Smooth);
   function("_Extrude", &Extrude);
-  function("_Triangulate", &TriangulateJS);
+  function("_Triangulate", &Triangulate);
   function("_Revolve", &Revolve);
   function("_LevelSet", &LevelSetJs);
 

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -145,11 +145,9 @@ Manifold Extrude(std::vector<std::vector<glm::vec2>>& polygons, float height,
 std::vector<glm::ivec3> TriangulateJS(
     std::vector<std::vector<glm::vec2>>& polygons) {
   CrossSection crossSection(polygons);
-  auto _polygons = crossSection.ToPolygons();
-
   int idx = 0;
   PolygonsIdx polygonsIndexed;
-  for (auto& poly : _polygons) {
+  for (auto& poly : polygons) {
     SimplePolygonIdx simpleIndexed;
     for (const glm::vec2& polyVert : poly) {
       simpleIndexed.push_back({polyVert, idx++});

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -302,9 +302,9 @@ Module.setup = function() {
     return result;
   };
 
-  Module.triangulate = function(polygons) {
+  Module.triangulate = function(polygons, precision = -1) {
     const polygonsVec = polygons2vec(polygons);
-    const result = fromVec(Module._Triangulate(polygonsVec), (x) => [x[0], x[1], x[2]]);
+    const result = fromVec(Module._Triangulate(polygonsVec, precision), (x) => [x[0], x[1], x[2]]);
     disposePolygons(polygonsVec);
     return result;
   }

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -302,6 +302,13 @@ Module.setup = function() {
     return result;
   };
 
+  Module.triangulate = function(polygons) {
+    const polygonsVec = polygons2vec(polygons);
+    const result = fromVec(Module._Triangulate(polygonsVec), (x) => [x[0], x[1], x[2]]);
+    disposePolygons(polygonsVec);
+    return result;
+  }
+
   Module.revolve = function(polygons, circularSegments = 0) {
     const polygonsVec = polygons2vec(polygons);
     const result = Module._Revolve(polygonsVec, circularSegments);

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -109,11 +109,14 @@ export function extrude(
     twistDegrees?: number, scaleTop?: Vec2): Manifold;
 
 /**
- * Triangulates a set of polygons.
- * 
- * @param crossSection A set of non-overlapping polygons to triangulate.
+ * Triangulates a set of /epsilon-valid polygons.
+ *
+ * @param polygons The set of polygons, wound CCW and representing multiple
+ * polygons and/or holes.
+ * @param precision The value of epsilon, bounding the uncertainty of the input
+ * @return The triangles, referencing the original polygon points in order.
  */
-export function triangulate(crossSection: Polygons): Vec3[];
+export function triangulate(polygons: Polygons, precision?: number): Vec3[];
 
 /**
  * Constructs a manifold from a set of polygons by revolving this cross-section

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -109,6 +109,13 @@ export function extrude(
     twistDegrees?: number, scaleTop?: Vec2): Manifold;
 
 /**
+ * Triangulates a set of polygons.
+ * 
+ * @param crossSection A set of non-overlapping polygons to triangulate.
+ */
+export function triangulate(crossSection: Polygons): Vec3[];
+
+/**
  * Constructs a manifold from a set of polygons by revolving this cross-section
  * around its Y-axis and then setting this as the Z-axis of the resulting
  * manifold. If the polygons cross the Y-axis, only the part on the positive X

--- a/bindings/wasm/manifold.d.ts
+++ b/bindings/wasm/manifold.d.ts
@@ -25,6 +25,7 @@ export interface ManifoldStatic {
   smooth: typeof T.smooth;
   tetrahedron: typeof T.tetrahedron;
   extrude: typeof T.extrude;
+  triangulate: typeof T.triangulate;
   revolve: typeof T.revolve;
   union: typeof T.union;
   difference: typeof T.difference;

--- a/src/manifold/src/constructors.cpp
+++ b/src/manifold/src/constructors.cpp
@@ -293,7 +293,7 @@ Manifold Manifold::Extrude(const CrossSection& crossSection, float height,
   if (isCone)
     for (int j = 0; j < polygons.size(); ++j)  // Duplicate vertex for Genus
       vertPos.push_back({0.0f, 0.0f, height});
-  std::vector<glm::ivec3> top = Triangulate(polygonsIndexed);
+  std::vector<glm::ivec3> top = TriangulateIdx(polygonsIndexed);
   for (const glm::ivec3& tri : top) {
     triVerts.push_back({tri[0], tri[2], tri[1]});
     if (!isCone) triVerts.push_back(tri + nCrossSection * nDivisions);

--- a/src/manifold/src/face_op.cpp
+++ b/src/manifold/src/face_op.cpp
@@ -121,7 +121,7 @@ void Manifold::Impl::Face2Tri(const VecDH<int>& faceEdge,
 
       const PolygonsIdx polys = Face2Polygons(face, projection, faceEdge);
 
-      std::vector<glm::ivec3> newTris = Triangulate(polys, precision_);
+      std::vector<glm::ivec3> newTris = TriangulateIdx(polys, precision_);
 
       for (auto tri : newTris) {
         triVerts.push_back(tri);

--- a/src/polygon/include/polygon.h
+++ b/src/polygon/include/polygon.h
@@ -36,8 +36,11 @@ struct PolyVert {
 using SimplePolygonIdx = std::vector<PolyVert>;
 using PolygonsIdx = std::vector<SimplePolygonIdx>;
 
-std::vector<glm::ivec3> Triangulate(const PolygonsIdx &polys,
-                                    float precision = -1);
+std::vector<glm::ivec3> TriangulateIdx(const PolygonsIdx &polys,
+                                       float precision = -1);
+
+std::vector<glm::ivec3> Triangulate(
+    std::vector<std::vector<glm::vec2>> &polygons, float precision = -1);
 
 ExecutionParams &PolygonParams();
 /** @} */

--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -1042,7 +1042,8 @@ namespace manifold {
  * @return std::vector<glm::ivec3> The triangles, referencing the original
  * vertex indicies.
  */
-std::vector<glm::ivec3> Triangulate(const PolygonsIdx &polys, float precision) {
+std::vector<glm::ivec3> TriangulateIdx(const PolygonsIdx &polys,
+                                       float precision) {
   std::vector<glm::ivec3> triangles;
   try {
     Monotones monotones(polys, precision);
@@ -1067,6 +1068,29 @@ std::vector<glm::ivec3> Triangulate(const PolygonsIdx &polys, float precision) {
 #endif
   }
   return triangles;
+}
+
+/**
+ * @brief Triangulates a set of /epsilon-valid polygons.
+ *
+ * @param polygons The set of polygons, wound CCW and representing multiple
+ * polygons and/or holes.
+ * @param precision The value of epsilon, bounding the uncertainty of the input
+ * @return std::vector<glm::ivec3> The triangles, referencing the original
+ * polygon points in order.
+ */
+std::vector<glm::ivec3> Triangulate(
+    std::vector<std::vector<glm::vec2>> &polygons, float precision) {
+  int idx = 0;
+  PolygonsIdx polygonsIndexed;
+  for (auto &poly : polygons) {
+    SimplePolygonIdx simpleIndexed;
+    for (const glm::vec2 &polyVert : poly) {
+      simpleIndexed.push_back({polyVert, idx++});
+    }
+    polygonsIndexed.push_back(simpleIndexed);
+  }
+  return TriangulateIdx(polygonsIndexed, precision);
 }
 
 ExecutionParams &PolygonParams() { return params; }

--- a/test/polygon_test.cpp
+++ b/test/polygon_test.cpp
@@ -91,13 +91,13 @@ void TestPoly(const PolygonsIdx &polys, int expectedNumTri,
   PolygonParams().verbose = options.params.verbose;
 
   std::vector<glm::ivec3> triangles;
-  EXPECT_NO_THROW(triangles = Triangulate(polys, precision));
+  EXPECT_NO_THROW(triangles = TriangulateIdx(polys, precision));
   EXPECT_EQ(triangles.size(), expectedNumTri) << "Basic";
 
-  EXPECT_NO_THROW(triangles = Triangulate(Turn180(polys), precision));
+  EXPECT_NO_THROW(triangles = TriangulateIdx(Turn180(polys), precision));
   EXPECT_EQ(triangles.size(), expectedNumTri) << "Turn 180";
 
-  EXPECT_NO_THROW(triangles = Triangulate(Duplicate(polys), precision));
+  EXPECT_NO_THROW(triangles = TriangulateIdx(Duplicate(polys), precision));
   EXPECT_EQ(triangles.size(), 2 * expectedNumTri) << "Duplicate";
 
   PolygonParams().verbose = false;


### PR DESCRIPTION
The triangulation algorithm available from JS allows you to create specific shapes efficiently, often without the need for boolean operations.

I was missing this very much as I frequently create custom polyhedrons, either from scratch, or based on modified geometry. This allows me to construct a manifold from a set of planar 3D polygons. I just project them to 2D (axis-aligned projection), triangulate and feed all the triangles to the manifold mesh constructor. Similar functionality is in OpenSCAD too [(polyhedron)](https://en.wikibooks.org/wiki/OpenSCAD_User_Manual/Primitive_Solids#polyhedron).

I believe the triangulation could be useful for many other users of the JS bindings and hope you'll be willing to merge this in some form.