### PR TITLE
Workaround assimp exporting empty 3mfs

### DIFF
--- a/meshIO/src/meshIO.cpp
+++ b/meshIO/src/meshIO.cpp
@@ -79,6 +79,13 @@ void ExportScene(aiScene* scene, const std::string& filename) {
   //   std::cout << i << ", id = " << desc->id << ", " << desc->description
   //             << std::endl;
   // }
+  auto ext = filename.substr(filename.length() - 4, 4);
+  if (ext == ".3mf") {
+    // Workaround https://github.com/assimp/assimp/issues/3816
+    aiNode* old_root = scene->mRootNode;
+    scene->mRootNode = new aiNode();
+    scene->mRootNode->addChildren(1, &old_root);
+  }
 
   auto result = exporter.Export(scene, GetType(filename), filename);
 


### PR DESCRIPTION
This is something that I actually noticed a long time ago, but forgot to mention or return to myself, but 3mf export via `MeshIO` doesn't actually work (a file containing no meshes is written).

There is actually a [long standing issue](https://github.com/assimp/assimp/issues/3816) for this in the assimp tracker, but fortunately it has an easy workaround. This PR implements that workaround by nesting the node holding the mesh into a child of the root node if the extension is `.3mf`.