### PR TITLE
Backward compat

### DIFF
--- a/bindings/wasm/examples/public/examples.js
+++ b/bindings/wasm/examples/public/examples.js
@@ -16,10 +16,11 @@ export const examples = {
   functions: {
     Intro: function() {
       // Write code in JavaScript or TypeScript and this editor will show the
-      // API docs. Type e.g. "box." to see the Manifold API. Type "module." to
-      // see the static API - these functions can also be used bare. Use
-      // console.log() to print output (lower-right). This editor defines Z as
-      // up and units of mm.
+      // API docs. Type e.g. "box." to see the Manifold API. Type
+      // "CrossSection." or "Manifold." to list the 2D and 3D constructors,
+      // respectively. Type "module." to see the static API - these functions
+      // can also be used bare. Use console.log() to print output (lower-right).
+      // This editor defines Z as up and units of mm.
       const {cube, sphere} = Manifold;
       const box = cube([100, 100, 100], true);
       const ball = sphere(60, 100);

--- a/bindings/wasm/examples/worker.ts
+++ b/bindings/wasm/examples/worker.ts
@@ -66,7 +66,8 @@ const toplevel = [
   'setMinCircularAngle', 'setMinCircularEdgeLength', 'setCircularSegments',
   'getCircularSegments', 'Mesh', 'GLTFNode', 'Manifold', 'CrossSection'
 ];
-const exposedFunctions = toplevelConstructors.concat(toplevel);
+const exposedFunctions =
+    toplevelConstructors.concat(toplevel, manifoldStaticFunctions);
 
 // Setup memory management, such that users don't have to care about
 // calling `delete` manually.
@@ -107,6 +108,12 @@ for (const name of toplevelConstructors) {
     memoryRegistry.push(result);
     return result;
   };
+}
+
+// for backwards compatibility
+for (const name of manifoldStaticFunctions) {
+  //@ts-ignore
+  module[name] = module.Manifold[name];
 }
 
 module.cleanup = function() {


### PR DESCRIPTION
We made a breaking change in #440 to pull the static methods up into `module.Manifold`, which I think is the right call, but this breaks people's existing scripts in ManifoldCAD.org. I decided to add back in the bare manifold constructors so that those scripts will still run, though I did not add them back into the `.d.ts`. This means they get a red error telling them to update while their script still runs - this feels like a reasonable compromise for now. 