### PR TITLE
fix openscad build

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -157,6 +157,28 @@ jobs:
         cd build/test
         ./Release/manifold_test.exe
 
+  build_mxe:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        parallel_backend: [NONE, TBB]
+      max-parallel: 1
+    runs-on: ubuntu-latest
+    container: openscad/mxe-x86_64-gui:latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_DEBUG=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} .. && make
+    - name: Test
+      run: |
+        cd build/test
+        ./manifold_test
+
   build_mac:
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -173,7 +173,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_DEBUG=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} .. && make
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PYBIND=OFF -DMANIFOLD_DEBUG=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} .. && make
     - name: Test
       run: |
         cd build/test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,6 @@ else()
   option(CMAKE_BUILD_TYPE "Build type" Release)
 endif()
 
-set(MANIFOLD_FLAGS ${MANIFOLD_FLAGS} -O3)
-
 if(EMSCRIPTEN)
   message("Building for Emscripten")
   set(MANIFOLD_FLAGS -fexceptions -D_LIBCUDACXX_HAS_THREAD_API_EXTERNAL -D_LIBCUDACXX_HAS_THREAD_API_CUDA)
@@ -65,22 +63,20 @@ if(CMAKE_EXPORT_COMPILE_COMMANDS AND NOT EMSCRIPTEN)
       ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 endif()
 
-if(NOT MSVC)
+if (MSVC)
+  set(MANIFOLD_FLAGS ${MANIFOLD_FLAGS} /DNOMINMAX)
+else()
   if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(WARNING_FLAGS -Werror -Wall -Wno-sign-compare -Wno-unused -Wno-array-bounds -Wno-stringop-overflow)
   else()
     set(WARNING_FLAGS -Werror -Wall -Wno-sign-compare -Wno-unused)
   endif()
-  set(MANIFOLD_FLAGS
-    "${MANIFOLD_FLAGS}"
-    "$<$<COMPILE_LANGUAGE:CXX>:${WARNING_FLAGS}>")
+  set(MANIFOLD_FLAGS ${MANIFOLD_FLAGS} ${WARNING_FLAGS} -O3)
 endif()
 
 if(CODE_COVERAGE AND NOT MSVC)
   set(COVERAGE_FLAGS -coverage -fno-inline-small-functions -fkeep-inline-functions -fkeep-static-functions)
-  set(MANIFOLD_FLAGS
-    "${MANIFOLD_FLAGS}"
-    "$<$<COMPILE_LANGUAGE:CXX>:${COVERAGE_FLAGS}>")
+  set(MANIFOLD_FLAGS ${MANIFOLD_FLAGS} ${COVERAGE_FLAGS})
   add_link_options("-coverage")
 endif()
 

