### PR TITLE
fix performance regression for CreateProperties

### DIFF
--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -533,7 +533,9 @@ void CreateProperties(Manifold::Impl &outR, const Manifold::Impl &inP,
   using Entry = std::pair<glm::ivec3, int>;
   int idMissProp = outR.NumVert();
   std::vector<std::vector<Entry>> propIdx(outR.NumVert() + 1);
-  std::vector<int> propMissIdx(outR.NumVert() * 6, -1);
+  std::vector<int> propMissIdx[2];
+  propMissIdx[0].resize(inQ.NumPropVert(), -1);
+  propMissIdx[1].resize(inP.NumPropVert(), -1);
   outR.meshRelation_.properties.reserve(outR.NumVert() * numProp);
   int idx = 0;
 
@@ -580,7 +582,7 @@ void CreateProperties(Manifold::Impl &outR, const Manifold::Impl &inP,
 
       if (key.y == idMissProp && key.z >= 0) {
         // only key.x/key.z matters
-        auto &entry = propMissIdx[key.z * 2 + key.x];
+        auto &entry = propMissIdx[key.x][key.z];
         if (entry >= 0) {
           outR.meshRelation_.triProperties[tri][i] = entry;
           continue;

--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -14,8 +14,6 @@
 
 #include <algorithm>
 #include <array>
-#define GLM_ENABLE_EXPERIMENTAL
-#include <glm/gtx/hash.hpp>
 #include <map>
 
 #if MANIFOLD_PAR == 'T' && __has_include(<tbb/concurrent_map.h>)
@@ -534,7 +532,8 @@ void CreateProperties(Manifold::Impl &outR, const Manifold::Impl &inP,
 
   using Entry = std::pair<glm::ivec3, int>;
   int idMissProp = outR.NumVert();
-  std::vector<std::unordered_map<glm::ivec3, int>> propIdx(outR.NumVert() + 1);
+  std::vector<std::vector<Entry>> propIdx(outR.NumVert() + 1);
+  std::vector<int> propMissIdx(outR.NumVert() * 2, -1);
   outR.meshRelation_.properties.reserve(outR.NumVert() * numProp);
   int idx = 0;
 
@@ -579,15 +578,29 @@ void CreateProperties(Manifold::Impl &outR, const Manifold::Impl &inP,
         }
       }
 
-      auto &bin = propIdx[key.y];
-      auto entry = bin.find(glm::ivec3(key.x, key.z, key.w));
-      if (entry != bin.end()) {
-        outR.meshRelation_.triProperties[tri][i] = entry->second;
-        continue;
+      if (key.y == idMissProp && key.z >= 0) {
+        // only key.x/key.z matters
+        auto &entry = propMissIdx[key.z * 2 + key.x];
+        if (entry >= 0) {
+          outR.meshRelation_.triProperties[tri][i] = entry;
+          continue;
+        }
+        entry = idx;
+      } else {
+        auto &bin = propIdx[key.y];
+        bool bFound = false;
+        for (int k = 0; k < bin.size(); ++k) {
+          if (bin[k].first == glm::ivec3(key.x, key.z, key.w)) {
+            bFound = true;
+            outR.meshRelation_.triProperties[tri][i] = bin[k].second;
+            break;
+          }
+        }
+        if (bFound) continue;
+        bin.push_back(std::make_pair(glm::ivec3(key.x, key.z, key.w), idx));
       }
-      bin.insert(std::make_pair(glm::ivec3(key.x, key.z, key.w), idx));
-      outR.meshRelation_.triProperties[tri][i] = idx++;
 
+      outR.meshRelation_.triProperties[tri][i] = idx++;
       for (int p = 0; p < numProp; ++p) {
         if (p < oldNumProp) {
           glm::vec3 oldProps;

--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -15,6 +15,8 @@
 #include <algorithm>
 #include <array>
 #include <map>
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/hash.hpp>
 
 #if MANIFOLD_PAR == 'T' && __has_include(<tbb/concurrent_map.h>)
 #define TBB_PREVIEW_CONCURRENT_ORDERED_CONTAINERS 1
@@ -533,7 +535,7 @@ void CreateProperties(Manifold::Impl &outR, const Manifold::Impl &inP,
   using Entry = std::pair<glm::ivec3, int>;
   int idMissProp = outR.NumVert();
   std::vector<std::vector<Entry>> propIdx(outR.NumVert() + 1);
-  std::vector<int> propMissIdx(outR.NumVert() * 2, -1);
+  std::unordered_map<glm::ivec2, int> propMissIdx[2];
   outR.meshRelation_.properties.reserve(outR.NumVert() * numProp);
   int idx = 0;
 
@@ -579,13 +581,12 @@ void CreateProperties(Manifold::Impl &outR, const Manifold::Impl &inP,
       }
 
       if (key.y == idMissProp && key.z >= 0) {
-        // only key.x/key.z matters
-        auto &entry = propMissIdx[key.z * 2 + key.x];
-        if (entry >= 0) {
-          outR.meshRelation_.triProperties[tri][i] = entry;
+        auto entry = propMissIdx[key.x].find(glm::ivec2(key.z, key.w));
+        if (entry != propMissIdx[key.x].end()) {
+          outR.meshRelation_.triProperties[tri][i] = entry->second;
           continue;
         }
-        entry = idx;
+        propMissIdx[key.x].insert({glm::ivec2(key.z, key.w), idx});
       } else {
         auto &bin = propIdx[key.y];
         bool bFound = false;

--- a/src/utilities/include/sparse.h
+++ b/src/utilities/include/sparse.h
@@ -48,7 +48,11 @@ class SparseIndices {
   }
 
   SparseIndices() = default;
-  SparseIndices(size_t size) : data_(size * sizeof(int64_t)) {}
+  SparseIndices(size_t size) {
+    if (size >= std::numeric_limits<int32_t>::max() / sizeof(int64_t))
+      throw std::out_of_range("SparseIndices too large");
+    data_ = Vec<char>(size * sizeof(int64_t));
+  }
 
   int size() const { return data_.size() / sizeof(int64_t); }
 

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -1345,11 +1345,9 @@ TEST(Boolean, InterpolatedNormals) {
 TEST(Boolean, CreatePropertiesSlow) {
   Manifold a = Manifold::Sphere(10, 1024).SetProperties(
       3, [](float* newprop, glm::vec3 pos, const float* old) {
-        newprop[0] = 0.0;
-        newprop[1] = 0.0;
-        newprop[2] = 0.0;
+        for (int i = 0; i < 3; i++) newprop[i] = 0;
       });
-  Manifold b = Manifold::Sphere(10, 1024);
+  Manifold b = Manifold::Sphere(10, 1024).Translate({5, 0, 0});
   Manifold result = a + b;
   EXPECT_EQ(result.NumProp(), 3);
 }

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -1341,3 +1341,15 @@ TEST(Boolean, InterpolatedNormals) {
 
   RelatedGL(aMinusB, meshList, false, false);
 }
+
+TEST(Boolean, CreatePropertiesSlow) {
+  Manifold a = Manifold::Sphere(10, 1024).SetProperties(
+      3, [](float* newprop, glm::vec3 pos, const float* old) {
+        newprop[0] = 0.0;
+        newprop[1] = 0.0;
+        newprop[2] = 0.0;
+      });
+  Manifold b = Manifold::Sphere(10, 1024);
+  Manifold result = a + b;
+  EXPECT_EQ(result.NumProp(), 3);
+}


### PR DESCRIPTION
Closes #619.

For some reason the proposed fix by @stephomi caused wrong index calculation and caused invalid index access later. I just do the minimum required to fix the performance issue, and it seems that it is not too slow. Perf doesn't report `CreateProperties` as a bottleneck.

The test case can check the performance regression. Basically, without this fix, the performance is so slow that I am not willing to wait for it to complete. It now takes 1200ms to complete.