### PR TITLE
V2.2.2

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -1,0 +1,25 @@
+name: publish_npm
+
+on: [release, workflow_dispatch]
+
+jobs:
+  deploy_github_pages:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Download built examples
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: manifold.yml
+        workflow_conclusion: completed
+        name: wasm
+        path: ./bindings/wasm/
+
+    - name: Publish to npm
+      run: |
+        cd ./bindings/wasm/
+        npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manifold-3d",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Geometry library for topological robustness",
   "main": "manifold.js",
   "files": [

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
             }: pkgs.stdenv.mkDerivation {
               inherit doCheck;
               pname = "manifold-${parallel-backend}";
-              version = "2.2.1";
+              version = "2.2.2";
               src = self;
               nativeBuildInputs = (with pkgs; [
                 cmake
@@ -103,7 +103,7 @@
               parallelBackends)) // {
             manifold-js = pkgs.buildEmscriptenPackage {
               name = "manifold-js";
-              version = "2.2.1";
+              version = "2.2.2";
               src = self;
               nativeBuildInputs = (with pkgs; [ cmake python39 ]);
               buildInputs = [ pkgs.nodejs ];
@@ -134,7 +134,7 @@
             # but how should we make it work with other python versions?
             manifold3d = with pkgs.python3Packages; buildPythonPackage {
               pname = "manifold3d";
-              version = "2.2.1";
+              version = "2.2.2";
               src = self;
               propagatedBuildInputs = [
                 numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manifold3d"
-version = "2.2.1"
+version = "2.2.2"
 authors = [
   { name="Emmett Lalish", email="elalish@gmail.com" },
 ]


### PR DESCRIPTION
Fixes #611

Release Notes:

## Bug Fixes
- Fixed CMake problems. #591, #595 (@pca006132)
- Fixed Python `split` binding. #593 (@zalo)
- Fixed JS GLB validator errors. #596 (@elalish)
- Allow skipping degenerate triangle removal, to handle zero-volume meshes. #603 (@ramcdona)
- Fixed triangulator bug. #608, #609, #610 (@starseeker, @elalish)
- Fixed JS GLB I/O for mixed properties. #612 (@elalish)
- Fixed Python `smooth` binding and added `calculate_curvature`. #615 (@elalish, @pca006132, @zalo)
- Added `level_set` to Python bindings. #616 (@zalo)
- Check python format in CI. #618 (@pca006132)
- Fixed performance regression with properties. #621 (@pca006132, @stephomi)