### PR TITLE
maybe fix release actions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,6 +1,9 @@
 name: build_wheels
 
-on: [release, workflow_dispatch]
+on: 
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   build_wheels:

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -1,13 +1,22 @@
 name: publish_npm
 
-on: [release, workflow_dispatch]
+on: 
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
-  deploy_github_pages:
-    runs-on: ubuntu-20.04
+  publish_npm:
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3
+
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '20.x'
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Download built examples
       uses: dawidd6/action-download-artifact@v2


### PR DESCRIPTION
I'm not sure why npm isn't authenticating the CI - I generated an automation token that supposedly doesn't require 2FA. Of course we won't be able to test for quite some time...

I published v2.2.2. to npm manually for now.