### PR TITLE
Only link MeshIO when MANIFOLD_EXPORT is on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,6 @@ option(BUILD_SHARED_LIBS "Build dynamic/shared libraries" OFF)
 set(PYBIND11_DIR ${PROJECT_SOURCE_DIR}/bindings/python/third_party/pybind11)
 set(THRUST_INC_DIR ${PROJECT_SOURCE_DIR}/src/third_party/thrust)
 
-if(MANIFOLD_CBIND)
-  set(MANIFOLD_EXPORT ON)
-endif()
-
 if(BUILD_SHARED_LIBS OR MANIFOLD_CBIND)
   # Allow shared libraries to be relocatable (add Place Independent Code flag).
   # Also include when statically linking C bindings to avoid issues with bundling

--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -1,18 +1,22 @@
 project(manifoldc)
 
-
-add_library(manifoldc manifoldc.cpp conv.cpp)
+add_library(${PROJECT_NAME} manifoldc.cpp conv.cpp)
 
 if(MANIFOLD_USE_CUDA)
     set_source_files_properties(manifoldc.cpp conv.cpp PROPERTIES LANGUAGE CUDA)
-    set_property(TARGET manifoldc PROPERTY CUDA_ARCHITECTURES 61)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY CUDA_ARCHITECTURES 61)
+endif()
+
+if(MANIFOLD_EXPORT)
+  target_link_libraries(${PROJECT_NAME} PRIVATE meshIO)
+  target_compile_options(${PROJECT_NAME} PUBLIC -DMANIFOLD_EXPORT)
 endif()
 
 target_link_libraries(
-  manifoldc
-  PRIVATE manifold sdf meshIO graphlite cross_section
+  ${PROJECT_NAME}
+  PRIVATE manifold sdf graphlite cross_section
 )
 
-target_include_directories(manifoldc PUBLIC ${PROJECT_SOURCE_DIR}/include)
-target_compile_options(manifoldc PRIVATE ${MANIFOLD_FLAGS})
-target_compile_features(manifoldc PRIVATE cxx_std_17)
+target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/bindings/c/conv.cpp
+++ b/bindings/c/conv.cpp
@@ -1,6 +1,5 @@
 #include <conv.h>
 #include <manifold.h>
-#include <meshIO.h>
 #include <sdf.h>
 
 #include <vector>
@@ -111,14 +110,6 @@ ManifoldRect *to_c(manifold::Rect *m) {
   return reinterpret_cast<ManifoldRect *>(m);
 }
 
-ManifoldMaterial *to_c(manifold::Material *m) {
-  return reinterpret_cast<ManifoldMaterial *>(m);
-}
-
-ManifoldExportOptions *to_c(manifold::ExportOptions *m) {
-  return reinterpret_cast<ManifoldExportOptions *>(m);
-}
-
 ManifoldVec2 to_c(glm::vec2 v) { return {v.x, v.y}; }
 
 ManifoldVec3 to_c(glm::vec3 v) { return {v.x, v.y, v.z}; }
