### PR TITLE
Add 2d hull operation

### DIFF
--- a/src/cross_section/include/cross_section.h
+++ b/src/cross_section/include/cross_section.h
@@ -153,6 +153,15 @@ class CrossSection {
   std::vector<CrossSection> Decompose() const;
   ///@}
 
+  /** @name Convex Hulling
+   */
+  ///@{
+  CrossSection Hull() const;
+  static CrossSection Hull(const std::vector<CrossSection>& crossSections);
+  static CrossSection Hull(const SimplePolygon poly);
+  static CrossSection Hull(const Polygons polys);
+  ///@}
+  ///
   /** @name Conversion
    */
   ///@{

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -168,10 +168,10 @@ C2::PathD HullImpl(SimplePolygon& pts) {
     HullBacktrack(pts, i, keep, 1);
     keep.push_back(i);
   }
-  int n_lower = keep.size();
+  int nLower = keep.size();
   for (int i = 0; i < len - 1; i++) {
     int idx = len - 2 - i;
-    HullBacktrack(pts, idx, keep, n_lower);
+    HullBacktrack(pts, idx, keep, nLower);
     if (idx > 0) keep.push_back(idx);
   }
   auto path = C2::PathD(keep.size());

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -161,7 +161,7 @@ void HullBacktrack(const SimplePolygon& pts, const int idx,
 // https://www.hackerearth.com/practice/math/geometry/line-sweep-technique/tutorial/
 C2::PathD HullImpl(SimplePolygon& pts) {
   int len = pts.size();
-  if (len < 2) return C2::PathD();
+  if (len < 3) return C2::PathD();  // not enough points to create a polygon
   std::sort(pts.begin(), pts.end(), V2Lesser);
   auto keep = std::vector<int>{0, 1};
   for (int i = 2; i < len; i++) {

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -137,13 +137,17 @@ bool V2Lesser(glm::vec2 a, glm::vec2 b) {
   return a.x < b.x;
 }
 
-double cross(glm::vec2 a, glm::vec2 b) { return a.x * b.y - a.y * b.x; }
+double Cross(glm::vec2 a, glm::vec2 b) { return a.x * b.y - a.y * b.x; }
+
+double SquaredDistance(glm::vec2 a, glm::vec2 b) {
+  auto d = a - b;
+  return d.x * d.x + d.y * d.y;
+}
 
 bool IsCw(glm::vec2 a, glm::vec2 b, glm::vec2 c) {
-  double lhs = cross(a - c, b - c);
-  double rhs = 1e-9 * glm::distance(a, c) * glm::distance(b, c);
-  // return lhs < -rhs;
-  return lhs <= rhs;
+  double lhs = Cross(a - c, b - c);
+  double rhs = 1e-18 * SquaredDistance(a, c) * SquaredDistance(b, c);
+  return lhs * std::abs(lhs) <= rhs;
 }
 
 void HullBacktrack(const SimplePolygon& pts, const int idx,

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -141,7 +141,7 @@ double Cross(glm::vec2 a, glm::vec2 b) { return a.x * b.y - a.y * b.x; }
 
 double SquaredDistance(glm::vec2 a, glm::vec2 b) {
   auto d = a - b;
-  return d.x * d.x + d.y * d.y;
+  return glm::dot(d, d);
 }
 
 bool IsCw(glm::vec2 a, glm::vec2 b, glm::vec2 c) {

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -132,6 +132,58 @@ void decompose_hole(const C2::PolyTreeD* outline,
   }
 }
 
+bool v2_lesser(glm::vec2 a, glm::vec2 b) {
+  if (a.x == b.x) return a.y < b.y;
+  return a.x < b.x;
+}
+
+double cross(glm::vec2 a, glm::vec2 b) { return a.x * b.y - a.y * b.x; }
+
+double distance(glm::vec2 a, glm::vec2 b) {
+  auto d = a - b;
+  return std::sqrt(d.x * d.x + d.y * d.y);
+}
+
+bool is_cw(glm::vec2 a, glm::vec2 b, glm::vec2 c) {
+  double lhs = cross(a - c, b - c);
+  double rhs = 1e-9 * distance(a, c) * distance(b, c);
+  return lhs < -rhs;
+}
+
+void backtrack(const SimplePolygon& pts, const int idx, std::vector<int>& keep,
+               const int hold) {
+  const int stop = keep.size() - hold;
+  int i = 0;
+  while (i < stop && !is_cw(pts[idx], pts[keep[keep.size() - 1]],
+                            pts[keep[keep.size() - 2]])) {
+    keep.pop_back();
+    i++;
+  }
+}
+
+// Based on method described here:
+// https://www.hackerearth.com/practice/math/geometry/line-sweep-technique/tutorial/
+C2::PathD hull(SimplePolygon pts) {
+  int len = pts.size();
+  if (len < 2) return C2::PathD();
+  std::sort(pts.begin(), pts.end(), v2_lesser);
+  auto keep = std::vector<int>{0, 1};
+  for (int i = 2; i < len; i++) {
+    backtrack(pts, i, keep, 1);
+    keep.push_back(i);
+  }
+  int n_lower = keep.size();
+  for (int i = 0; i < len - 1; i++) {
+    int idx = len - 2 - i;
+    backtrack(pts, idx, keep, n_lower);
+    if (idx > 0) keep.push_back(idx);
+  }
+  auto path = C2::PathD(keep.size());
+  for (int i = 0; i < keep.size(); i++) {
+    path[i] = v2_to_pd(pts[keep[i]]);
+  }
+  return path;
+}
 }  // namespace
 
 namespace manifold {
@@ -558,6 +610,41 @@ CrossSection CrossSection::Offset(double delta, JoinType jointype,
       C2::InflatePaths(GetPaths(), delta, jt(jointype), C2::EndType::Polygon,
                        miter_limit, precision_, arc_tol);
   return CrossSection(ps);
+}
+
+CrossSection CrossSection::Hull(
+    const std::vector<CrossSection>& crossSections) {
+  int n = 0;
+  for (auto cs : crossSections) n += cs.NumVert();
+  SimplePolygon pts;
+  pts.reserve(n);
+  for (auto cs : crossSections) {
+    auto paths = cs.GetPaths();
+    for (auto path : paths) {
+      for (auto p : path) {
+        pts.push_back(v2_of_pd(p));
+      }
+    }
+  }
+  return CrossSection(C2::PathsD{hull(pts)});
+}
+
+CrossSection CrossSection::Hull() const {
+  return Hull(std::vector<CrossSection>{*this});
+}
+
+CrossSection CrossSection::Hull(const SimplePolygon pts) {
+  return CrossSection(C2::PathsD{hull(pts)});
+}
+
+CrossSection CrossSection::Hull(const Polygons polys) {
+  SimplePolygon pts;
+  for (auto poly : polys) {
+    for (auto p : poly) {
+      pts.push_back(p);
+    }
+  }
+  return Hull(pts);
 }
 
 /**

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -163,7 +163,7 @@ void backtrack(const SimplePolygon& pts, const int idx, std::vector<int>& keep,
 
 // Based on method described here:
 // https://www.hackerearth.com/practice/math/geometry/line-sweep-technique/tutorial/
-C2::PathD hull(SimplePolygon pts) {
+C2::PathD hull(SimplePolygon& pts) {
   int len = pts.size();
   if (len < 2) return C2::PathD();
   std::sort(pts.begin(), pts.end(), v2_lesser);
@@ -633,7 +633,8 @@ CrossSection CrossSection::Hull() const {
   return Hull(std::vector<CrossSection>{*this});
 }
 
-CrossSection CrossSection::Hull(const SimplePolygon pts) {
+CrossSection CrossSection::Hull(const SimplePolygon poly) {
+  auto pts = poly;  // hull will sort inplace, so we copy here
   return CrossSection(C2::PathsD{hull(pts)});
 }
 

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -629,8 +629,7 @@ CrossSection CrossSection::Hull() const {
   return Hull(std::vector<CrossSection>{*this});
 }
 
-CrossSection CrossSection::Hull(const SimplePolygon poly) {
-  auto pts = poly;  // HullImpl will sort inplace, so we copy here
+CrossSection CrossSection::Hull(SimplePolygon pts) {
   return CrossSection(C2::PathsD{HullImpl(pts)});
 }
 

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -177,11 +177,12 @@ TEST(CrossSection, Hull) {
   auto circ_tri = CrossSection::Hull(circs);
   auto centres = SimplePolygon{{0, 0}, {0, 30}, {30, 0}, {15, 5}};
   auto tri = CrossSection::Hull(centres);
-  auto circ_tri_ex = Manifold::Extrude(circ_tri, 10);
 
 #ifdef MANIFOLD_EXPORT
-  if (options.exportModels)
+  if (options.exportModels) {
+    auto circ_tri_ex = Manifold::Extrude(circ_tri, 10);
     ExportMesh("cross_section_hull_circ_tri.glb", circ_tri_ex.GetMesh(), {});
+  }
 #endif
 
   auto circ_area = circ.Area();

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -171,7 +171,7 @@ TEST(CrossSection, FillRule) {
 }
 
 TEST(CrossSection, Hull) {
-  auto circ = CrossSection::Circle(10);
+  auto circ = CrossSection::Circle(10, 360);
   auto circs = std::vector<CrossSection>{circ, circ.Translate({0, 30}),
                                          circ.Translate({30, 0})};
   auto circ_tri = CrossSection::Hull(circs);

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -174,11 +174,19 @@ TEST(CrossSection, Hull) {
   auto circ = CrossSection::Circle(10);
   auto circs = std::vector<CrossSection>{circ, circ.Translate({0, 30}),
                                          circ.Translate({30, 0})};
-  auto tri = CrossSection::Hull(circs);
-  auto tri_ex = Manifold::Extrude(tri, 10);
+  auto circ_tri = CrossSection::Hull(circs);
+  auto centres = SimplePolygon{{0, 0}, {0, 30}, {30, 0}, {15, 5}};
+  auto tri = CrossSection::Hull(centres);
+  auto circ_tri_ex = Manifold::Extrude(circ_tri, 10);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels)
-    ExportMesh("cross_section_hull_tri.glb", tri_ex.GetMesh(), {});
+    ExportMesh("cross_section_hull_circ_tri.glb", circ_tri_ex.GetMesh(), {});
 #endif
+
+  auto circ_area = circ.Area();
+  EXPECT_FLOAT_EQ(circ_area, (circ - circ.Scale({0.8, 0.8})).Hull().Area());
+  EXPECT_FLOAT_EQ(
+      circ_area * 2.5,
+      (CrossSection::BatchBoolean(circs, OpType::Add) - tri).Area());
 }

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <vector>
+
 #include "glm/geometric.hpp"
 #include "manifold.h"
 #include "polygon.h"
@@ -166,4 +168,17 @@ TEST(CrossSection, FillRule) {
 
   CrossSection nonZero(polygon, CrossSection::FillRule::NonZero);
   EXPECT_NEAR(nonZero.Area(), 0.875, 0.001);
+}
+
+TEST(CrossSection, Hull) {
+  auto circ = CrossSection::Circle(10);
+  auto circs = std::vector<CrossSection>{circ, circ.Translate({0, 30}),
+                                         circ.Translate({30, 0})};
+  auto tri = CrossSection::Hull(circs);
+  auto tri_ex = Manifold::Extrude(tri, 10);
+
+#ifdef MANIFOLD_EXPORT
+  if (options.exportModels)
+    ExportMesh("cross_section_hull_tri.glb", tri_ex.GetMesh(), {});
+#endif
 }


### PR DESCRIPTION
This adds a 2d convex hull operation to CrossSection (ported from OCADml, which I ported based on BOSL2). I'll do similar for Manifold (3d convex hull) next.