### PR TITLE
misc

### DIFF
--- a/src/manifold/src/boolean3.cpp
+++ b/src/manifold/src/boolean3.cpp
@@ -496,7 +496,12 @@ Vec<int> Winding03(const Manifold::Impl &inP, Vec<int> &vertices, Vec<int> &s02,
   Vec<int> w03(inP.NumVert(), 0);
   // checking is slow, so just sort and reduce
   auto policy = autoPolicy(vertices.size());
-  stable_sort_by_key(policy, vertices.begin(), vertices.end(), s02.begin());
+  stable_sort(
+      policy, zip(vertices.begin(), s02.begin()),
+      zip(vertices.end(), s02.end()),
+      [](const thrust::tuple<int, int> &a, const thrust::tuple<int, int> &b) {
+        return thrust::get<0>(a) < thrust::get<0>(b);
+      });
   Vec<int> w03val(w03.size());
   Vec<int> w03vert(w03.size());
   // sum known s02 values into w03 (winding number)

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -684,7 +684,12 @@ void Manifold::Impl::CreateHalfedges(const Vec<glm::ivec3>& triVerts) {
   // degenerate situations the triangulator can add the same internal edge in
   // two different faces, causing this edge to not be 2-manifold. These are
   // fixed by duplicating verts in SimplifyTopology.
-  stable_sort_by_key(policy, edge.begin(), edge.end(), ids.begin());
+  stable_sort(policy, zip(edge.begin(), ids.begin()),
+              zip(edge.end(), ids.end()),
+              [](const thrust::tuple<uint64_t, int>& a,
+                 const thrust::tuple<uint64_t, int>& b) {
+                return thrust::get<0>(a) < thrust::get<0>(b);
+              });
   // Once sorted, the first half of the range is the forward halfedges, which
   // correspond to their backward pair at the same offset in the second half
   // of the range.

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -181,8 +181,6 @@ STL_DYNAMIC_BACKEND(all_of, bool)
 STL_DYNAMIC_BACKEND(is_sorted, bool)
 STL_DYNAMIC_BACKEND(reduce, void)
 STL_DYNAMIC_BACKEND(count_if, int)
-STL_DYNAMIC_BACKEND(binary_search, bool)
 STL_DYNAMIC_BACKEND(remove_if, void)
-STL_DYNAMIC_BACKEND(unique, void)
 
 }  // namespace manifold

--- a/src/utilities/include/sparse.h
+++ b/src/utilities/include/sparse.h
@@ -128,9 +128,7 @@ class SparseIndices {
   void Unique() {
     Sort();
     VecView<int64_t> view = AsVec64();
-    int newSize = unique<decltype(view.begin())>(autoPolicy(view.size()),
-                                                 view.begin(), view.end()) -
-                  view.begin();
+    int newSize = std::unique(view.begin(), view.end()) - view.begin();
     Resize(newSize);
   }
 


### PR DESCRIPTION
1. Use `std::unique` instead of `thrust::unique`, as it is known that `thrust::unique` can cause out of bound access.
2. Use standard sort instead of sort_by_key. This is an effort to reduce the thrust dependencies.
3. Use stl algorithms instead of thrust algorithms when we use single threaded backend. This is for wasm binding.