--- a/src/collider/CMakeLists.txt
+++ b/src/collider/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(${PROJECT_NAME} ${SOURCE_FILES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(${PROJECT_NAME} PUBLIC utilities)
+target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
 
 target_compile_features(${PROJECT_NAME}
     PUBLIC cxx_std_17

--- a/src/manifold/CMakeLists.txt
+++ b/src/manifold/CMakeLists.txt
@@ -23,6 +23,8 @@ target_link_libraries(${PROJECT_NAME}
     PRIVATE collider polygon ${MANIFOLD_INCLUDE} graphlite Clipper2 quickhull
 )
 
+target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
+
 target_compile_features(${PROJECT_NAME}
     PUBLIC cxx_std_17
 )

--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -16,7 +16,7 @@
 #include <array>
 #include <map>
 
-#if MANIFOLD_PAR == 'T' && __has_include(<tbb/tbb.h>)
+#if MANIFOLD_PAR == 'T' && __has_include(<tbb/concurrent_map.h>)
 #define TBB_PREVIEW_CONCURRENT_ORDERED_CONTAINERS 1
 #include <tbb/concurrent_map.h>
 #include <tbb/parallel_for.h>

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if MANIFOLD_PAR == 'T' && __has_include(<tbb/tbb.h>)
+#if MANIFOLD_PAR == 'T' && __has_include(<tbb/concurrent_priority_queue.h>)
 #include <tbb/tbb.h>
 #define TBB_PREVIEW_CONCURRENT_ORDERED_CONTAINERS 1
 #include <tbb/concurrent_priority_queue.h>

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -498,6 +498,7 @@ std::shared_ptr<Manifold::Impl> CsgOpNode::BatchBoolean(
   // apply boolean operations starting from smaller meshes
   // the assumption is that boolean operations on smaller meshes is faster,
   // due to less data being copied and processed
+  auto cmpFn = MeshCompare();
   std::make_heap(results.begin(), results.end(), cmpFn);
   while (results.size() > 1) {
     std::pop_heap(results.begin(), results.end(), cmpFn);

--- a/src/manifold/src/face_op.cpp
+++ b/src/manifold/src/face_op.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if MANIFOLD_PAR == 'T' && __has_include(<tbb/tbb.h>)
+#if MANIFOLD_PAR == 'T' && __has_include(<tbb/concurrent_map.h>)
 #include <tbb/tbb.h>
 #define TBB_PREVIEW_CONCURRENT_ORDERED_CONTAINERS 1
 #include <tbb/concurrent_map.h>

--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -13,9 +13,13 @@
 // limitations under the License.
 
 #include "polygon.h"
+#if MANIFOLD_PAR == 'T'
+#include "tbb/tbb.h"
+#endif
 
 #include <algorithm>
-#if MANIFOLD_PAR == 'T' && __has_include(<pstl/glue_execution_defs.h>)
+#if MANIFOLD_PAR == 'T' && TBB_INTERFACE_VERSION >= 10000 && \
+    __has_include(<pstl/glue_execution_defs.h>)
 #include <execution>
 #endif
 #include <list>
@@ -832,7 +836,8 @@ class Monotones {
         starts.push_back(v);
       }
     }
-#if MANIFOLD_PAR == 'T' && __has_include(<pstl/glue_execution_defs.h>)
+#if MANIFOLD_PAR == 'T' && TBB_INTERFACE_VERSION >= 10000 && \
+    __has_include(<pstl/glue_execution_defs.h>)
     std::sort(std::execution::par_unseq, starts.begin(), starts.end(), cmp);
 #else
     std::sort(starts.begin(), starts.end(), cmp);

--- a/src/sdf/CMakeLists.txt
+++ b/src/sdf/CMakeLists.txt
@@ -23,6 +23,8 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME} PUBLIC utilities)
 
+target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
+
 install(
   TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -69,8 +69,7 @@ endif()
 target_include_directories(${PROJECT_NAME} INTERFACE ${THRUST_INC_DIR})
 target_link_libraries(${PROJECT_NAME} INTERFACE glm)
 
-target_compile_options(${PROJECT_NAME}
-    INTERFACE ${MANIFOLD_FLAGS}
+target_compile_options(${PROJECT_NAME} INTERFACE
     -DTHRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_${MANIFOLD_PAR}
 )
 

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -33,6 +33,8 @@
 #include <algorithm>
 #include <execution>
 #include <numeric>
+
+#include "tbb/tbb.h"
 #define MANIFOLD_PAR_NS tbb
 #else
 #define MANIFOLD_PAR_NS cpp
@@ -82,7 +84,8 @@ inline constexpr ExecutionPolicy autoPolicy(int size) {
     return thrust::NAME(thrust::cpp::par, args...);                 \
   }
 
-#if MANIFOLD_PAR == 'T' && __has_include(<pstl/glue_execution_defs.h>)
+#if MANIFOLD_PAR == 'T' && TBB_INTERFACE_VERSION >= 10000 && \
+    __has_include(<pstl/glue_execution_defs.h>)
 // sometimes stl variant is faster
 #define STL_DYNAMIC_BACKEND(NAME, RET)                        \
   template <typename Ret = RET, typename... Args>             \

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -30,9 +30,12 @@
 #elif MANIFOLD_PAR == 'T'
 #include <thrust/system/tbb/execution_policy.h>
 
+#if MANIFOLD_PAR == 'T' && TBB_INTERFACE_VERSION >= 10000 && \
+    __has_include(<pstl/glue_execution_defs.h>)
 #include <algorithm>
 #include <execution>
 #include <numeric>
+#endif
 
 #include "tbb/tbb.h"
 #define MANIFOLD_PAR_NS tbb

--- a/src/utilities/include/sparse.h
+++ b/src/utilities/include/sparse.h
@@ -38,7 +38,7 @@ class SparseIndices {
     defined(__LITTLE_ENDIAN__) || defined(__ARMEL__) ||                    \
     defined(__THUMBEL__) || defined(__AARCH64EL__) || defined(_MIPSEL) ||  \
     defined(__MIPSEL) || defined(__MIPSEL__) || defined(__EMSCRIPTEN__) || \
-    defined(_MSC_VER)
+    defined(_WIN32)
   static constexpr size_t pOffset = 1;
 #else
 #error "unknown architecture"


### PR DESCRIPTION
https://github.com/openscad/openscad/issues/4679#issuecomment-1694420791

1. Do not use PSTL if tbb version is too old.
2. Only use tbb concurrent containers if the header exists.
3. Avoid leaking `MANIFOLD_FLAGS` to downstream consumers.

I think we should probably put `public.h` into a separate directory as well, as other headers in utilities are not supposed to be visible to users.

@t-paul can you verify if this patch fixes the compilation errors for you?