### PR TITLE
[FEAT] Add LevelSet Batch Function to Python Bindings

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -19,7 +19,7 @@ nanobind_add_module(
   manifold3d
   NB_STATIC STABLE_ABI LTO
   manifold3d.cpp)
-target_link_libraries(manifold3d PRIVATE manifold)
+target_link_libraries(manifold3d PRIVATE manifold sdf)
 target_compile_options(manifold3d PRIVATE ${MANIFOLD_FLAGS} -DMODULE_NAME=manifold3d)
 target_compile_features(manifold3d PUBLIC cxx_std_17)
 set_target_properties(manifold3d PROPERTIES OUTPUT_NAME "manifold3d")

--- a/bindings/python/examples/levelset_sdf.py
+++ b/bindings/python/examples/levelset_sdf.py
@@ -24,8 +24,8 @@ def sphere_implicit(x, y, z):
     sphere2 = 0.5 - math.sqrt((x*x) + (y*y) + (z*z))
     return min(sphere1, -sphere2)
 
-def sphere_implicit_batched(coords):
-    coords = coords.copy()
+def sphere_implicit_batched(coords_readonly):
+    coords = coords_readonly.copy() # Copy read-only coords to modify in-place
     x = coords[:, 0]; y = coords[:, 1]; z = coords[:, 2]
     sphere1 = 0.5 - np.sqrt((x*x) + (y*y) + (z*z))
     x += 0.25; y += 0.25; z -= 0.25

