### PR TITLE
fixed for_each_host and for_each_n_host

### DIFF
--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -134,9 +134,9 @@ inline ExecutionPolicy autoPolicy(int size) {
         thrust::NAME(thrust::MANIFOLD_PAR_NS::par, args...); \
         break;                                               \
       case ExecutionPolicy::Seq:                             \
+        thrust::NAME(thrust::cpp::par, args...);             \
         break;                                               \
     }                                                        \
-    thrust::NAME(thrust::cpp::par, args...);                 \
   }
 
 #if MANIFOLD_PAR == 'T' && !(__APPLE__)


### PR DESCRIPTION
this is a really silly mistake... luckily this is only used in csg_tree and we rarely have over 4096 nodes to operate over.