### PR TITLE
optimization in #483

### DIFF
--- a/src/utilities/include/vec_dh.h
+++ b/src/utilities/include/vec_dh.h
@@ -400,13 +400,9 @@ class VecDH {
 
   const T *ptrH() const { return cptrH(); }
 
-  T &operator[](int i) {
-    return impl_[i];
-  }
+  T &operator[](int i) { return impl_[i]; }
 
-  const T &operator[](int i) const {
-    return impl_[i];
-  }
+  const T &operator[](int i) const { return impl_[i]; }
 
   T &back() { return impl_.back(); }
 

--- a/src/utilities/include/vec_dh.h
+++ b/src/utilities/include/vec_dh.h
@@ -401,12 +401,10 @@ class VecDH {
   const T *ptrH() const { return cptrH(); }
 
   T &operator[](int i) {
-    impl_.prefetch_to(true);
     return impl_[i];
   }
 
   const T &operator[](int i) const {
-    impl_.prefetch_to(true);
     return impl_[i];
   }
 


### PR DESCRIPTION
This implements the optimization proposed by  @stephomi in #483, as well as fixed a performance issue in `VecDH`.
Closes #483.

Some performance number with the TBB backend:
```
Before:                             | After:
nTri = 512, time = 0.00176141 sec   | nTri = 512, time = 0.00177805 sec
nTri = 2048, time = 0.004547 sec    | nTri = 2048, time = 0.0044065 sec
nTri = 8192, time = 0.0106173 sec   | nTri = 8192, time = 0.0103378 sec
nTri = 32768, time = 0.0311056 sec  | nTri = 32768, time = 0.0337022 sec
nTri = 131072, time = 0.0618168 sec | nTri = 131072, time = 0.058903 sec
nTri = 524288, time = 0.181978 sec  | nTri = 524288, time = 0.164333 sec
nTri = 2097152, time = 0.802989 sec | nTri = 2097152, time = 0.719347 sec
nTri = 8388608, time = 3.39968 sec  | nTri = 8388608, time = 3.14456 sec

Boolean.Close        (870 ms)       | Boolean.Close        (801 ms)
Boolean.Sweep        (247 ms)       | Boolean.Sweep        (235 ms)
SDF.Resize           (49 ms)        | SDF.Resize           (40 ms)
Samples.Bracelet     (362 ms)       | Samples.Bracelet     (328 ms)
Samples.GyroidModule (346 ms)       | Samples.GyroidModule (307 ms)
Samples.Sponge4      (8757 ms)      | Samples.Sponge4      (8139 ms)
```

For the performance issue in `VecDH`, it turns out the prefetch is in the hot path and causes tight loops to be slower than that with std::vector, even when CUDA is not being used.