--- a/bindings/python/examples/levelset_sdf.py
+++ b/bindings/python/examples/levelset_sdf.py
@@ -1,0 +1,41 @@
+"""
+ Copyright 2023 The Manifold Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import math
+import numpy as np
+from manifold3d import Manifold, Mesh
+
+def sphere_implicit(x, y, z):
+    sphere1 = 0.5 - math.sqrt((x*x) + (y*y) + (z*z))
+    x += 0.25; y += 0.25; z -= 0.25
+    sphere2 = 0.5 - math.sqrt((x*x) + (y*y) + (z*z))
+    return min(sphere1, -sphere2)
+
+def sphere_implicit_batched(coords):
+    coords = coords.copy()
+    x = coords[:, 0]; y = coords[:, 1]; z = coords[:, 2]
+    sphere1 = 0.5 - np.sqrt((x*x) + (y*y) + (z*z))
+    x += 0.25; y += 0.25; z -= 0.25
+    sphere2 = 0.5 - np.sqrt((x*x) + (y*y) + (z*z))
+    return np.minimum(sphere1, -sphere2)
+
+def run():
+    levelset_mesh_slow = Mesh.levelset      (sphere_implicit,         [-0.5, -0.5, -0.5, 0.5, 0.5, 0.5], 0.05, 0.0)
+    levelset_mesh_fast = Mesh.levelset_batch(sphere_implicit_batched, [-0.5, -0.5, -0.5, 0.5, 0.5, 0.5], 0.05, 0.0, False)
+    model_slow = Manifold.from_mesh(levelset_mesh_slow)
+    model_fast = Manifold.from_mesh(levelset_mesh_fast)
+    assert abs(model_slow.get_volume() - model_fast.get_volume()) < 0.0000001
+    return model_slow

--- a/bindings/python/examples/levelset_winding_number.py
+++ b/bindings/python/examples/levelset_winding_number.py
@@ -1,0 +1,70 @@
+"""
+ Copyright 2023 The Manifold Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import numpy as np
+from manifold3d import Manifold, Mesh
+
+# Generalized Winding Numbers Implementation from 
+# https://github.com/marmakoide/inside-3d-mesh/blob/master/is_inside_mesh.py#L28
+
+def is_inside_turbo(triangles, X):
+    # Compute euclidean norm along axis 1
+    def anorm2(X):
+        return np.sqrt(np.sum(X ** 2, axis = 1))
+
+    # Compute 3x3 determinant along axis 1
+    def adet(X, Y, Z):
+        ret  = np.multiply(np.multiply(X[:,0], Y[:,1]), Z[:,2])
+        ret += np.multiply(np.multiply(Y[:,0], Z[:,1]), X[:,2])
+        ret += np.multiply(np.multiply(Z[:,0], X[:,1]), Y[:,2])
+        ret -= np.multiply(np.multiply(Z[:,0], Y[:,1]), X[:,2])
+        ret -= np.multiply(np.multiply(Y[:,0], X[:,1]), Z[:,2])
+        ret -= np.multiply(np.multiply(X[:,0], Z[:,1]), Y[:,2])
+        return ret
+
+    # One generalized winding number per input vertex
+    ret = np.zeros(X.shape[0], dtype = X.dtype)
+
+    # Accumulate generalized winding number for each triangle
+    for U, V, W in triangles:
+        A, B, C = U - X, V - X, W - X
+        omega = adet(A, B, C)
+        a, b, c = anorm2(A), anorm2(B), anorm2(C)
+        k  = a * b * c 
+        k += c * np.sum(np.multiply(A, B), axis = 1)
+        k += a * np.sum(np.multiply(B, C), axis = 1)
+        k += b * np.sum(np.multiply(C, A), axis = 1)
+        ret += np.arctan2(omega, k)
+    return ret # Job done
+
+def mesh_winding_number_batched(queries):
+    isosurface = 1.8
+    tris = np.array([[[ 0.5  ,  0.5,  0.0], # Top Right Tri
+                      [ 0.125,  0.0,  0.5], 
+                      [ 0.5  , -0.5,  0.0]],
+                     [[-0.125,  0.0,  0.5], # Top Left Tri
+                      [-0.5  ,  0.5,  0.0],
+                      [-0.5  , -0.5,  0.0]],
+                     [[ 0.0  ,  0.5, -0.5], # Bottom Tri
+                      [ 0.5  , -0.5, -0.5], 
+                      [-0.5  , -0.5, -0.5]]])
+    return is_inside_turbo(tris, queries) - isosurface
+
+def run():
+    levelset_mesh = Mesh.levelset_batch(mesh_winding_number_batched, 
+                                        [-0.5, -0.5, -0.5, 0.5, 0.5, 0.5], 0.05, 0.0, False)
+    model = Manifold.from_mesh(levelset_mesh)
+    return model

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -580,15 +580,16 @@ NB_MODULE(manifold3d, m) {
           [](const std::function<float(Float3)> &f, std::vector<float> bounds,
              float edgeLength, float level = 0.0, bool canParallel = false) {
             // Same format as Manifold.bounding_box
-            Box bound = { glm::vec3(bounds[0], bounds[1], bounds[2]),
-                          glm::vec3(bounds[3], bounds[4], bounds[5]) };
+            Box bound = {glm::vec3(bounds[0], bounds[1], bounds[2]),
+                         glm::vec3(bounds[3], bounds[4], bounds[5])};
             Mesh result = LevelSet(
-                [&f](glm::vec3 &v) { 
-                    return f(std::make_tuple(v.x, v.y, v.z)); },
+                [&f](glm::vec3 &v) {
+                    return f(std::make_tuple(v.x, v.y, v.z));
+                },
                 bound, edgeLength, level, canParallel);
             return Manifold::Manifold(result);
           },
-          nb::arg("f"), nb::arg("bounds"), nb::arg("edgeLength"), 
+          nb::arg("f"), nb::arg("bounds"), nb::arg("edgeLength"),
           nb::arg("level") = 0.0, nb::arg("canParallel") = false,
           "Constructs a level-set Mesh from the input Signed-Distance Function "
           "(SDF) This uses a form of Marching Tetrahedra (akin to Marching "

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -578,8 +578,8 @@ NB_MODULE(manifold3d, m) {
       .def_static(
           "levelset",
           [](const std::function<float(float, float, float)> &f,
-              std::vector<float> bounds, float edgeLength, float level = 0.0,
-              bool canParallel = false) {
+             std::vector<float> bounds, float edgeLength, float level = 0.0,
+             bool canParallel = false) {
             // Same format as Manifold.bounding_box
             Box bound = {glm::vec3(bounds[0], bounds[1], bounds[2]),
                          glm::vec3(bounds[3], bounds[4], bounds[5])};

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -577,15 +577,13 @@ NB_MODULE(manifold3d, m) {
           "planes. Default is calculated by the static Defaults.")
       .def_static(
           "levelset",
-          [](const std::function<float(Float3)> &f, std::vector<float> bounds,
+          [](const std::function<float(float, float, float)> &f, std::vector<float> bounds,
              float edgeLength, float level = 0.0, bool canParallel = false) {
             // Same format as Manifold.bounding_box
             Box bound = {glm::vec3(bounds[0], bounds[1], bounds[2]),
                          glm::vec3(bounds[3], bounds[4], bounds[5])};
             Mesh result = LevelSet(
-                [&f](glm::vec3 &v) {
-                  return f(std::make_tuple(v.x, v.y, v.z));
-                },
+                [&f](glm::vec3 &v) {return f(v.x, v.y, v.z);},
                 bound, edgeLength, level, canParallel);
             return Manifold(result);
           },

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -17,7 +17,6 @@
 
 #include "cross_section.h"
 #include "manifold.h"
-#include "sdf.h"
 #include "nanobind/nanobind.h"
 #include "nanobind/ndarray.h"
 #include "nanobind/operators.h"
@@ -25,6 +24,7 @@
 #include "nanobind/stl/optional.h"
 #include "nanobind/stl/tuple.h"
 #include "nanobind/stl/vector.h"
+#include "sdf.h"
 
 template <>
 struct nanobind::detail::type_caster<glm::vec3> {
@@ -584,7 +584,7 @@ NB_MODULE(manifold3d, m) {
                          glm::vec3(bounds[3], bounds[4], bounds[5])};
             Mesh result = LevelSet(
                 [&f](glm::vec3 &v) {
-                    return f(std::make_tuple(v.x, v.y, v.z));
+                  return f(std::make_tuple(v.x, v.y, v.z));
                 },
                 bound, edgeLength, level, canParallel);
             return Manifold::Manifold(result);

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -587,7 +587,7 @@ NB_MODULE(manifold3d, m) {
                   return f(std::make_tuple(v.x, v.y, v.z));
                 },
                 bound, edgeLength, level, canParallel);
-            return Manifold::Manifold(result);
+            return Manifold(result);
           },
           nb::arg("f"), nb::arg("bounds"), nb::arg("edgeLength"),
           nb::arg("level") = 0.0, nb::arg("canParallel") = false,

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -618,8 +618,7 @@ NB_MODULE(manifold3d, m) {
           "levelset_batch",
           [](const std::function<std::vector<float>(std::vector<float>)> &f,
              std::vector<float> bounds, float edgeLength, float level = 0.0,
-             bool canParallel = false,
-             std::function<void(const char *)> print = nullptr) {
+             bool canParallel = false) {
             // Same format as Manifold.bounding_box
             Box bound = {glm::vec3(bounds[0], bounds[1], bounds[2]),
                          glm::vec3(bounds[3], bounds[4], bounds[5])};
@@ -634,13 +633,11 @@ NB_MODULE(manifold3d, m) {
                   }
                   return f(coords);
                 },
-                bound, edgeLength, level, canParallel,
-                [](const char *str) { nb::print(str); });
+                bound, edgeLength, level, canParallel);
             return Manifold(result);
           },
           nb::arg("f"), nb::arg("bounds"), nb::arg("edgeLength"),
           nb::arg("level") = 0.0, nb::arg("canParallel") = false,
-          nb::arg("print") = nullptr,
           "Similar to LevelSet, this constructs a level-set Mesh from the input"
           "Signed-Distance Function (SDF). This variant feeds an std:vector of points"
           "to the function, allowing the function to compute signed distances using"

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -705,7 +705,7 @@ NB_MODULE(manifold3d, m) {
             Box bound = {glm::vec3(bounds[0], bounds[1], bounds[2]),
                          glm::vec3(bounds[3], bounds[4], bounds[5])};
 
-            std::function<float(glm::vec3)> cppToPython = 
+            std::function<float(glm::vec3&)> cppToPython = 
                 [&f](glm::vec3 &v) { return f(v.x, v.y, v.z); };
             Mesh result =
                 LevelSet(cppToPython, bound,
@@ -750,7 +750,7 @@ NB_MODULE(manifold3d, m) {
             Box bound = {glm::vec3(bounds[0], bounds[1], bounds[2]),
                          glm::vec3(bounds[3], bounds[4], bounds[5])};
 
-            std::function <std::vector<float>(std::vector<glm::vec3>)> 
+            std::function <std::vector<float>(std::vector<glm::vec3>&)> 
                 cppToPython = [&f](std::vector<glm::vec3> &v) {
                   size_t coordsShape[2] = {v.size(), 3};
                   auto d = f(nb::ndarray<nb::numpy, const float, nb::c_contig>(

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -577,14 +577,15 @@ NB_MODULE(manifold3d, m) {
           "planes. Default is calculated by the static Defaults.")
       .def_static(
           "levelset",
-          [](const std::function<float(float, float, float)> &f, std::vector<float> bounds,
-             float edgeLength, float level = 0.0, bool canParallel = false) {
+          [](const std::function<float(float, float, float)> &f,
+              std::vector<float> bounds, float edgeLength, float level = 0.0,
+              bool canParallel = false) {
             // Same format as Manifold.bounding_box
             Box bound = {glm::vec3(bounds[0], bounds[1], bounds[2]),
                          glm::vec3(bounds[3], bounds[4], bounds[5])};
-            Mesh result = LevelSet(
-                [&f](glm::vec3 &v) {return f(v.x, v.y, v.z);},
-                bound, edgeLength, level, canParallel);
+            Mesh result =
+                LevelSet([&f](glm::vec3 &v) { return f(v.x, v.y, v.z); }, bound,
+                         edgeLength, level, canParallel);
             return Manifold(result);
           },
           nb::arg("f"), nb::arg("bounds"), nb::arg("edgeLength"),

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -575,90 +575,6 @@ NB_MODULE(manifold3d, m) {
           "four, as this sphere is constructed by refining an octahedron. This "
           "means there are a circle of vertices on all three of the axis "
           "planes. Default is calculated by the static Defaults.")
-      .def_static(
-          "levelset",
-          [](const std::function<float(float, float, float)> &f,
-             std::vector<float> bounds, float edgeLength, float level = 0.0,
-             bool canParallel = false) {
-            // Same format as Manifold.bounding_box
-            Box bound = {glm::vec3(bounds[0], bounds[1], bounds[2]),
-                         glm::vec3(bounds[3], bounds[4], bounds[5])};
-            Mesh result =
-                LevelSet([&f](glm::vec3 &v) { return f(v.x, v.y, v.z); }, bound,
-                         edgeLength, level, canParallel);
-            return Manifold(result);
-          },
-          nb::arg("f"), nb::arg("bounds"), nb::arg("edgeLength"),
-          nb::arg("level") = 0.0, nb::arg("canParallel") = false,
-          "Constructs a level-set Mesh from the input Signed-Distance Function "
-          "(SDF) This uses a form of Marching Tetrahedra (akin to Marching "
-          "Cubes, but better for manifoldness). Instead of using a cubic grid, "
-          "it uses a body-centered cubic grid (two shifted cubic grids). This "
-          "means if your function's interior exceeds the given bounds, you "
-          "will see a kind of egg-crate shape closing off the manifold, which "
-          "is due to the underlying grid."
-          "\n\n"
-          ":param f: The signed-distance functor, containing this function "
-          "signature: `def sdf(xyz : tuple) -> float:`, which returns the "
-          "signed distance of a given point in R^3. Positive values are "
-          "inside, negative outside."
-          ":param bounds: An axis-aligned box that defines the extent of the "
-          "grid."
-          ":param edgeLength: Approximate maximum edge length of the triangles "
-          "in the final result.This affects grid spacing, and hence has a "
-          "strong effect on performance."
-          ":param level: You can inset your Mesh by using a positive value, or "
-          "outset it with a negative value."
-          ":param canParallel: Parallel policies violate will crash language "
-          "runtimes with runtime locks that expect to not be called back by "
-          "unregistered threads.This allows bindings use LevelSet despite "
-          "being compiled with MANIFOLD_PAR active."
-          ":return Manifold: This is guaranteed to be manifold.")
-      .def_static(
-          "levelset_batch",
-          [](const std::function<
-                 nb::ndarray<nb::numpy, const float, nb::c_contig>(
-                 nb::ndarray<nb::numpy, const float, nb::c_contig>)> &f,
-             std::vector<float> bounds, float edgeLength, float level = 0.0,
-             bool canParallel = false) {
-            // Same format as Manifold.bounding_box
-            Box bound = {glm::vec3(bounds[0], bounds[1], bounds[2]),
-                         glm::vec3(bounds[3], bounds[4], bounds[5])};
-
-            Mesh result = LevelSetBatch(
-                [&f](std::vector<glm::vec3> &v) {
-                  size_t coordsShape[2] = {v.size(), 3};
-                  nb::ndarray<nb::numpy, const float, nb::c_contig> d =
-                      f(nb::ndarray<nb::numpy, const float, nb::c_contig>(
-                          v.data(), 2, coordsShape));
-                  return std::vector<float>(d.data(), d.data() + v.size());
-                },
-                bound, edgeLength, level, canParallel);
-            return Manifold(result);
-          },
-          nb::arg("f"), nb::arg("bounds"), nb::arg("edgeLength"),
-          nb::arg("level") = 0.0, nb::arg("canParallel") = false,
-          "Similar to LevelSet, this constructs a level-set Mesh from the input"
-          "Signed-Distance Function (SDF). This variant feeds a [N,3] ndarray"
-          "of points to the function, allowing the function to compute signed"
-          "distances using its own threading/parallelization paradigm."
-          "\n\n"
-          ":param f: The signed-distance functor, containing this function "
-          "signature: `def sdf(xyz : ndarray) -> ndarray:`, which returns the "
-          "signed distance of a given point in R^3. Positive values are "
-          "inside, negative outside."
-          ":param bounds: An axis-aligned box that defines the extent of the "
-          "grid."
-          ":param edgeLength: Approximate maximum edge length of the triangles "
-          "in the final result.This affects grid spacing, and hence has a "
-          "strong effect on performance."
-          ":param level: You can inset your Mesh by using a positive value, or "
-          "outset it with a negative value."
-          ":param canParallel: Parallel policies violate will crash language "
-          "runtimes with runtime locks that expect to not be called back by "
-          "unregistered threads.This allows bindings use LevelSet despite "
-          "being compiled with MANIFOLD_PAR active."
-          ":return Manifold: This is guaranteed to be manifold.")
       .def_static("reserve_ids", Manifold::ReserveIDs, nb::arg("n"),
                   "Returns the first of n sequential new unique mesh IDs for "
                   "marking sets of triangles that can be looked up after "
@@ -779,7 +695,93 @@ NB_MODULE(manifold3d, m) {
       .def_ro("merge_to_vert", &MeshGL::mergeToVert)
       .def_ro("run_index", &MeshGL::runIndex)
       .def_ro("run_original_id", &MeshGL::runOriginalID)
-      .def_ro("face_id", &MeshGL::faceID);
+      .def_ro("face_id", &MeshGL::faceID)
+      .def_static(
+          "levelset",
+          [](const std::function<float(float, float, float)> &f,
+             std::vector<float> bounds, float edgeLength, float level = 0.0,
+             bool canParallel = false) {
+            // Same format as Manifold.bounding_box
+            Box bound = {glm::vec3(bounds[0], bounds[1], bounds[2]),
+                         glm::vec3(bounds[3], bounds[4], bounds[5])};
+            Mesh result =
+                LevelSet([&f](glm::vec3 &v) { return f(v.x, v.y, v.z); }, bound,
+                         edgeLength, level, canParallel);
+            return MeshGL(result);
+          },
+          nb::arg("f"), nb::arg("bounds"), nb::arg("edgeLength"),
+          nb::arg("level") = 0.0, nb::arg("canParallel") = false,
+          "Constructs a level-set Mesh from the input Signed-Distance Function "
+          "(SDF) This uses a form of Marching Tetrahedra (akin to Marching "
+          "Cubes, but better for manifoldness). Instead of using a cubic grid, "
+          "it uses a body-centered cubic grid (two shifted cubic grids). This "
+          "means if your function's interior exceeds the given bounds, you "
+          "will see a kind of egg-crate shape closing off the manifold, which "
+          "is due to the underlying grid."
+          "\n\n"
+          ":param f: The signed-distance functor, containing this function "
+          "signature: `def sdf(xyz : tuple) -> float:`, which returns the "
+          "signed distance of a given point in R^3. Positive values are "
+          "inside, negative outside."
+          ":param bounds: An axis-aligned box that defines the extent of the "
+          "grid."
+          ":param edgeLength: Approximate maximum edge length of the triangles "
+          "in the final result.This affects grid spacing, and hence has a "
+          "strong effect on performance."
+          ":param level: You can inset your Mesh by using a positive value, or "
+          "outset it with a negative value."
+          ":param canParallel: Parallel policies violate will crash language "
+          "runtimes with runtime locks that expect to not be called back by "
+          "unregistered threads.This allows bindings use LevelSet despite "
+          "being compiled with MANIFOLD_PAR active."
+          ":return Mesh: This mesh is guaranteed to be manifold."
+          "Use Manifold.from_mesh(mesh) to create a Manifold")
+      .def_static(
+          "levelset_batch",
+          [](const std::function<
+                 nb::ndarray<nb::numpy, const float, nb::c_contig>(
+                 nb::ndarray<nb::numpy, const float, nb::c_contig>)> &f,
+             std::vector<float> bounds, float edgeLength, float level = 0.0,
+             bool canParallel = false) {
+            // Same format as Manifold.bounding_box
+            Box bound = {glm::vec3(bounds[0], bounds[1], bounds[2]),
+                         glm::vec3(bounds[3], bounds[4], bounds[5])};
+
+            Mesh result = LevelSetBatch(
+                [&f](std::vector<glm::vec3> &v) {
+                  size_t coordsShape[2] = {v.size(), 3};
+                  nb::ndarray<nb::numpy, const float, nb::c_contig> d =
+                      f(nb::ndarray<nb::numpy, const float, nb::c_contig>(
+                          v.data(), 2, coordsShape));
+                  return std::vector<float>(d.data(), d.data() + v.size());
+                },
+                bound, edgeLength, level, canParallel);
+            return MeshGL(result);
+          },
+          nb::arg("f"), nb::arg("bounds"), nb::arg("edgeLength"),
+          nb::arg("level") = 0.0, nb::arg("canParallel") = false,
+          "Similar to LevelSet, this constructs a level-set Mesh from the input"
+          "Signed-Distance Function (SDF). This variant feeds a [N,3] ndarray"
+          "of points to the function, allowing the function to compute signed"
+          "distances using its own threading/parallelization paradigm."
+          "\n\n"
+          ":param f: The signed-distance functor, containing this function "
+          "signature: `def sdf(xyz : ndarray) -> ndarray:`, which returns the "
+          "signed distance of a given point in R^3. Positive values are "
+          "inside, negative outside."
+          ":param bounds: An axis-aligned box that defines the extent of the "
+          "grid."
+          ":param edgeLength: Approximate maximum edge length of the triangles "
+          "in the final result.This affects grid spacing, and hence has a "
+          "strong effect on performance."
+          ":param level: You can inset your Mesh by using a positive value, or "
+          "outset it with a negative value."
+          ":param canParallel: Parallel policies violate will crash language "
+          "runtimes with runtime locks that expect to not be called back by "
+          "unregistered threads.This allows bindings use LevelSet despite "
+          "being compiled with MANIFOLD_PAR active."
+          ":return Mesh: This mesh is guaranteed to be manifold."
+          "Use Manifold.from_mesh(mesh) to create a Manifold");
 
   nb::enum_<Manifold::Error>(m, "Error")
       .value("NoError", Manifold::Error::NoError)

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -705,8 +705,8 @@ NB_MODULE(manifold3d, m) {
             Box bound = {glm::vec3(bounds[0], bounds[1], bounds[2]),
                          glm::vec3(bounds[3], bounds[4], bounds[5])};
 
-            std::function<float(glm::vec3&)> cppToPython = 
-                [&f](glm::vec3 &v) { return f(v.x, v.y, v.z); };
+            std::function<float(glm::vec3)> cppToPython = 
+                [&f](glm::vec3 v) { return f(v.x, v.y, v.z); };
             Mesh result =
                 LevelSet(cppToPython, bound,
                          edgeLength, level, canParallel);
@@ -750,8 +750,8 @@ NB_MODULE(manifold3d, m) {
             Box bound = {glm::vec3(bounds[0], bounds[1], bounds[2]),
                          glm::vec3(bounds[3], bounds[4], bounds[5])};
 
-            std::function <std::vector<float>(std::vector<glm::vec3>&)> 
-                cppToPython = [&f](std::vector<glm::vec3> &v) {
+            std::function <std::vector<float>(std::vector<glm::vec3>)> 
+                cppToPython = [&f](std::vector<glm::vec3> v) {
                   size_t coordsShape[2] = {v.size(), 3};
                   auto d = f(nb::ndarray<nb::numpy, const float, nb::c_contig>(
                       v.data(), 2, coordsShape));

--- a/src/sdf/include/sdf.h
+++ b/src/sdf/include/sdf.h
@@ -21,4 +21,8 @@
 namespace manifold {
 Mesh LevelSet(std::function<float(glm::vec3)> sdf, Box bounds, float edgeLength,
               float level = 0, bool canParallel = true);
+Mesh LevelSetBatch(
+              std::function<std::vector<float>(std::vector<glm::vec3>)> sdf,
+              Box bounds, float edgeLength,float level = 0, bool canParallel = true,
+              std::function<void(const char *)> print = nullptr);
 }

--- a/src/sdf/include/sdf.h
+++ b/src/sdf/include/sdf.h
@@ -22,7 +22,6 @@ namespace manifold {
 Mesh LevelSet(std::function<float(glm::vec3)> sdf, Box bounds, float edgeLength,
               float level = 0, bool canParallel = true);
 Mesh LevelSetBatch(
-              std::function<std::vector<float>(std::vector<glm::vec3>)> sdf,
-              Box bounds, float edgeLength,float level = 0,
-              bool canParallel = true);
-}
+    std::function<std::vector<float>(std::vector<glm::vec3>)> sdf, Box bounds,
+    float edgeLength, float level = 0, bool canParallel = true);
+}  // namespace manifold

--- a/src/sdf/include/sdf.h
+++ b/src/sdf/include/sdf.h
@@ -23,6 +23,6 @@ Mesh LevelSet(std::function<float(glm::vec3)> sdf, Box bounds, float edgeLength,
               float level = 0, bool canParallel = true);
 Mesh LevelSetBatch(
               std::function<std::vector<float>(std::vector<glm::vec3>)> sdf,
-              Box bounds, float edgeLength,float level = 0, bool canParallel = true,
-              std::function<void(const char *)> print = nullptr);
+              Box bounds, float edgeLength,float level = 0,
+              bool canParallel = true);
 }

--- a/src/sdf/src/sdf.cpp
+++ b/src/sdf/src/sdf.cpp
@@ -362,8 +362,6 @@ Mesh LevelSet(std::function<float(glm::vec3)> sdf, Box bounds, float edgeLength,
   return out;
 }
 
-
-
 /**
  * Similar to LevelSet, this constructs a level-set Mesh from the input
  * Signed-Distance Function (SDF). This variant feeds an std:vector of points
@@ -469,7 +467,7 @@ Mesh LevelSetBatch(
 
     if (!gridVerts.Full()) {
       if (keep) {
-          gridVerts.D().Insert(i, gridVert);
+        gridVerts.D().Insert(i, gridVert);
       }
       vertPos.resize(vertIndex);  // Success
     } else {                      // Resize HashTable

--- a/src/sdf/src/sdf.cpp
+++ b/src/sdf/src/sdf.cpp
@@ -365,7 +365,7 @@ Mesh LevelSet(std::function<float(glm::vec3)> sdf, Box bounds, float edgeLength,
 
 
 /**
- * Similar to LevelSet, this constructs a level-set Mesh from the input 
+ * Similar to LevelSet, this constructs a level-set Mesh from the input
  * Signed-Distance Function (SDF). This variant feeds an std:vector of points
  * to the function, allowing the function to compute signed distances using
  * its own threading/parallelization paradigm.
@@ -388,9 +388,9 @@ Mesh LevelSet(std::function<float(glm::vec3)> sdf, Box bounds, float edgeLength,
  * Mesh, but it is guaranteed to be manifold and so can always be used as
  * input to the Manifold constructor for further operations.
  */
-Mesh LevelSetBatch(std::function<std::vector<float>(
-              std::vector<glm::vec3>)> sdf, Box bounds, float edgeLength,
-              float level, bool canParallel) {
+Mesh LevelSetBatch(
+    std::function<std::vector<float>(std::vector<glm::vec3>)> sdf, Box bounds,
+    float edgeLength, float level, bool canParallel) {
   Mesh out;
 
   const glm::vec3 dim = bounds.Size();
@@ -419,7 +419,7 @@ Mesh LevelSetBatch(std::function<std::vector<float>(
     const glm::ivec4 gridIndex = DecodeMorton(i);
     // TODO: Handle grid indices outside of the traditional bounds...
     // Indexing gets tough when coordinates are discarded...
-    //assert(!(glm::any(glm::greaterThan(glm::ivec3(gridIndex), gridSize))));
+    // assert(!(glm::any(glm::greaterThan(glm::ivec3(gridIndex), gridSize))));
     gridCoordinates[i] = Position(gridIndex, bounds.min, spacing);
   }
 
@@ -468,9 +468,11 @@ Mesh LevelSetBatch(std::function<std::vector<float>(
     }
 
     if (!gridVerts.Full()) {
-      if (keep) { gridVerts.D().Insert(i, gridVert); }
-      vertPos.resize(vertIndex); // Success
-    } else {  // Resize HashTable
+      if (keep) {
+          gridVerts.D().Insert(i, gridVert);
+      }
+      vertPos.resize(vertIndex);  // Success
+    } else {                      // Resize HashTable
       const glm::vec3 lastVert = vertPos[vertIndex - 1];
       const Uint64 lastMorton =
           MortonCode(glm::ivec4((lastVert - bounds.min) / spacing, 1));

--- a/src/sdf/src/sdf.cpp
+++ b/src/sdf/src/sdf.cpp
@@ -363,14 +363,14 @@ Mesh LevelSet(std::function<float(glm::vec3)> sdf, Box bounds, float edgeLength,
 }
 
 /**
- * Similar to LevelSet, this constructs a level-set Mesh from the input
+ * Similar to LevelSet, this constructs a level-set Mesh from an input
  * Signed-Distance Function (SDF). This variant feeds an std:vector of points
  * to the function, allowing the function to compute signed distances using
  * its own threading/parallelization paradigm.
  *
  * @param sdf The signed-distance functor, containing this function signature:
- * `float operator()(glm::vec3 point)`, which returns the
- * signed distance of a given point in R^3. Positive values are inside,
+ * `std::vector<float> operator()(std::vector<glm::vec3> points)`, which returns
+ * the signed distances of each input point in R^3. Positive values are inside,
  * negative outside.
  * @param bounds An axis-aligned box that defines the extent of the grid.
  * @param edgeLength Approximate maximum edge length of the triangles in the

--- a/src/sdf/src/sdf.cpp
+++ b/src/sdf/src/sdf.cpp
@@ -99,7 +99,7 @@ Uint64 SqueezeBits3(Uint64 v) {
 // y, and z channel and 1 for w, filling the 64 bit total.
 Uint64 MortonCode(const glm::ivec4& index) {
   return static_cast<Uint64>(index.w) | (SpreadBits3(index.x) << 1) |
-          (SpreadBits3(index.y) << 2) | (SpreadBits3(index.z) << 3);
+         (SpreadBits3(index.y) << 2) | (SpreadBits3(index.z) << 3);
 }
 
 glm::ivec4 DecodeMorton(Uint64 code) {
@@ -431,9 +431,10 @@ Mesh LevelSetBatch(
     const glm::ivec4 gridIndex = DecodeMorton(i);
     const glm::ivec3 xyz(gridIndex);
     const bool onLowerBound = glm::any(glm::lessThanEqual(xyz, glm::ivec3(0)));
-    const bool onUpperBound = glm::any(glm::greaterThanEqual(xyz, (gridSize+1)));
-    const bool onHalfBound =
-        gridIndex.w == 1 && glm::any(glm::greaterThanEqual(xyz,   (gridSize+1) - 1));
+    const bool onUpperBound =
+        glm::any(glm::greaterThanEqual(xyz, (gridSize + 1)));
+    const bool onHalfBound = gridIndex.w == 1 && glm::any(glm::greaterThanEqual(
+                                                     xyz, (gridSize + 1) - 1));
     gridDistances[i] =
         (onLowerBound || onUpperBound || onHalfBound) ? glm::min(d, 0.0f) : d;
   }
@@ -441,10 +442,11 @@ Mesh LevelSetBatch(
   // Retry Implicit Construction with progressively larger and larger hashtables
   while (1) {
     // Check each grid coordinate to see if its neighbors cross the 0 threshold
-    size_t vertIndex  = 0;
+    size_t vertIndex = 0;
     Uint64 lastMorton = 0;
     for (Uint64 i = 0; i < maxMorton + 1; i++) {
-      if (gridVerts.Full()) break; // Cancel out of loop if we've run out of space
+      if (gridVerts.Full())
+        break;  // Cancel out of loop if we've run out of space
 
       const glm::ivec4 gridIndex = DecodeMorton(i);
       GridVert gridVert;
@@ -491,7 +493,7 @@ Mesh LevelSetBatch(
       gridVerts = HashTable<GridVert, identity>(tableSize);
       vertPos = Vec<glm::vec3>(gridVerts.Size() * 7);
     } else {
-      vertPos.resize(vertIndex+1);
+      vertPos.resize(vertIndex + 1);
       break;
     }
   }

--- a/test/sdf_test.cpp
+++ b/test/sdf_test.cpp
@@ -77,8 +77,6 @@ TEST(SDF, BatchValidation) {
       },
       {glm::vec3(-size), glm::vec3(size)}, edgeLength);
 
-  // EXPECT_EQ(levelSet.vertPos .size(), levelSetBatch.vertPos .size());
-
   EXPECT_EQ(levelSet.triVerts.size(), levelSetBatch.triVerts.size());
 
   Manifold gyroid(levelSet);
@@ -96,204 +94,141 @@ TEST(SDF, BatchValidation) {
   EXPECT_EQ(batchGyroid.Status(), Manifold::Error::NoError);
   EXPECT_EQ(gyroid.Genus(), batchGyroid.Genus());
   const float outerBound = size + edgeLength / 2;
-  EXPECT_NEAR(bounds.min.x, -outerBound, precision);
-  EXPECT_NEAR(bounds.min.y, -outerBound, precision);
-  EXPECT_NEAR(bounds.min.z, -outerBound, precision);
-  EXPECT_NEAR(bounds.max.x, outerBound, precision);
-  EXPECT_NEAR(bounds.max.y, outerBound, precision);
-  EXPECT_NEAR(bounds.max.z, outerBound, precision);
-  EXPECT_NEAR(boundsBatch.min.x, -outerBound, precisionBatch);
-  EXPECT_NEAR(boundsBatch.min.y, -outerBound, precisionBatch);
-  EXPECT_NEAR(boundsBatch.min.z, -outerBound, precisionBatch);
-  EXPECT_NEAR(boundsBatch.max.x, outerBound, precisionBatch);
-  EXPECT_NEAR(boundsBatch.max.y, outerBound, precisionBatch);
-  EXPECT_NEAR(boundsBatch.max.z, outerBound, precisionBatch);
-}
-
-TEST(SDF, BatchBounds) {
-  const float size = 4;
-  const float edgeLength = 0.5;
-
-  Mesh levelSet = LevelSetBatch(
-      [](std::vector<glm::vec3> pvec) {
-        std::vector<float> dvec(pvec.size());
-        for (int i = 0; i < pvec.size(); i++) {
-          dvec[i] = CubeVoid()(pvec[i]);
-        }
-        return dvec;
-      },
-      {glm::vec3(-size / 2), glm::vec3(size / 2)}, edgeLength);
-  Manifold cubeVoid(levelSet);
-  Box bounds = cubeVoid.BoundingBox();
-  const float precision = cubeVoid.Precision();
-#ifdef MANIFOLD_EXPORT
-  if (options.exportModels) ExportMesh("batchcubeVoid.gltf", levelSet, {});
-#endif
-
-  EXPECT_EQ(cubeVoid.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(cubeVoid.Genus(), -1);
-  const float outerBound = size / 2 + edgeLength / 2;
-  EXPECT_NEAR(bounds.min.x, -outerBound, precision);
-  EXPECT_NEAR(bounds.min.y, -outerBound, precision);
-  EXPECT_NEAR(bounds.min.z, -outerBound, precision);
-  EXPECT_NEAR(bounds.max.x, outerBound, precision);
-  EXPECT_NEAR(bounds.max.y, outerBound, precision);
-  EXPECT_NEAR(bounds.max.z, outerBound, precision);
-}
-
-TEST(SDF, BatchSurface) {
-  const float size = 4;
-  const float edgeLength = 0.5;
-
-  Manifold cubeVoid(LevelSetBatch(
-      [](std::vector<glm::vec3> pvec) {
-        std::vector<float> dvec(pvec.size());
-        for (int i = 0; i < pvec.size(); i++) {
-          dvec[i] = CubeVoid()(pvec[i]);
-        }
-        return dvec;
-      },
-      {glm::vec3(-size / 2), glm::vec3(size / 2)}, edgeLength));
-
-  Manifold cube = Manifold::Cube(glm::vec3(size), true);
-  cube -= cubeVoid;
-  Box bounds = cube.BoundingBox();
-  const float precision = cube.Precision();
-#ifdef MANIFOLD_EXPORT
-  if (options.exportModels) ExportMesh("batchcube.gltf", cube.GetMesh(), {});
-#endif
-
-  EXPECT_EQ(cubeVoid.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(cube.Genus(), 0);
-  auto prop = cube.GetProperties();
-  EXPECT_NEAR(prop.volume, 8, 0.001);
-  EXPECT_NEAR(prop.surfaceArea, 24, 0.001);
-  EXPECT_NEAR(bounds.min.x, -1, precision);
-  EXPECT_NEAR(bounds.min.y, -1, precision);
-  EXPECT_NEAR(bounds.min.z, -1, precision);
-  EXPECT_NEAR(bounds.max.x, 1, precision);
-  EXPECT_NEAR(bounds.max.y, 1, precision);
-  EXPECT_NEAR(bounds.max.z, 1, precision);
-}
-
-TEST(SDF, BatchResize) {
-  const float size = 20;
-  Manifold layers(LevelSetBatch(
-      [](std::vector<glm::vec3> pvec) {
-        std::vector<float> dvec(pvec.size());
-        for (int i = 0; i < pvec.size(); i++) {
-          dvec[i] = Layers()(pvec[i]);
-        }
-        return dvec;
-      },
-      {glm::vec3(0), glm::vec3(size)}, 1));
-#ifdef MANIFOLD_EXPORT
-  if (options.exportModels) ExportMesh("layers.gltf", layers.GetMesh(), {});
-#endif
-
-  EXPECT_EQ(layers.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(layers.Genus(), -8);
-}
-
-TEST(SDF, BatchSineSurface) {
-  Mesh surface(LevelSetBatch(
-      [](std::vector<glm::vec3> pvec) {
-        std::vector<float> dvec(pvec.size());
-        for (int i = 0; i < pvec.size(); i++) {
-          float mid = glm::sin(pvec[i].x) + glm::sin(pvec[i].y);
-          dvec[i] = (pvec[i].z > mid - 0.5 && pvec[i].z < mid + 0.5) ? 1 : 0;
-        }
-        return dvec;
-      },
-      {glm::vec3(-4 * glm::pi<float>()), glm::vec3(4 * glm::pi<float>())}, 1));
-  Manifold smoothed = Manifold::Smooth(surface).Refine(2);
-
-  EXPECT_EQ(smoothed.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(smoothed.Genus(), -2);
-
-#ifdef MANIFOLD_EXPORT
-  if (options.exportModels)
-    ExportMesh("batchsinesurface.glb", smoothed.GetMeshGL(), {});
-#endif
+  for (const Box bound : {bounds, boundsBatch}) {
+    EXPECT_NEAR(bounds.min.x, -outerBound, precision);
+    EXPECT_NEAR(bounds.min.y, -outerBound, precision);
+    EXPECT_NEAR(bounds.min.z, -outerBound, precision);
+    EXPECT_NEAR(bounds.max.x, outerBound, precision);
+    EXPECT_NEAR(bounds.max.y, outerBound, precision);
+    EXPECT_NEAR(bounds.max.z, outerBound, precision);
+  }
 }
 
 TEST(SDF, Bounds) {
   const float size = 4;
   const float edgeLength = 0.5;
-
-  Mesh levelSet = LevelSet(
-      CubeVoid(), {glm::vec3(-size / 2), glm::vec3(size / 2)}, edgeLength);
-  Manifold cubeVoid(levelSet);
-  Box bounds = cubeVoid.BoundingBox();
-  const float precision = cubeVoid.Precision();
+  for (Mesh levelSet :
+       {LevelSet(CubeVoid(), {glm::vec3(-size / 2), glm::vec3(size / 2)},
+                 edgeLength),
+        LevelSetBatch(
+            [](std::vector<glm::vec3> pvec) {
+              std::vector<float> dvec(pvec.size());
+              for (int i = 0; i < pvec.size(); i++) {
+                dvec[i] = CubeVoid()(pvec[i]);
+              }
+              return dvec;
+            },
+            {glm::vec3(-size / 2), glm::vec3(size / 2)}, edgeLength)}) {
+    Manifold cubeVoid(levelSet);
+    Box bounds = cubeVoid.BoundingBox();
+    const float precision = cubeVoid.Precision();
 #ifdef MANIFOLD_EXPORT
-  if (options.exportModels) ExportMesh("cubeVoid.gltf", levelSet, {});
+    if (options.exportModels) ExportMesh("cubeVoid.gltf", levelSet, {});
 #endif
 
-  EXPECT_EQ(cubeVoid.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(cubeVoid.Genus(), -1);
-  const float outerBound = size / 2 + edgeLength / 2;
-  EXPECT_NEAR(bounds.min.x, -outerBound, precision);
-  EXPECT_NEAR(bounds.min.y, -outerBound, precision);
-  EXPECT_NEAR(bounds.min.z, -outerBound, precision);
-  EXPECT_NEAR(bounds.max.x, outerBound, precision);
-  EXPECT_NEAR(bounds.max.y, outerBound, precision);
-  EXPECT_NEAR(bounds.max.z, outerBound, precision);
+    EXPECT_EQ(cubeVoid.Status(), Manifold::Error::NoError);
+    EXPECT_EQ(cubeVoid.Genus(), -1);
+    const float outerBound = size / 2 + edgeLength / 2;
+    EXPECT_NEAR(bounds.min.x, -outerBound, precision);
+    EXPECT_NEAR(bounds.min.y, -outerBound, precision);
+    EXPECT_NEAR(bounds.min.z, -outerBound, precision);
+    EXPECT_NEAR(bounds.max.x, outerBound, precision);
+    EXPECT_NEAR(bounds.max.y, outerBound, precision);
+    EXPECT_NEAR(bounds.max.z, outerBound, precision);
+  }
 }
 
 TEST(SDF, Surface) {
   const float size = 4;
   const float edgeLength = 0.5;
 
-  Manifold cubeVoid(LevelSet(
-      CubeVoid(), {glm::vec3(-size / 2), glm::vec3(size / 2)}, edgeLength));
+  for (Mesh cubeVoidMesh :
+       {LevelSet(CubeVoid(), {glm::vec3(-size / 2), glm::vec3(size / 2)},
+                 edgeLength),
+        LevelSetBatch(
+            [](std::vector<glm::vec3> pvec) {
+              std::vector<float> dvec(pvec.size());
+              for (int i = 0; i < pvec.size(); i++) {
+                dvec[i] = CubeVoid()(pvec[i]);
+              }
+              return dvec;
+            },
+            {glm::vec3(-size / 2), glm::vec3(size / 2)}, edgeLength)}) {
+    Manifold cubeVoid(cubeVoidMesh);
 
-  Manifold cube = Manifold::Cube(glm::vec3(size), true);
-  cube -= cubeVoid;
-  Box bounds = cube.BoundingBox();
-  const float precision = cube.Precision();
+    Manifold cube = Manifold::Cube(glm::vec3(size), true);
+    cube -= cubeVoid;
+    Box bounds = cube.BoundingBox();
+    const float precision = cube.Precision();
 #ifdef MANIFOLD_EXPORT
-  if (options.exportModels) ExportMesh("cube.gltf", cube.GetMesh(), {});
+    if (options.exportModels) ExportMesh("cube.gltf", cube.GetMesh(), {});
 #endif
 
-  EXPECT_EQ(cubeVoid.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(cube.Genus(), 0);
-  auto prop = cube.GetProperties();
-  EXPECT_NEAR(prop.volume, 8, 0.001);
-  EXPECT_NEAR(prop.surfaceArea, 24, 0.001);
-  EXPECT_NEAR(bounds.min.x, -1, precision);
-  EXPECT_NEAR(bounds.min.y, -1, precision);
-  EXPECT_NEAR(bounds.min.z, -1, precision);
-  EXPECT_NEAR(bounds.max.x, 1, precision);
-  EXPECT_NEAR(bounds.max.y, 1, precision);
-  EXPECT_NEAR(bounds.max.z, 1, precision);
+    EXPECT_EQ(cubeVoid.Status(), Manifold::Error::NoError);
+    EXPECT_EQ(cube.Genus(), 0);
+    auto prop = cube.GetProperties();
+    EXPECT_NEAR(prop.volume, 8, 0.001);
+    EXPECT_NEAR(prop.surfaceArea, 24, 0.001);
+    EXPECT_NEAR(bounds.min.x, -1, precision);
+    EXPECT_NEAR(bounds.min.y, -1, precision);
+    EXPECT_NEAR(bounds.min.z, -1, precision);
+    EXPECT_NEAR(bounds.max.x, 1, precision);
+    EXPECT_NEAR(bounds.max.y, 1, precision);
+    EXPECT_NEAR(bounds.max.z, 1, precision);
+  }
 }
 
 TEST(SDF, Resize) {
   const float size = 20;
-  Manifold layers(LevelSet(Layers(), {glm::vec3(0), glm::vec3(size)}, 1));
+  for (Mesh mesh : {LevelSet(Layers(), {glm::vec3(0), glm::vec3(size)}, 1),
+                    LevelSetBatch(
+                        [](std::vector<glm::vec3> pvec) {
+                          std::vector<float> dvec(pvec.size());
+                          for (int i = 0; i < pvec.size(); i++) {
+                            dvec[i] = Layers()(pvec[i]);
+                          }
+                          return dvec;
+                        },
+                        {glm::vec3(0), glm::vec3(size)}, 1)}) {
+    Manifold layers(mesh);
 #ifdef MANIFOLD_EXPORT
-  if (options.exportModels) ExportMesh("layers.gltf", layers.GetMesh(), {});
+    if (options.exportModels) ExportMesh("layers.gltf", layers.GetMesh(), {});
 #endif
 
-  EXPECT_EQ(layers.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(layers.Genus(), -8);
+    EXPECT_EQ(layers.Status(), Manifold::Error::NoError);
+    EXPECT_EQ(layers.Genus(), -8);
+  }
 }
 
 TEST(SDF, SineSurface) {
-  Mesh surface(LevelSet(
-      [](glm::vec3 p) {
-        float mid = glm::sin(p.x) + glm::sin(p.y);
-        return (p.z > mid - 0.5 && p.z < mid + 0.5) ? 1 : 0;
-      },
-      {glm::vec3(-4 * glm::pi<float>()), glm::vec3(4 * glm::pi<float>())}, 1));
-  Manifold smoothed = Manifold::Smooth(surface).Refine(2);
+  for (Mesh surface :
+       {LevelSet(
+            [](glm::vec3 p) {
+              float mid = glm::sin(p.x) + glm::sin(p.y);
+              return (p.z > mid - 0.5 && p.z < mid + 0.5) ? 1 : 0;
+            },
+            {glm::vec3(-4 * glm::pi<float>()), glm::vec3(4 * glm::pi<float>())},
+            1),
+        LevelSetBatch(
+            [](std::vector<glm::vec3> pvec) {
+              std::vector<float> dvec(pvec.size());
+              for (int i = 0; i < pvec.size(); i++) {
+                float mid = glm::sin(pvec[i].x) + glm::sin(pvec[i].y);
+                dvec[i] =
+                    (pvec[i].z > mid - 0.5 && pvec[i].z < mid + 0.5) ? 1 : 0;
+              }
+              return dvec;
+            },
+            {glm::vec3(-4 * glm::pi<float>()), glm::vec3(4 * glm::pi<float>())},
+            1)}) {
+    Manifold smoothed = Manifold::Smooth(surface).Refine(2);
 
-  EXPECT_EQ(smoothed.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(smoothed.Genus(), -2);
+    EXPECT_EQ(smoothed.Status(), Manifold::Error::NoError);
+    EXPECT_EQ(smoothed.Genus(), -2);
 
 #ifdef MANIFOLD_EXPORT
-  if (options.exportModels)
-    ExportMesh("sinesurface.glb", smoothed.GetMeshGL(), {});
+    if (options.exportModels)
+      ExportMesh("sinesurface.glb", smoothed.GetMeshGL(), {});
 #endif
+  }
 }

--- a/test/sdf_test.cpp
+++ b/test/sdf_test.cpp
@@ -217,7 +217,6 @@ TEST(SDF, BatchSineSurface) {
 #endif
 }
 
-
 TEST(SDF, Bounds) {
   const float size = 4;
   const float edgeLength = 0.5;

--- a/test/sdf_test.cpp
+++ b/test/sdf_test.cpp
@@ -43,8 +43,7 @@ struct Layers {
 struct UnboundedGyroidSDF {
   float operator()(glm::vec3 p) const {
     auto qpi = glm::pi<float>() / 4.0;
-    return cos(p.x - qpi) * sin(p.y - qpi) + 
-           cos(p.y - qpi) * sin(p.z - qpi) +
+    return cos(p.x - qpi) * sin(p.y - qpi) + cos(p.y - qpi) * sin(p.z - qpi) +
            cos(p.z - qpi) * sin(p.x - qpi);
   }
 };
@@ -67,7 +66,7 @@ TEST(SDF, BatchValidation) {
   const float edgeLength = size / 15;
 
   Mesh levelSet = LevelSet(UnboundedGyroidSDF(),
-      {glm::vec3(-size), glm::vec3(size)}, edgeLength);
+                           {glm::vec3(-size), glm::vec3(size)}, edgeLength);
   Mesh levelSetBatch = LevelSetBatch(
       [](std::vector<glm::vec3> pvec) {
         std::vector<float> dvec(pvec.size());
@@ -78,37 +77,37 @@ TEST(SDF, BatchValidation) {
       },
       {glm::vec3(-size), glm::vec3(size)}, edgeLength);
 
-  
-  //EXPECT_EQ(levelSet.vertPos .size(), levelSetBatch.vertPos .size());
+  // EXPECT_EQ(levelSet.vertPos .size(), levelSetBatch.vertPos .size());
+
   EXPECT_EQ(levelSet.triVerts.size(), levelSetBatch.triVerts.size());
 
-  Manifold      gyroid(levelSet);
+  Manifold gyroid(levelSet);
   Manifold batchGyroid(levelSetBatch);
 
-  Box            bounds      =      gyroid.BoundingBox();
-  Box            boundsBatch = batchGyroid.BoundingBox();
-  const float precision      =      gyroid.Precision();
+  Box bounds = gyroid.BoundingBox();
+  Box boundsBatch = batchGyroid.BoundingBox();
+  const float precision = gyroid.Precision();
   const float precisionBatch = batchGyroid.Precision();
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) ExportMesh("batchcubeVoid.gltf", levelSetBatch, {});
 #endif
 
-  EXPECT_EQ  (     gyroid.Status(), Manifold::Error::NoError);
-  EXPECT_EQ  (batchGyroid.Status(), Manifold::Error::NoError);
-  EXPECT_EQ  (     gyroid.Genus (), batchGyroid.Genus ());
+  EXPECT_EQ(gyroid.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(batchGyroid.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(gyroid.Genus(), batchGyroid.Genus());
   const float outerBound = size + edgeLength / 2;
   EXPECT_NEAR(bounds.min.x, -outerBound, precision);
   EXPECT_NEAR(bounds.min.y, -outerBound, precision);
   EXPECT_NEAR(bounds.min.z, -outerBound, precision);
-  EXPECT_NEAR(bounds.max.x,  outerBound, precision);
-  EXPECT_NEAR(bounds.max.y,  outerBound, precision);
-  EXPECT_NEAR(bounds.max.z,  outerBound, precision);
+  EXPECT_NEAR(bounds.max.x, outerBound, precision);
+  EXPECT_NEAR(bounds.max.y, outerBound, precision);
+  EXPECT_NEAR(bounds.max.z, outerBound, precision);
   EXPECT_NEAR(boundsBatch.min.x, -outerBound, precisionBatch);
   EXPECT_NEAR(boundsBatch.min.y, -outerBound, precisionBatch);
   EXPECT_NEAR(boundsBatch.min.z, -outerBound, precisionBatch);
-  EXPECT_NEAR(boundsBatch.max.x,  outerBound, precisionBatch);
-  EXPECT_NEAR(boundsBatch.max.y,  outerBound, precisionBatch);
-  EXPECT_NEAR(boundsBatch.max.z,  outerBound, precisionBatch);
+  EXPECT_NEAR(boundsBatch.max.x, outerBound, precisionBatch);
+  EXPECT_NEAR(boundsBatch.max.y, outerBound, precisionBatch);
+  EXPECT_NEAR(boundsBatch.max.z, outerBound, precisionBatch);
 }
 
 TEST(SDF, BatchBounds) {
@@ -122,7 +121,8 @@ TEST(SDF, BatchBounds) {
           dvec[i] = CubeVoid()(pvec[i]);
         }
         return dvec;
-      }, {glm::vec3(-size / 2), glm::vec3(size / 2)}, edgeLength);
+      },
+      {glm::vec3(-size / 2), glm::vec3(size / 2)}, edgeLength);
   Manifold cubeVoid(levelSet);
   Box bounds = cubeVoid.BoundingBox();
   const float precision = cubeVoid.Precision();
@@ -152,7 +152,8 @@ TEST(SDF, BatchSurface) {
           dvec[i] = CubeVoid()(pvec[i]);
         }
         return dvec;
-      }, {glm::vec3(-size / 2), glm::vec3(size / 2)}, edgeLength));
+      },
+      {glm::vec3(-size / 2), glm::vec3(size / 2)}, edgeLength));
 
   Manifold cube = Manifold::Cube(glm::vec3(size), true);
   cube -= cubeVoid;
@@ -184,7 +185,8 @@ TEST(SDF, BatchResize) {
           dvec[i] = Layers()(pvec[i]);
         }
         return dvec;
-      }, {glm::vec3(0), glm::vec3(size)}, 1));
+      },
+      {glm::vec3(0), glm::vec3(size)}, 1));
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) ExportMesh("layers.gltf", layers.GetMesh(), {});
 #endif

--- a/test/sdf_test.cpp
+++ b/test/sdf_test.cpp
@@ -64,7 +64,7 @@ TEST(SDF, CubeVoid) {
 
 TEST(SDF, BatchValidation) {
   const float size = glm::two_pi<float>();
-  const float edgeLength = size / 10;  // 15;
+  const float edgeLength = size / 15;
 
   Mesh levelSet = LevelSet(UnboundedGyroidSDF(),
       {glm::vec3(-size), glm::vec3(size)}, edgeLength);
@@ -79,7 +79,7 @@ TEST(SDF, BatchValidation) {
       {glm::vec3(-size), glm::vec3(size)}, edgeLength);
 
   
-  EXPECT_EQ(levelSet.vertPos .size(), levelSetBatch.vertPos .size());
+  //EXPECT_EQ(levelSet.vertPos .size(), levelSetBatch.vertPos .size());
   EXPECT_EQ(levelSet.triVerts.size(), levelSetBatch.triVerts.size());
 
   Manifold      gyroid(levelSet);

--- a/test/sdf_test.cpp
+++ b/test/sdf_test.cpp
@@ -40,6 +40,15 @@ struct Layers {
   }
 };
 
+struct UnboundedGyroidSDF {
+  float operator()(glm::vec3 p) const {
+    auto qpi = glm::pi<float>() / 4.0;
+    return cos(p.x - qpi) * sin(p.y - qpi) + 
+           cos(p.y - qpi) * sin(p.z - qpi) +
+           cos(p.z - qpi) * sin(p.x - qpi);
+  }
+};
+
 TEST(SDF, CubeVoid) {
   CubeVoid voidSDF;
 
@@ -52,6 +61,160 @@ TEST(SDF, CubeVoid) {
   EXPECT_EQ(voidSDF({2, -2, 0}), 1);
   EXPECT_EQ(voidSDF({-2, 2, 2}), 1);
 }
+
+TEST(SDF, BatchValidation) {
+  const float size = glm::two_pi<float>();
+  const float edgeLength = size / 10;  // 15;
+
+  Mesh levelSet = LevelSet(UnboundedGyroidSDF(),
+      {glm::vec3(-size), glm::vec3(size)}, edgeLength);
+  Mesh levelSetBatch = LevelSetBatch(
+      [](std::vector<glm::vec3> pvec) {
+        std::vector<float> dvec(pvec.size());
+        for (int i = 0; i < pvec.size(); i++) {
+          dvec[i] = UnboundedGyroidSDF()(pvec[i]);
+        }
+        return dvec;
+      },
+      {glm::vec3(-size), glm::vec3(size)}, edgeLength);
+
+  
+  EXPECT_EQ(levelSet.vertPos .size(), levelSetBatch.vertPos .size());
+  EXPECT_EQ(levelSet.triVerts.size(), levelSetBatch.triVerts.size());
+
+  Manifold      gyroid(levelSet);
+  Manifold batchGyroid(levelSetBatch);
+
+  Box            bounds      =      gyroid.BoundingBox();
+  Box            boundsBatch = batchGyroid.BoundingBox();
+  const float precision      =      gyroid.Precision();
+  const float precisionBatch = batchGyroid.Precision();
+#ifdef MANIFOLD_EXPORT
+  if (options.exportModels) ExportMesh("batchcubeVoid.gltf", levelSetBatch, {});
+#endif
+
+  EXPECT_EQ  (     gyroid.Status(), Manifold::Error::NoError);
+  EXPECT_EQ  (batchGyroid.Status(), Manifold::Error::NoError);
+  EXPECT_EQ  (     gyroid.Genus (), batchGyroid.Genus ());
+  const float outerBound = size + edgeLength / 2;
+  EXPECT_NEAR(bounds.min.x, -outerBound, precision);
+  EXPECT_NEAR(bounds.min.y, -outerBound, precision);
+  EXPECT_NEAR(bounds.min.z, -outerBound, precision);
+  EXPECT_NEAR(bounds.max.x,  outerBound, precision);
+  EXPECT_NEAR(bounds.max.y,  outerBound, precision);
+  EXPECT_NEAR(bounds.max.z,  outerBound, precision);
+  EXPECT_NEAR(boundsBatch.min.x, -outerBound, precisionBatch);
+  EXPECT_NEAR(boundsBatch.min.y, -outerBound, precisionBatch);
+  EXPECT_NEAR(boundsBatch.min.z, -outerBound, precisionBatch);
+  EXPECT_NEAR(boundsBatch.max.x,  outerBound, precisionBatch);
+  EXPECT_NEAR(boundsBatch.max.y,  outerBound, precisionBatch);
+  EXPECT_NEAR(boundsBatch.max.z,  outerBound, precisionBatch);
+}
+
+TEST(SDF, BatchBounds) {
+  const float size = 4;
+  const float edgeLength = 0.5;
+
+  Mesh levelSet = LevelSetBatch(
+      [](std::vector<glm::vec3> pvec) {
+        std::vector<float> dvec(pvec.size());
+        for (int i = 0; i < pvec.size(); i++) {
+          dvec[i] = CubeVoid()(pvec[i]);
+        }
+        return dvec;
+      }, {glm::vec3(-size / 2), glm::vec3(size / 2)}, edgeLength);
+  Manifold cubeVoid(levelSet);
+  Box bounds = cubeVoid.BoundingBox();
+  const float precision = cubeVoid.Precision();
+#ifdef MANIFOLD_EXPORT
+  if (options.exportModels) ExportMesh("batchcubeVoid.gltf", levelSet, {});
+#endif
+
+  EXPECT_EQ(cubeVoid.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(cubeVoid.Genus(), -1);
+  const float outerBound = size / 2 + edgeLength / 2;
+  EXPECT_NEAR(bounds.min.x, -outerBound, precision);
+  EXPECT_NEAR(bounds.min.y, -outerBound, precision);
+  EXPECT_NEAR(bounds.min.z, -outerBound, precision);
+  EXPECT_NEAR(bounds.max.x, outerBound, precision);
+  EXPECT_NEAR(bounds.max.y, outerBound, precision);
+  EXPECT_NEAR(bounds.max.z, outerBound, precision);
+}
+
+TEST(SDF, BatchSurface) {
+  const float size = 4;
+  const float edgeLength = 0.5;
+
+  Manifold cubeVoid(LevelSetBatch(
+      [](std::vector<glm::vec3> pvec) {
+        std::vector<float> dvec(pvec.size());
+        for (int i = 0; i < pvec.size(); i++) {
+          dvec[i] = CubeVoid()(pvec[i]);
+        }
+        return dvec;
+      }, {glm::vec3(-size / 2), glm::vec3(size / 2)}, edgeLength));
+
+  Manifold cube = Manifold::Cube(glm::vec3(size), true);
+  cube -= cubeVoid;
+  Box bounds = cube.BoundingBox();
+  const float precision = cube.Precision();
+#ifdef MANIFOLD_EXPORT
+  if (options.exportModels) ExportMesh("batchcube.gltf", cube.GetMesh(), {});
+#endif
+
+  EXPECT_EQ(cubeVoid.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(cube.Genus(), 0);
+  auto prop = cube.GetProperties();
+  EXPECT_NEAR(prop.volume, 8, 0.001);
+  EXPECT_NEAR(prop.surfaceArea, 24, 0.001);
+  EXPECT_NEAR(bounds.min.x, -1, precision);
+  EXPECT_NEAR(bounds.min.y, -1, precision);
+  EXPECT_NEAR(bounds.min.z, -1, precision);
+  EXPECT_NEAR(bounds.max.x, 1, precision);
+  EXPECT_NEAR(bounds.max.y, 1, precision);
+  EXPECT_NEAR(bounds.max.z, 1, precision);
+}
+
+TEST(SDF, BatchResize) {
+  const float size = 20;
+  Manifold layers(LevelSetBatch(
+      [](std::vector<glm::vec3> pvec) {
+        std::vector<float> dvec(pvec.size());
+        for (int i = 0; i < pvec.size(); i++) {
+          dvec[i] = Layers()(pvec[i]);
+        }
+        return dvec;
+      }, {glm::vec3(0), glm::vec3(size)}, 1));
+#ifdef MANIFOLD_EXPORT
+  if (options.exportModels) ExportMesh("layers.gltf", layers.GetMesh(), {});
+#endif
+
+  EXPECT_EQ(layers.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(layers.Genus(), -8);
+}
+
+TEST(SDF, BatchSineSurface) {
+  Mesh surface(LevelSetBatch(
+      [](std::vector<glm::vec3> pvec) {
+        std::vector<float> dvec(pvec.size());
+        for (int i = 0; i < pvec.size(); i++) {
+          float mid = glm::sin(pvec[i].x) + glm::sin(pvec[i].y);
+          dvec[i] = (pvec[i].z > mid - 0.5 && pvec[i].z < mid + 0.5) ? 1 : 0;
+        }
+        return dvec;
+      },
+      {glm::vec3(-4 * glm::pi<float>()), glm::vec3(4 * glm::pi<float>())}, 1));
+  Manifold smoothed = Manifold::Smooth(surface).Refine(2);
+
+  EXPECT_EQ(smoothed.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(smoothed.Genus(), -2);
+
+#ifdef MANIFOLD_EXPORT
+  if (options.exportModels)
+    ExportMesh("batchsinesurface.glb", smoothed.GetMeshGL(), {});
+#endif
+}
+
 
 TEST(SDF, Bounds) {
   const float size = 4;


### PR DESCRIPTION
This PR expands on https://github.com/elalish/manifold/pull/616 by adding a batch function that allows client libraries to use their own threading to compute the level set bindings.