### PR TITLE
fix warp simplification

### DIFF
--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -549,6 +549,8 @@ Manifold Manifold::Warp(std::function<void(glm::vec3&)> warpFunc) const {
   pImpl->faceNormal_.resize(0);  // force recalculation of triNormal
   pImpl->CalculateNormals();
   pImpl->SetPrecision();
+  pImpl->CreateFaces();
+  pImpl->SimplifyTopology();
   return Manifold(std::make_shared<CsgLeafNode>(pImpl));
 }
 

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -215,6 +215,21 @@ TEST(Manifold, Revolve2) {
   EXPECT_NEAR(prop.surfaceArea, 96.0f * glm::pi<float>(), 1.0f);
 }
 
+TEST(Manifold, Warp) {
+  CrossSection square = CrossSection::Square({1, 1});
+  Manifold shape = Manifold::Extrude(square, 2, 10).Warp([](glm::vec3& v) {
+    v.x += v.z * v.z;
+  });
+  auto propBefore = shape.GetProperties();
+
+  Manifold simplified = Manifold::Compose({shape});
+  auto propAfter = simplified.GetProperties();
+
+  EXPECT_FLOAT_EQ(propBefore.volume, propAfter.volume);
+  EXPECT_FLOAT_EQ(propBefore.surfaceArea, propAfter.surfaceArea);
+  EXPECT_NEAR(propBefore.volume, 2, 0.0001);
+}
+
 TEST(Manifold, Smooth) {
   Manifold tet = Manifold::Tetrahedron();
   Manifold smooth = Manifold::Smooth(tet.GetMesh());

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -225,8 +225,8 @@ TEST(Manifold, Warp) {
   Manifold simplified = Manifold::Compose({shape});
   auto propAfter = simplified.GetProperties();
 
-  EXPECT_FLOAT_EQ(propBefore.volume, propAfter.volume);
-  EXPECT_FLOAT_EQ(propBefore.surfaceArea, propAfter.surfaceArea);
+  EXPECT_NEAR(propBefore.volume, propAfter.volume, 0.0001);
+  EXPECT_NEAR(propBefore.surfaceArea, propAfter.surfaceArea, 0.0001);
   EXPECT_NEAR(propBefore.volume, 2, 0.0001);
 }
 


### PR DESCRIPTION
Fixes #413 

Our simplification is driven by what faces are marked as coplanar, but `Warp` is in general nonlinear, so coplanarity must be re-evaluated. `Warp` was also not simplifying, so this problem would only be seen after another op like a Boolean or Compose that calls simplify. Both of these problems are fixed, with a test added. 