### PR TITLE
tighten CCW

### DIFF
--- a/src/utilities/include/public.h
+++ b/src/utilities/include/public.h
@@ -106,7 +106,7 @@ inline HOST_DEVICE int CCW(glm::vec2 p0, glm::vec2 p1, glm::vec2 p2,
   glm::vec2 v2 = p2 - p0;
   float area = v1.x * v2.y - v1.y * v2.x;
   float base2 = glm::max(glm::dot(v1, v1), glm::dot(v2, v2));
-  if (area * area <= base2 * tol * tol)
+  if (area * area * 4 <= base2 * tol * tol)
     return 0;
   else
     return area > 0 ? 1 : -1;

--- a/test/polygon_test.cpp
+++ b/test/polygon_test.cpp
@@ -301,6 +301,23 @@ TEST(Polygon, ColinearY) {
   TestPoly(polys, 16);
 }
 
+TEST(Polygon, NearlyColinearY) {
+  Polygons polys;
+  polys.push_back({
+      {3.5, 0},       //
+      {3.0, 0.5},     //
+      {3.0, 0.0144},  //
+      {2.0, 0.4},     //
+      {1.8, 0.1},     //
+      {1.6, 0.0155},  //
+      {1.5, 0.0147},  //
+      {1.4, 0.0144},  //
+      {1.0, 0.1},     //
+      {0, 0},         //
+  });
+  TestPoly(polys, 8, 0.001);
+}
+
 TEST(Polygon, Concave) {
   Polygons polys;
   polys.push_back({


### PR DESCRIPTION
Partially solves #502 

Alternative to #507. I found a problem with `CCW`, where it was not properly conservative because the base could be up to twice as long as calculated if the `v0` is near the midpoint between `v1` and `v2`. 