### PR TITLE
fixed WASM segfault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,9 @@ build
 buildWASM
 docs/html
 node_modules/
+bindings/wasm/examples/built
+bindings/wasm/examples/dist
+bindings/wasm/examples/public/manifold*
 __pycache__
 .vscode/c_cpp_properties.json
 *.sublime-project

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -661,12 +661,12 @@ void Manifold::Impl::CreateFaces(const std::vector<float>& propertyTolerance) {
  */
 void Manifold::Impl::CreateHalfedges(const VecDH<glm::ivec3>& triVerts) {
   const int numTri = triVerts.size();
-  const int numEdge = 3 * numTri / 2;
+  const int numHalfedge = 3 * numTri;
   // drop the old value first to avoid copy
   halfedge_.resize(0);
-  halfedge_.resize(2 * numEdge);
-  VecDH<uint64_t> edge(2 * numEdge);
-  VecDH<int> ids(2 * numEdge);
+  halfedge_.resize(numHalfedge);
+  VecDH<uint64_t> edge(numHalfedge);
+  VecDH<int> ids(numHalfedge);
   auto policy = autoPolicy(numTri);
   sequence(policy, ids.begin(), ids.end());
   for_each_n(policy, zip(countAt(0), triVerts.begin()), numTri,
@@ -680,8 +680,8 @@ void Manifold::Impl::CreateHalfedges(const VecDH<glm::ivec3>& triVerts) {
   // Once sorted, the first half of the range is the forward halfedges, which
   // correspond to their backward pair at the same offset in the second half
   // of the range.
-  for_each_n(policy, countAt(0), numEdge,
-             LinkHalfedges({halfedge_.ptrD(), ids.ptrD(), numEdge}));
+  for_each_n(policy, countAt(0), numHalfedge / 2,
+             LinkHalfedges({halfedge_.ptrD(), ids.ptrD(), numHalfedge / 2}));
 }
 
 /**


### PR DESCRIPTION
Fixes #432 

Turns out this problem had nothing to do with `Merge`, but rather with constructing a manifold with an odd number of triangles. Of course this can't be a valid 2-manifold ever, but we create the halfedges before we check manifoldness, and when `numTri` was odd, a round-down was making our array too short, causing a segfault that for some reason only WASM noticed. 

I also updated out .gitignore.