### PR TITLE
please gcc

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
             , doCheck ? true
             , build-tools ? [ ]
             , ...
-            }: pkgs.llvmPackages_15.stdenv.mkDerivation {
+            }: pkgs.stdenv.mkDerivation {
               inherit doCheck;
               pname =
                 if cuda-support then

--- a/src/utilities/include/vec_dh.h
+++ b/src/utilities/include/vec_dh.h
@@ -228,19 +228,9 @@ class ManagedVec {
 
   const T &back() const { return *(ptr_ + size_ - 1); }
 
-  T &operator[](size_t i) {
-    // ASSERT(i < size_, logicErr,
-    //        "Index out of bounds: " + std::to_string(i) +
-    //            ", size: " + std::to_string(size_));
-    return *(ptr_ + i);
-  }
+  T &operator[](size_t i) { return *(ptr_ + i); }
 
-  const T &operator[](size_t i) const {
-    // ASSERT(i < size_, logicErr,
-    //        "Index out of bounds: " + std::to_string(i) +
-    //            ", size: " + std::to_string(size_));
-    return *(ptr_ + i);
-  }
+  const T &operator[](size_t i) const { return *(ptr_ + i); }
 
   bool empty() const { return size_ == 0; }
 
@@ -253,6 +243,10 @@ class ManagedVec {
   static constexpr int DEVICE_MAX_BYTES = 1 << 16;
 
   static void mallocManaged(T **ptr, size_t bytes) {
+    // only exists to please the compiler
+    if (bytes >= (1ull << 63)) {
+      throw std::bad_alloc();
+    }
 #ifdef MANIFOLD_USE_CUDA
     if (CudaEnabled())
       cudaMallocManaged(reinterpret_cast<void **>(ptr), bytes);

--- a/src/utilities/include/vec_dh.h
+++ b/src/utilities/include/vec_dh.h
@@ -244,6 +244,7 @@ class ManagedVec {
 
   static void mallocManaged(T **ptr, size_t bytes) {
     // only exists to please the compiler
+    // see https://github.com/elalish/manifold/pull/496 for background
     if (bytes >= (1ull << 63)) {
       throw std::bad_alloc();
     }


### PR DESCRIPTION
Closes #460
Closes #467

This is not a real fix, this is just to tell gcc that anything that reaches the malloc is at most `1 << 63`, and we have an exception otherwise.  I think the warning is most probably caused by Thrust (and interaction with something in gcc), as we don't really have a lot of large constants here. Previous experiment shows that making everything unsigned doesn't help, so it should not be related to having something negative and casting to unsigned. It is hard to get a MRE as the thrust code is just too complicated. This is the simplest way I can think of to please GCC.

@emil-peters @jw3126 can you please check if this works with your gcc version?