### PR TITLE
Remove RectClip API + Rect::AsCrossSection fix

### DIFF
--- a/bindings/c/cross.cpp
+++ b/bindings/c/cross.cpp
@@ -106,13 +106,6 @@ ManifoldCrossSection *manifold_cross_section_intersection(
   return to_c(new (mem) CrossSection(cs));
 }
 
-ManifoldCrossSection *manifold_cross_section_rect_clip(void *mem,
-                                                       ManifoldCrossSection *cs,
-                                                       ManifoldRect *r) {
-  auto clipped = from_c(cs)->RectClip(*from_c(r));
-  return to_c(new (mem) CrossSection(clipped));
-}
-
 ManifoldCrossSection *manifold_cross_section_translate(void *mem,
                                                        ManifoldCrossSection *cs,
                                                        float x, float y) {

--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -195,9 +195,6 @@ ManifoldCrossSection *manifold_cross_section_difference(
     void *mem, ManifoldCrossSection *a, ManifoldCrossSection *b);
 ManifoldCrossSection *manifold_cross_section_intersection(
     void *mem, ManifoldCrossSection *a, ManifoldCrossSection *b);
-ManifoldCrossSection *manifold_cross_section_rect_clip(void *mem,
-                                                       ManifoldCrossSection *cs,
-                                                       ManifoldRect *r);
 
 // CrossSection Transformation
 

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -114,7 +114,6 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("_Bounds", &CrossSection::Bounds)
       .function("simplify", &CrossSection::Simplify)
       .function("_Offset", &cross_js::Offset)
-      .function("_RectClip", &CrossSection::RectClip)
       .function("_ToPolygons", &CrossSection::ToPolygons);
 
   // CrossSection Static Methods

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -165,14 +165,6 @@ Module.setup = function() {
         delta, joinTypeToInt(joinType), miterLimit, circularSegments);
   };
 
-  Module.CrossSection.prototype.rectClip = function(rect) {
-    const rect2 = {
-      min: {x: rect.min[0], y: rect.min[1]},
-      max: {x: rect.max[0], y: rect.max[1]},
-    };
-    return this._RectClip(rect2);
-  };
-
   Module.CrossSection.prototype.extrude = function(
       height, nDivisions = 0, twistDegrees = 0.0, scaleTop = [1.0, 1.0],
       center = false) {

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -245,14 +245,6 @@ export class CrossSection {
    */
   static intersection(polygons: (CrossSection|Polygons)[]): CrossSection;
 
-  /**
-   * Compute the intersection between a cross-section and an axis-aligned
-   * rectangle. This operation has much higher performance (O(n) vs
-   * >O(n^3)) than the general purpose intersection algorithm
-   * used for sets of cross-sections.
-   */
-  rectClip(rect: Rect): CrossSection;
-
   // Topological Operations
 
   /**

--- a/src/cross_section/include/cross_section.h
+++ b/src/cross_section/include/cross_section.h
@@ -77,6 +77,7 @@ class CrossSection {
                FillRule fillrule = FillRule::Positive);
   CrossSection(const Polygons& contours,
                FillRule fillrule = FillRule::Positive);
+  CrossSection(const Rect& rect);
   static CrossSection Square(const glm::vec2 dims, bool center = false);
   static CrossSection Circle(float radius, int circularSegments = 0);
   ///@}
@@ -143,7 +144,6 @@ class CrossSection {
   CrossSection& operator-=(const CrossSection&);
   CrossSection operator^(const CrossSection&) const;
   CrossSection& operator^=(const CrossSection&);
-  CrossSection RectClip(const Rect& rect) const;
   ///@}
 
   /** @name Topological
@@ -197,6 +197,7 @@ class Rect {
    */
   ///@{
   glm::vec2 Size() const;
+  float Area() const;
   float Scale() const;
   glm::vec2 Center() const;
   bool Contains(const glm::vec2& pt) const;

--- a/src/manifold/src/constructors.cpp
+++ b/src/manifold/src/constructors.cpp
@@ -338,7 +338,6 @@ Manifold Manifold::Revolve(const CrossSection& crossSection,
     CrossSection posBoundingBox = CrossSection(
         {{0.0, min.y}, {max.x, min.y}, {max.x, max.y}, {0.0, max.y}});
 
-    // Can't use RectClip because it can't distinguish holes from outlines.
     polygons = (crossSection ^ posBoundingBox).ToPolygons();
   }
 

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -72,13 +72,17 @@ TEST(CrossSection, Empty) {
   EXPECT_TRUE(e.IsEmpty());
 }
 
-TEST(CrossSection, RectClip) {
-  auto sq = CrossSection::Square({10, 10});
-  auto rect = Rect({0, 0}, {10, 5});
-  auto clipped = sq.RectClip(rect);
+TEST(CrossSection, Rect) {
+  float w = 10;
+  float h = 5;
+  auto rect = Rect({0, 0}, {w, h});
+  auto cross = rect.AsCrossSection();
+  auto area = rect.Area();
 
-  EXPECT_EQ(sq.Area() / 2, clipped.Area());
+  EXPECT_FLOAT_EQ(area, w * h);
+  EXPECT_FLOAT_EQ(area, cross.Area());
   EXPECT_TRUE(rect.Contains({5, 5}));
+  EXPECT_TRUE(rect.Contains(cross.Bounds()));
   EXPECT_TRUE(rect.Contains(Rect()));
   EXPECT_TRUE(rect.DoesOverlap(Rect({5, 5}, {15, 15})));
   EXPECT_TRUE(Rect().IsEmpty());


### PR DESCRIPTION
Following discussion on https://github.com/elalish/manifold/pull/455, this removes `RectClip` from our API, as it does not provide the same guarantees that Clipper2's regular boolean clipping operations give us (that make sure that `CrossSection`s can be extruded successfully).

Also, this fixes `AsCrossSection` which was returning empty `CrossSection`s due to incorrect winding followed by a `Positive` fill rule union operation. Now it is working as advertised, while skipping over the needless clipping by implementing it as a `CrossSection` constructor (building a `PathsD` directly).