### PR TITLE
fix memory leak for vec

### DIFF
--- a/src/utilities/include/vec.h
+++ b/src/utilities/include/vec.h
@@ -273,10 +273,10 @@ class Vec : public VecView<T> {
       TracyAllocS(newBuffer, size_ * sizeof(T), 3);
       uninitialized_copy(autoPolicy(this->size_), this->ptr_,
                          this->ptr_ + this->size_, newBuffer);
-      if (this->ptr_ != nullptr) {
-        TracyFreeS(ptr_, 3);
-        free(this->ptr_);
-      }
+    }
+    if (this->ptr_ != nullptr) {
+      TracyFreeS(ptr_, 3);
+      free(this->ptr_);
     }
     this->ptr_ = newBuffer;
     capacity_ = this->size_;


### PR DESCRIPTION
it turns out I placed this in the wrong position, causing memory leak after resizing to 0.