### PR TITLE
Fix editor warp crash

### DIFF
--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -72,6 +72,11 @@ Module.setup = function() {
     }, 'vi');
     const out = this._Warp(wasmFuncPtr);
     removeFunction(wasmFuncPtr);
+
+    const status = out.status();
+    if (status.value !== 0) {
+      throw new Module.ManifoldError(status.value);
+    }
     return out;
   };
 

--- a/bindings/wasm/examples/editor.js
+++ b/bindings/wasm/examples/editor.js
@@ -377,7 +377,6 @@ function createWorker() {
 
     finishRun();
     runButton.disabled = true;
-    setScript('safe', 'true');
 
     URL.revokeObjectURL(objectURL);
     objectURL = e.data.objectURL;
@@ -385,6 +384,9 @@ function createWorker() {
     if (objectURL == null) {
       mv.showPoster();
       poster.textContent = 'Error';
+      createWorker();
+    } else {
+      setScript('safe', 'true');
     }
   }
 }

--- a/bindings/wasm/examples/index.html
+++ b/bindings/wasm/examples/index.html
@@ -29,6 +29,10 @@
       }
     }
   </script>
+  <script>
+    self.ModelViewerElement = self.ModelViewerElement || {};
+    self.ModelViewerElement.modelCacheSize = 0;
+  </script>
   <script type="module" src="/examples.js"></script>
 </head>
 

--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -75,6 +75,7 @@ struct Manifold::Impl {
 
   void Update();
   void MarkFailure(Error status);
+  void Warp(std::function<void(glm::vec3&)> warpFunc);
   Impl Transform(const glm::mat4x3& transform) const;
   SparseIndices EdgeCollisions(const Impl& B) const;
   SparseIndices VertexCollisionsZ(const VecDH<glm::vec3>& vertsIn) const;

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -563,15 +563,7 @@ Manifold Manifold::Mirror(glm::vec3 normal) const {
  */
 Manifold Manifold::Warp(std::function<void(glm::vec3&)> warpFunc) const {
   auto pImpl = std::make_shared<Impl>(*GetCsgLeafNode().GetImpl());
-  thrust::for_each_n(thrust::host, pImpl->vertPos_.begin(), NumVert(),
-                     warpFunc);
-  pImpl->Update();
-  pImpl->faceNormal_.resize(0);  // force recalculation of triNormal
-  pImpl->CalculateNormals();
-  pImpl->SetPrecision();
-  pImpl->CreateFaces();
-  pImpl->SimplifyTopology();
-  pImpl->Finish();
+  pImpl->Warp(warpFunc);
   return Manifold(std::make_shared<CsgLeafNode>(pImpl));
 }
 


### PR DESCRIPTION
I was finding that warp would sometimes crash (saying something really unhelpful like out of memory) and then the editor was unusable until after a reload. I fixed this three ways:

1) When the worker throws an error, we now recreate it, like when we cancel. This keeps the editor usable.
2) I added our non-finite vertex check to `Warp` - turns out I was just generating a NaN somewhere.
3) I surfaced this error through to throw in the JS bindings, so you actually get some feedback on what went wrong.