### PR TITLE
Manifold extension for glTF

### DIFF
--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -356,7 +356,7 @@ size_t manifold_meshgl_tri_length(ManifoldMeshGL *m) {
 }
 
 size_t manifold_meshgl_merge_length(ManifoldMeshGL *m) {
-  return from_c(m)->mergeFromVert.size();
+  return from_c(m)->mergeTriVert.size();
 }
 
 size_t manifold_meshgl_run_index_length(ManifoldMeshGL *m) {
@@ -388,7 +388,7 @@ uint32_t *manifold_meshgl_tri_verts(void *mem, ManifoldMeshGL *m) {
 }
 
 uint32_t *manifold_meshgl_merge_from_vert(void *mem, ManifoldMeshGL *m) {
-  return copy_data(mem, from_c(m)->mergeFromVert);
+  return copy_data(mem, from_c(m)->mergeTriVert);
 }
 
 uint32_t *manifold_meshgl_merge_to_vert(void *mem, ManifoldMeshGL *m) {

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -56,8 +56,7 @@ std::vector<SimplePolygon> ToPolygon(
   return simplePolygons;
 }
 
-val GetMeshJS(const Manifold& manifold, const glm::ivec3& normalIdx) {
-  MeshGL mesh = manifold.GetMeshGL(normalIdx);
+val MeshGL2JS(const MeshGL& mesh) {
   val meshJS = val::object();
 
   meshJS.set("numProp", mesh.numProp);
@@ -126,6 +125,20 @@ MeshGL MeshJS2GL(const val& mesh) {
     out.runTransform =
         convertJSArrayToNumberVector<float>(mesh["runTransform"]);
   }
+  return out;
+}
+
+val GetMeshJS(const Manifold& manifold, const glm::ivec3& normalIdx) {
+  MeshGL mesh = manifold.GetMeshGL(normalIdx);
+  return MeshGL2JS(mesh);
+}
+
+val Merge(const val& mesh) {
+  val out = val::object();
+  MeshGL meshGL = MeshJS2GL(mesh);
+  bool changed = meshGL.Merge();
+  out.set("changed", changed);
+  out.set("mesh", changed ? MeshGL2JS(meshGL) : mesh);
   return out;
 }
 
@@ -270,6 +283,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
   function("_Triangulate", &Triangulate);
   function("_Revolve", &Revolve);
   function("_LevelSet", &LevelSetJs);
+  function("_Merge", &Merge);
 
   function("_unionN", &UnionN);
   function("_differenceN", &DifferenceN);

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -68,9 +68,9 @@ val GetMeshJS(const Manifold& manifold, const glm::ivec3& normalIdx) {
              val(typed_memory_view(mesh.vertProperties.size(),
                                    mesh.vertProperties.data()))
                  .call<val>("slice"));
-  meshJS.set("mergeFromVert", val(typed_memory_view(mesh.mergeFromVert.size(),
-                                                    mesh.mergeFromVert.data()))
-                                  .call<val>("slice"));
+  meshJS.set("mergeTriVert", val(typed_memory_view(mesh.mergeTriVert.size(),
+                                                   mesh.mergeTriVert.data()))
+                                 .call<val>("slice"));
   meshJS.set("mergeToVert", val(typed_memory_view(mesh.mergeToVert.size(),
                                                   mesh.mergeToVert.data()))
                                 .call<val>("slice"));
@@ -100,9 +100,9 @@ MeshGL MeshJS2GL(const val& mesh) {
   out.triVerts = convertJSArrayToNumberVector<uint32_t>(mesh["triVerts"]);
   out.vertProperties =
       convertJSArrayToNumberVector<float>(mesh["vertProperties"]);
-  if (mesh["mergeFromVert"] != val::undefined()) {
-    out.mergeFromVert =
-        convertJSArrayToNumberVector<uint32_t>(mesh["mergeFromVert"]);
+  if (mesh["mergeTriVert"] != val::undefined()) {
+    out.mergeTriVert =
+        convertJSArrayToNumberVector<uint32_t>(mesh["mergeTriVert"]);
   }
   if (mesh["mergeToVert"] != val::undefined()) {
     out.mergeToVert =

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -153,6 +153,12 @@ Module.setup = function() {
       return this.runOriginalID.length;
     }
 
+    merge() {
+      const {changed, mesh} = Module._Merge(this);
+      Object.assign(this, {...mesh});
+      return changed;
+    }
+
     verts(tri) {
       return this.triVerts.subarray(3 * tri, 3 * (tri + 1));
     }

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -121,7 +121,7 @@ Module.setup = function() {
       numProp = 3,
       triVerts = new Uint32Array(),
       vertProperties = new Float32Array(),
-      mergeFromVert,
+      mergeTriVert,
       mergeToVert,
       runIndex,
       runOriginalID,
@@ -132,7 +132,7 @@ Module.setup = function() {
       this.numProp = numProp;
       this.triVerts = triVerts;
       this.vertProperties = vertProperties;
-      this.mergeFromVert = mergeFromVert;
+      this.mergeTriVert = mergeTriVert;
       this.mergeToVert = mergeToVert;
       this.runIndex = runIndex;
       this.runOriginalID = runOriginalID;
@@ -302,14 +302,16 @@ Module.setup = function() {
     return result;
   };
 
-  Module.triangulate = function(polygons, precision = -1) {
+  Module.triangulate =
+      function(polygons, precision = -1) {
     const polygonsVec = polygons2vec(polygons);
-    const result = fromVec(Module._Triangulate(polygonsVec, precision), (x) => [x[0], x[1], x[2]]);
+    const result = fromVec(
+        Module._Triangulate(polygonsVec, precision), (x) => [x[0], x[1], x[2]]);
     disposePolygons(polygonsVec);
     return result;
   }
 
-  Module.revolve = function(polygons, circularSegments = 0) {
+      Module.revolve = function(polygons, circularSegments = 0) {
     const polygonsVec = polygons2vec(polygons);
     const result = Module._Revolve(polygonsVec, circularSegments);
     disposePolygons(polygonsVec);

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -56,10 +56,14 @@
 </script>
 <script type="module" src="https://ajax.googleapis.com/ajax/libs/model-viewer/2.0.1/model-viewer.min.js"></script>
 <script type="module">
-  import { loadTexture, toGLTFMesh, disposeMesh, getGLTFDoc, writeGLB, getRootNode } from '../gltfIO.js';
+  import { Document } from '@gltf-transform/core';
+  import { loadTexture, toGLTFMesh, disposeMesh, writeGLB } from '../gltfIO.js';
   import Module from '../manifold.js';
 
-  const doc = getGLTFDoc();
+  const doc = new Document();
+  const node = doc.createNode();
+  doc.createScene().addChild(node);
+
   const moonTexture = doc.createTexture('moon');
   const spaceTexture = doc.createTexture('space');
   const moonMaterial = doc.createMaterial('moon').setBaseColorTexture(moonTexture);
@@ -94,14 +98,13 @@
     // From Z-up to Y-up (glTF)
     const manifoldMesh = manifold.rotate([-90, 0, 0]).getMesh();
 
-    const node = getRootNode();
     disposeMesh(node.getMesh());
-    const mesh = toGLTFMesh(manifoldMesh, attributeArray, materialArray);
+    const mesh = toGLTFMesh(doc, manifoldMesh, attributeArray, materialArray);
     node.setMesh(mesh);
 
     await texturesLoad;
 
-    const glb = await writeGLB();
+    const glb = await writeGLB(doc);
 
     const blob = new Blob([glb], { type: 'application/octet-stream' });
     URL.revokeObjectURL(objectURL);

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -177,8 +177,22 @@
     const mesh = manifold.rotate([-90, 0, 0]).getMesh();
 
     indices.setArray(mesh.triVerts);
-    mergeIndices.setArray(mesh.mergeFromVert);
-    mergeValues.setArray(mesh.mergeToVert);
+
+    const vert2merge = [...Array(mesh.numVert).keys()];
+    for (const [i, from] of mesh.mergeFromVert.entries()) {
+      vert2merge[from] = mesh.mergeToVert[i];
+    }
+    const ind = [];
+    const val = [];
+    for (const [i, vert] of mesh.triVerts.entries()) {
+      const newVert = vert2merge[vert];
+      if (vert !== newVert) {
+        ind.push(i);
+        val.push(newVert);
+      }
+    }
+    mergeIndices.setArray(new Uint32Array(ind));
+    mergeValues.setArray(new Uint32Array(val));
 
     const numVert = mesh.numVert;
     const numProp = mesh.numProp;

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -169,6 +169,7 @@
     const runOriginalID = new Uint32Array(1);
     const meshUV = new wasm.Mesh({ numProp, triVerts, vertProperties, runOriginalID });
     runOriginalID[0] = id;
+    const vert2vert = new Uint32Array(numVert);
     let idx = 0;
     for (let i = 0; i < numVert; ++i) {
       const x = mesh.vertProperties[numPropIn * i];
@@ -182,6 +183,7 @@
       vertProperties[numProp * i + 4] = v;
       if (Math.abs(y) < tol && x < -tol) {// Seam
         const iNew = numVert + idx;
+        vert2vert[i] = iNew;
         vertProperties[numProp * iNew] = x;
         vertProperties[numProp * iNew + 1] = y;
         vertProperties[numProp * iNew + 2] = z;
@@ -190,6 +192,7 @@
         vertProperties[numProp * i + 3] = 0;
         ++idx;
       } else {
+        vert2vert[i] = i;
         vertProperties[numProp * i + 3] = u;
       }
     }
@@ -197,9 +200,17 @@
       const v0 = mesh.triVerts[3 * tri];
       const v1 = mesh.triVerts[3 * tri + 1];
       const v2 = mesh.triVerts[3 * tri + 2];
-      triVerts[3 * tri] = v0;
-      triVerts[3 * tri + 1] = v1;
-      triVerts[3 * tri + 2] = v2;
+      if ((vert2vert[v0] !== v0 || vert2vert[v1] !== v1 || vert2vert[v2] !== v2) &&
+        (vertProperties[numProp * v0 + 1] > tol || vertProperties[numProp * v1 + 1] > tol ||
+          vertProperties[numProp * v2 + 1] > tol)) {
+        triVerts[3 * tri] = vert2vert[v0];
+        triVerts[3 * tri + 1] = vert2vert[v1];
+        triVerts[3 * tri + 2] = vert2vert[v2];
+      } else {
+        triVerts[3 * tri] = v0;
+        triVerts[3 * tri + 1] = v1;
+        triVerts[3 * tri + 2] = v2;
+      }
     }
     meshUV.merge();
     return wasm.Manifold(meshUV);

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -134,10 +134,10 @@
     const v4 = [0, 1, 2, 5];
     const v6 = [0, 1, 2, 0, 2, 3];
     const vertProperties = new Float32Array(numProp * numPropVert);
-    const mergeFromVert = new Uint32Array(numPropVert - numVert);
+    const mergeTriVert = new Uint32Array(numPropVert - numVert);
     const mergeToVert = new Uint32Array(numPropVert - numVert);
     const runOriginalID = new Uint32Array(1);
-    const meshUV = new wasm.Mesh({ numProp, triVerts, vertProperties, mergeFromVert, mergeToVert, runOriginalID });
+    const meshUV = new wasm.Mesh({ numProp, triVerts, vertProperties, mergeTriVert, mergeToVert, runOriginalID });
     runOriginalID[0] = id;
     const vert2vert = [-1, -1, -1, -1, -1, -1, -1, -1];
     let idx = 0;
@@ -148,7 +148,7 @@
         if (vert2vert[vOld] === -1) {
           vert2vert[vOld] = vIdx;
         } else {
-          mergeFromVert[idx] = vIdx;
+          mergeTriVert[idx] = vIdx;
           mergeToVert[idx] = vert2vert[vOld];
           ++idx;
         }
@@ -176,10 +176,10 @@
     const numProp = 5;
     const triVerts = new Uint32Array(3 * numTri);
     const vertProperties = new Float32Array(numProp * (numVert + nMerge));
-    const mergeFromVert = new Uint32Array(nMerge);
+    const mergeTriVert = new Uint32Array(nMerge);
     const mergeToVert = new Uint32Array(nMerge);
     const runOriginalID = new Uint32Array(1);
-    const meshUV = new wasm.Mesh({ numProp, triVerts, vertProperties, mergeFromVert, mergeToVert, runOriginalID });
+    const meshUV = new wasm.Mesh({ numProp, triVerts, vertProperties, mergeTriVert, mergeToVert, runOriginalID });
     runOriginalID[0] = id;
     const vert2vert = new Uint32Array(numVert);
     let idx = 0;
@@ -195,7 +195,7 @@
       vertProperties[numProp * i + 4] = v;
       if (Math.abs(y) < tol && x < -tol) {// Seam
         const iNew = numVert + idx;
-        mergeFromVert[idx] = iNew;
+        mergeTriVert[idx] = iNew;
         mergeToVert[idx] = i;
         vert2vert[i] = iNew;
         vertProperties[numProp * iNew] = x;

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -57,7 +57,7 @@
 <script type="module" src="https://ajax.googleapis.com/ajax/libs/model-viewer/2.0.1/model-viewer.min.js"></script>
 <script type="module">
   import { Document, WebIO } from '@gltf-transform/core';
-  import { loadTexture, toGLTFMesh, disposeMesh, setupIO } from '../gltfIO.js';
+  import { loadTexture, writeMesh, disposeMesh, setupIO, getMaterialMap } from '../gltfIO.js';
   import Module from '../manifold.js';
 
   const io = setupIO(new WebIO());
@@ -79,7 +79,9 @@
   const firstID = wasm.reserveIDs(2);
   const space = cubeUV(firstID).scale(50);
   const moon = sphereUV(firstID + 1).scale(60);
-  const materialArray = [spaceMaterial, moonMaterial];
+  const materialMap = getMaterialMap();
+  materialMap.set(firstID, spaceMaterial);
+  materialMap.set(firstID + 1, moonMaterial);
   const attributeArray = ['POSITION', 'TEXCOORD_0'];
 
   const csg = function (operation) {
@@ -100,7 +102,7 @@
     const manifoldMesh = manifold.rotate([-90, 0, 0]).getMesh();
 
     disposeMesh(node.getMesh());
-    const mesh = toGLTFMesh(doc, manifoldMesh, attributeArray, materialArray);
+    const mesh = writeMesh(doc, manifoldMesh, attributeArray);
     node.setMesh(mesh);
 
     await texturesLoad;

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -47,50 +47,33 @@
   </select>
   <model-viewer camera-controls shadow-intensity="1" alt="Output of mesh Boolean operation"></model-viewer>
 </body>
+<script type="importmap">
+  {
+    "imports": {
+      "@gltf-transform/core": "https://cdn.jsdelivr.net/npm/@gltf-transform/core@3.1.2/+esm"
+    }
+  }
+</script>
 <script type="module" src="https://ajax.googleapis.com/ajax/libs/model-viewer/2.0.1/model-viewer.min.js"></script>
 <script type="module">
-  import { Accessor, Document, WebIO, Format, BufferUtils } from 'https://cdn.jsdelivr.net/npm/@gltf-transform/core@3.1.2/+esm';
+  import { Document, WebIO } from '@gltf-transform/core';
+  import { EXTManifold } from '../manifold-gltf.js';
+  import { loadTexture, toGLTFMesh, disposeMesh } from '../gltfIO.js';
   import Module from '../manifold.js';
 
-  const io = new WebIO();
+  const io = new WebIO().registerExtensions([EXTManifold]);
   const doc = new Document();
+  doc.createBuffer();
+  const node = doc.createNode();
+  doc.createScene().addChild(node);
 
-  const buffer = doc.createBuffer();
-  const position = doc.createAccessor().setBuffer(buffer).setType(Accessor.Type.VEC3);
-  const uv = doc.createAccessor().setBuffer(buffer).setType(Accessor.Type.VEC2);
-  const indices = doc.createAccessor('indices').setBuffer(buffer).setType(Accessor.Type.SCALAR);
   const moonTexture = doc.createTexture('moon');
   const spaceTexture = doc.createTexture('space');
   const moonMaterial = doc.createMaterial('moon').setBaseColorTexture(moonTexture);
   const spaceMaterial = doc.createMaterial('space').setBaseColorTexture(spaceTexture);
-  const moonPrimitive = doc.createPrimitive().setMaterial(moonMaterial)
-    .setIndices(indices).setAttribute('POSITION', position).setAttribute('TEXCOORD_0', uv);
-  const spacePrimitive = doc.createPrimitive().setMaterial(spaceMaterial)
-    .setIndices(indices).setAttribute('POSITION', position).setAttribute('TEXCOORD_0', uv);
-  const manifoldPrimitive = doc.createPrimitive()
-    .setIndices(indices).setAttribute('POSITION', position);
-  const mesh = doc.createMesh('result').addPrimitive(moonPrimitive).addPrimitive(spacePrimitive).addPrimitive(manifoldPrimitive);
-  const node = doc.createNode().setMesh(mesh);
-  const scene = doc.createScene().addChild(node);
-
-  const mergeIndices = doc.createAccessor('mergeFrom').setBuffer(buffer).setType(Accessor.Type.SCALAR);
-  const mergeValues = doc.createAccessor('mergeTo').setBuffer(buffer).setType(Accessor.Type.SCALAR);
-
-  async function loadTexture(texture, uri) {
-    const response = await fetch(uri);
-    const blob = await response.blob();
-    texture.setMimeType(blob.type);
-    texture.setImage(new Uint8Array(await blob.arrayBuffer()));
-  }
-
-  async function loadTextures() {
-    const moonLoads = loadTexture(moonTexture, './moonAltitude.jpg');
-    const spaceLoads = loadTexture(spaceTexture, './hubbleDeepField.jpg');
-    await Promise.all([moonLoads, spaceLoads]);
-  }
-
-  const texturesLoad = loadTextures();
-  const materialMap = new Map();
+  const moonLoads = loadTexture(moonTexture, './moonAltitude.jpg');
+  const spaceLoads = loadTexture(spaceTexture, './hubbleDeepField.jpg');
+  const texturesLoad = Promise.all([moonLoads, spaceLoads]);
 
   const wasm = await Module();
   wasm.setup();
@@ -98,8 +81,8 @@
   const firstID = wasm.reserveIDs(2);
   const space = cubeUV(firstID).scale(50);
   const moon = sphereUV(firstID + 1).scale(60);
-  materialMap.set(firstID, 'space');
-  materialMap.set(firstID + 1, 'moon');
+  const materialArray = [spaceMaterial, moonMaterial];
+  const attributeArray = ['POSITION', 'TEXCOORD_0'];
 
   const csg = function (operation) {
     push2MV(wasm[operation](space, moon));
@@ -114,107 +97,17 @@
   const mv = document.querySelector('model-viewer');
   let objectURL = null;
 
-  function addExtension(json, mesh) {
-    const indicesAccessor = json.accessors.find((a) => { return a.name == 'indices'; });
-    const mergeFromAccessor = json.accessors.find((a) => { return a.name == 'mergeFrom'; });
-    const mergeToAccessor = json.accessors.find((a) => { return a.name == 'mergeTo'; });
-    indicesAccessor.sparse = {
-      count: mergeFromAccessor.count,
-      indices: {
-        bufferView: mergeFromAccessor.bufferView,
-        byteOffset: mergeFromAccessor.byteOffset,
-        componentType: 5125
-      },
-      values: {
-        bufferView: mergeToAccessor.bufferView,
-        byteOffset: mergeToAccessor.byteOffset,
-      }
-    };
-
-    for (const [i, id] of mesh.runOriginalID.entries()) {
-      const name = materialMap.get(id);
-      const primitive = json.meshes[0].primitives.find((p) => { return json.materials[p.material].name == name; });
-      primitive.indices = json.accessors.length;
-      json.accessors.push({
-        name,
-        type: "SCALAR",
-        componentType: 5125,
-        count: mesh.runIndex[i + 1] - mesh.runIndex[i],
-        bufferView: indicesAccessor.bufferView,
-        byteOffset: 4 * mesh.runIndex[i]
-      });
-    }
-
-    console.log(json);
-    // const manifoldIdx = json.meshes[0].primitives.findIndex((p) => { return p.material == null; });
-    // const manifoldPrimitives = json.meshes[0].primitives.splice(manifoldIdx, 1);
-  }
-
-  async function writeGLB(json, resources) {
-    const header = new Uint32Array([0x46546c67, 2, 12]);
-
-    const jsonText = JSON.stringify(json);
-    const jsonChunkData = BufferUtils.pad(BufferUtils.encodeText(jsonText), 0x20);
-    const jsonChunkHeader = BufferUtils.toView(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]));
-    const jsonChunk = BufferUtils.concat([jsonChunkHeader, jsonChunkData]);
-    header[header.length - 1] += jsonChunk.byteLength;
-
-    const binBuffer = Object.values(resources)[0];
-    if (!binBuffer || !binBuffer.byteLength) {
-      return BufferUtils.concat([BufferUtils.toView(header), jsonChunk]);
-    }
-
-    const binChunkData = BufferUtils.pad(binBuffer, 0x00);
-    const binChunkHeader = BufferUtils.toView(new Uint32Array([binChunkData.byteLength, 0x004e4942]));
-    const binChunk = BufferUtils.concat([binChunkHeader, binChunkData]);
-    header[header.length - 1] += binChunk.byteLength;
-
-    return BufferUtils.concat([BufferUtils.toView(header), jsonChunk, binChunk]);
-  }
-
   async function push2MV(manifold) {
     // From Z-up to Y-up (glTF)
-    const mesh = manifold.rotate([-90, 0, 0]).getMesh();
+    const manifoldMesh = manifold.rotate([-90, 0, 0]).getMesh();
 
-    indices.setArray(mesh.triVerts);
-
-    const vert2merge = [...Array(mesh.numVert).keys()];
-    for (const [i, from] of mesh.mergeFromVert.entries()) {
-      vert2merge[from] = mesh.mergeToVert[i];
-    }
-    const ind = [];
-    const val = [];
-    for (const [i, vert] of mesh.triVerts.entries()) {
-      const newVert = vert2merge[vert];
-      if (vert !== newVert) {
-        ind.push(i);
-        val.push(newVert);
-      }
-    }
-    mergeIndices.setArray(new Uint32Array(ind));
-    mergeValues.setArray(new Uint32Array(val));
-
-    const numVert = mesh.numVert;
-    const numProp = mesh.numProp;
-    const posArray = new Float32Array(3 * numVert);
-    const uvArray = new Float32Array(2 * numVert);
-    for (let i = 0; i < numVert; ++i) {
-      posArray[3 * i] = mesh.vertProperties[numProp * i];
-      posArray[3 * i + 1] = mesh.vertProperties[numProp * i + 1];
-      posArray[3 * i + 2] = mesh.vertProperties[numProp * i + 2];
-      uvArray[2 * i] = mesh.vertProperties[numProp * i + 3];
-      uvArray[2 * i + 1] = mesh.vertProperties[numProp * i + 4];
-    }
-    position.setArray(posArray);
-    uv.setArray(uvArray);
+    disposeMesh(node.getMesh());
+    const mesh = toGLTFMesh(doc, manifoldMesh, attributeArray, materialArray);
+    node.setMesh(mesh);
 
     await texturesLoad;
 
-    const { json, resources } = await io.writeJSON(doc, { format: Format.GLB });
-
-    addExtension(json, mesh);
-
-    const glb = await writeGLB(json, resources);
+    const glb = await io.writeBinary(doc);
 
     const blob = new Blob([glb], { type: 'application/octet-stream' });
     URL.revokeObjectURL(objectURL);

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -134,24 +134,13 @@
     const v4 = [0, 1, 2, 5];
     const v6 = [0, 1, 2, 0, 2, 3];
     const vertProperties = new Float32Array(numProp * numPropVert);
-    const mergeTriVert = new Uint32Array(numPropVert - numVert);
-    const mergeToVert = new Uint32Array(numPropVert - numVert);
     const runOriginalID = new Uint32Array(1);
-    const meshUV = new wasm.Mesh({ numProp, triVerts, vertProperties, mergeTriVert, mergeToVert, runOriginalID });
+    const meshUV = new wasm.Mesh({ numProp, triVerts, vertProperties, runOriginalID });
     runOriginalID[0] = id;
-    const vert2vert = [-1, -1, -1, -1, -1, -1, -1, -1];
-    let idx = 0;
     for (let face = 0; face < 6; ++face) {
       for (let v = 0; v < 4; ++v) {
         const vIdx = 4 * face + v;
         const vOld = triVerts[6 * face + v4[v]];
-        if (vert2vert[vOld] === -1) {
-          vert2vert[vOld] = vIdx;
-        } else {
-          mergeTriVert[idx] = vIdx;
-          mergeToVert[idx] = vert2vert[vOld];
-          ++idx;
-        }
         for (let i = 0; i < 3; ++i) {
           vertProperties[numProp * vIdx + i] = vertPos[3 * vOld + i];
         }
@@ -162,6 +151,7 @@
         triVerts[6 * face + i] = 4 * face + v6[i];
       }
     }
+    meshUV.merge();
     return wasm.Manifold(meshUV);
   }
 
@@ -176,10 +166,8 @@
     const numProp = 5;
     const triVerts = new Uint32Array(3 * numTri);
     const vertProperties = new Float32Array(numProp * (numVert + nMerge));
-    const mergeTriVert = new Uint32Array(nMerge);
-    const mergeToVert = new Uint32Array(nMerge);
     const runOriginalID = new Uint32Array(1);
-    const meshUV = new wasm.Mesh({ numProp, triVerts, vertProperties, mergeTriVert, mergeToVert, runOriginalID });
+    const meshUV = new wasm.Mesh({ numProp, triVerts, vertProperties, runOriginalID });
     runOriginalID[0] = id;
     const vert2vert = new Uint32Array(numVert);
     let idx = 0;
@@ -195,9 +183,6 @@
       vertProperties[numProp * i + 4] = v;
       if (Math.abs(y) < tol && x < -tol) {// Seam
         const iNew = numVert + idx;
-        mergeTriVert[idx] = iNew;
-        mergeToVert[idx] = i;
-        vert2vert[i] = iNew;
         vertProperties[numProp * iNew] = x;
         vertProperties[numProp * iNew + 1] = y;
         vertProperties[numProp * iNew + 2] = z;
@@ -206,7 +191,6 @@
         vertProperties[numProp * i + 3] = 0;
         ++idx;
       } else {
-        vert2vert[i] = i;
         vertProperties[numProp * i + 3] = u;
       }
     }
@@ -214,18 +198,11 @@
       const v0 = mesh.triVerts[3 * tri];
       const v1 = mesh.triVerts[3 * tri + 1];
       const v2 = mesh.triVerts[3 * tri + 2];
-      if ((vert2vert[v0] !== v0 || vert2vert[v1] !== v1 || vert2vert[v2] !== v2) &&
-        (vertProperties[numProp * v0 + 1] > tol || vertProperties[numProp * v1 + 1] > tol ||
-          vertProperties[numProp * v2 + 1] > tol)) {
-        triVerts[3 * tri] = vert2vert[v0];
-        triVerts[3 * tri + 1] = vert2vert[v1];
-        triVerts[3 * tri + 2] = vert2vert[v2];
-      } else {
-        triVerts[3 * tri] = v0;
-        triVerts[3 * tri + 1] = v1;
-        triVerts[3 * tri + 2] = v2;
-      }
+      triVerts[3 * tri] = v0;
+      triVerts[3 * tri + 1] = v1;
+      triVerts[3 * tri + 2] = v2;
     }
+    meshUV.merge();
     return wasm.Manifold(meshUV);
   }
 </script>

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -56,17 +56,10 @@
 </script>
 <script type="module" src="https://ajax.googleapis.com/ajax/libs/model-viewer/2.0.1/model-viewer.min.js"></script>
 <script type="module">
-  import { Document, WebIO } from '@gltf-transform/core';
-  import { EXTManifold } from '../manifold-gltf.js';
-  import { loadTexture, toGLTFMesh, disposeMesh } from '../gltfIO.js';
+  import { loadTexture, toGLTFMesh, disposeMesh, getGLTFDoc, writeGLB, getRootNode } from '../gltfIO.js';
   import Module from '../manifold.js';
 
-  const io = new WebIO().registerExtensions([EXTManifold]);
-  const doc = new Document();
-  doc.createBuffer();
-  const node = doc.createNode();
-  doc.createScene().addChild(node);
-
+  const doc = getGLTFDoc();
   const moonTexture = doc.createTexture('moon');
   const spaceTexture = doc.createTexture('space');
   const moonMaterial = doc.createMaterial('moon').setBaseColorTexture(moonTexture);
@@ -101,13 +94,14 @@
     // From Z-up to Y-up (glTF)
     const manifoldMesh = manifold.rotate([-90, 0, 0]).getMesh();
 
+    const node = getRootNode();
     disposeMesh(node.getMesh());
-    const mesh = toGLTFMesh(doc, manifoldMesh, attributeArray, materialArray);
+    const mesh = toGLTFMesh(manifoldMesh, attributeArray, materialArray);
     node.setMesh(mesh);
 
     await texturesLoad;
 
-    const glb = await io.writeBinary(doc);
+    const glb = await writeGLB();
 
     const blob = new Blob([glb], { type: 'application/octet-stream' });
     URL.revokeObjectURL(objectURL);

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -169,7 +169,6 @@
     const runOriginalID = new Uint32Array(1);
     const meshUV = new wasm.Mesh({ numProp, triVerts, vertProperties, runOriginalID });
     runOriginalID[0] = id;
-    const vert2vert = new Uint32Array(numVert);
     let idx = 0;
     for (let i = 0; i < numVert; ++i) {
       const x = mesh.vertProperties[numPropIn * i];

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -49,7 +49,7 @@
 </body>
 <script type="module" src="https://ajax.googleapis.com/ajax/libs/model-viewer/2.0.1/model-viewer.min.js"></script>
 <script type="module">
-  import { Accessor, Document, WebIO } from 'https://cdn.skypack.dev/pin/@gltf-transform/core@v3.0.0-SfbIFhNPTRdr1UE2VSan/mode=imports,min/optimized/@gltf-transform/core.js';
+  import { Accessor, Document, WebIO, Format, BufferUtils } from 'https://cdn.jsdelivr.net/npm/@gltf-transform/core@3.1.2/+esm';
   import Module from '../manifold.js';
 
   const io = new WebIO();
@@ -58,19 +58,23 @@
   const buffer = doc.createBuffer();
   const position = doc.createAccessor().setBuffer(buffer).setType(Accessor.Type.VEC3);
   const uv = doc.createAccessor().setBuffer(buffer).setType(Accessor.Type.VEC2);
-  const moonIndices = doc.createAccessor().setBuffer(buffer).setType(Accessor.Type.SCALAR);
-  const spaceIndices = doc.createAccessor().setBuffer(buffer).setType(Accessor.Type.SCALAR);
+  const indices = doc.createAccessor('indices').setBuffer(buffer).setType(Accessor.Type.SCALAR);
   const moonTexture = doc.createTexture('moon');
   const spaceTexture = doc.createTexture('space');
   const moonMaterial = doc.createMaterial('moon').setBaseColorTexture(moonTexture);
-  const spaceMaterial = doc.createMaterial('moon').setBaseColorTexture(spaceTexture);
+  const spaceMaterial = doc.createMaterial('space').setBaseColorTexture(spaceTexture);
   const moonPrimitive = doc.createPrimitive().setMaterial(moonMaterial)
-    .setIndices(moonIndices).setAttribute('POSITION', position).setAttribute('TEXCOORD_0', uv);
+    .setIndices(indices).setAttribute('POSITION', position).setAttribute('TEXCOORD_0', uv);
   const spacePrimitive = doc.createPrimitive().setMaterial(spaceMaterial)
-    .setIndices(spaceIndices).setAttribute('POSITION', position).setAttribute('TEXCOORD_0', uv);
-  const mesh = doc.createMesh('result').addPrimitive(moonPrimitive).addPrimitive(spacePrimitive);
+    .setIndices(indices).setAttribute('POSITION', position).setAttribute('TEXCOORD_0', uv);
+  const manifoldPrimitive = doc.createPrimitive()
+    .setIndices(indices).setAttribute('POSITION', position);
+  const mesh = doc.createMesh('result').addPrimitive(moonPrimitive).addPrimitive(spacePrimitive).addPrimitive(manifoldPrimitive);
   const node = doc.createNode().setMesh(mesh);
   const scene = doc.createScene().addChild(node);
+
+  const mergeIndices = doc.createAccessor('mergeFrom').setBuffer(buffer).setType(Accessor.Type.SCALAR);
+  const mergeValues = doc.createAccessor('mergeTo').setBuffer(buffer).setType(Accessor.Type.SCALAR);
 
   async function loadTexture(texture, uri) {
     const response = await fetch(uri);
@@ -94,8 +98,8 @@
   const firstID = wasm.reserveIDs(2);
   const space = cubeUV(firstID).scale(50);
   const moon = sphereUV(firstID + 1).scale(60);
-  materialMap.set(firstID, spaceIndices);
-  materialMap.set(firstID + 1, moonIndices);
+  materialMap.set(firstID, 'space');
+  materialMap.set(firstID + 1, 'moon');
 
   const csg = function (operation) {
     push2MV(wasm[operation](space, moon));
@@ -110,14 +114,71 @@
   const mv = document.querySelector('model-viewer');
   let objectURL = null;
 
+  function addExtension(json, mesh) {
+    const indicesAccessor = json.accessors.find((a) => { return a.name == 'indices'; });
+    const mergeFromAccessor = json.accessors.find((a) => { return a.name == 'mergeFrom'; });
+    const mergeToAccessor = json.accessors.find((a) => { return a.name == 'mergeTo'; });
+    indicesAccessor.sparse = {
+      count: mergeFromAccessor.count,
+      indices: {
+        bufferView: mergeFromAccessor.bufferView,
+        byteOffset: mergeFromAccessor.byteOffset,
+        componentType: 5125
+      },
+      values: {
+        bufferView: mergeToAccessor.bufferView,
+        byteOffset: mergeToAccessor.byteOffset,
+      }
+    };
+
+    for (const [i, id] of mesh.runOriginalID.entries()) {
+      const name = materialMap.get(id);
+      const primitive = json.meshes[0].primitives.find((p) => { return json.materials[p.material].name == name; });
+      primitive.indices = json.accessors.length;
+      json.accessors.push({
+        name,
+        type: "SCALAR",
+        componentType: 5125,
+        count: mesh.runIndex[i + 1] - mesh.runIndex[i],
+        bufferView: indicesAccessor.bufferView,
+        byteOffset: 4 * mesh.runIndex[i]
+      });
+    }
+
+    console.log(json);
+    // const manifoldIdx = json.meshes[0].primitives.findIndex((p) => { return p.material == null; });
+    // const manifoldPrimitives = json.meshes[0].primitives.splice(manifoldIdx, 1);
+  }
+
+  async function writeGLB(json, resources) {
+    const header = new Uint32Array([0x46546c67, 2, 12]);
+
+    const jsonText = JSON.stringify(json);
+    const jsonChunkData = BufferUtils.pad(BufferUtils.encodeText(jsonText), 0x20);
+    const jsonChunkHeader = BufferUtils.toView(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]));
+    const jsonChunk = BufferUtils.concat([jsonChunkHeader, jsonChunkData]);
+    header[header.length - 1] += jsonChunk.byteLength;
+
+    const binBuffer = Object.values(resources)[0];
+    if (!binBuffer || !binBuffer.byteLength) {
+      return BufferUtils.concat([BufferUtils.toView(header), jsonChunk]);
+    }
+
+    const binChunkData = BufferUtils.pad(binBuffer, 0x00);
+    const binChunkHeader = BufferUtils.toView(new Uint32Array([binChunkData.byteLength, 0x004e4942]));
+    const binChunk = BufferUtils.concat([binChunkHeader, binChunkData]);
+    header[header.length - 1] += binChunk.byteLength;
+
+    return BufferUtils.concat([BufferUtils.toView(header), jsonChunk, binChunk]);
+  }
+
   async function push2MV(manifold) {
     // From Z-up to Y-up (glTF)
     const mesh = manifold.rotate([-90, 0, 0]).getMesh();
 
-    for (const [i, id] of mesh.runOriginalID.entries()) {
-      const indices = materialMap.get(id);
-      indices.setArray(mesh.triVerts.subarray(mesh.runIndex[i], mesh.runIndex[i + 1]));
-    }
+    indices.setArray(mesh.triVerts);
+    mergeIndices.setArray(mesh.mergeFromVert);
+    mergeValues.setArray(mesh.mergeToVert);
 
     const numVert = mesh.numVert;
     const numProp = mesh.numProp;
@@ -135,7 +196,11 @@
 
     await texturesLoad;
 
-    const glb = await io.writeBinary(doc);
+    const { json, resources } = await io.writeJSON(doc, { format: Format.GLB });
+
+    addExtension(json, mesh);
+
+    const glb = await writeGLB(json, resources);
 
     const blob = new Blob([glb], { type: 'application/octet-stream' });
     URL.revokeObjectURL(objectURL);

--- a/bindings/wasm/examples/model-viewer.html
+++ b/bindings/wasm/examples/model-viewer.html
@@ -56,10 +56,11 @@
 </script>
 <script type="module" src="https://ajax.googleapis.com/ajax/libs/model-viewer/2.0.1/model-viewer.min.js"></script>
 <script type="module">
-  import { Document } from '@gltf-transform/core';
-  import { loadTexture, toGLTFMesh, disposeMesh, writeGLB } from '../gltfIO.js';
+  import { Document, WebIO } from '@gltf-transform/core';
+  import { loadTexture, toGLTFMesh, disposeMesh, setupIO } from '../gltfIO.js';
   import Module from '../manifold.js';
 
+  const io = setupIO(new WebIO());
   const doc = new Document();
   const node = doc.createNode();
   doc.createScene().addChild(node);
@@ -104,7 +105,7 @@
 
     await texturesLoad;
 
-    const glb = await writeGLB(doc);
+    const glb = await io.writeBinary(doc);
 
     const blob = new Blob([glb], { type: 'application/octet-stream' });
     URL.revokeObjectURL(objectURL);

--- a/bindings/wasm/gltfIO.js
+++ b/bindings/wasm/gltfIO.js
@@ -18,6 +18,7 @@ import {EXTManifold} from './manifold-gltf.js';
 
 const io = new WebIO().registerExtensions([EXTManifold]);
 const doc = new Document();
+const manifoldExtension = doc.createExtension(EXTManifold);
 doc.createBuffer();
 const node = doc.createNode();
 doc.createScene().addChild(node);
@@ -102,7 +103,6 @@ export function toGLTFMesh(manifoldMesh, attributeArray, materialArray) {
     offset += n;
   }
 
-  const manifoldExtension = doc.createExtension(EXTManifold);
   const manifoldPrimitive = manifoldExtension.createManifoldPrimitive();
   mesh.setExtension('EXT_manifold', manifoldPrimitive);
 
@@ -134,7 +134,7 @@ export function disposeMesh(mesh) {
   if (!mesh) return;
   const primitives = mesh.listPrimitives();
   const manifoldPrimitive = mesh.getExtension('EXT_manifold');
-  if (!!manifoldPrimitive) {
+  if (manifoldPrimitive) {
     manifoldPrimitive.getMergeIndices()?.dispose();
     manifoldPrimitive.getMergeValues()?.dispose();
     primitives.push(manifoldPrimitive.getPrimitive());

--- a/bindings/wasm/gltfIO.js
+++ b/bindings/wasm/gltfIO.js
@@ -12,16 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Accessor, Document, WebIO} from '@gltf-transform/core';
+import {Accessor, WebIO} from '@gltf-transform/core';
 
 import {EXTManifold} from './manifold-gltf.js';
 
 const io = new WebIO().registerExtensions([EXTManifold]);
-const doc = new Document();
-const manifoldExtension = doc.createExtension(EXTManifold);
-doc.createBuffer();
-const node = doc.createNode();
-doc.createScene().addChild(node);
 
 export const attributeDefs = {
   'POSITION': {type: Accessor.Type.VEC3, components: 3},
@@ -35,22 +30,22 @@ export const attributeDefs = {
   'WEIGHTS_0': {type: Accessor.Type.VEC4, components: 4},
 };
 
-export function getGLTFDoc() {
-  return doc;
+export async function loadGLB(url) {
+  return io.read(url);
 }
 
-export function getRootNode() {
-  return node;
-}
-
-export async function writeGLB() {
+export async function writeGLB(doc) {
   return io.writeBinary(doc);
 }
 
-export function toGLTFMesh(manifoldMesh, attributeArray, materialArray) {
-  if (doc.getRoot().listBuffers().length !== 1)
-    throw new Error('Document must have a single buffer.');
+export function toGLTFMesh(doc, manifoldMesh, attributeArray, materialArray) {
+  if (doc.getRoot().listBuffers().length > 1)
+    throw new Error('Document must not have multiple buffers.');
+  if (doc.getRoot().listBuffers().length === 0) {
+    doc.createBuffer();
+  }
   const buffer = doc.getRoot().listBuffers()[0];
+  const manifoldExtension = doc.createExtension(EXTManifold);
 
   const indices = doc.createAccessor('indices')
                       .setBuffer(buffer)

--- a/bindings/wasm/gltfIO.js
+++ b/bindings/wasm/gltfIO.js
@@ -110,14 +110,21 @@ export function toGLTFMesh(manifoldMesh, attributeArray, materialArray) {
       'POSITION', mesh.listPrimitives()[0].getAttribute('POSITION'));
   manifoldPrimitive.setPrimitive(primitive, manifoldMesh.runIndex);
 
+  const idx = [...manifoldMesh.mergeTriVert.keys()];
+  idx.sort(
+      (a, b) => manifoldMesh.mergeTriVert[a] - manifoldMesh.mergeTriVert[b]);
+  const mergeTriVert =
+      new Uint32Array(idx.map(i => manifoldMesh.mergeTriVert[i]));
+  const mergeToVert =
+      new Uint32Array(idx.map(i => manifoldMesh.mergeToVert[i]));
   const indicesAccessor = doc.createAccessor()
                               .setBuffer(buffer)
                               .setType(Accessor.Type.SCALAR)
-                              .setArray(manifoldMesh.mergeTriVert);
+                              .setArray(mergeTriVert);
   const valuesAccessor = doc.createAccessor()
                              .setBuffer(buffer)
                              .setType(Accessor.Type.SCALAR)
-                             .setArray(manifoldMesh.mergeToVert);
+                             .setArray(mergeToVert);
   manifoldPrimitive.setMerge(indicesAccessor, valuesAccessor);
 
   return mesh;

--- a/bindings/wasm/gltfIO.js
+++ b/bindings/wasm/gltfIO.js
@@ -16,6 +16,8 @@ import {Accessor} from '@gltf-transform/core';
 
 import {EXTManifold} from './manifold-gltf.js';
 
+const materialMap = new Map();
+
 export const attributeDefs = {
   'POSITION': {type: Accessor.Type.VEC3, components: 3},
   'SKIP': {type: null, components: 1},
@@ -32,7 +34,11 @@ export function setupIO(io) {
   return io.registerExtensions([EXTManifold]);
 }
 
-export function toGLTFMesh(doc, manifoldMesh, attributeArray, materialArray) {
+export function getMaterialMap() {
+  return materialMap;
+}
+
+export function writeMesh(doc, manifoldMesh, attributeArray) {
   if (doc.getRoot().listBuffers().length > 1)
     throw new Error('Document must not have multiple buffers.');
   if (doc.getRoot().listBuffers().length === 0) {
@@ -48,12 +54,12 @@ export function toGLTFMesh(doc, manifoldMesh, attributeArray, materialArray) {
 
   const mesh = doc.createMesh();
   const numPrimitive = manifoldMesh.runIndex.length - 1;
-  if (materialArray.length != numPrimitive)
-    throw new Error('materialArray does not match number of triangle runs.');
-
   for (let run = 0; run < numPrimitive; ++run) {
-    const primitive = doc.createPrimitive().setIndices(indices).setMaterial(
-        materialArray[run]);
+    const primitive = doc.createPrimitive().setIndices(indices);
+    const material = materialMap.get(manifoldMesh.runOriginalID[run]);
+    if (material) {
+      primitive.setMaterial(material);
+    }
     mesh.addPrimitive(primitive);
   }
 

--- a/bindings/wasm/gltfIO.js
+++ b/bindings/wasm/gltfIO.js
@@ -113,7 +113,7 @@ export function toGLTFMesh(manifoldMesh, attributeArray, materialArray) {
   const indicesAccessor = doc.createAccessor()
                               .setBuffer(buffer)
                               .setType(Accessor.Type.SCALAR)
-                              .setArray(manifoldMesh.mergeFromVert);
+                              .setArray(manifoldMesh.mergeTriVert);
   const valuesAccessor = doc.createAccessor()
                              .setBuffer(buffer)
                              .setType(Accessor.Type.SCALAR)

--- a/bindings/wasm/gltfIO.js
+++ b/bindings/wasm/gltfIO.js
@@ -12,9 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Accessor} from '@gltf-transform/core';
+import {Accessor, Document, WebIO} from '@gltf-transform/core';
 
 import {EXTManifold} from './manifold-gltf.js';
+
+const io = new WebIO().registerExtensions([EXTManifold]);
+const doc = new Document();
+doc.createBuffer();
+const node = doc.createNode();
+doc.createScene().addChild(node);
 
 export const attributeDefs = {
   'POSITION': {type: Accessor.Type.VEC3, components: 3},
@@ -28,7 +34,19 @@ export const attributeDefs = {
   'WEIGHTS_0': {type: Accessor.Type.VEC4, components: 4},
 };
 
-export function toGLTFMesh(doc, manifoldMesh, attributeArray, materialArray) {
+export function getGLTFDoc() {
+  return doc;
+}
+
+export function getRootNode() {
+  return node;
+}
+
+export async function writeGLB() {
+  return io.writeBinary(doc);
+}
+
+export function toGLTFMesh(manifoldMesh, attributeArray, materialArray) {
   if (doc.getRoot().listBuffers().length !== 1)
     throw new Error('Document must have a single buffer.');
   const buffer = doc.getRoot().listBuffers()[0];

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -414,7 +414,7 @@ export class Mesh {
     numProp: number,
     vertProperties: Float32Array,
     triVerts: Uint32Array,
-    mergeFromVert?: Uint32Array,
+    mergeTriVert?: Uint32Array,
     mergeToVert?: Uint32Array,
     runIndex?: Uint32Array,
     runOriginalID?: Uint32Array,
@@ -425,7 +425,7 @@ export class Mesh {
   numProp: number;
   vertProperties: Float32Array;
   triVerts: Uint32Array;
-  mergeFromVert?: Uint32Array;
+  mergeTriVert?: Uint32Array;
   mergeToVert?: Uint32Array;
   runIndex?: Uint32Array;
   runOriginalID?: Uint32Array;

--- a/bindings/wasm/manifold-gltf.js
+++ b/bindings/wasm/manifold-gltf.js
@@ -60,6 +60,7 @@ export class EXTManifold extends Extension {
   read(context) {
     const {json} = context.jsonDoc;
     const meshDefs = json.meshes || [];
+
     meshDefs.forEach((meshDef, meshIndex) => {
       if (!meshDef.extensions || !meshDef.extensions[NAME]) return;
 

--- a/bindings/wasm/manifold-gltf.js
+++ b/bindings/wasm/manifold-gltf.js
@@ -58,8 +58,8 @@ export class ManifoldPrimitive extends ExtensionProperty {
   setMerge(indicesAccessor, valuesAccessor) {
     if (indicesAccessor.getCount() !== valuesAccessor.getCount())
       throw new Error('merge vectors must be the same length.');
-    this.setRef('mergeValues', indicesAccessor);
-    return this.setRef('mergeIndices', valuesAccessor);
+    this.setRef('mergeIndices', indicesAccessor);
+    return this.setRef('mergeValues', valuesAccessor);
   }
 }
 
@@ -121,9 +121,6 @@ export class EXTManifold extends Extension {
           byteOffset: mergeValues.byteOffset,
         }
       };
-
-      json.accessors.splice(mergeIndicesIndex, 1);
-      json.accessors.splice(mergeValuesIndex, 1);
 
       const {runIndex} = manifoldPrimitive;
       const numPrimitive = runIndex.length - 1;

--- a/bindings/wasm/manifold-gltf.js
+++ b/bindings/wasm/manifold-gltf.js
@@ -88,6 +88,9 @@ export class EXTManifold extends Extension {
           const indices = context.accessors[primitive.indices];
           manifoldPrimitive.runIndex.push(indices.byteOffset / 4);
         }
+        const indices =
+            context.accessors[manifoldDef.manifoldPrimitive.indices];
+        runIndex.push(indices.count);
       }
 
       if (manifoldDef.mergeIndices && manifoldDef.mergeValues) {

--- a/bindings/wasm/manifold-gltf.js
+++ b/bindings/wasm/manifold-gltf.js
@@ -1,0 +1,147 @@
+// Copyright 2023 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Extension} from '@gltf-transform/core';
+
+const NAME = 'EXT_manifold';
+
+export class ManifoldPrimitive extends ExtensionProperty {
+  constructor() {
+    super();
+    this.EXTENSION_NAME = NAME;
+    this.propertyType = 'ManifoldPrimitive';
+    this.parentTypes = [PropertyType.MESH];
+
+    this.runIndex = [];
+  }
+
+  getDefaults() {
+    return Object.assign(
+        super.getDefaults(),
+        {manifoldPrimitive: null, mergeIndices: null, mergeValues: null});
+  }
+
+  getPrimitive() {
+    return this.getRef('manifoldPrimitive');
+  }
+
+  setPrimitive(primitive, runIndex) {
+    const mesh = this.listParents[0];
+    if (mesh.listPrimitives.length !== runIndex.length - 1)
+      throw new Error(
+          'You must attach all material primitives to the mesh before setting the manifold primitive.');
+    mesh.addPrimitive(primitive);
+    return this.setRef('manifoldPrimitive', primitive);
+  }
+
+  getMergeIndices() {
+    return this.getRef('mergeIndices');
+  }
+
+  getMergeValues() {
+    return this.getRef('mergeValues');
+  }
+
+  setMerge(indicesAccessor, valuesAccessor) {
+    if (indicesAccessor.getCount() !== valuesAccessor.getCount())
+      throw new Error('merge vectors must be the same length.');
+    this.setRef('mergeValues', indicesAccessor);
+    return this.setRef('mergeIndices', valuesAccessor);
+  }
+}
+
+export class EXTManifold extends Extension {
+  constructor() {
+    super();
+    this.extensionName = NAME;
+    this.EXTENSION_NAME = NAME;
+  }
+
+  createManifoldPrimitive() {
+    return new ManifoldPrimitive(this.document.getGraph());
+  }
+
+  read(context) {
+    const {json} = context.jsonDoc;
+    const meshDefs = json.meshes || [];
+    meshDefs.forEach((meshDef, meshIndex) => {
+      if (!meshDef.extensions || !meshDef.extensions[NAME]) return;
+
+      const manifoldPrimitive = this.createManifoldPrimitive();
+      context.meshes[meshIndex].setExtension(NAME, manifoldPrimitive);
+
+      const manifoldDef = meshDef.extensions[NAME];
+
+      if (manifoldDef.manifoldPrimitive != null) {
+        manifoldPrimitive.setPrimitive(manifoldDef.manifoldPrimitive);
+      }
+    });
+
+    return this;
+  }
+
+  write(context) {
+    const {json} = context.jsonDoc;
+
+    this.document.getRoot().listMeshes().forEach((mesh) => {
+      const manifoldPrimitive = mesh.getExtension(NAME);
+      if (!manifoldPrimitive) return;
+
+      const meshIndex = context.meshIndexMap.get(mesh);
+      const meshDef = json.meshes[meshIndex];
+
+      const mergeIndicesIndex =
+          context.accessorIndexMap.get(manifoldPrimitive.getMergeIndices());
+      const mergeValuesIndex =
+          context.accessorIndexMap.get(manifoldPrimitive.getMergeValues());
+      const mergeIndices = json.accessors[mergeIndicesIndex];
+      const mergeValues = json.accessors[mergeValuesIndex];
+
+      const primitive = meshDef.primitives.pop();
+      const indices = json.accessors[primitive.indices];
+      indices.sparse = {
+        count: mergeIndices.count,
+        indices: {
+          bufferView: mergeIndices.bufferView,
+          byteOffset: mergeIndices.byteOffset,
+          componentType: 5125
+        },
+        values: {
+          bufferView: mergeValues.bufferView,
+          byteOffset: mergeValues.byteOffset,
+        }
+      };
+
+      json.accessors.splice(mergeIndicesIndex, 1);
+      json.accessors.splice(mergeValuesIndex, 1);
+
+      const {runIndex} = manifoldPrimitive;
+      for (let i = 0; i < runIndex - 1; ++i) {
+        meshDef.primitives[i].indices = json.accessors.length;
+        json.accessors.push({
+          type: 'SCALAR',
+          componentType: 5125,
+          count: runIndex[i + 1] - runIndex[i],
+          bufferView: indices.bufferView,
+          byteOffset: 4 * runIndex[i]
+        });
+      }
+
+      meshDef.extensions = meshDef.extensions || {};
+      meshDef.extensions[NAME] = {manifoldPrimitive: primitive};
+    });
+
+    return this;
+  }
+}

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -41,6 +41,9 @@
   "scripts": {
     "test": "mocha -u tdd -t 30000"
   },
+  "dependencies": {
+    "@gltf-transform/core": "^3.2.0"
+  },
   "devDependencies": {
     "chai": "*",
     "mocha": "*",

--- a/bindings/wasm/test/test.js
+++ b/bindings/wasm/test/test.js
@@ -83,8 +83,8 @@ function runExample(name) {
     const manifold = f(...exposedFunctions.map(name => wasm[name]), glMatrix);
 
     const mesh = manifold.getMesh();
-    expect(mesh.mergeFromVert.length).to.equal(mesh.mergeToVert.length);
-    expect(mesh.mergeFromVert.length)
+    expect(mesh.mergeTriVert.length).to.equal(mesh.mergeToVert.length);
+    expect(mesh.mergeTriVert.length)
         .to.equal(mesh.numVert - manifold.numVert());
 
     const prop = manifold.getProperties();

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -58,10 +58,10 @@ struct MeshGL {
   /// The vertex indices of the three triangle corners in CCW (from the outside)
   /// order, for each triangle.
   std::vector<uint32_t> triVerts;
-  /// Optional: A list of only the vertex indicies that need to be merged to
+  /// Optional: A list of only the triVerts indicies that need to be merged to
   /// reconstruct the manifold.
-  std::vector<uint32_t> mergeFromVert;
-  /// Optional: The same length as mergeFromVert, and the corresponding value
+  std::vector<uint32_t> mergeTriVert;
+  /// Optional: The same length as mergeTriVert, and the corresponding value
   /// contains the vertex to merge with. It will have an identical position, but
   /// the other properties may differ.
   std::vector<uint32_t> mergeToVert;

--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -94,7 +94,7 @@ struct Manifold::Impl {
   Curvature GetCurvature() const;
   void CalculateBBox();
   bool IsFinite() const;
-  bool IsIndexInBounds(const VecDH<glm::ivec3>& triVerts) const;
+  bool IsIndexInBounds(const VecDH<glm::ivec3>& triVerts, int size) const;
   void SetPrecision(float minPrecision = -1);
   bool IsManifold() const;
   bool Is2Manifold() const;

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -305,7 +305,7 @@ MeshGL Manifold::GetMeshGL(glm::ivec3 normalIdx) const {
         if (vert2idx[vert] == -1) {
           vert2idx[vert] = idx;
         } else {
-          out.mergeFromVert.push_back(idx);
+          out.mergeTriVert.push_back(3 * tri + i);
           out.mergeToVert.push_back(vert2idx[vert]);
         }
       }

--- a/src/manifold/src/properties.cpp
+++ b/src/manifold/src/properties.cpp
@@ -154,7 +154,7 @@ struct NormalizeCurvature {
   }
 };
 
-struct CheckNormals {
+struct CheckManifold {
   const Halfedge* halfedges;
 
   __host__ __device__ bool operator()(int edge) {
@@ -241,7 +241,7 @@ bool Manifold::Impl::IsManifold() const {
   auto policy = autoPolicy(halfedge_.size());
 
   return all_of(policy, countAt(0), countAt(halfedge_.size()),
-                CheckNormals({halfedge_.cptrD()}));
+                CheckManifold({halfedge_.cptrD()}));
 }
 
 /**
@@ -355,10 +355,11 @@ bool Manifold::Impl::IsFinite() const {
 }
 
 /**
- * Checks that the input triVerts array has all indices inside bounds of the
- * vertPos_ array.
+ * Checks that the input array has all indices inside bounds of the
+ * given size.
  */
-bool Manifold::Impl::IsIndexInBounds(const VecDH<glm::ivec3>& triVerts) const {
+bool Manifold::Impl::IsIndexInBounds(const VecDH<glm::ivec3>& triVerts,
+                                     int size) const {
   auto policy = autoPolicy(triVerts.size());
   glm::ivec2 minmax = transform_reduce<glm::ivec2>(
       policy, triVerts.begin(), triVerts.end(), MakeMinMax(),
@@ -366,6 +367,6 @@ bool Manifold::Impl::IsIndexInBounds(const VecDH<glm::ivec3>& triVerts) const {
                  std::numeric_limits<int>::min()),
       MinMax());
 
-  return minmax[0] >= 0 && minmax[1] < NumVert();
+  return minmax[0] >= 0 && minmax[1] < size;
 }
 }  // namespace manifold

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -86,7 +86,7 @@ TEST(Boolean, Normals) {
 #endif
 
   MeshGL output = result.GetMeshGL({3, 4, 5});
-  output.mergeFromVert.clear();
+  output.mergeTriVert.clear();
   output.mergeToVert.clear();
   output.Merge();
   Manifold roundTrip(output);

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -123,7 +123,7 @@ TEST(Manifold, InvalidInput4) {
 
 TEST(Manifold, InvalidInput5) {
   MeshGL tetGL = TetGL();
-  tetGL.mergeFromVert[tetGL.mergeFromVert.size() - 1] = 7;
+  tetGL.mergeTriVert[tetGL.mergeTriVert.size() - 1] = 12;
   Manifold tet(tetGL);
   EXPECT_TRUE(tet.IsEmpty());
   EXPECT_EQ(tet.Status(), Manifold::Error::MergeIndexOutOfBounds);
@@ -504,12 +504,12 @@ TEST(Manifold, Merge) {
   CheckCube(cubeSTL);
 
   EXPECT_FALSE(cubeSTL.Merge());
-  EXPECT_EQ(cubeSTL.mergeFromVert.size(), 28);
-  cubeSTL.mergeFromVert.resize(14);
+  EXPECT_EQ(cubeSTL.mergeTriVert.size(), 28);
+  cubeSTL.mergeTriVert.resize(14);
   cubeSTL.mergeToVert.resize(14);
 
   EXPECT_TRUE(cubeSTL.Merge());
-  EXPECT_EQ(cubeSTL.mergeFromVert.size(), 28);
+  EXPECT_EQ(cubeSTL.mergeTriVert.size(), 28);
   CheckCube(cubeSTL);
 }
 

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -152,8 +152,8 @@ MeshGL TetGL() {
                         1,  -1, -1, 5, -5,  //
                         1,  1,  1,  6, -6};
   tet.triVerts = {2, 0, 1, 0, 3, 1, 2, 3, 0, 6, 5, 4};
-  tet.mergeFromVert = {4, 5, 6};
-  tet.mergeToVert = {1, 2, 3};
+  tet.mergeTriVert = {9, 10, 11};
+  tet.mergeToVert = {3, 2, 1};
   return tet;
 }
 
@@ -368,8 +368,8 @@ void ExpectMeshes(const Manifold& manifold,
     EXPECT_EQ(manifolds[i].NumProp(), meshSize[i].numProp);
     EXPECT_EQ(manifolds[i].NumPropVert(), meshSize[i].numPropVert);
     const MeshGL meshGL = manifolds[i].GetMeshGL();
-    EXPECT_EQ(meshGL.mergeFromVert.size(), meshGL.mergeToVert.size());
-    EXPECT_EQ(meshGL.mergeFromVert.size(),
+    EXPECT_EQ(meshGL.mergeTriVert.size(), meshGL.mergeToVert.size());
+    EXPECT_EQ(meshGL.mergeTriVert.size(),
               meshGL.NumVert() - manifolds[i].NumVert());
     const Mesh mesh = manifolds[i].GetMesh();
     for (const glm::vec3& normal : mesh.vertNormal) {
@@ -393,8 +393,8 @@ void CheckStrictly(const Manifold& manifold) {
 void CheckGL(const Manifold& manifold) {
   ASSERT_FALSE(manifold.IsEmpty());
   const MeshGL meshGL = manifold.GetMeshGL();
-  EXPECT_EQ(meshGL.mergeFromVert.size(), meshGL.mergeToVert.size());
-  EXPECT_EQ(meshGL.mergeFromVert.size(), meshGL.NumVert() - manifold.NumVert());
+  EXPECT_EQ(meshGL.mergeTriVert.size(), meshGL.mergeToVert.size());
+  EXPECT_EQ(meshGL.mergeTriVert.size(), meshGL.NumVert() - manifold.NumVert());
   EXPECT_EQ(meshGL.runIndex.size(), meshGL.runOriginalID.size() + 1);
   EXPECT_EQ(meshGL.runIndex.front(), 0);
   EXPECT_EQ(meshGL.runIndex.back(), 3 * meshGL.NumTri());


### PR DESCRIPTION
This is the beginning of a JS glTF I/O library for Manifold, allowing lossless round-trip of multi-material models by defining a new glTF extension (which I plan to write up and submit to the Khronos). 