### PR TITLE
Flip triangles in csg_tree

### DIFF
--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -23,6 +23,7 @@
 
 #include "graph.h"
 #include "hashtable.h"
+#include "mesh_fixes.h"
 #include "par.h"
 
 namespace {
@@ -43,12 +44,6 @@ __host__ __device__ void AtomicAddVec3(glm::vec3& target,
   }
 }
 
-__host__ __device__ int FlipHalfedge(int halfedge) {
-  const int tri = halfedge / 3;
-  const int vert = 2 - (halfedge - 3 * tri);
-  return 3 * tri + vert;
-}
-
 struct Normalize {
   __host__ __device__ void operator()(glm::vec3& v) { v = SafeNormalize(v); }
 };
@@ -58,52 +53,6 @@ struct Transform4x3 {
 
   __host__ __device__ glm::vec3 operator()(glm::vec3 position) {
     return transform * glm::vec4(position, 1.0f);
-  }
-};
-
-struct TransformNormals {
-  const glm::mat3 transform;
-
-  __host__ __device__ glm::vec3 operator()(glm::vec3 normal) {
-    normal = glm::normalize(transform * normal);
-    if (isnan(normal.x)) normal = glm::vec3(0.0f);
-    return normal;
-  }
-};
-
-struct TransformTangents {
-  const glm::mat3 transform;
-  const bool invert;
-  const glm::vec4* oldTangents;
-  const Halfedge* halfedge;
-
-  __host__ __device__ void operator()(thrust::tuple<glm::vec4&, int> inOut) {
-    glm::vec4& tangent = thrust::get<0>(inOut);
-    int edge = thrust::get<1>(inOut);
-    if (invert) {
-      edge = halfedge[FlipHalfedge(edge)].pairedHalfedge;
-    }
-
-    tangent = glm::vec4(transform * glm::vec3(oldTangents[edge]),
-                        oldTangents[edge].w);
-  }
-};
-
-struct FlipTris {
-  Halfedge* halfedge;
-
-  __host__ __device__ void operator()(thrust::tuple<TriRef&, int> inOut) {
-    TriRef& bary = thrust::get<0>(inOut);
-    const int tri = thrust::get<1>(inOut);
-
-    thrust::swap(halfedge[3 * tri], halfedge[3 * tri + 2]);
-
-    for (const int i : {0, 1, 2}) {
-      thrust::swap(halfedge[3 * tri + i].startVert,
-                   halfedge[3 * tri + i].endVert);
-      halfedge[3 * tri + i].pairedHalfedge =
-          FlipHalfedge(halfedge[3 * tri + i].pairedHalfedge);
-    }
   }
 };
 

--- a/src/manifold/src/mesh_fixes.h
+++ b/src/manifold/src/mesh_fixes.h
@@ -1,0 +1,57 @@
+#include "impl.h"
+
+namespace {
+using namespace manifold;
+
+__host__ __device__ inline int FlipHalfedge(int halfedge) {
+  const int tri = halfedge / 3;
+  const int vert = 2 - (halfedge - 3 * tri);
+  return 3 * tri + vert;
+}
+
+struct TransformNormals {
+  const glm::mat3 transform;
+
+  __host__ __device__ glm::vec3 operator()(glm::vec3 normal) {
+    normal = glm::normalize(transform * normal);
+    if (isnan(normal.x)) normal = glm::vec3(0.0f);
+    return normal;
+  }
+};
+
+struct TransformTangents {
+  const glm::mat3 transform;
+  const bool invert;
+  const glm::vec4* oldTangents;
+  const Halfedge* halfedge;
+
+  __host__ __device__ void operator()(thrust::tuple<glm::vec4&, int> inOut) {
+    glm::vec4& tangent = thrust::get<0>(inOut);
+    int edge = thrust::get<1>(inOut);
+    if (invert) {
+      edge = halfedge[FlipHalfedge(edge)].pairedHalfedge;
+    }
+
+    tangent = glm::vec4(transform * glm::vec3(oldTangents[edge]),
+                        oldTangents[edge].w);
+  }
+};
+
+struct FlipTris {
+  Halfedge* halfedge;
+
+  __host__ __device__ void operator()(thrust::tuple<TriRef&, int> inOut) {
+    TriRef& bary = thrust::get<0>(inOut);
+    const int tri = thrust::get<1>(inOut);
+
+    thrust::swap(halfedge[3 * tri], halfedge[3 * tri + 2]);
+
+    for (const int i : {0, 1, 2}) {
+      thrust::swap(halfedge[3 * tri + i].startVert,
+                   halfedge[3 * tri + i].endVert);
+      halfedge[3 * tri + i].pairedHalfedge =
+          FlipHalfedge(halfedge[3 * tri + i].pairedHalfedge);
+    }
+  }
+};
+}  // namespace

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -507,6 +507,12 @@ TEST(Manifold, MirrorUnion) {
   EXPECT_TRUE(a.Mirror(glm::vec3(0)).IsEmpty());
 }
 
+TEST(Manifold, MirrorUnion2) {
+  auto a = Manifold::Cube();
+  auto result = Manifold::Compose({a.Mirror({1, 0, 0})});
+  EXPECT_TRUE(result.MatchesTriNormals());
+}
+
 TEST(Manifold, Invalid) {
   auto invalid = Manifold::Error::InvalidConstruction;
   auto circ = CrossSection::Circle(10.);


### PR DESCRIPTION
Although we already have related logic in `impl.cpp`, the compose code will skip performing transformation on the original mesh, and apply transformation on the combined mesh directly, skipping the previous fix. The logic is now added to the compose function to fix the bug without much performance penalty. This also factors out some functions used in both `impl.cpp` and `csg_tree.cpp` (although we should probably give it a better name).

Fixes #403