@@ -219,14 +210,6 @@ const manifold::Box *from_c(ManifoldBox *m) {
 
 const manifold::Rect *from_c(ManifoldRect *m) {
   return reinterpret_cast<manifold::Rect const *>(m);
-}
-
-manifold::Material *from_c(ManifoldMaterial *mat) {
-  return reinterpret_cast<manifold::Material *>(mat);
-}
-
-manifold::ExportOptions *from_c(ManifoldExportOptions *options) {
-  return reinterpret_cast<manifold::ExportOptions *>(options);
 }
 
 glm::vec2 from_c(ManifoldVec2 v) { return glm::vec2(v.x, v.y); }

--- a/bindings/c/include/conv.h
+++ b/bindings/c/include/conv.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <manifold.h>
-#include <meshIO.h>
 #include <public.h>
 #include <sdf.h>
 #include <types.h>
@@ -24,8 +23,6 @@ ManifoldBox *to_c(manifold::Box *m);
 ManifoldRect *to_c(manifold::Rect *m);
 ManifoldCurvature *to_c(manifold::Curvature *m);
 ManifoldError to_c(manifold::Manifold::Error error);
-ManifoldMaterial *to_c(manifold::Material *m);
-ManifoldExportOptions *to_c(manifold::ExportOptions *m);
 ManifoldVec2 to_c(glm::vec2 v);
 ManifoldVec3 to_c(glm::vec3 v);
 ManifoldIVec3 to_c(glm::ivec3 v);
@@ -45,8 +42,6 @@ CrossSection::JoinType from_c(ManifoldJoinType jt);
 const manifold::Box *from_c(ManifoldBox *m);
 const manifold::Rect *from_c(ManifoldRect *r);
 const manifold::Curvature *from_c(ManifoldCurvature *m);
-manifold::Material *from_c(ManifoldMaterial *mat);
-manifold::ExportOptions *from_c(ManifoldExportOptions *options);
 glm::vec2 from_c(ManifoldVec2 v);
 glm::vec3 from_c(ManifoldVec3 v);
 glm::ivec3 from_c(ManifoldIVec3 v);

--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -310,7 +310,45 @@ float *manifold_meshgl_run_transform(void *mem, ManifoldMeshGL *m);
 uint32_t *manifold_meshgl_face_id(void *mem, ManifoldMeshGL *m);
 float *manifold_meshgl_halfedge_tangent(void *mem, ManifoldMeshGL *m);
 
+// memory size
+size_t manifold_manifold_size();
+size_t manifold_manifold_vec_size();
+size_t manifold_cross_section_size();
+size_t manifold_cross_section_vec_size();
+size_t manifold_simple_polygon_size();
+size_t manifold_polygons_size();
+size_t manifold_manifold_pair_size();
+size_t manifold_meshgl_size();
+size_t manifold_box_size();
+size_t manifold_rect_size();
+size_t manifold_curvature_size();
+
+// destruction
+void manifold_destruct_manifold(ManifoldManifold *m);
+void manifold_destruct_manifold_vec(ManifoldManifoldVec *ms);
+void manifold_destruct_cross_section(ManifoldCrossSection *m);
+void manifold_destruct_cross_section_vec(ManifoldCrossSectionVec *csv);
+void manifold_destruct_simple_polygon(ManifoldSimplePolygon *p);
+void manifold_destruct_polygons(ManifoldPolygons *p);
+void manifold_destruct_meshgl(ManifoldMeshGL *m);
+void manifold_destruct_box(ManifoldBox *b);
+void manifold_destruct_rect(ManifoldRect *b);
+void manifold_destruct_curvature(ManifoldCurvature *c);
+
+// pointer free + destruction
+void manifold_delete_manifold(ManifoldManifold *m);
+void manifold_delete_manifold_vec(ManifoldManifoldVec *ms);
+void manifold_delete_cross_section(ManifoldCrossSection *cs);
+void manifold_delete_cross_section_vec(ManifoldCrossSectionVec *csv);
+void manifold_delete_simple_polygon(ManifoldSimplePolygon *p);
+void manifold_delete_polygons(ManifoldPolygons *p);
+void manifold_delete_meshgl(ManifoldMeshGL *m);
+void manifold_delete_box(ManifoldBox *b);
+void manifold_delete_rect(ManifoldRect *b);
+void manifold_delete_curvature(ManifoldCurvature *c);
+
 // MeshIO / Export
+#ifdef MANIFOLD_EXPORT
 ManifoldMaterial *manifold_material(void *mem);
 void manifold_material_set_roughness(ManifoldMaterial *mat, float roughness);
 void manifold_material_set_metalness(ManifoldMaterial *mat, float metalness);
@@ -327,48 +365,15 @@ void manifold_export_meshgl(const char *filename, ManifoldMeshGL *mesh,
 ManifoldMeshGL *manifold_import_meshgl(void *mem, const char *filename,
                                        int force_cleanup);
 
-// memory size
-size_t manifold_manifold_size();
-size_t manifold_manifold_vec_size();
-size_t manifold_cross_section_size();
-size_t manifold_cross_section_vec_size();
-size_t manifold_simple_polygon_size();
-size_t manifold_polygons_size();
-size_t manifold_manifold_pair_size();
-size_t manifold_meshgl_size();
-size_t manifold_box_size();
-size_t manifold_rect_size();
-size_t manifold_curvature_size();
 size_t manifold_material_size();
 size_t manifold_export_options_size();
 
-// destruction
-void manifold_destruct_manifold(ManifoldManifold *m);
-void manifold_destruct_manifold_vec(ManifoldManifoldVec *ms);
-void manifold_destruct_cross_section(ManifoldCrossSection *m);
-void manifold_destruct_cross_section_vec(ManifoldCrossSectionVec *csv);
-void manifold_destruct_simple_polygon(ManifoldSimplePolygon *p);
-void manifold_destruct_polygons(ManifoldPolygons *p);
-void manifold_destruct_meshgl(ManifoldMeshGL *m);
-void manifold_destruct_box(ManifoldBox *b);
-void manifold_destruct_rect(ManifoldRect *b);
-void manifold_destruct_curvature(ManifoldCurvature *c);
 void manifold_destruct_material(ManifoldMaterial *m);
 void manifold_destruct_export_options(ManifoldExportOptions *options);
 
-// pointer free + destruction
-void manifold_delete_manifold(ManifoldManifold *m);
-void manifold_delete_manifold_vec(ManifoldManifoldVec *ms);
-void manifold_delete_cross_section(ManifoldCrossSection *cs);
-void manifold_delete_cross_section_vec(ManifoldCrossSectionVec *csv);
-void manifold_delete_simple_polygon(ManifoldSimplePolygon *p);
-void manifold_delete_polygons(ManifoldPolygons *p);
-void manifold_delete_meshgl(ManifoldMeshGL *m);
-void manifold_delete_box(ManifoldBox *b);
-void manifold_delete_rect(ManifoldRect *b);
-void manifold_delete_curvature(ManifoldCurvature *c);
 void manifold_delete_material(ManifoldMaterial *m);
 void manifold_delete_export_options(ManifoldExportOptions *options);
+#endif
 
 #ifdef __cplusplus
 }

--- a/bindings/c/include/types.h
+++ b/bindings/c/include/types.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <stddef.h>
 
+// opaque pointers
+
 typedef struct ManifoldManifold ManifoldManifold;
 typedef struct ManifoldManifoldVec ManifoldManifoldVec;
 typedef struct ManifoldCrossSection ManifoldCrossSection;
@@ -12,8 +14,13 @@ typedef struct ManifoldMeshGL ManifoldMeshGL;
 typedef struct ManifoldCurvature ManifoldCurvature;
 typedef struct ManifoldBox ManifoldBox;
 typedef struct ManifoldRect ManifoldRect;
+
+#ifdef MANIFOLD_EXPORT
 typedef struct ManifoldMaterial ManifoldMaterial;
 typedef struct ManifoldExportOptions ManifoldExportOptions;
+#endif
+
+// structs
 
 typedef struct ManifoldManifoldPair {
   ManifoldManifold* first;
@@ -55,6 +62,8 @@ typedef struct ManifoldCurvatureBounds {
   float max_gaussian_curvature;
   float min_gaussian_curvature;
 } ManifoldCurvatureBounds;
+
+// enums
 
 typedef enum ManifoldOpType {
   MANIFOLD_ADD,

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -15,8 +15,6 @@
 #include "types.h"
 
 #ifdef MANIFOLD_EXPORT
-#include <meshIO.h>
-
 #include "meshio.cpp"
 #endif
 

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -2,7 +2,6 @@
 #include <cross_section.h>
 #include <manifold.h>
 #include <manifoldc.h>
-#include <meshIO.h>
 #include <public.h>
 #include <sdf.h>
 
@@ -12,9 +11,14 @@
 #include "cross.cpp"
 #include "include/conv.h"
 #include "include/types.h"
-#include "meshio.cpp"
 #include "rect.cpp"
 #include "types.h"
+
+#ifdef MANIFOLD_EXPORT
+#include <meshIO.h>
+
+#include "meshio.cpp"
+#endif
 
 using namespace manifold;
 

--- a/bindings/c/meshio.cpp
+++ b/bindings/c/meshio.cpp
@@ -4,9 +4,29 @@
 
 #include "include/types.h"
 
+// C <-> C++ conversions
+
+ManifoldMaterial *to_c(manifold::Material *m) {
+  return reinterpret_cast<ManifoldMaterial *>(m);
+}
+
+ManifoldExportOptions *to_c(manifold::ExportOptions *m) {
+  return reinterpret_cast<ManifoldExportOptions *>(m);
+}
+
+manifold::Material *from_c(ManifoldMaterial *mat) {
+  return reinterpret_cast<manifold::Material *>(mat);
+}
+
+manifold::ExportOptions *from_c(ManifoldExportOptions *options) {
+  return reinterpret_cast<manifold::ExportOptions *>(options);
+}
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// material
 
 ManifoldMaterial *manifold_material(void *mem) {
   return to_c(new (mem) manifold::Material());
@@ -29,6 +49,8 @@ void manifold_material_set_vert_color(ManifoldMaterial *mat,
   from_c(mat)->vertColor = vector_of_vec_array(vert_color, n_vert);
 }
 
+// export options
+
 ManifoldExportOptions *manifold_export_options(void *mem) {
   return to_c(new (mem) manifold::ExportOptions());
 }
@@ -42,6 +64,8 @@ void manifold_export_options_set_material(ManifoldExportOptions *options,
                                           ManifoldMaterial *mat) {
   from_c(options)->mat = *from_c(mat);
 }
+
+// mesh IO
 
 void manifold_export_meshgl(const char *filename, ManifoldMeshGL *mesh,
                             ManifoldExportOptions *options) {

--- a/test/manifoldc_test.cpp
+++ b/test/manifoldc_test.cpp
@@ -67,7 +67,7 @@ TEST(CBIND, level_set) {
 #ifdef MANIFOLD_EXPORT
   ManifoldExportOptions *options =
       manifold_export_options(malloc(manifold_export_options_size()));
-  const char *name = "cbind_sdf_test.stl";
+  const char *name = "cbind_sdf_test.glb";
   manifold_export_meshgl(name, sdf_mesh, options);
   manifold_delete_export_options(options);
 #endif


### PR DESCRIPTION
This makes linking MeshIO optional for the C bindings, rather than forcing the flag on.