### PR TITLE
fix ubuntu build

### DIFF
--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -30,6 +30,8 @@ FetchContent_MakeAvailable(glm)
 FetchContent_Declare(Thrust
     GIT_REPOSITORY https://github.com/NVIDIA/thrust.git
     GIT_TAG 2.1.0
+    GIT_SHALLOW TRUE
+    GIT_PROGRESS TRUE
     FIND_PACKAGE_ARGS NAMES Thrust
 )
 FetchContent_MakeAvailable(Thrust)


### PR DESCRIPTION
Managed to reproduce #580. It seems that with the CMake version in Ubuntu 22.04, `FetchContent_Declare` without `GIT_SHALLOW TRUE` and `GIT_PROGRESS TRUE` generates incorrect cmake file which attempts to clone the repository in directory '' and failed.

@jirihon can you check if it works for you now? I tried running it inside a docker and it seems to work fine.