### PR TITLE
added deterministic option

### DIFF
--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -207,8 +207,8 @@ void AddNewEdgeVerts(
   // parallelize operations, requires concurrent_map so we can only enable this
   // with tbb
   if (!ManifoldParams().deterministic && p1q2.size() > kParallelThreshold) {
-    // ideally we should have 1 mutex per key, but kParallelThreshold is enough to avoid
-    // contention for most of the cases
+    // ideally we should have 1 mutex per key, but kParallelThreshold is enough
+    // to avoid contention for most of the cases
     std::array<std::mutex, kParallelThreshold> mutexes;
     static tbb::affinity_partitioner ap;
     auto processFun = std::bind(

--- a/src/manifold/src/edge_op.cpp
+++ b/src/manifold/src/edge_op.cpp
@@ -157,7 +157,7 @@ void Manifold::Impl::SimplifyTopology() {
     entries[i].index = i;
   });
 
-  sort(policy, entries.begin(), entries.end());
+  stable_sort(policy, entries.begin(), entries.end());
   for (int i = 0; i < nbEdges - 1; ++i) {
     if (entries[i].start == entries[i + 1].start &&
         entries[i].end == entries[i + 1].end) {

--- a/src/manifold/src/properties.cpp
+++ b/src/manifold/src/properties.cpp
@@ -313,11 +313,26 @@ int Manifold::Impl::NumDegenerateTris() const {
 
 Properties Manifold::Impl::GetProperties() const {
   if (IsEmpty()) return {0, 0};
-  auto areaVolume = transform_reduce<thrust::pair<float, float>>(
-      autoPolicy(NumTri()), countAt(0), countAt(NumTri()),
-      FaceAreaVolume({halfedge_, vertPos_, precision_}),
-      thrust::make_pair(0.0f, 0.0f), SumPair());
-  return {areaVolume.first, areaVolume.second};
+  // Kahan summation
+  float area = 0;
+  float volume = 0;
+  float areaCompensation = 0;
+  float volumeCompensation = 0;
+  for (int i = 0; i < NumTri(); ++i) {
+    auto [area1, volume1] =
+        FaceAreaVolume({halfedge_, vertPos_, precision_})(i);
+    const float t1 = area + area1;
+    const float t2 = volume + volume1;
+    // we know that the elements are non-negative
+    areaCompensation += (area - t1) + area1;
+    volumeCompensation += (volume - t2) + volume1;
+    area = t1;
+    volume = t2;
+  }
+  area += areaCompensation;
+  volume += volumeCompensation;
+
+  return {area, volume};
 }
 
 void Manifold::Impl::CalculateCurvature(int gaussianIdx, int meanIdx) {

--- a/src/manifold/src/properties.cpp
+++ b/src/manifold/src/properties.cpp
@@ -286,7 +286,7 @@ bool Manifold::Impl::Is2Manifold() const {
   if (!IsManifold()) return false;
 
   Vec<Halfedge> halfedge(halfedge_);
-  sort(policy, halfedge.begin(), halfedge.end());
+  stable_sort(policy, halfedge.begin(), halfedge.end());
 
   return all_of(policy, countAt(0), countAt(2 * NumEdge() - 1),
                 NoDuplicates({halfedge}));

--- a/src/manifold/src/sort.cpp
+++ b/src/manifold/src/sort.cpp
@@ -310,12 +310,12 @@ void Manifold::Impl::SortVerts() {
   Vec<int> vertNew2Old(numVert);
   sequence(policy, vertNew2Old.begin(), vertNew2Old.end());
 
-  sort(policy, zip(vertMorton.begin(), vertNew2Old.begin()),
-       zip(vertMorton.end(), vertNew2Old.end()),
-       [](const thrust::tuple<uint32_t, int>& a,
-          const thrust::tuple<uint32_t, int>& b) {
-         return thrust::get<0>(a) < thrust::get<0>(b);
-       });
+  stable_sort(policy, zip(vertMorton.begin(), vertNew2Old.begin()),
+              zip(vertMorton.end(), vertNew2Old.end()),
+              [](const thrust::tuple<uint32_t, int>& a,
+                 const thrust::tuple<uint32_t, int>& b) {
+                return thrust::get<0>(a) < thrust::get<0>(b);
+              });
 
   ReindexVerts(vertNew2Old, numVert);
 
@@ -394,12 +394,12 @@ void Manifold::Impl::SortFaces(Vec<Box>& faceBox, Vec<uint32_t>& faceMorton) {
   auto policy = autoPolicy(faceNew2Old.size());
   sequence(policy, faceNew2Old.begin(), faceNew2Old.end());
 
-  sort(policy, zip(faceMorton.begin(), faceNew2Old.begin()),
-       zip(faceMorton.end(), faceNew2Old.end()),
-       [](const thrust::tuple<uint32_t, int>& a,
-          const thrust::tuple<uint32_t, int>& b) {
-         return thrust::get<0>(a) < thrust::get<0>(b);
-       });
+  stable_sort(policy, zip(faceMorton.begin(), faceNew2Old.begin()),
+              zip(faceMorton.end(), faceNew2Old.end()),
+              [](const thrust::tuple<uint32_t, int>& a,
+                 const thrust::tuple<uint32_t, int>& b) {
+                return thrust::get<0>(a) < thrust::get<0>(b);
+              });
 
   // Tris were flagged for removal with pairedHalfedge = -1 and assigned kNoCode
   // to sort them to the end, which allows them to be removed.
@@ -572,12 +572,13 @@ bool MeshGL::Merge() {
              zip(vertMorton.begin(), vertBox.begin(), openVerts.cbegin()),
              numOpenVert, VertMortonBox({vertPropD, numProp, precision, bBox}));
 
-  sort(policy, zip(vertMorton.begin(), vertBox.begin(), openVerts.begin()),
-       zip(vertMorton.end(), vertBox.end(), openVerts.end()),
-       [](const thrust::tuple<uint32_t, Box, int>& a,
-          const thrust::tuple<uint32_t, Box, int>& b) {
-         return thrust::get<0>(a) < thrust::get<0>(b);
-       });
+  stable_sort(policy,
+              zip(vertMorton.begin(), vertBox.begin(), openVerts.begin()),
+              zip(vertMorton.end(), vertBox.end(), openVerts.end()),
+              [](const thrust::tuple<uint32_t, Box, int>& a,
+                 const thrust::tuple<uint32_t, Box, int>& b) {
+                return thrust::get<0>(a) < thrust::get<0>(b);
+              });
 
   Collider collider(vertBox, vertMorton);
   SparseIndices toMerge = collider.Collisions<true>(vertBox.cview());

--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -838,7 +838,8 @@ class Monotones {
     }
 #if MANIFOLD_PAR == 'T' && TBB_INTERFACE_VERSION >= 10000 && \
     __has_include(<pstl/glue_execution_defs.h>)
-    std::stable_sort(std::execution::par_unseq, starts.begin(), starts.end(), cmp);
+    std::stable_sort(std::execution::par_unseq, starts.begin(), starts.end(),
+                     cmp);
 #else
     std::stable_sort(starts.begin(), starts.end(), cmp);
 #endif

--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -119,8 +119,8 @@ void CheckTopology(const std::vector<PolyEdge> &halfedges) {
     return a.startVert < b.startVert ||
            (a.startVert == b.startVert && a.endVert < b.endVert);
   };
-  std::sort(forward.begin(), forward.end(), cmp);
-  std::sort(backward.begin(), backward.end(), cmp);
+  std::stable_sort(forward.begin(), forward.end(), cmp);
+  std::stable_sort(backward.begin(), backward.end(), cmp);
   for (int i = 0; i < n_edges; ++i) {
     ASSERT(forward[i].startVert == backward[i].startVert &&
                forward[i].endVert == backward[i].endVert,
@@ -838,9 +838,9 @@ class Monotones {
     }
 #if MANIFOLD_PAR == 'T' && TBB_INTERFACE_VERSION >= 10000 && \
     __has_include(<pstl/glue_execution_defs.h>)
-    std::sort(std::execution::par_unseq, starts.begin(), starts.end(), cmp);
+    std::stable_sort(std::execution::par_unseq, starts.begin(), starts.end(), cmp);
 #else
-    std::sort(starts.begin(), starts.end(), cmp);
+    std::stable_sort(starts.begin(), starts.end(), cmp);
 #endif
 
     std::vector<VertItr> skipped;

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -177,7 +177,6 @@ STL_DYNAMIC_BACKEND_VOID(fill)
 STL_DYNAMIC_BACKEND_VOID(copy)
 STL_DYNAMIC_BACKEND_VOID(inclusive_scan)
 STL_DYNAMIC_BACKEND_VOID(copy_n)
-STL_DYNAMIC_BACKEND_VOID(sort)
 
 // void implies that the user have to specify the return type in the template
 // argument, as we are unable to deduce it

--- a/src/utilities/include/public.h
+++ b/src/utilities/include/public.h
@@ -292,17 +292,17 @@ struct Box {
   /**
    * Does this box overlap the one given (including equality)?
    */
-  bool DoesOverlap(const Box& box) const {
-    return min.x <= box.max.x && min.y <= box.max.y && min.z <= box.max.z &&
-           max.x >= box.min.x && max.y >= box.min.y && max.z >= box.min.z;
+  inline bool DoesOverlap(const Box& box) const {
+    return (min.x <= box.max.x) & (min.y <= box.max.y) & (min.z <= box.max.z) &
+           (max.x >= box.min.x) & (max.y >= box.min.y) & (max.z >= box.min.z);
   }
 
   /**
    * Does the given point project within the XY extent of this box
    * (including equality)?
    */
-  bool DoesOverlap(glm::vec3 p) const {  // projected in z
-    return p.x <= max.x && p.x >= min.x && p.y <= max.y && p.y >= min.y;
+  inline bool DoesOverlap(glm::vec3 p) const {  // projected in z
+    return (p.x <= max.x) & (p.x >= min.x) & (p.y <= max.y) & (p.y >= min.y);
   }
 
   /**
@@ -445,6 +445,8 @@ struct ExecutionParams {
   /// Suppresses printed errors regarding CW triangles. Has no effect if
   /// processOverlaps is true.
   bool suppressErrors = false;
+  /// Deterministic outputs. Will disable some parallel optimizations.
+  bool deterministic = false;
 };
 
 #ifdef MANIFOLD_DEBUG

--- a/src/utilities/include/public.h
+++ b/src/utilities/include/public.h
@@ -293,8 +293,8 @@ struct Box {
    * Does this box overlap the one given (including equality)?
    */
   inline bool DoesOverlap(const Box& box) const {
-    return (min.x <= box.max.x) & (min.y <= box.max.y) & (min.z <= box.max.z) &
-           (max.x >= box.min.x) & (max.y >= box.min.y) & (max.z >= box.min.z);
+    return min.x <= box.max.x && min.y <= box.max.y && min.z <= box.max.z &&
+           max.x >= box.min.x && max.y >= box.min.y && max.z >= box.min.z;
   }
 
   /**
@@ -302,7 +302,7 @@ struct Box {
    * (including equality)?
    */
   inline bool DoesOverlap(glm::vec3 p) const {  // projected in z
-    return (p.x <= max.x) & (p.x >= min.x) & (p.y <= max.y) & (p.y >= min.y);
+    return p.x <= max.x && p.x >= min.x && p.y <= max.y && p.y >= min.y;
   }
 
   /**

--- a/src/utilities/include/sparse.h
+++ b/src/utilities/include/sparse.h
@@ -64,7 +64,7 @@ class SparseIndices {
 
   void Sort() {
     VecView<int64_t> view = AsVec64();
-    sort(autoPolicy(size()), view.begin(), view.end());
+    stable_sort(autoPolicy(size()), view.begin(), view.end());
   }
 
   void Resize(int size) { data_.resize(size * sizeof(int64_t), -1); }

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -665,6 +665,7 @@ TEST(Boolean, TreeTransforms) {
 
 TEST(Boolean, Sweep) {
   PolygonParams().processOverlaps = true;
+  ManifoldParams().deterministic = true;
 
   // generate the minimum equivalent positive angle
   auto minPosAngle = [](float angle) {
@@ -879,7 +880,6 @@ TEST(Boolean, Sweep) {
   std::vector<Manifold> result;
 
   for (int i = 0; i < numPoints; i++) {
-    // std::cerr << i << std::endl;
     std::vector<Manifold> primitives =
         cutterPrimitives(pathPoints[i], pathPoints[(i + 1) % numPoints],
                          pathPoints[(i + 2) % numPoints]);
@@ -898,6 +898,7 @@ TEST(Boolean, Sweep) {
   }
 
   Manifold shape = Manifold::BatchBoolean(result, OpType::Add);
+  EXPECT_EQ(shape.NumTri(), 4400);
   auto prop = shape.GetProperties();
 
   EXPECT_NEAR(prop.volume, 3757, 1);
@@ -906,4 +907,5 @@ TEST(Boolean, Sweep) {
 #endif
 
   PolygonParams().processOverlaps = false;
+  ManifoldParams().deterministic = false;
 }

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -905,5 +905,4 @@ TEST(Boolean, Sweep) {
 #endif
 
   PolygonParams().processOverlaps = false;
-  ManifoldParams().deterministic = false;
 }

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -665,7 +665,6 @@ TEST(Boolean, TreeTransforms) {
 
 TEST(Boolean, Sweep) {
   PolygonParams().processOverlaps = true;
-  ManifoldParams().deterministic = true;
 
   // generate the minimum equivalent positive angle
   auto minPosAngle = [](float angle) {
@@ -898,7 +897,6 @@ TEST(Boolean, Sweep) {
   }
 
   Manifold shape = Manifold::BatchBoolean(result, OpType::Add);
-  EXPECT_EQ(shape.NumTri(), 4400);
   auto prop = shape.GetProperties();
 
   EXPECT_NEAR(prop.volume, 3757, 1);


### PR DESCRIPTION
This disables some racy optimizations when user wants deterministic output. We should now consider non-deterministic output when deterministic option is enabled a bug.

The area and volume calculation now uses Kahan summation, which is numerically stable.

Also, it turns out parallel compose will somehow cause non-determinism. Considering we already do parallel for inside compose, I just disabled doing multiple compose in parallel and rewrote it in a simpler way.

Fixes #545. 