### PR TITLE
Update Clipper2 to latest commit

### DIFF
--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -399,7 +399,7 @@ std::vector<CrossSection> CrossSection::Decompose() const {
  */
 CrossSection CrossSection::RectClip(const Rect& rect) const {
   auto r = C2::RectD(rect.min.x, rect.min.y, rect.max.x, rect.max.y);
-  auto ps = C2::ExecuteRectClip(r, GetPaths(), false, precision_);
+  auto ps = C2::RectClip(r, GetPaths(), precision_);
   return CrossSection(ps);
 }
 


### PR DESCRIPTION
Clipping self-intersecting/collinear paths received some attention on the commits since the one we were on, which seems to have squashed the bugs observed in #457 and its surrounding discussion. 

There are no changes to our exposed API brought on by this update, with only a minor internal touchup on the binding of `RectClip`.