### PR TITLE
Partial Revolve

### DIFF
--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -182,7 +182,8 @@ Module.setup = function() {
     return (center ? man.translate([0., 0., -height / 2.]) : man);
   };
 
-  Module.CrossSection.prototype.revolve = function(circularSegments = 0, revolveDegrees = 360.0) {
+  Module.CrossSection.prototype.revolve = function(
+      circularSegments = 0, revolveDegrees = 360.0) {
     return Module._Revolve(this, circularSegments, revolveDegrees);
   };
 
@@ -555,7 +556,8 @@ Module.setup = function() {
     return cs.extrude(height, nDivisions, twistDegrees, scaleTop, center);
   };
 
-  Module.Manifold.revolve = function(polygons, circularSegments = 0, revolveDegrees = 360.0) {
+  Module.Manifold.revolve = function(
+      polygons, circularSegments = 0, revolveDegrees = 360.0) {
     const cs = (polygons instanceof CrossSectionCtor) ?
         polygons :
         Module.CrossSection(polygons, 'Positive');

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -182,8 +182,8 @@ Module.setup = function() {
     return (center ? man.translate([0., 0., -height / 2.]) : man);
   };
 
-  Module.CrossSection.prototype.revolve = function(circularSegments = 0) {
-    return Module._Revolve(this, circularSegments);
+  Module.CrossSection.prototype.revolve = function(circularSegments = 0, revolveDegrees = 360.0) {
+    return Module._Revolve(this, circularSegments, revolveDegrees);
   };
 
   Module.CrossSection.prototype.add = function(other) {
@@ -555,11 +555,11 @@ Module.setup = function() {
     return cs.extrude(height, nDivisions, twistDegrees, scaleTop, center);
   };
 
-  Module.Manifold.revolve = function(polygons, circularSegments = 0) {
+  Module.Manifold.revolve = function(polygons, circularSegments = 0, revolveDegrees = 360.0) {
     const cs = (polygons instanceof CrossSectionCtor) ?
         polygons :
         Module.CrossSection(polygons, 'Positive');
-    return cs.revolve(circularSegments);
+    return cs.revolve(circularSegments, revolveDegrees);
   };
 
   Module.Manifold.reserveIDs = function(n) {

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -91,7 +91,7 @@ export class CrossSection {
    * @param circularSegments Number of segments along its diameter. Default is
    * calculated by the static Defaults.
    */
-  revolve(circularSegments?: number): Manifold;
+  revolve(circularSegments?: number, revolveDegrees?: number): Manifold;
 
   // Transformations
 

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -421,8 +421,9 @@ export class Manifold {
    * @param polygons A set of non-overlapping polygons to revolve.
    * @param circularSegments Number of segments along its diameter. Default is
    * calculated by the static Defaults.
+   * @param revolveDegrees Number of degrees to revolve. Default is 360 degrees.
    */
-  static revolve(polygons: CrossSection|Polygons, circularSegments?: number):
+  static revolve(polygons: CrossSection|Polygons, circularSegments?: number, revolveDegrees?: number):
       Manifold;
 
   // Mesh Conversion

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -423,8 +423,9 @@ export class Manifold {
    * calculated by the static Defaults.
    * @param revolveDegrees Number of degrees to revolve. Default is 360 degrees.
    */
-  static revolve(polygons: CrossSection|Polygons, circularSegments?: number, revolveDegrees?: number):
-      Manifold;
+  static revolve(
+      polygons: CrossSection|Polygons, circularSegments?: number,
+      revolveDegrees?: number): Manifold;
 
   // Mesh Conversion
 

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -141,7 +141,8 @@ class Manifold {
                           int nDivisions = 0, float twistDegrees = 0.0f,
                           glm::vec2 scaleTop = glm::vec2(1.0f));
   static Manifold Revolve(const CrossSection& crossSection,
-                          int circularSegments = 0);
+                          int circularSegments = 0,
+                          float revolveDegrees = 360.0f);
   ///@}
 
   /** @name Topological

--- a/src/manifold/src/constructors.cpp
+++ b/src/manifold/src/constructors.cpp
@@ -365,12 +365,9 @@ Manifold Manifold::Revolve(const CrossSection& crossSection,
   std::vector<int> startPoses;
   std::vector<int> endPoses;
 
-  float dPhi = revolveDegrees / nDivisions;
+  const float dPhi = revolveDegrees / nDivisions;
   // first and last slice are distinguished if not a full revolution.
-  int nSlices = isFullRevolution ? nDivisions : nDivisions + 1;
-
-  int nVertices = 0;
-  int nFaces = 0;
+  const int nSlices = isFullRevolution ? nDivisions : nDivisions + 1;
 
   for (const auto& poly : polygons) {
 
@@ -391,22 +388,20 @@ Manifold Manifold::Revolve(const CrossSection& crossSection,
       if (!isFullRevolution)
         startPoses.push_back(startPosIndex);
 
-      int prevStartPosIndex = startPosIndex + (polyVert == 0 ? nRevolveAxisVerts + (nSlices * nPosVerts) - nSlices
-                                                             : poly[polyVert-1].x == 0.0 ? -1 : -nSlices);
+      const int prevStartPosIndex = startPosIndex + (polyVert == 0 ? nRevolveAxisVerts + (nSlices * nPosVerts) - nSlices
+                                                                   : poly[polyVert-1].x == 0.0 ? -1 : -nSlices);
       glm::vec2 currPolyVertex = poly[polyVert];
       glm::vec2 prevPolyVertex = poly[polyVert == 0 ? poly.size() - 1 : polyVert - 1];
 
-      int nFacesAdded = 0;
       for (int slice = 0; slice < nSlices; ++slice) {
 
         float phi = slice * dPhi;
         if (slice == 0 || currPolyVertex.x > 0) {
           vertPos.push_back({currPolyVertex.x * cosd(phi), currPolyVertex.x * sind(phi), currPolyVertex.y});
-          nVertices += 1;
         }
 
         if (isFullRevolution || slice > 0) {
-          int lastSlice = (slice == 0 ? nDivisions : slice) - 1;
+          const int lastSlice = (slice == 0 ? nDivisions : slice) - 1;
           if (currPolyVertex.x > 0.0) {
             triVerts.push_back({startPosIndex + slice,
                 startPosIndex + lastSlice,

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -198,9 +198,11 @@ TEST(Manifold, ExtrudeCone) {
 }
 
 TEST(Manifold, Revolve) {
-  Polygons polys = SquareHole();
-  Manifold vug = Manifold::Revolve(polys, 48);
-  EXPECT_EQ(vug.Genus(), -1);
+  //Polygons polys = SquareHole();
+  Polygons polys = CrossSection::Square({4, 4}).ToPolygons();
+  Manifold vug = Manifold::Revolve(polys, 4);
+  ///EXPECT_EQ(vug.Genus(), 1);
+  ExportMesh("revolve.glb", vug.GetMesh(), {});
   auto prop = vug.GetProperties();
   EXPECT_NEAR(prop.volume, 14.0f * glm::pi<float>(), 0.2f);
   EXPECT_NEAR(prop.surfaceArea, 30.0f * glm::pi<float>(), 0.2f);
@@ -209,10 +211,19 @@ TEST(Manifold, Revolve) {
 TEST(Manifold, Revolve2) {
   Polygons polys = SquareHole(2.0f);
   Manifold donutHole = Manifold::Revolve(polys, 48);
-  EXPECT_EQ(donutHole.Genus(), 0);
+  EXPECT_EQ(donutHole.Genus(), 1);
   auto prop = donutHole.GetProperties();
   EXPECT_NEAR(prop.volume, 48.0f * glm::pi<float>(), 1.0f);
   EXPECT_NEAR(prop.surfaceArea, 96.0f * glm::pi<float>(), 1.0f);
+}
+
+TEST(Manifold, PartialRevolve) {
+  Polygons polys = SquareHole(2.0f);
+  Manifold donutHole = Manifold::Revolve(polys, 48, 180);
+  EXPECT_EQ(donutHole.Genus(), 1);
+  auto prop = donutHole.GetProperties();
+  EXPECT_NEAR(prop.volume, 24.0f * glm::pi<float>(), 1.0f);
+  EXPECT_NEAR(prop.surfaceArea, 48.0f * glm::pi<float>() + 4.0f*4.0f*2.0f - 2.0f*2.0f*2.0f, 1.0f);
 }
 
 TEST(Manifold, Warp) {

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -198,10 +198,9 @@ TEST(Manifold, ExtrudeCone) {
 }
 
 TEST(Manifold, Revolve) {
-  //Polygons polys = SquareHole();
-  Polygons polys = CrossSection::Square({4, 4}).ToPolygons();
-  Manifold vug = Manifold::Revolve(polys, 4);
-  ///EXPECT_EQ(vug.Genus(), 1);
+  Polygons polys = SquareHole();
+  Manifold vug = Manifold::Revolve(polys, 48);
+  EXPECT_EQ(vug.Genus(), -1);
   ExportMesh("revolve.glb", vug.GetMesh(), {});
   auto prop = vug.GetProperties();
   EXPECT_NEAR(prop.volume, 14.0f * glm::pi<float>(), 0.2f);
@@ -211,7 +210,7 @@ TEST(Manifold, Revolve) {
 TEST(Manifold, Revolve2) {
   Polygons polys = SquareHole(2.0f);
   Manifold donutHole = Manifold::Revolve(polys, 48);
-  EXPECT_EQ(donutHole.Genus(), 1);
+  EXPECT_EQ(donutHole.Genus(), 0);
   auto prop = donutHole.GetProperties();
   EXPECT_NEAR(prop.volume, 48.0f * glm::pi<float>(), 1.0f);
   EXPECT_NEAR(prop.surfaceArea, 96.0f * glm::pi<float>(), 1.0f);

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -14,9 +14,10 @@
 
 #include "manifold.h"
 
+#include <iostream>
+
 #include "cross_section.h"
 #include "test.h"
-#include <iostream>
 
 #ifdef MANIFOLD_EXPORT
 #include "meshIO.h"
@@ -201,11 +202,12 @@ TEST(Manifold, ExtrudeCone) {
 TEST(Manifold, Revolve) {
   Polygons polys = SquareHole();
   Manifold vug = Manifold::Revolve(polys, 48);
-  for(int i = 0; i < polys[0].size(); i++) {
+  for (int i = 0; i < polys[0].size(); i++) {
     Polygons rotatedPolys;
-    for(auto &polygon : polys) {
+    for (auto& polygon : polys) {
       auto rotatedPolygon = polygon;
-      std::rotate(rotatedPolygon.begin(), rotatedPolygon.begin() + i, rotatedPolygon.end());
+      std::rotate(rotatedPolygon.begin(), rotatedPolygon.begin() + i,
+                  rotatedPolygon.end());
       rotatedPolys.push_back(rotatedPolygon);
     }
     Manifold vug = Manifold::Revolve(rotatedPolys, 48);
@@ -229,17 +231,19 @@ TEST(Manifold, PartialRevolve) {
   Polygons polys = SquareHole(2.0f);
   Polygons offsetPolys = SquareHole(10.0f);
 
-  for(int i = 0; i < polys[0].size(); i++) {
+  for (int i = 0; i < polys[0].size(); i++) {
     Polygons rotatedPolys;
-    for(auto &polygon : polys) {
+    for (auto& polygon : polys) {
       auto rotatedPolygon = polygon;
-      std::rotate(rotatedPolygon.begin(), rotatedPolygon.begin() + i, rotatedPolygon.end());
+      std::rotate(rotatedPolygon.begin(), rotatedPolygon.begin() + i,
+                  rotatedPolygon.end());
       rotatedPolys.push_back(rotatedPolygon);
     }
     Polygons rotatedOffsetPolys;
-    for(auto &polygon : offsetPolys) {
+    for (auto& polygon : offsetPolys) {
       auto rotatedPolygon = polygon;
-      std::rotate(rotatedPolygon.begin(), rotatedPolygon.begin() + i, rotatedPolygon.end());
+      std::rotate(rotatedPolygon.begin(), rotatedPolygon.begin() + i,
+                  rotatedPolygon.end());
       rotatedOffsetPolys.push_back(rotatedPolygon);
     }
 
@@ -248,7 +252,10 @@ TEST(Manifold, PartialRevolve) {
     EXPECT_EQ(halfDonut.Genus(), 1);
     auto prop = halfDonut.GetProperties();
     EXPECT_NEAR(prop.volume, 24.0f * glm::pi<float>(), 1.0f);
-    EXPECT_NEAR(prop.surfaceArea, 48.0f * glm::pi<float>() + 4.0f*4.0f*2.0f - 2.0f*2.0f*2.0f, 1.0f);
+    EXPECT_NEAR(
+        prop.surfaceArea,
+        48.0f * glm::pi<float>() + 4.0f * 4.0f * 2.0f - 2.0f * 2.0f * 2.0f,
+        1.0f);
 
     halfDonut = Manifold::Revolve(rotatedOffsetPolys, 48, 180);
     prop = halfDonut.GetProperties();


### PR DESCRIPTION
This adds an optional arity for Revolve that supports partial revolutions. It changes the implementation slightly by first taking the x>=0 slice if the bounding box contains negative x values. The cases of vertices lying on the revolve axis is handled in the same loop, arguably simplifying the logic slightly and making it easier to support partial evolves.  I believe the tessellation of full revolutions is equivalent to the previous version.

It might be worth noting it's not strictly required to implement special handling of coincident vertices. The logic is far simpler in this case and the core implementation seems to be able handle it no problem. However, it does break Genus. I think it's better to do the correct construction, but might be something to consider. The complexity overhead is quite high unfortunately... Perhaps it can be simplified.