### PR TITLE
fix undefined behavior for SparseIndices

### DIFF
--- a/src/manifold/src/boolean3.cpp
+++ b/src/manifold/src/boolean3.cpp
@@ -382,10 +382,10 @@ std::tuple<Vec<int>, Vec<float>> Shadow02(const Manifold::Impl &inP,
 };
 
 struct Kernel12 {
-  const Vec<int64_t> &p0q2;
+  VecView<const int64_t> p0q2;
   VecView<const int> s02;
   VecView<const float> z02;
-  const Vec<int64_t> &p1q1;
+  VecView<const int64_t> p1q1;
   VecView<const int> s11;
   VecView<const glm::vec4> xyzz11;
   VecView<const Halfedge> halfedgesP;

--- a/src/utilities/include/vec.h
+++ b/src/utilities/include/vec.h
@@ -44,6 +44,8 @@ class VecView {
   using Iter = T *;
   using IterC = const T *;
 
+  VecView(T *ptr_, int size_) : ptr_(ptr_), size_(size_) {}
+
   VecView(const VecView &other) {
     ptr_ = other.ptr_;
     size_ = other.size_;
@@ -110,7 +112,6 @@ class VecView {
   int size_ = 0;
 
   VecView() = default;
-  VecView(T *ptr_, int size_) : ptr_(ptr_), size_(size_) {}
   friend class Vec<T>;
   friend class Vec<typename std::remove_const<T>::type>;
   friend class VecView<typename std::remove_const<T>::type>;


### PR DESCRIPTION
The previous behavior violates c++ aliasing requirements. More specifically, we cannot alias int32 and int64, we can only alias int32 <-> char, and int64 <-> char.

https://en.cppreference.com/w/cpp/language/reinterpret_cast#Type_aliasing :

> Whenever an attempt is made to read or modify the stored value of an object of type DynamicType through a glvalue of type AliasedType, the behavior is undefined unless one of the following is true:
>
> -  AliasedType and DynamicType are similar.
> -  AliasedType is the (possibly [cv](https://en.cppreference.com/w/cpp/language/cv)-qualified) signed or unsigned variant of DynamicType.
> -  AliasedType is [std::byte](https://en.cppreference.com/w/cpp/types/byte), (since C++17) char, or unsigned char: this permits examination of the [object representation](https://en.cppreference.com/w/cpp/language/object#Object_representation_and_value_representation) of any object as an array of bytes. 
> 
> Informally, two types are similar if, ignoring top-level cv-qualification:
> 
> -  they are the same type; or
> -  they are both pointers, and the pointed-to types are similar; or
> -  they are both pointers to member of the same class, and the types of the pointed-to members are similar;

And there are real consequences... I discovered some really abnormal behavior when working on 3D offsetting.