### PR TITLE
Fix oversized malloc error (gcc inlining related)

### DIFF
--- a/src/utilities/include/vec_dh.h
+++ b/src/utilities/include/vec_dh.h
@@ -166,8 +166,9 @@ class ManagedVec {
   void shrink_to_fit() {
     T *newBuffer = nullptr;
     if (size_ > 0) {
-      mallocManaged(&newBuffer, size_ * sizeof(T));
-      prefetch(newBuffer, size_ * sizeof(T), onHost);
+      int n_bytes = size_ * sizeof(T);
+      mallocManaged(&newBuffer, n_bytes);
+      prefetch(newBuffer, n_bytes, onHost);
       uninitialized_copy(autoPolicy(size_), ptr_, ptr_ + size_, newBuffer);
     }
     freeManaged(ptr_);


### PR DESCRIPTION
Fixes #450

This breaks the allocation size calculation in `ManagedVec::shrink_to_fit` onto a separate line in order to work around spooky inlining (I think) by GCC that trips up an excessive allocation compilation error in `malloc`.