### PR TITLE
[FEAT] Add Batch Boolean to Python Bindings

### DIFF
--- a/bindings/python/examples/swiss_cheese.py
+++ b/bindings/python/examples/swiss_cheese.py
@@ -1,0 +1,37 @@
+"""
+ Copyright 2022 The Manifold Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+ 
+import time
+import random
+from manifold3d import Manifold
+from functools import reduce
+
+def run(n=10):
+    a = Manifold.cube(1, 1, 1).translate(-0.5, -0.5, -0.5)
+
+    spheres = [Manifold.sphere(0.01+random.random()*0.2, 50).translate(random.random()-0.5, random.random()-0.5, random.random()-0.5)
+               for i in range(n) for j in range(n)]
+
+    t0 = time.perf_counter()
+    spheres = reduce(lambda a, b: a + b, spheres)
+    slow_cheese = a - spheres
+    print("Individual cheese:", (time.perf_counter() - t0)*1000.0, "ms")
+
+    t0 = time.perf_counter()
+    fast_cheese = Manifold.batch_boolean([a]+spheres, Manifold.OpType.Difference)
+    print("Batch cheese: %s" % (time.perf_counter() - t0))
+
+    return fast_cheese

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -134,6 +134,10 @@ NB_MODULE(manifold3d, m) {
       .def(nb::self + nb::self, "Boolean union.")
       .def(nb::self - nb::self, "Boolean difference.")
       .def(nb::self ^ nb::self, "Boolean intersection.")
+      .def_static(
+          "batch_boolean",
+          [](std::vector<Manifold> &ms, OpType op) { return Manifold::BatchBoolean(ms, op); },
+          "Compute the aggregate boolean operation of a set of manifolds.")
       .def(
           "hull", [](Manifold &self) { return self.Hull(); },
           "Compute the convex hull of all points in this manifold.")
@@ -695,6 +699,11 @@ NB_MODULE(manifold3d, m) {
       .def_ro("run_index", &MeshGL::runIndex)
       .def_ro("run_original_id", &MeshGL::runOriginalID)
       .def_ro("face_id", &MeshGL::faceID);
+
+  nb::enum_<OpType>(m, "OpType")
+      .value("Add", OpType::Add)
+      .value("Subtract", OpType::Subtract)
+      .value("Intersect", OpType::Intersect);
 
   nb::enum_<Manifold::Error>(m, "Error")
       .value("NoError", Manifold::Error::NoError)


### PR DESCRIPTION
This PR adds the Batch Boolean function to the Python Bindings...

But I'm not sure if there is a speed improvement; is there any benefit to doing this, or are the manifolds already lazily evaluated when converted to meshes?  If they are, then this PR can be safely closed and ignored.