### PR TITLE
Clean up `CrossSection` constructor in pymanifold

### DIFF
--- a/bindings/python/pymanifold.cpp
+++ b/bindings/python/pymanifold.cpp
@@ -578,12 +578,11 @@ PYBIND11_MODULE(pymanifold, m) {
                        CrossSection::FillRule fillrule) {
              std::vector<SimplePolygon> simplePolygons(polygons.size());
              for (int i = 0; i < polygons.size(); i++) {
-               std::vector<glm::vec2> vertices(polygons[i].size());
+               simplePolygons[i] = std::vector<glm::vec2>(polygons[i].size());
                for (int j = 0; j < polygons[i].size(); j++) {
-                 vertices[j] = {std::get<0>(polygons[i][j]),
-                                std::get<1>(polygons[i][j])};
+                 simplePolygons[i][j] = {std::get<0>(polygons[i][j]),
+                                         std::get<1>(polygons[i][j])};
                }
-               simplePolygons[i] = {vertices};
              }
              return CrossSection(simplePolygons, fillrule);
            }),


### PR DESCRIPTION
Removes `vertices` intermediary and `{vertices}` assignment in the `CrossSection` constructor of pymanifold. I'm not sure why `{vertices}` was compiling obviously, and I'm not sure it'd ever be a problem, but it seemed odd to me to be wrapping the vector in braces as though the `SimplePolygon` was a vector of contours, rather than a single one. Is this clearer, or am I just not used to the cpp way of doing things?