### PR TITLE
fix nixos js build

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -220,7 +220,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        variant: [none, omp, tbb, none-cuda, omp-cuda, tbb-cuda]
+        variant: [none, omp, tbb, none-cuda, omp-cuda, tbb-cuda, js]
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:

--- a/bindings/wasm/CMakeLists.txt
+++ b/bindings/wasm/CMakeLists.txt
@@ -29,7 +29,7 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/examples/built)
 
 # ensure that interface files are copied over when modified
 add_custom_target(js_deps ALL
-        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/manifold.*
+        DEPENDS manifoldjs
                ${CMAKE_CURRENT_SOURCE_DIR}/manifold*.d.ts)
 
 add_custom_command(

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -114,7 +114,9 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("_Bounds", &CrossSection::Bounds)
       .function("simplify", &CrossSection::Simplify)
       .function("_Offset", &cross_js::Offset)
-      .function("_ToPolygons", &CrossSection::ToPolygons);
+      .function("_ToPolygons", &CrossSection::ToPolygons)
+      .function("hull",
+                select_overload<CrossSection() const>(&CrossSection::Hull));
 
   // CrossSection Static Methods
   function("_Square", &CrossSection::Square);

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -103,7 +103,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("_Warp", &cross_js::Warp)
       .function("transform", &cross_js::Transform)
       .function("_Translate", &CrossSection::Translate)
-      .function("_Rotate", &CrossSection::Rotate)
+      .function("rotate", &CrossSection::Rotate)
       .function("_Scale", &CrossSection::Scale)
       .function("_Mirror", &CrossSection::Mirror)
       .function("_Decompose", &CrossSection::Decompose)

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -114,10 +114,6 @@ Module.setup = function() {
     return this._Translate(vararg2vec2(vec));
   };
 
-  Module.CrossSection.prototype.rotate = function(vec) {
-    return this._Rotate(...vec);
-  };
-
   Module.CrossSection.prototype.scale = function(vec) {
     // if only one factor provided, scale both x and y with it
     if (typeof vec == 'number') {

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -113,16 +113,12 @@ export class CrossSection {
   translate(v: Vec2): CrossSection;
 
   /**
-   * Applies an Euler angle rotation to the cross-section, first about the X
-   * axis, then Y, then Z, in degrees. We use degrees so that we can minimize
-   * rounding error, and eliminate it completely for any multiples of 90
-   * degrees. Additionally, more efficient code paths are used to update the
-   * cross-section when the transforms only rotate by multiples of 90 degrees.
-   * This operation can be chained. Transforms are combined and applied lazily.
+   * Applies a (Z-axis) rotation to the CrossSection, in degrees. This operation
+   * can be chained. Transforms are combined and applied lazily.
    *
-   * @param v [X, Y, Z] rotation in degrees.
+   * @param degrees degrees about the Z-axis to rotate.
    */
-  rotate(v: Vec2): CrossSection;
+  rotate(v: number): CrossSection;
 
   /**
    * Scale this CrossSection in space. This operation can be chained. Transforms

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -174,6 +174,11 @@ export class CrossSection {
       circularSegments?: number): CrossSection;
 
   /**
+   * Compute the convex hull of the contours in this CrossSection.
+   */
+  hull(): CrossSection;
+
+  /**
    * Remove vertices from the contours in this CrossSection that are less than
    * the specified distance epsilon from an imaginary line that passes through
    * its two adjacent vertices. Near duplicate vertices and collinear points

--- a/flake.lock
+++ b/flake.lock
@@ -17,16 +17,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657296039,
-        "narHash": "sha256-Ghh39+aS+pw5sTP/ZO8VIKE6sBhMadDaQZtf+3yu4Vc=",
+        "lastModified": 1689008574,
+        "narHash": "sha256-VFMgyHDiqsGDkRg73alv6OdHJAqhybryWHv77bSCGIw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "71d7a4c037dc4f3e98d5c4a81b941933cf5bf675",
+        "rev": "4a729ce4b1fe5ec4fffc71c67c96aa5184ebb462",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-22.05",
+        "ref": "nixos-unstable",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.nixpkgs.url = "nixpkgs/nixos-22.05";
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
 
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem
@@ -25,7 +25,7 @@
                   "manifold-${parallel-backend}";
               version = "beta";
               src = self;
-              nativeBuildInputs = (with pkgs; [ cmake (python39.withPackages(ps: with ps; [trimesh])) ]) ++ build-tools ++
+              nativeBuildInputs = (with pkgs; [ cmake (python39.withPackages (ps: with ps; [ trimesh ])) ]) ++ build-tools ++
                 (if cuda-support then with pkgs.cudaPackages; [ cuda_nvcc cuda_cudart cuda_cccl pkgs.addOpenGLRunpath ] else [ ]);
               cmakeFlags = [
                 "-DMANIFOLD_PYBIND=ON"


### PR DESCRIPTION
This fixes the broken wasm build on nixos. Closes #424.

@elalish I am not sure if js_deps should depend on `${CMAKE_CURRENT_BINARY_DIR}/manifold.*`, as this causes error when I run the build.
```
*** No rule to make target 'bindings/wasm/manifold.*', needed by 'bindings/wasm/CMakeFiles/js_deps'.  Stop.
```