### PR TITLE
Drop CrossSection precision_ (decimal places) from 8 to 6

### DIFF
--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -17,7 +17,7 @@
 using namespace manifold;
 
 namespace {
-const int precision_ = 8;
+const int precision_ = 6;
 
 C2::ClipType cliptype_of_op(OpType op) {
   C2::ClipType ct = C2::ClipType::Union;


### PR DESCRIPTION
Since `glm::vec2` uses single precision floats, the decimal places past the sixth once converted to doubles for Clipper2 aren't really meaningful anyway.