### PR TITLE
Use quality globals instead of arc tolerance for offset

### DIFF
--- a/bindings/c/cross.cpp
+++ b/bindings/c/cross.cpp
@@ -169,9 +169,9 @@ ManifoldCrossSection *manifold_cross_section_simplify(void *mem,
 
 ManifoldCrossSection *manifold_cross_section_offset(
     void *mem, ManifoldCrossSection *cs, double delta, ManifoldJoinType jt,
-    double miter_limit, double arc_tolerance) {
+    double miter_limit, int circular_segments) {
   auto offset =
-      from_c(cs)->Offset(delta, from_c(jt), miter_limit, arc_tolerance);
+      from_c(cs)->Offset(delta, from_c(jt), miter_limit, circular_segments);
   return to_c(new (mem) CrossSection(offset));
 }
 

--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -222,7 +222,7 @@ ManifoldCrossSection *manifold_cross_section_simplify(void *mem,
                                                       double epsilon);
 ManifoldCrossSection *manifold_cross_section_offset(
     void *mem, ManifoldCrossSection *cs, double delta, ManifoldJoinType jt,
-    double miter_limit, double arc_tolerance);
+    double miter_limit, int circular_segments);
 
 // CrossSection Info
 

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -160,9 +160,9 @@ Module.setup = function() {
   };
 
   Module.CrossSection.prototype.offset = function(
-      delta, joinType = 'Square', miterLimit = 2.0, arcTolerance = 0.) {
+      delta, joinType = 'Square', miterLimit = 2.0, circularSegments = 0) {
     return this._Offset(
-        delta, joinTypeToInt(joinType), miterLimit, arcTolerance);
+        delta, joinTypeToInt(joinType), miterLimit, circularSegments);
   };
 
   Module.CrossSection.prototype.rectClip = function(rect) {

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -168,14 +168,14 @@ export class CrossSection {
    * minimum allowed). See the [Clipper2
    * MiterLimit](http://www.angusj.com/clipper2/Docs/Units/Clipper.Offset/Classes/ClipperOffset/Properties/MiterLimit.htm)
    * page for a visual example.
-   * @param arcTolerance The maximum acceptable imperfection for curves drawn
-   * (approximated with line segments) for Round joins (not relevant for other
-   * JoinTypes). By default (when undefined or =0), the allowable imprecision is
-   * scaled in inverse proportion to the offset delta.
+   * @param circularSegments Number of segments per 360 degrees of
+   * <B>JoinType::Round</B> corners (roughly, the number of vertices that
+   * will be added to each contour). Default is calculated by the static Quality
+   * defaults according to the radius.
    */
   offset(
       delta: number, joinType?: JoinType, miterLimit?: number,
-      arcTolerance?: number): CrossSection;
+      circularSegments?: number): CrossSection;
 
   /**
    * Remove vertices from the contours in this CrossSection that are less than

--- a/src/cross_section/include/cross_section.h
+++ b/src/cross_section/include/cross_section.h
@@ -127,7 +127,7 @@ class CrossSection {
   };
 
   CrossSection Offset(double delta, JoinType jt, double miter_limit = 2.0,
-                      double arc_tolerance = 0.0) const;
+                      int circularSegments = 0) const;
   ///@}
 
   /** @name Boolean

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -533,27 +533,28 @@ CrossSection CrossSection::Simplify(double epsilon) const {
  * minimum allowed). See the [Clipper2
  * MiterLimit](http://www.angusj.com/clipper2/Docs/Units/Clipper.Offset/Classes/ClipperOffset/Properties/MiterLimit.htm)
  * page for a visual example.
- * @param arc_tolerance The maximum acceptable imperfection for curves drawn
- * (approximated with line segments) for Round joins (not relevant for other
- * JoinTypes). By default (when undefined or =0), the allowable imprecision is
- * scaled in inverse proportion to the offset delta.
+ * @param circularSegments Number of segments per 360 degrees of
+ * <B>JoinType::Round</B> corners (roughly, the number of vertices that
+ * will be added to each contour). Default is calculated by the static Quality
+ * defaults according to the radius.
  */
 CrossSection CrossSection::Offset(double delta, JoinType jointype,
                                   double miter_limit,
                                   int circularSegments) const {
-  double tol = 0.;
+  double arc_tol = 0.;
   if (jointype == JoinType::Round) {
     int n = circularSegments > 2 ? circularSegments
                                  : Quality::GetCircularSegments(delta);
     // This calculates tolerance as a function of circular segments and delta
     // (radius) in order to get back the same number of segments in Clipper2:
     // steps_per_360 = PI / acos(1 - arc_tol / abs_delta)
-    double scaled_delta = std::abs(delta * std::pow(10, precision_));
-    tol = (std::cos(Clipper2Lib::PI / n) - 1) * -scaled_delta;
+    const double abs_delta = std::fabs(delta);
+    const double scaled_delta = abs_delta * std::pow(10, precision_);
+    arc_tol = (std::cos(Clipper2Lib::PI / n) - 1) * -scaled_delta;
   }
   auto ps =
       C2::InflatePaths(GetPaths(), delta, jt(jointype), C2::EndType::Polygon,
-                       miter_limit, precision_, tol);
+                       miter_limit, precision_, arc_tol);
   return CrossSection(ps);
 }
 

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -52,7 +52,8 @@ TEST(CrossSection, MirrorUnion) {
 
 TEST(CrossSection, RoundOffset) {
   auto a = CrossSection::Square({20., 20.}, true);
-  auto rounded = a.Offset(5., CrossSection::JoinType::Round);
+  int segments = 20;
+  auto rounded = a.Offset(5., CrossSection::JoinType::Round, 2, segments);
   auto result = Manifold::Extrude(rounded, 5.);
 
 #ifdef MANIFOLD_EXPORT
@@ -61,7 +62,8 @@ TEST(CrossSection, RoundOffset) {
 #endif
 
   EXPECT_EQ(result.Genus(), 0);
-  EXPECT_NEAR(result.GetProperties().volume, 4393, 1);
+  EXPECT_NEAR(result.GetProperties().volume, 4386, 1);
+  EXPECT_EQ(rounded.NumVert(), segments + 4);
 }
 
 TEST(CrossSection, Empty) {


### PR DESCRIPTION
Use `circularSegments` and the `Quality` globals rather than `arc_tolerance` to control offset roundovers. 

I'll add commits for the doc strings and JS bindings soon. 