### PR TITLE
Add SetProperties()

### DIFF
--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -206,6 +206,9 @@ class Manifold {
   Manifold Transform(const glm::mat4x3&) const;
   Manifold Mirror(glm::vec3) const;
   Manifold Warp(std::function<void(glm::vec3&)>) const;
+  Manifold SetProperties(
+      int,
+      std::function<void(glm::vec3, const float* const, float* const)>) const;
   Manifold Refine(int) const;
   // Manifold RefineToLength(float);
   // Manifold RefineToPrecision(float);

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -207,8 +207,7 @@ class Manifold {
   Manifold Mirror(glm::vec3) const;
   Manifold Warp(std::function<void(glm::vec3&)>) const;
   Manifold SetProperties(
-      int,
-      std::function<void(glm::vec3, const float* const, float* const)>) const;
+      int, std::function<void(glm::vec3, const float*, float*)>) const;
   Manifold Refine(int) const;
   // Manifold RefineToLength(float);
   // Manifold RefineToPrecision(float);

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -586,10 +586,9 @@ Manifold Manifold::Warp(std::function<void(glm::vec3&)> warpFunc) const {
  * @param propFunc A function that modifies the properties of a given vertex.
  */
 Manifold Manifold::SetProperties(
-    int numProp,
-    std::function<void(glm::vec3 position, const float* const oldProp,
-                       float* const newProp)>
-        propFunc) const {
+    int numProp, std::function<void(glm::vec3 position, const float* oldProp,
+                                    float* newProp)>
+                     propFunc) const {
   auto pImpl = std::make_shared<Impl>(*GetCsgLeafNode().GetImpl());
   const int oldNumProp = NumProp();
   const VecDH<float> oldProperties = pImpl->meshRelation_.properties;

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -211,26 +211,24 @@ MeshGL WithIndexColors(const Mesh& in) {
 }
 
 MeshGL WithPositionColors(const Manifold& in) {
-  MeshGL inGL = in.GetMeshGL();
-  inGL.runIndex.clear();
-  inGL.runOriginalID.clear();
-  inGL.runTransform.clear();
-  inGL.faceID.clear();
-  inGL.runOriginalID = {Manifold::ReserveIDs(1)};
-  const int numVert = in.NumVert();
   const Box bbox = in.BoundingBox();
   const glm::vec3 size = bbox.Size();
-  const std::vector<float> oldProp = inGL.vertProperties;
-  inGL.numProp = 6;
-  inGL.vertProperties.resize(6 * numVert);
-  for (int i = 0; i < numVert; ++i) {
-    for (int j : {0, 1, 2}) inGL.vertProperties[6 * i + j] = oldProp[3 * i + j];
-    // vertex colors
-    inGL.vertProperties[6 * i + 3] = (oldProp[3 * i] - bbox.min.x) / size.x;
-    inGL.vertProperties[6 * i + 4] = (oldProp[3 * i + 1] - bbox.min.y) / size.y;
-    inGL.vertProperties[6 * i + 5] = (oldProp[3 * i + 2] - bbox.min.z) / size.z;
-  }
-  return inGL;
+
+  Manifold out = in.SetProperties(
+      3, [bbox, size](glm::vec3 pos, const float* const oldProp,
+                      float* const prop) {
+        for (int i : {0, 1, 2}) {
+          prop[i] = (pos[i] - bbox.min[i]) / size[i];
+        }
+      });
+
+  MeshGL outGL = out.GetMeshGL();
+  outGL.runIndex.clear();
+  outGL.runOriginalID.clear();
+  outGL.runTransform.clear();
+  outGL.faceID.clear();
+  outGL.runOriginalID = {Manifold::ReserveIDs(1)};
+  return outGL;
 }
 
 MeshGL WithNormals(const Manifold& in) {

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -215,8 +215,7 @@ MeshGL WithPositionColors(const Manifold& in) {
   const glm::vec3 size = bbox.Size();
 
   Manifold out = in.SetProperties(
-      3, [bbox, size](glm::vec3 pos, const float* const oldProp,
-                      float* const prop) {
+      3, [bbox, size](glm::vec3 pos, const float* oldProp, float* prop) {
         for (int i : {0, 1, 2}) {
           prop[i] = (pos[i] - bbox.min[i]) / size[i];
         }


### PR DESCRIPTION
This might seem a little random timing-wise, but I'm doing a bit of 3D data-visualization for work and manifoldCAD happens to be working very well for it. The only lack is I need to apply vertex colors to the output. This seems like it could be useful in general and I also realized that a generic warp-like function for creating properties on a Manifold would also be quite generally convenient, so I'm starting with that. The rest will probably come in a PR addressing #431, which I think I can also throw together pretty quickly given that `gltf-transform` does the heavy lifting already. 