### PR TITLE
3mf node export

### DIFF
--- a/bindings/wasm/examples/package-lock.json
+++ b/bindings/wasm/examples/package-lock.json
@@ -11,7 +11,7 @@
         "@gltf-transform/core": "^3.2.1",
         "@gltf-transform/extensions": "^3.2.1",
         "@gltf-transform/functions": "^3.2.1",
-        "@jscadui/3mf-export": "^0.3.0",
+        "@jscadui/3mf-export": "^0.4.2",
         "fflate": "^0.8.0",
         "gl-matrix": "^3.4.3",
         "simple-dropzone": "0.8.3",
@@ -414,9 +414,9 @@
       "dev": true
     },
     "node_modules/@jscadui/3mf-export": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@jscadui/3mf-export/-/3mf-export-0.3.0.tgz",
-      "integrity": "sha512-5NfknQSTO2+rt7m7PGDvIST8V2RNNWBGvQPEmVY2DTMCEZ6y4zyIltxwVbnQ6NRCEeWZseSb3FpmflU1AWE9vw=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@jscadui/3mf-export/-/3mf-export-0.4.2.tgz",
+      "integrity": "sha512-VFRxT/wNCVEu4bsY1dwjFvC0WaoGsYbl52YPGr3Ka3GwvQ4Sw9EJsA/SlIdUnCCTtxmC662LWcgDNtgOc3Uayg=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/bindings/wasm/examples/package.json
+++ b/bindings/wasm/examples/package.json
@@ -16,7 +16,7 @@
     "@gltf-transform/core": "^3.2.1",
     "@gltf-transform/extensions": "^3.2.1",
     "@gltf-transform/functions": "^3.2.1",
-    "@jscadui/3mf-export": "^0.4.0",
+    "@jscadui/3mf-export": "^0.4.2",
     "fflate": "^0.8.0",
     "gl-matrix": "^3.4.3",
     "simple-dropzone": "0.8.3",

--- a/bindings/wasm/examples/package.json
+++ b/bindings/wasm/examples/package.json
@@ -16,7 +16,7 @@
     "@gltf-transform/core": "^3.2.1",
     "@gltf-transform/extensions": "^3.2.1",
     "@gltf-transform/functions": "^3.2.1",
-    "@jscadui/3mf-export": "^0.3.0",
+    "@jscadui/3mf-export": "^0.4.0",
     "fflate": "^0.8.0",
     "gl-matrix": "^3.4.3",
     "simple-dropzone": "0.8.3",


### PR DESCRIPTION
This makes our 3MF export consistent with our GLB export when `GLTFNode` is used, creating the same scene hierarchy with mesh reuse. No materials yet, but we do include object names and a proper header. 

This is blocked on https://github.com/hrgdavor/jscadui/pull/37, which will need an npm release for us.