### PR TITLE
RFC  to make SimplifyTopology() steps optional

### DIFF
--- a/src/manifold/src/edge_op.cpp
+++ b/src/manifold/src/edge_op.cpp
@@ -178,6 +178,10 @@ void Manifold::Impl::SimplifyTopology() {
   }
 #endif
 
+  if (!ManifoldParams().cleanupTriangles) {
+    return;
+  }
+
   std::vector<int> scratchBuffer;
   scratchBuffer.reserve(10);
   {

--- a/src/utilities/include/public.h
+++ b/src/utilities/include/public.h
@@ -613,6 +613,8 @@ struct ExecutionParams {
   bool suppressErrors = false;
   /// Deterministic outputs. Will disable some parallel optimizations.
   bool deterministic = false;
+  /// Perform optional but recommended triangle cleanups in SimplifyTopology()
+  bool cleanupTriangles = true;
 };
 
 #ifdef MANIFOLD_DEBUG


### PR DESCRIPTION
This is not intended for real inclusion.

Each major step in SimplifyTopology() was made separately optional.  While this is handy for debugging, it is unlikely the way to production.  In particular, some of the steps may depend on one another in ways that this can violate.

However, this gives a base for testing the optionality of steps in SimplifyTopology() and it provides a starting point for the discussion of how these options should be implemented in production.