### PR TITLE
Fix size_t inconsistencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(MANIFOLD_USE_CUDA)
 endif()
 
 if(NOT MSVC)
-  set(WARNING_FLAGS -Werror -Wall -Wno-sign-compare -Wno-unused)
+  set(WARNING_FLAGS -Werror -Wall -Wno-sign-compare -Wno-unused -Wno-alloc-size-larger-than)
   add_compile_options(
     "$<$<COMPILE_LANGUAGE:CXX>:${WARNING_FLAGS}>"
     "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${WARNING_FLAGS}>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,10 @@ if(MANIFOLD_USE_CUDA)
 endif()
 
 if(NOT MSVC)
-  set(WARNING_FLAGS -Werror -Wall -Wno-sign-compare -Wno-unused -Wno-alloc-size-larger-than)
+  set(WARNING_FLAGS -Werror -Wall -Wno-sign-compare -Wno-unused)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(WARNING_FLAGS ${WARNING_FLAGS} -Wno-alloc-size-larger-than)
+  endif()
   add_compile_options(
     "$<$<COMPILE_LANGUAGE:CXX>:${WARNING_FLAGS}>"
     "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${WARNING_FLAGS}>")

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -21,7 +21,6 @@ message("CUDA Support: ${MANIFOLD_USE_CUDA}")
 message("Parallel Backend: ${MANIFOLD_PAR}")
 
 target_include_directories(${PROJECT_NAME} INTERFACE ${PROJECT_SOURCE_DIR}/include)
-target_include_directories(${PROJECT_NAME} INTERFACE ${THRUST_INC_DIR}/dependencies/libcudacxx/include)
 
 if(MANIFOLD_PAR STREQUAL "OMP")
     find_package(OpenMP REQUIRED)
@@ -42,6 +41,7 @@ else()
 endif()
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${THRUST_INC_DIR})
+target_include_directories(${PROJECT_NAME} PUBLIC ${THRUST_INC_DIR}/dependencies/libcudacxx/include)
 target_link_libraries(${PROJECT_NAME} PUBLIC glm)
 
 if(MANIFOLD_USE_CUDA)

--- a/src/utilities/include/hashtable.h
+++ b/src/utilities/include/hashtable.h
@@ -128,8 +128,8 @@ template <typename V, hash_fun_t H = hash64bit>
 class HashTable {
  public:
   HashTable(uint32_t size, uint32_t step = 1)
-      : keys_{1 << (int)ceil(log2(size)), kOpen},
-        values_{1 << (int)ceil(log2(size)), {}},
+      : keys_{1lu << (int)ceil(log2(size)), kOpen},
+        values_{1lu << (int)ceil(log2(size)), {}},
         table_{keys_, values_, used_, step} {}
 
   HashTableD<V, H> D() { return table_; }

--- a/src/utilities/include/utils.h
+++ b/src/utilities/include/utils.h
@@ -99,10 +99,7 @@ thrust::permutation_iterator<A, B> perm(A a, B b) {
   return thrust::make_permutation_iterator(a, b);
 }
 
-template <typename T>
-thrust::counting_iterator<T> countAt(T i) {
-  return thrust::make_counting_iterator(i);
-}
+thrust::counting_iterator<int> countAt(int i);
 
 inline __host__ __device__ int Next3(int i) {
   constexpr glm::ivec3 next3(1, 2, 0);

--- a/src/utilities/include/vec_dh.h
+++ b/src/utilities/include/vec_dh.h
@@ -166,7 +166,6 @@ class ManagedVec {
   void shrink_to_fit() {
     T *newBuffer = nullptr;
     if (size_ > 0) {
-      size_t n_bytes = size_ * sizeof(T);
       mallocManaged(&newBuffer, size_ * sizeof(T));
       prefetch(newBuffer, size_ * sizeof(T), onHost);
       uninitialized_copy(autoPolicy(size_), ptr_, ptr_ + size_, newBuffer);
@@ -250,7 +249,7 @@ class ManagedVec {
   size_t capacity_ = 0;
   mutable bool onHost = true;
 
-  static constexpr int DEVICE_MAX_BYTES = 1 << 16;
+  static constexpr size_t DEVICE_MAX_BYTES = 1ul << 16;
 
   static void mallocManaged(T **ptr, size_t bytes) {
 #ifdef MANIFOLD_USE_CUDA

--- a/src/utilities/src/util.cpp
+++ b/src/utilities/src/util.cpp
@@ -1,0 +1,20 @@
+// Copyright 2022 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <thrust/iterator/counting_iterator.h>
+
+namespace manifold {
+thrust::counting_iterator<int> countAt(int i) {
+  return thrust::make_counting_iterator(i);
+}
+}  // namespace manifold


### PR DESCRIPTION
For some reason `vec_dh.h` was mixing size_t and int for indices and vector size. This is now fixed to use `size_t` everywhere, which should allow large meshes in the future (note that most of the functions/data structure still expect 32 bit integer indices so large meshes are not yet supported). As I cannot see `countAt` that uses long, so I hardcoded it to use 32 bit integers (otherwise we need a lot of long to int casts).

This also disabled the alloc-size-larger-than warning which causes #450 and #460. I originally thought that the warning might be related to mixing 32 bit and 64 bit signed/unsigned integers but it seems not related.

Fixes #460

@emil-peters @geoffder can you help me test if this can compile on your machine?