### PR TITLE
fix wasm cmake problems

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -105,8 +105,8 @@ jobs:
         # setup emscripten
         git clone https://github.com/emscripten-core/emsdk.git
         cd emsdk
-        ./emsdk install latest
-        ./emsdk activate latest
+        ./emsdk install 3.1.45
+        ./emsdk activate 3.1.45
     - uses: jwlawson/actions-setup-cmake@v1.12
     - name: Build WASM
       run: |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Offline building:
 The build instructions used by our CI are in [manifold.yml](https://github.com/elalish/manifold/blob/master/.github/workflows/manifold.yml), which is a good source to check if something goes wrong and for instructions specific to other platforms, like Windows.
 
 ### WASM
+
+> Note that we have only tested emscripten version 3.1.45. It is known that
+  3.1.48 has some issues compiling manifold.
+
 To build the JS WASM library, first install NodeJS and set up emscripten:
 
 (on Mac):

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -32,9 +32,11 @@ FetchContent_Declare(Thrust
     GIT_TAG 2.1.0
     GIT_SHALLOW TRUE
     GIT_PROGRESS TRUE
-    FIND_PACKAGE_ARGS NAMES Thrust
 )
-FetchContent_MakeAvailable(Thrust)
+find_package(Thrust QUIET)
+if(NOT Thrust_FOUND AND NOT DEFINED thrust_SOURCE_DIR)
+    FetchContent_Populate(Thrust)
+endif()
 
 if (TRACY_ENABLE)
     include(FetchContent)
@@ -66,7 +68,7 @@ if(MANIFOLD_PAR STREQUAL "TBB")
             GIT_PROGRESS   TRUE
         )
         FetchContent_MakeAvailable(TBB)
-        set_property(DIRECTORY ${TBB_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL YES)
+        set_property(DIRECTORY ${tbb_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL YES)
     endif()
     target_compile_options(${PROJECT_NAME} INTERFACE -DMANIFOLD_PAR='T')
     if(TARGET TBB::tbb)
@@ -84,10 +86,10 @@ endif()
 
 target_include_directories(${PROJECT_NAME} INTERFACE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(${PROJECT_NAME} INTERFACE glm::glm)
-if(DEFINED Thrust_SOURCE_DIR)
+if(DEFINED thrust_SOURCE_DIR)
 target_include_directories(${PROJECT_NAME} INTERFACE
-    ${Thrust_SOURCE_DIR}
-    ${Thrust_SOURCE_DIR}/dependencies/libcudacxx/include
+    ${thrust_SOURCE_DIR}
+    ${thrust_SOURCE_DIR}/dependencies/libcudacxx/include
 )
 else()
 target_include_directories(${PROJECT_NAME} INTERFACE


### PR DESCRIPTION
We don't use thrust's CMake script as it can cause some weird problems on some machines, so just use `FetchContent_Populate` instead of `FetchContent_MakeAvailable`. This also fix some issues about letter case, as the [documentation](https://cmake.org/cmake/help/latest/module/FetchContent.html#command:fetchcontent_populate) states that `<lowercaseName>_SOURCE_DIR` the name is in lowercase...

Also adds emsdk version requirement. I found that the latest emsdk (3.1.48) has some issue and 3.1.45 works fine.