### PR TITLE
fix compose index error

### DIFF
--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -221,13 +221,13 @@ Manifold::Impl CsgLeafNode::Compose(
               combined.halfedge_.begin() + edgeIndices[i],
               UpdateHalfedge({vertIndices[i], edgeIndices[i], triIndices[i]}));
           const bool invert = glm::determinant(glm::mat3(node->transform_)) < 0;
-          for_each_n(
-              policy,
-              zip(combined.halfedgeTangent_.begin(), countAt(edgeIndices[i])),
-              node->pImpl_->halfedgeTangent_.size(),
-              TransformTangents{glm::mat3(node->transform_), invert,
-                                node->pImpl_->halfedgeTangent_.cptrD(),
-                                node->pImpl_->halfedge_.cptrD()});
+          for_each_n(policy,
+                     zip(combined.halfedgeTangent_.begin() + edgeIndices[i],
+                         countAt(0)),
+                     node->pImpl_->halfedgeTangent_.size(),
+                     TransformTangents{glm::mat3(node->transform_), invert,
+                                       node->pImpl_->halfedgeTangent_.cptrD(),
+                                       node->pImpl_->halfedge_.cptrD()});
           if (invert)
             for_each_n(policy,
                        zip(combined.meshRelation_.triRef.begin(),

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -1088,3 +1088,12 @@ TEST(Manifold, Invalid) {
   EXPECT_EQ(Manifold::Extrude(empty_circ, 10.).Status(), invalid);
   EXPECT_EQ(Manifold::Revolve(empty_sq).Status(), invalid);
 }
+
+TEST(Manifold, MultiCompose) {
+  auto legAssembly = Manifold::Compose({Manifold::Cube({100, 140, 38})});
+  auto finalAssembly = Manifold::Compose(
+      {legAssembly, legAssembly.Translate({0, 300, 0}),
+       legAssembly.Mirror({1, 0, 0}).Translate({300, 0, 0}),
+       legAssembly.Mirror({1, 0, 0}).Translate({300, 300, 0})});
+  finalAssembly.GetMesh();
+}

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -1090,10 +1090,10 @@ TEST(Manifold, Invalid) {
 }
 
 TEST(Manifold, MultiCompose) {
-  auto legAssembly = Manifold::Compose({Manifold::Cube({100, 140, 38})});
-  auto finalAssembly = Manifold::Compose(
-      {legAssembly, legAssembly.Translate({0, 300, 0}),
-       legAssembly.Mirror({1, 0, 0}).Translate({300, 0, 0}),
-       legAssembly.Mirror({1, 0, 0}).Translate({300, 300, 0})});
-  finalAssembly.GetMesh();
+  auto part = Manifold::Compose({Manifold::Cube({10, 10, 10})});
+  auto finalAssembly =
+      Manifold::Compose({part, part.Translate({0, 10, 0}),
+                         part.Mirror({1, 0, 0}).Translate({10, 0, 0}),
+                         part.Mirror({1, 0, 0}).Translate({10, 10, 0})});
+  EXPECT_FLOAT_EQ(finalAssembly.GetProperties().volume, 4000);
 }


### PR DESCRIPTION
Fixes https://github.com/elalish/manifold/issues/425#issuecomment-1540356917
Also, for #429, it seems that the error is now:

```
Triangulation failed! Precision = 0.000444848
Error in file: /home/pca006132/code/manifold/src/polygon/src/polygon.cpp (39): 'condition' is false: Not Geometrically Valid! None of the skipped verts is valid.
polys.push_back({
    {27.2981834, -7.01095772},  //
    {27.4199429, -7.07648039},  //
    {27.2981834, -7.01095724},  //
    {27.7852192, -7.27304506},  //
    {27.5622101, -6.52031708},  //
});
array([
  [27.2981834, -7.01095772],
  [27.4199429, -7.07648039],
  [27.2981834, -7.01095724],
  [27.7852192, -7.27304506],
  [27.5622101, -6.52031708],
])
```