### PR TITLE
intermediateChecks debug

### DIFF
--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -1074,6 +1074,9 @@ std::vector<glm::ivec3> TriangulateIdx(const PolygonsIdx &polys,
     Monotones monotones(polys, precision);
     monotones.Triangulate(triangles);
 #ifdef MANIFOLD_DEBUG
+    std::cout << "in triangulator: "
+              << (PolygonParams().intermediateChecks ? "true" : "false")
+              << std::endl;
     if (params.intermediateChecks) {
       CheckTopology(triangles, polys);
       if (!params.processOverlaps) {

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -26,6 +26,8 @@ using namespace manifold;
  * The very simplest Boolean operation test.
  */
 TEST(Boolean, Tetra) {
+  std::cout << (PolygonParams().intermediateChecks ? "true" : "false")
+            << std::endl;
   Manifold tetra = Manifold::Tetrahedron();
   MeshGL tetraGL = WithPositionColors(tetra);
   tetra = Manifold(tetraGL);
@@ -37,6 +39,8 @@ TEST(Boolean, Tetra) {
   ExpectMeshes(result, {{8, 12, 3, 11}});
 
   RelatedGL(result, {tetraGL});
+  std::cout << (PolygonParams().intermediateChecks ? "true" : "false")
+            << std::endl;
 }
 
 TEST(Boolean, MeshGLRoundTrip) {

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -65,6 +65,7 @@ int main(int argc, char** argv) {
   }
 
   manifold::PolygonParams().intermediateChecks = true;
+
   manifold::PolygonParams().processOverlaps = false;
 
   return RUN_ALL_TESTS();


### PR DESCRIPTION
Okay, so here's an example of the problem I'm seeing. I believe this is true across our tests generally, but I'd recommend testing with `./manifold_test --gtest_filter=Boolean.Tetra` since it's short enough to keep the console spew manageable. What this outputs for me is:
```
true
in triangulator: false
true
```
which I cannot in any way explain. 