### PR TITLE
Add hull bindings (c, wasm/js, and python)

### DIFF
--- a/bindings/c/cross.cpp
+++ b/bindings/c/cross.cpp
@@ -106,6 +106,30 @@ ManifoldCrossSection *manifold_cross_section_intersection(
   return to_c(new (mem) CrossSection(cs));
 }
 
+ManifoldCrossSection *manifold_cross_section_hull(void *mem,
+                                                  ManifoldCrossSection *cs) {
+  auto hulled = from_c(cs)->Hull();
+  return to_c(new (mem) CrossSection(hulled));
+}
+
+ManifoldCrossSection *manifold_cross_section_batch_hull(
+    void *mem, ManifoldCrossSectionVec *css) {
+  auto hulled = CrossSection::Hull(*from_c(css));
+  return to_c(new (mem) CrossSection(hulled));
+}
+
+ManifoldCrossSection *manifold_cross_section_hull_simple_polygon(
+    void *mem, ManifoldSimplePolygon *ps) {
+  auto hulled = CrossSection::Hull(*from_c(ps));
+  return to_c(new (mem) CrossSection(hulled));
+}
+
+ManifoldCrossSection *manifold_cross_section_hull_polygons(
+    void *mem, ManifoldPolygons *ps) {
+  auto hulled = CrossSection::Hull(*from_c(ps));
+  return to_c(new (mem) CrossSection(hulled));
+}
+
 ManifoldCrossSection *manifold_cross_section_translate(void *mem,
                                                        ManifoldCrossSection *cs,
                                                        float x, float y) {

--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -8,6 +8,7 @@ extern "C" {
 #endif
 
 // Polygons
+
 ManifoldSimplePolygon *manifold_simple_polygon(void *mem, ManifoldVec2 *ps,
                                                size_t length);
 ManifoldPolygons *manifold_polygons(void *mem, ManifoldSimplePolygon **ps,
@@ -24,6 +25,7 @@ ManifoldVec2 manifold_polygons_get_point(ManifoldPolygons *ps, int simple_idx,
                                          int pt_idx);
 
 // Mesh Construction
+
 ManifoldMeshGL *manifold_meshgl(void *mem, float *vert_props, size_t n_verts,
                                 size_t n_props, uint32_t *tri_verts,
                                 size_t n_tris);
@@ -94,7 +96,14 @@ ManifoldManifold *manifold_trim_by_plane(void *mem, ManifoldManifold *m,
                                          float normal_x, float normal_y,
                                          float normal_z, float offset);
 
+// Convex Hulls
+
+ManifoldManifold *manifold_hull(void *mem, ManifoldManifold *m);
+ManifoldManifold *manifold_batch_hull(void *mem, ManifoldManifoldVec *ms);
+ManifoldManifold *manifold_hull_pts(void *mem, ManifoldVec3 *ps, size_t length);
+
 // Manifold Transformations
+
 ManifoldManifold *manifold_translate(void *mem, ManifoldManifold *m, float x,
                                      float y, float z);
 ManifoldManifold *manifold_rotate(void *mem, ManifoldManifold *m, float x,
@@ -112,6 +121,7 @@ ManifoldManifold *manifold_warp(void *mem, ManifoldManifold *m,
 ManifoldManifold *manifold_refine(void *mem, ManifoldManifold *m, int refine);
 
 // Manifold Shapes / Constructors
+
 ManifoldManifold *manifold_empty(void *mem);
 ManifoldManifold *manifold_copy(void *mem, ManifoldManifold *m);
 ManifoldManifold *manifold_tetrahedron(void *mem);
@@ -137,6 +147,7 @@ ManifoldManifoldVec *manifold_decompose(void *mem, ManifoldManifold *m);
 ManifoldManifold *manifold_as_original(void *mem, ManifoldManifold *m);
 
 // Manifold Info
+
 int manifold_is_empty(ManifoldManifold *m);
 ManifoldError manifold_status(ManifoldManifold *m);
 int manifold_num_vert(ManifoldManifold *m);
@@ -204,6 +215,17 @@ ManifoldCrossSection *manifold_cross_section_difference(
 ManifoldCrossSection *manifold_cross_section_intersection(
     void *mem, ManifoldCrossSection *a, ManifoldCrossSection *b);
 
+// CrossSection Convex Hulls
+
+ManifoldCrossSection *manifold_cross_section_hull(void *mem,
+                                                  ManifoldCrossSection *cs);
+ManifoldCrossSection *manifold_cross_section_batch_hull(
+    void *mem, ManifoldCrossSectionVec *css);
+ManifoldCrossSection *manifold_cross_section_hull_simple_polygon(
+    void *mem, ManifoldSimplePolygon *ps);
+ManifoldCrossSection *manifold_cross_section_hull_polygons(
+    void *mem, ManifoldPolygons *ps);
+
 // CrossSection Transformation
 
 ManifoldCrossSection *manifold_cross_section_translate(void *mem,
@@ -268,6 +290,7 @@ ManifoldCrossSection *manifold_rect_as_cross_section(void *mem,
                                                      ManifoldRect *r);
 
 // Bounding Box
+
 ManifoldBox *manifold_box(void *mem, float x1, float y1, float z1, float x2,
                           float y2, float z2);
 ManifoldVec3 manifold_box_min(ManifoldBox *b);
@@ -292,11 +315,13 @@ int manifold_box_does_overlap_box(ManifoldBox *a, ManifoldBox *b);
 int manifold_box_is_finite(ManifoldBox *b);
 
 // Static Quality Globals
+
 void manifold_set_min_circular_angle(float degrees);
 void manifold_set_min_circular_edge_length(float length);
 void manifold_set_circular_segments(int number);
 
 // Manifold Mesh Extraction
+
 int manifold_meshgl_num_prop(ManifoldMeshGL *m);
 int manifold_meshgl_num_vert(ManifoldMeshGL *m);
 int manifold_meshgl_num_tri(ManifoldMeshGL *m);
@@ -319,6 +344,7 @@ uint32_t *manifold_meshgl_face_id(void *mem, ManifoldMeshGL *m);
 float *manifold_meshgl_halfedge_tangent(void *mem, ManifoldMeshGL *m);
 
 // memory size
+
 size_t manifold_manifold_size();
 size_t manifold_manifold_vec_size();
 size_t manifold_cross_section_size();
@@ -332,6 +358,7 @@ size_t manifold_rect_size();
 size_t manifold_curvature_size();
 
 // destruction
+
 void manifold_destruct_manifold(ManifoldManifold *m);
 void manifold_destruct_manifold_vec(ManifoldManifoldVec *ms);
 void manifold_destruct_cross_section(ManifoldCrossSection *m);
@@ -343,6 +370,7 @@ void manifold_destruct_box(ManifoldBox *b);
 void manifold_destruct_rect(ManifoldRect *b);
 
 // pointer free + destruction
+
 void manifold_delete_manifold(ManifoldManifold *m);
 void manifold_delete_manifold_vec(ManifoldManifoldVec *ms);
 void manifold_delete_cross_section(ManifoldCrossSection *cs);
@@ -354,6 +382,7 @@ void manifold_delete_box(ManifoldBox *b);
 void manifold_delete_rect(ManifoldRect *b);
 
 // MeshIO / Export
+
 #ifdef MANIFOLD_EXPORT
 ManifoldMaterial *manifold_material(void *mem);
 void manifold_material_set_roughness(ManifoldMaterial *mat, float roughness);

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -190,6 +190,26 @@ ManifoldManifold *manifold_trim_by_plane(void *mem, ManifoldManifold *m,
   return to_c(new (mem) Manifold(trimmed));
 }
 
+ManifoldManifold *manifold_hull(void *mem, ManifoldManifold *m) {
+  auto hulled = from_c(m)->Hull();
+  return to_c(new (mem) Manifold(hulled));
+}
+
+ManifoldManifold *manifold_batch_hull(void *mem, ManifoldManifoldVec *ms) {
+  auto hulled = Manifold::Hull(*from_c(ms));
+  return to_c(new (mem) Manifold(hulled));
+}
+
+ManifoldManifold *manifold_hull_pts(void *mem, ManifoldVec3 *ps,
+                                    size_t length) {
+  std::vector<glm::vec3> vec(length);
+  for (int i = 0; i < length; ++i) {
+    vec[i] = {ps[i].x, ps[i].y, ps[i].z};
+  }
+  auto hulled = Manifold::Hull(vec);
+  return to_c(new (mem) Manifold(hulled));
+}
+
 ManifoldManifold *manifold_translate(void *mem, ManifoldManifold *m, float x,
                                      float y, float z) {
   auto v = glm::vec3(x, y, z);

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -86,6 +86,12 @@ PYBIND11_MODULE(manifold3d, m) {
       .def(py::self - py::self, "Boolean difference.")
       .def(py::self ^ py::self, "Boolean intersection.")
       .def(
+          "hull", [](Manifold &self) { return self.Hull(); }, "Convex Hull.")
+      .def_static(
+          "batch_hull",
+          [](std::vector<Manifold> &ms) { return Manifold::Hull(ms); },
+          "Compute the convex hull enveloping a set of manifolds.")
+      .def(
           "transform",
           [](Manifold &self, py::array_t<float> &mat) {
             auto mat_view = mat.unchecked<2>();
@@ -287,6 +293,11 @@ PYBIND11_MODULE(manifold3d, m) {
            "that edge will be kept.")
       .def("is_empty", &Manifold::IsEmpty,
            "Does the Manifold have any triangles?")
+      .def("compose", &Manifold::Compose,
+           "Constructs a new manifold from a vector of other manifolds. This "
+           "is a purely topological operation, so care should be taken to "
+           "avoid creating overlapping results. It is the inverse operation of "
+           "Decompose().")
       .def(
           "decompose", [](Manifold &self) { return self.Decompose(); },
           "This operation returns a vector of Manifolds that are "
@@ -743,6 +754,23 @@ PYBIND11_MODULE(manifold3d, m) {
       .def(py::self + py::self, "Boolean union.")
       .def(py::self - py::self, "Boolean difference.")
       .def(py::self ^ py::self, "Boolean intersection.")
+      .def(
+          "hull", [](CrossSection &self) { return self.Hull(); },
+          "Convex Hull.")
+      .def_static(
+          "batch_hull",
+          [](std::vector<CrossSection> &cs) { return CrossSection::Hull(cs); },
+          "Compute the convex hull enveloping a set of cross-sections.")
+      .def_static(
+          "hull_points",
+          [](std::vector<Float2> &pts) {
+            std::vector<glm::vec2> poly(pts.size());
+            for (int i = 0; i < pts.size(); i++) {
+              poly[i] = {std::get<0>(pts[i]), std::get<1>(pts[i])};
+            }
+            return CrossSection::Hull(poly);
+          },
+          "Compute the convex hull enveloping a set of 2d points.")
       .def("decompose", &CrossSection::Decompose,
            "This operation returns a vector of CrossSections that are "
            "topologically disconnected, each containing one outline contour "

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -305,11 +305,6 @@ PYBIND11_MODULE(manifold3d, m) {
            "that edge will be kept.")
       .def("is_empty", &Manifold::IsEmpty,
            "Does the Manifold have any triangles?")
-      .def("compose", &Manifold::Compose,
-           "Constructs a new manifold from a vector of other manifolds. This "
-           "is a purely topological operation, so care should be taken to "
-           "avoid creating overlapping results. It is the inverse operation of "
-           "Decompose().")
       .def(
           "decompose", [](Manifold &self) { return self.Decompose(); },
           "This operation returns a vector of Manifolds that are "

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -86,11 +86,23 @@ PYBIND11_MODULE(manifold3d, m) {
       .def(py::self - py::self, "Boolean difference.")
       .def(py::self ^ py::self, "Boolean intersection.")
       .def(
-          "hull", [](Manifold &self) { return self.Hull(); }, "Convex Hull.")
+          "hull", [](Manifold &self) { return self.Hull(); },
+          "Compute the convex hull of all points in this manifold.")
       .def_static(
           "batch_hull",
           [](std::vector<Manifold> &ms) { return Manifold::Hull(ms); },
           "Compute the convex hull enveloping a set of manifolds.")
+      .def_static(
+          "hull_points",
+          [](std::vector<Float3> &pts) {
+            std::vector<glm::vec3> vec(pts.size());
+            for (int i = 0; i < pts.size(); i++) {
+              vec[i] = {std::get<0>(pts[i]), std::get<1>(pts[i]),
+                        std::get<2>(pts[i])};
+            }
+            return Manifold::Hull(vec);
+          },
+          "Compute the convex hull enveloping a set of 3d points.")
       .def(
           "transform",
           [](Manifold &self, py::array_t<float> &mat) {
@@ -756,7 +768,7 @@ PYBIND11_MODULE(manifold3d, m) {
       .def(py::self ^ py::self, "Boolean intersection.")
       .def(
           "hull", [](CrossSection &self) { return self.Hull(); },
-          "Convex Hull.")
+          "Compute the convex hull of this cross-section.")
       .def_static(
           "batch_hull",
           [](std::vector<CrossSection> &cs) { return CrossSection::Hull(cs); },

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -125,6 +125,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
   function("_crossSectionUnionN", &cross_js::UnionN);
   function("_crossSectionDifferenceN", &cross_js::DifferenceN);
   function("_crossSectionIntersectionN", &cross_js::IntersectionN);
+  function("_crossSectionCollectVertices", &cross_js::CollectVertices);
   function("_crossSectionHullPoints",
            select_overload<CrossSection(std::vector<glm::vec2>)>(
                &CrossSection::Hull));
@@ -180,6 +181,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
   function("_manifoldUnionN", &man_js::UnionN);
   function("_manifoldDifferenceN", &man_js::DifferenceN);
   function("_manifoldIntersectionN", &man_js::IntersectionN);
+  function("_manifoldCollectVertices", &man_js::CollectVertices);
   function("_manifoldHullPoints",
            select_overload<Manifold(const std::vector<glm::vec3>&)>(
                &Manifold::Hull));

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -125,6 +125,9 @@ EMSCRIPTEN_BINDINGS(whatever) {
   function("_crossSectionUnionN", &cross_js::UnionN);
   function("_crossSectionDifferenceN", &cross_js::DifferenceN);
   function("_crossSectionIntersectionN", &cross_js::IntersectionN);
+  function("_crossSectionHullPoints",
+           select_overload<CrossSection(std::vector<glm::vec2>)>(
+               &CrossSection::Hull));
 
   class_<Manifold>("Manifold")
       .constructor(&man_js::FromMeshJS)
@@ -134,6 +137,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("_Split", &man_js::Split)
       .function("_SplitByPlane", &man_js::SplitByPlane)
       .function("_TrimByPlane", &Manifold::TrimByPlane)
+      .function("hull", select_overload<Manifold() const>(&Manifold::Hull))
       .function("_GetMeshJS", &js::GetMeshJS)
       .function("refine", &Manifold::Refine)
       .function("_Warp", &man_js::Warp)
@@ -176,6 +180,9 @@ EMSCRIPTEN_BINDINGS(whatever) {
   function("_manifoldUnionN", &man_js::UnionN);
   function("_manifoldDifferenceN", &man_js::DifferenceN);
   function("_manifoldIntersectionN", &man_js::IntersectionN);
+  function("_manifoldHullPoints",
+           select_overload<Manifold(const std::vector<glm::vec3>&)>(
+               &Manifold::Hull));
 
   // Quality Globals
   function("setMinCircularAngle", &Quality::SetMinCircularAngle);

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -472,6 +472,47 @@ Module.setup = function() {
   Module.CrossSection.difference = crossSectionBatchbool('DifferenceN');
   Module.CrossSection.intersection = crossSectionBatchbool('IntersectionN');
 
+  Module.CrossSection.hull = function(...args) {
+    if (args.length == 1) args = args[0];
+    let pts = new Module.Vector_vec2();
+    for (const cs of args) {
+      if (cs instanceof CrossSectionCtor) {
+        const polyVecs = cs._ToPolygons();
+        for (let i = 0; i < polyVecs.size(); i++) {
+          const vec = polyVecs.get(i);
+          for (let j = 0; j < vec.size(); j++) {
+            pts.push_back(vec.get(j));
+          }
+          vec.delete();
+        }
+        disposePolygons(polyVecs);
+      } else if (
+          cs instanceof Array && cs.length == 2 && typeof cs[0] == 'number') {
+        pts.push_back({x: cs[0], y: cs[1]});
+      } else if (cs.x) {
+        pts.push_back(cs);
+      } else {
+        const polys = cs instanceof Array &&
+                ((cs[0].length == 2 && typeof cs[0][0] == 'number') ||
+                 cs[0].x) ?
+            [cs] :
+            cs;
+        for (const poly of polys) {
+          for (const p of poly) {
+            if (p instanceof Array) {
+              pts.push_back({x: p[0], y: p[1]});
+            } else {
+              pts.push_back(p);
+            }
+          }
+        }
+      }
+    }
+    const result = Module._crossSectionHullPoints(pts);
+    pts.delete();
+    return result;
+  };
+
   Module.CrossSection.prototype = Object.create(CrossSectionCtor.prototype);
 
   // Because the constructor and prototype are being replaced, instanceof will

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -472,40 +472,29 @@ Module.setup = function() {
   Module.CrossSection.difference = crossSectionBatchbool('DifferenceN');
   Module.CrossSection.intersection = crossSectionBatchbool('IntersectionN');
 
+  function pushVec2(vec, ps) {
+    toVec(vec, ps, p => {
+      if (p instanceof Array) return {x: p[0], y: p[1]};
+      return p;
+    })
+  }
+
   Module.CrossSection.hull = function(...args) {
     if (args.length == 1) args = args[0];
     let pts = new Module.Vector_vec2();
     for (const cs of args) {
       if (cs instanceof CrossSectionCtor) {
-        const polyVecs = cs._ToPolygons();
-        for (let i = 0; i < polyVecs.size(); i++) {
-          const vec = polyVecs.get(i);
-          for (let j = 0; j < vec.size(); j++) {
-            pts.push_back(vec.get(j));
-          }
-          vec.delete();
-        }
-        disposePolygons(polyVecs);
+        Module._crossSectionCollectVertices(pts, cs);
       } else if (
           cs instanceof Array && cs.length == 2 && typeof cs[0] == 'number') {
         pts.push_back({x: cs[0], y: cs[1]});
       } else if (cs.x) {
         pts.push_back(cs);
       } else {
-        const polys = cs instanceof Array &&
-                ((cs[0].length == 2 && typeof cs[0][0] == 'number') ||
-                 cs[0].x) ?
-            [cs] :
-            cs;
-        for (const poly of polys) {
-          for (const p of poly) {
-            if (p instanceof Array) {
-              pts.push_back({x: p[0], y: p[1]});
-            } else {
-              pts.push_back(p);
-            }
-          }
-        }
+        const wrap =
+            ((cs[0].length == 2 && typeof cs[0][0] == 'number') || cs[0].x);
+        const polys = wrap ? [cs] : cs;
+        for (const poly of polys) pushVec2(pts, poly);
       }
     }
     const result = Module._crossSectionHullPoints(pts);
@@ -635,6 +624,33 @@ Module.setup = function() {
     const out = Module._LevelSet(wasmFuncPtr, bounds2, edgeLength, level);
     removeFunction(wasmFuncPtr);
     return out;
+  };
+
+  function pushVec3(vec, ps) {
+    toVec(vec, ps, p => {
+      if (p instanceof Array) return {x: p[0], y: p[1], z: p[2]};
+      return p;
+    })
+  }
+
+  Module.Manifold.hull = function(...args) {
+    if (args.length == 1) args = args[0];
+    let pts = new Module.Vector_vec3();
+    for (const m of args) {
+      if (m instanceof ManifoldCtor) {
+        Module._manifoldCollectVertices(pts, m);
+      } else if (
+          m instanceof Array && m.length == 3 && typeof m[0] == 'number') {
+        pts.push_back({x: m[0], y: m[1], z: m[2]});
+      } else if (m.x) {
+        pts.push_back(m);
+      } else {
+        pushVec3(pts, m);
+      }
+    }
+    const result = Module._manifoldHullPoints(pts);
+    pts.delete();
+    return result;
   };
 
   Module.Manifold.prototype = Object.create(ManifoldCtor.prototype);

--- a/bindings/wasm/examples/worker.ts
+++ b/bindings/wasm/examples/worker.ts
@@ -42,23 +42,23 @@ io.registerExtensions(KHRONOS_EXTENSIONS);
 // manifold static methods (that return a new manifold)
 const manifoldStaticFunctions = [
   'cube', 'cylinder', 'sphere', 'tetrahedron', 'extrude', 'revolve', 'compose',
-  'union', 'difference', 'intersection', 'levelSet', 'smooth', 'ofMesh'
+  'union', 'difference', 'intersection', 'levelSet', 'smooth', 'ofMesh', 'hull'
 ];
 // manifold member functions (that return a new manifold)
 const manifoldMemberFunctions = [
   'add', 'subtract', 'intersect', 'decompose', 'warp', 'transform', 'translate',
   'rotate', 'scale', 'mirror', 'refine', 'setProperties', 'asOriginal',
-  'trimByPlane', 'split', 'splitByPlane'
+  'trimByPlane', 'split', 'splitByPlane', 'hull'
 ];
 // CrossSection static methods (that return a new cross-section)
 const crossSectionStaticFunctions = [
   'square', 'circle', 'union', 'difference', 'intersection', 'compose',
-  'ofPolygons'
+  'ofPolygons', 'hull'
 ];
 // CrossSection member functions (that return a new cross-section)
 const crossSectionMemberFunctions = [
   'add', 'subtract', 'intersect', 'rectClip', 'decompose', 'transform',
-  'translate', 'rotate', 'scale', 'mirror', 'simplify', 'offset'
+  'translate', 'rotate', 'scale', 'mirror', 'simplify', 'offset', 'hull'
 ];
 // top level functions that construct a new manifold/mesh
 const toplevelConstructors = ['show', 'only', 'setMaterial'];

--- a/bindings/wasm/helpers.cpp
+++ b/bindings/wasm/helpers.cpp
@@ -159,6 +159,11 @@ CrossSection Offset(CrossSection& cross_section, double delta, int join_type,
                              : CrossSection::JoinType::Miter;
   return cross_section.Offset(delta, jt, miter_limit, arc_tolerance);
 }
+
+void CollectVertices(std::vector<glm::vec2>& verts, const CrossSection& cs) {
+  auto polys = cs.ToPolygons();
+  for (auto poly : polys) verts.insert(verts.end(), poly.begin(), poly.end());
+}
 }  // namespace cross_js
 
 namespace man_js {
@@ -218,5 +223,10 @@ std::vector<Manifold> SplitByPlane(Manifold& m, glm::vec3 normal,
                                    float originOffset) {
   auto [a, b] = m.SplitByPlane(normal, originOffset);
   return {a, b};
+}
+
+void CollectVertices(std::vector<glm::vec3>& verts, const Manifold& manifold) {
+  Mesh mesh = manifold.GetMesh();
+  verts.insert(verts.end(), mesh.vertPos.begin(), mesh.vertPos.end());
 }
 }  // namespace man_js

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -246,6 +246,13 @@ export class CrossSection {
    */
   static intersection(polygons: (CrossSection|Polygons)[]): CrossSection;
 
+  // Convex Hulls
+
+  /**
+   * Compute the convex hull of all points in a list of polygons/cross-sections.
+   */
+  static hull(polygons: (CrossSection|Polygons)[]): CrossSection;
+
   // Topological Operations
 
   /**
@@ -674,6 +681,19 @@ export class Manifold {
    *     direction of the normal vector.
    */
   trimByPlane(normal: Vec3, originOffset: number): Manifold;
+
+  // Convex Hulls
+
+  /**
+   * Compute the convex hull of all points in this Manifold.
+   */
+  hull(): Manifold;
+
+  /**
+   * Compute the convex hull of all points contained within a set of Manifolds
+   * and point vectors.
+   */
+  static hull(points: (Manifold|Vec3)[]): Manifold;
 
   // Topological Operations
 

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -111,8 +111,7 @@ export class CrossSection {
    * @param v The vector to add to every vertex.
    */
   translate(v: Vec2): CrossSection;
-  translate(x: number): CrossSection;
-  translate(x: number, y: number): CrossSection;
+  translate(x: number, y?: number): CrossSection;
 
   /**
    * Applies a (Z-axis) rotation to the CrossSection, in degrees. This operation
@@ -516,9 +515,7 @@ export class Manifold {
    * @param v The vector to add to every vertex.
    */
   translate(v: Vec3): Manifold;
-  translate(x: number): Manifold;
-  translate(x: number, y: number): Manifold;
-  translate(x: number, y: number, z: number): Manifold;
+  translate(x: number, y?: number, z?: number): Manifold;
 
   /**
    * Applies an Euler angle rotation to the manifold, first about the X axis,
@@ -531,9 +528,7 @@ export class Manifold {
    * @param v [X, Y, Z] rotation in degrees.
    */
   rotate(v: Vec3): Manifold;
-  rotate(x: number): Manifold;
-  rotate(x: number, y: number): Manifold;
-  rotate(x: number, y: number, z: number): Manifold;
+  rotate(x: number, y?: number, z?: number): Manifold;
 
   /**
    * Scale this Manifold in space. This operation can be chained. Transforms are

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -111,6 +111,8 @@ export class CrossSection {
    * @param v The vector to add to every vertex.
    */
   translate(v: Vec2): CrossSection;
+  translate(x: number): CrossSection;
+  translate(x: number, y: number): CrossSection;
 
   /**
    * Applies a (Z-axis) rotation to the CrossSection, in degrees. This operation
@@ -172,11 +174,6 @@ export class CrossSection {
   offset(
       delta: number, joinType?: JoinType, miterLimit?: number,
       circularSegments?: number): CrossSection;
-
-  /**
-   * Compute the convex hull of the contours in this CrossSection.
-   */
-  hull(): CrossSection;
 
   /**
    * Remove vertices from the contours in this CrossSection that are less than
@@ -247,6 +244,11 @@ export class CrossSection {
   static intersection(polygons: (CrossSection|Polygons)[]): CrossSection;
 
   // Convex Hulls
+
+  /**
+   * Compute the convex hull of the contours in this CrossSection.
+   */
+  hull(): CrossSection;
 
   /**
    * Compute the convex hull of all points in a list of polygons/cross-sections.
@@ -514,6 +516,9 @@ export class Manifold {
    * @param v The vector to add to every vertex.
    */
   translate(v: Vec3): Manifold;
+  translate(x: number): Manifold;
+  translate(x: number, y: number): Manifold;
+  translate(x: number, y: number, z: number): Manifold;
 
   /**
    * Applies an Euler angle rotation to the manifold, first about the X axis,
@@ -526,6 +531,9 @@ export class Manifold {
    * @param v [X, Y, Z] rotation in degrees.
    */
   rotate(v: Vec3): Manifold;
+  rotate(x: number): Manifold;
+  rotate(x: number, y: number): Manifold;
+  rotate(x: number, y: number, z: number): Manifold;
 
   /**
    * Scale this Manifold in space. This operation can be chained. Transforms are

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -612,6 +612,12 @@ CrossSection CrossSection::Offset(double delta, JoinType jointype,
   return CrossSection(ps);
 }
 
+/**
+ * Compute the convex hull enveloping a set of cross-sections.
+ *
+ * @param crossSections A vector of cross-sections over which to compute a
+ * convex hull.
+ */
 CrossSection CrossSection::Hull(
     const std::vector<CrossSection>& crossSections) {
   int n = 0;
@@ -629,14 +635,31 @@ CrossSection CrossSection::Hull(
   return CrossSection(C2::PathsD{HullImpl(pts)});
 }
 
+/**
+ * Compute the convex hull of this cross-section.
+ */
 CrossSection CrossSection::Hull() const {
   return Hull(std::vector<CrossSection>{*this});
 }
 
+/**
+ * Compute the convex hull of a set of points. If the given points are fewer
+ * than 3, an empty CrossSection will be returned.
+ *
+ * @param pts A vector of 2-dimensional points over which to compute a convex
+ * hull.
+ */
 CrossSection CrossSection::Hull(SimplePolygon pts) {
   return CrossSection(C2::PathsD{HullImpl(pts)});
 }
 
+/**
+ * Compute the convex hull of a set of points/polygons. If the given points are
+ * fewer than 3, an empty CrossSection will be returned.
+ *
+ * @param pts A vector of vectors of 2-dimensional points over which to compute
+ * a convex hull.
+ */
 CrossSection CrossSection::Hull(const Polygons polys) {
   SimplePolygon pts;
   for (auto poly : polys) {


### PR DESCRIPTION
This updates the bindings to cover the addition of convex hulling to CrossSection and Manifold, including the static versions to spare unnecessary booleans (which may actually get in the way of hulling over arbitrary points, since one would need to pack them into valid shapes before hulling with the instance methods). 