### PR TITLE
fix ndarray creation (#543)

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -41,7 +41,7 @@ jobs:
         cd build/test
         ./manifold_test
         cd ../../
-        python3 bindings/python/examples/run_all.py
+        python3 bindings/python/examples/run_all.py -e
     - name: Coverage Report
       # only do code coverage for default sequential backend, it seems that TBB
       # backend will cause failure

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -649,19 +649,19 @@ NB_MODULE(manifold3d, m) {
           nb::arg("halfedge_tangent") = nb::none(), nb::arg("precision") = 0)
       .def_prop_ro("vert_properties",
                    [](const MeshGL &self) {
-                     return nb::ndarray<const float, nb::c_contig>(
+                     return nb::ndarray<nb::numpy, const float, nb::c_contig>(
                          self.vertProperties.data(),
                          {self.vertProperties.size() / self.numProp,
                           self.numProp});
                    }, nb::rv_policy::reference_internal)
       .def_prop_ro("tri_verts",
                    [](const MeshGL &self) {
-                     return nb::ndarray<const float, nb::c_contig>(
+                     return nb::ndarray<nb::numpy, const float, nb::c_contig>(
                          self.triVerts.data(), {self.triVerts.size() / 3, 3});
                    }, nb::rv_policy::reference_internal)
       .def_prop_ro("run_transform",
                    [](const MeshGL &self) {
-                     return nb::ndarray<const float, nb::c_contig>(
+                     return nb::ndarray<nb::numpy, const float, nb::c_contig>(
                          self.runTransform.data(), {self.runTransform.size() / 12, 4, 3});
                    }, nb::rv_policy::reference_internal)
       .def_prop_ro("halfedge_tangent",
@@ -671,7 +671,7 @@ NB_MODULE(manifold3d, m) {
                                self.halfedgeTangent.data() +
                                    self.halfedgeTangent.size(),
                                data);
-                     return nb::ndarray<const float, nb::c_contig>(
+                     return nb::ndarray<nb::numpy, const float, nb::c_contig>(
                          self.halfedgeTangent.data(), {self.halfedgeTangent.size() / 12, 3, 4});
                    }, nb::rv_policy::reference_internal)
       .def_ro("merge_from_vert", &MeshGL::mergeFromVert)


### PR DESCRIPTION
Fixes #543

It seems that ndarray defaults to exporting a PyCapsule. Although we can convert it to numpy array in the python code, it seems easier to convert them directly in our c++ code.

This also adds mesh export to our CI.