### PR TITLE
Update python mesh

### DIFF
--- a/bindings/python/examples/run_all.py
+++ b/bindings/python/examples/run_all.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         module = importlib.import_module(f)
         t0 = time()
         model = module.run()
-        mesh = model.to_meshgl()
+        mesh = model.to_mesh()
         if export_models:
             vertices = np.reshape(mesh.vert_properties, (-1, mesh.num_prop))
             if mesh.num_prop > 3:

--- a/bindings/python/examples/run_all.py
+++ b/bindings/python/examples/run_all.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
         if export_models:
             vertices = np.reshape(mesh.vert_properties, (-1, mesh.num_prop))
             if mesh.num_prop > 3:
-                vertices = np.hsplit(vertices, 3)
+                vertices = np.hsplit(vertices, 3)[0]
             meshOut = trimesh.Trimesh(
                 vertices=vertices, faces=np.reshape(mesh.tri_verts, (-1, 3)))
             trimesh.exchange.export.export_mesh(meshOut, f'{f}.glb', 'glb')

--- a/bindings/python/examples/run_all.py
+++ b/bindings/python/examples/run_all.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
         model = module.run()
         mesh = model.to_mesh()
         if export_models:
-            if mesh.num_prop > 3:
+            if mesh.vert_properties.shape[1] > 3:
                 vertices = np.hsplit(mesh.vert_properties, 3)[0]
             else:
                 vertices = mesh.vert_properties

--- a/bindings/python/examples/run_all.py
+++ b/bindings/python/examples/run_all.py
@@ -35,11 +35,11 @@ if __name__ == "__main__":
         model = module.run()
         mesh = model.to_mesh()
         if export_models:
-            vertices = np.reshape(mesh.vert_properties, (-1, mesh.num_prop))
             if mesh.num_prop > 3:
-                vertices = np.hsplit(vertices, 3)[0]
-            meshOut = trimesh.Trimesh(
-                vertices=vertices, faces=np.reshape(mesh.tri_verts, (-1, 3)))
+                vertices = np.hsplit(mesh.vert_properties, 3)[0]
+            else:
+                vertices = mesh.vert_properties
+            meshOut = trimesh.Trimesh(vertices=vertices, faces=mesh.tri_verts)
             trimesh.exchange.export.export_mesh(meshOut, f'{f}.glb', 'glb')
             print(f'Exported model to {f}.glb')
         t1 = time()

--- a/bindings/python/examples/run_all.py
+++ b/bindings/python/examples/run_all.py
@@ -18,6 +18,7 @@ import pathlib
 import sys
 import importlib
 import trimesh
+import numpy as np
 from time import time
 
 if __name__ == "__main__":
@@ -32,10 +33,13 @@ if __name__ == "__main__":
         module = importlib.import_module(f)
         t0 = time()
         model = module.run()
-        mesh = model.to_mesh()
+        mesh = model.to_meshgl()
         if export_models:
+            vertices = np.reshape(mesh.vert_properties, (-1, mesh.num_prop))
+            if mesh.num_prop > 3:
+                vertices = np.hsplit(vertices, 3)
             meshOut = trimesh.Trimesh(
-                vertices=mesh.vert_pos, faces=mesh.tri_verts)
+                vertices=vertices, faces=np.reshape(mesh.tri_verts, (-1, 3)))
             trimesh.exchange.export.export_mesh(meshOut, f'{f}.glb', 'glb')
             print(f'Exported model to {f}.glb')
         t1 = time()

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -29,6 +29,10 @@ typedef std::tuple<float, float, float> Float3;
 
 constexpr auto pyArrayFlags = py::array::c_style | py::array::forcecast;
 
+PYBIND11_MAKE_OPAQUE(std::vector<int>);
+PYBIND11_MAKE_OPAQUE(std::vector<uint32_t>);
+PYBIND11_MAKE_OPAQUE(std::vector<float>);
+
 template <typename T>
 std::vector<T> toVector(const py::array_t<T> &arr) {
   return std::vector<T>(arr.data(), arr.data() + arr.size());
@@ -493,7 +497,7 @@ PYBIND11_MODULE(manifold3d, m) {
                   "marking sets of triangles that can be looked up after "
                   "further operations. Assign to MeshGL.runOriginalID vector");
 
-  py::class_<MeshGL>(m, "MeshGL")
+  py::class_<MeshGL>(m, "Mesh")
       .def(
           // note that reshape requires mutable array_t, but this will not
           // affect the original array passed into the function
@@ -602,8 +606,7 @@ PYBIND11_MODULE(manifold3d, m) {
       .def_readonly("merge_to_vert", &MeshGL::mergeToVert)
       .def_readonly("run_index", &MeshGL::runIndex)
       .def_readonly("run_original_id", &MeshGL::runOriginalID)
-      .def_readonly("face_id", &MeshGL::faceID)
-      .def_readonly("num_prop", &MeshGL::numProp);
+      .def_readonly("face_id", &MeshGL::faceID);
 
   py::enum_<CrossSection::FillRule>(m, "FillRule")
       .value("EvenOdd", CrossSection::FillRule::EvenOdd,

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -404,7 +404,7 @@ PYBIND11_MODULE(manifold3d, m) {
           "by sharping all edges that are incident on it, allowing cones to be "
           "formed.")
       .def_static(
-          "from_mesh", [](const Mesh &mesh) { return Manifold(mesh); },
+          "from_mesh", [](const MeshGL &mesh) { return Manifold(mesh); },
           py::arg("mesh"))
       .def_static(
           "tetrahedron", []() { return Manifold::Tetrahedron(); },


### PR DESCRIPTION
Fixes #361 - at least I think so; please remind me if I've forgotten anything.

The main thing I'm adding here is `MeshGL` support, which is to say updating the Python Mesh class to work as MeshGL instead, akin to our JS binding. This PR is still WIP, as I need to update our `trimesh` integration, but we should now be able to export vertex colors and such right through to glTF with that soon.