### PR TITLE
Fix Merge manifoldness issues

### DIFF
--- a/bindings/wasm/examples/README.md
+++ b/bindings/wasm/examples/README.md
@@ -23,6 +23,12 @@ See `package.json` for other useful scripts.
 
 Note that the `emcmake` command automatically copies your WASM build into `built/`, (here, not just under the `buildWASM` directory) which is then packaged by Vite into `dist/assets/`.
 
+To debug the WASM build directly in Chrome dev tools, simply build in debug mode:
+```
+emcmake cmake -DCMAKE_BUILD_TYPE=Debug .. && emmake make
+```
+and install the [DWARF](goo.gle/wasm-debugging-extension) Chrome extension.
+
 When testing [ManifoldCAD.org](https://manifoldcad.org/) (either locally or the
 deployed version) note that it uses a service worker for faster loading. This
 means you need to open the page twice to see updates (the first time loads the

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -527,6 +527,9 @@ Manifold::Impl::Impl(const Mesh& mesh, const MeshRelationD& relation,
     MarkFailure(Error::NotManifold);
     return;
   }
+
+  SplitPinchedVerts();
+
   CalculateNormals();
 
   InitializeOriginal();

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -29,6 +29,8 @@
 namespace {
 using namespace manifold;
 
+constexpr uint64_t kRemove = std::numeric_limits<uint64_t>::max();
+
 __host__ __device__ void AtomicAddVec3(glm::vec3& target,
                                        const glm::vec3& add) {
   for (int i : {0, 1, 2}) {
@@ -104,6 +106,17 @@ struct Tri2Halfedges {
       thrust::tuple<int, const glm::ivec3&> in) {
     const int tri = thrust::get<0>(in);
     const glm::ivec3& triVerts = thrust::get<1>(in);
+
+    if (triVerts[0] == triVerts[1] || triVerts[1] == triVerts[2] ||
+        triVerts[2] == triVerts[0]) {
+      for (const int i : {0, 1, 2}) {
+        const int edge = 3 * tri + i;
+        halfedges[edge] = {-1, -1, -1, -1};
+        edges[edge] = kRemove;
+      }
+      return;
+    }
+
     for (const int i : {0, 1, 2}) {
       const int j = (i + 1) % 3;
       const int edge = 3 * tri + i;
@@ -677,11 +690,17 @@ void Manifold::Impl::CreateHalfedges(const VecDH<glm::ivec3>& triVerts) {
   // two different faces, causing this edge to not be 2-manifold. These are
   // fixed by duplicating verts in SimplifyTopology.
   stable_sort_by_key(policy, edge.begin(), edge.end(), ids.begin());
+  // Delete any triangles that have been flagged for removal due to containing
+  // duplicate verts, which occurred when verts were merged together.
+  const int newNumHalfedge = lower_bound<decltype(edge.begin())>(
+                                 policy, edge.begin(), edge.end(), kRemove) -
+                             edge.begin();
+  halfedge_.resize(newNumHalfedge);
   // Once sorted, the first half of the range is the forward halfedges, which
   // correspond to their backward pair at the same offset in the second half
   // of the range.
-  for_each_n(policy, countAt(0), numHalfedge / 2,
-             LinkHalfedges({halfedge_.ptrD(), ids.ptrD(), numHalfedge / 2}));
+  for_each_n(policy, countAt(0), newNumHalfedge / 2,
+             LinkHalfedges({halfedge_.ptrD(), ids.ptrD(), newNumHalfedge / 2}));
 }
 
 /**

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -490,14 +490,22 @@ Manifold::Impl::Impl(const MeshGL& meshGL,
 Manifold::Impl::Impl(const Mesh& mesh, const MeshRelationD& relation,
                      const std::vector<float>& propertyTolerance,
                      bool hasFaceIDs)
-    : vertPos_(mesh.vertPos),
-      halfedgeTangent_(mesh.halfedgeTangent),
-      meshRelation_(relation) {
+    : vertPos_(mesh.vertPos), halfedgeTangent_(mesh.halfedgeTangent) {
+  meshRelation_ = {relation.originalID, relation.numProp, relation.properties,
+                   relation.meshIDtransform};
+
   VecDH<glm::ivec3> triVerts;
-  for (const glm::ivec3 tri : mesh.triVerts) {
+  for (int i = 0; i < mesh.triVerts.size(); ++i) {
+    const glm::ivec3 tri = mesh.triVerts[i];
     // Remove topological degenerates
     if (tri[0] != tri[1] && tri[1] != tri[2] && tri[2] != tri[0]) {
       triVerts.push_back(tri);
+      if (relation.triRef.size() > 0) {
+        meshRelation_.triRef.push_back(relation.triRef[i]);
+      }
+      if (relation.triProperties.size() > 0) {
+        meshRelation_.triProperties.push_back(relation.triProperties[i]);
+      }
     }
   }
 

--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -127,6 +127,7 @@ struct Manifold::Impl {
   void UpdateVert(int vert, int startEdge, int endEdge);
   void FormLoop(int current, int end);
   void CollapseTri(const glm::ivec3& triEdge);
+  void SplitPinchedVerts();
 
   // smoothing.cu
   void CreateTangents(const std::vector<Smoothness>&);

--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -37,10 +37,10 @@ struct Manifold::Impl {
     /// The originalID of this Manifold if it is an original; -1 otherwise.
     int originalID = -1;
     int numProp = 0;
-    VecDH<TriRef> triRef;
-    VecDH<glm::ivec3> triProperties;
     VecDH<float> properties;
     std::map<int, Relation> meshIDtransform;
+    VecDH<TriRef> triRef;
+    VecDH<glm::ivec3> triProperties;
   };
 
   Box bBox_;

--- a/src/manifold/src/properties.cpp
+++ b/src/manifold/src/properties.cpp
@@ -197,9 +197,8 @@ struct CheckHalfedges {
 
   __host__ __device__ bool operator()(int edge) {
     const Halfedge halfedge = halfedges[edge];
-    if (halfedge.startVert == -1 && halfedge.endVert == -1 &&
-        halfedge.pairedHalfedge == -1)
-      return true;
+    if (halfedge.startVert == -1 && halfedge.endVert == -1) return true;
+    if (halfedge.pairedHalfedge == -1) return false;
 
     const Halfedge paired = halfedges[halfedge.pairedHalfedge];
     bool good = true;

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -682,3 +682,33 @@ TEST(Manifold, MergeDegenerates) {
   EXPECT_FALSE(squashed.IsEmpty());
   EXPECT_EQ(squashed.Status(), Manifold::Error::NoError);
 }
+
+TEST(Manifold, PinchedVert) {
+  Mesh shape;
+  shape.vertPos = {{0, 0, 0},         //
+                   {1, 1, 0},         //
+                   {1, -1, 0},        //
+                   {-0.00001, 0, 0},  //
+                   {-1, -1, -0},      //
+                   {-1, 1, 0},        //
+                   {0, 0, 2},         //
+                   {0, 0, -2}};
+  shape.triVerts = {{0, 2, 6},  //
+                    {2, 1, 6},  //
+                    {1, 0, 6},  //
+                    {4, 3, 6},  //
+                    {3, 5, 6},  //
+                    {5, 4, 6},  //
+                    {2, 0, 4},  //
+                    {0, 3, 4},  //
+                    {3, 0, 1},  //
+                    {3, 1, 5},  //
+                    {7, 2, 4},  //
+                    {7, 4, 5},  //
+                    {7, 5, 1},  //
+                    {7, 1, 2}};
+  Manifold touch(shape);
+  EXPECT_FALSE(touch.IsEmpty());
+  EXPECT_EQ(touch.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(touch.Genus(), 0);
+}

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -615,3 +615,20 @@ TEST(Manifold, MultiCompose) {
                          part.Mirror({1, 0, 0}).Translate({10, 10, 0})});
   EXPECT_FLOAT_EQ(finalAssembly.GetProperties().volume, 4000);
 }
+
+TEST(Manifold, MergeDegenerates) {
+  MeshGL cube = Manifold::Cube(glm::vec3(1), true).GetMeshGL();
+  MeshGL squash;
+  squash.vertProperties = cube.vertProperties;
+  squash.triVerts = cube.triVerts;
+  // Move one vert to the position of its neighbor and remove one triangle
+  // linking them to break the manifold.
+  squash.vertProperties[squash.vertProperties.size() - 1] *= -1;
+  squash.triVerts.resize(squash.triVerts.size() - 3);
+  // Merge should remove the now duplicate vertex.
+  EXPECT_TRUE(squash.Merge());
+  // Manifold should remove the triangle with two references to the same vert.
+  Manifold squashed = Manifold(squash);
+  EXPECT_FALSE(squashed.IsEmpty());
+  EXPECT_EQ(squashed.Status(), Manifold::Error::NoError);
+}

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -625,6 +625,9 @@ TEST(Manifold, MergeDegenerates) {
   // linking them to break the manifold.
   squash.vertProperties[squash.vertProperties.size() - 1] *= -1;
   squash.triVerts.resize(squash.triVerts.size() - 3);
+  // Rotate the degenerate triangle to the middle to catch more problems.
+  std::rotate(squash.triVerts.begin(), squash.triVerts.begin() + 3 * 5,
+              squash.triVerts.end());
   // Merge should remove the now duplicate vertex.
   EXPECT_TRUE(squash.Merge());
   // Manifold should remove the triangle with two references to the same vert.


### PR DESCRIPTION
Following on from #474, I was still surprised how infrequently I could create a manifold from seemingly-solid input meshes. Turns out there were two major problems I've fixed here:
1) When vertices are merged together, this often results in two triangles being degenerate (not geometrically, but topologically - actually referencing the same vert twice). This was causing the mesh to be marked as non-manifold. The fix is to simply remove those triangles, which allows many input meshes to show up manifold that weren't before. 
2) I finally found the problem with the Khronos-DragonAttenuation model. It was infinite-looping in the decimator. Turns out it was because of a pinched vertex (often called a non-manifold vertex - think two cones that share the same tip vert). I added a function to remove these, as they will also mess up the Genus calculation. 

I also discovered how to debug Manifold right in Chrome, which actually works really well. I added instructions to the README. 