### PR TITLE
EXT_manifold -> EXT_mesh_manifold

### DIFF
--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -24,7 +24,7 @@ Since Manifold is a WASM module, it does not automatically garbage-collect like 
 
 ## Examples
 
-Please see our usage [examples](https://github.com/elalish/manifold/tree/master/bindings/wasm/examples) to see how to interface this library with `three.js`, `<model-viewer>`, and `glTF`. Of particular note are the included libraries for lossless roundtrip of manifold meshes through glTF files, via a new extension: [EXT_manifold](https://github.com/KhronosGroup/glTF/pull/2286). 
+Please see our usage [examples](https://github.com/elalish/manifold/tree/master/bindings/wasm/examples) to see how to interface this library with `three.js`, `<model-viewer>`, and `glTF`. Of particular note are the included libraries for lossless roundtrip of manifold meshes through glTF files, via a new extension: [EXT_mesh_manifold](https://github.com/KhronosGroup/glTF/pull/2286). 
 
 ## About the author
 

--- a/bindings/wasm/examples/gltf-io.ts
+++ b/bindings/wasm/examples/gltf-io.ts
@@ -49,7 +49,7 @@ export function setupIO(io: WebIO) {
 
 /**
  * Read an input mesh into Manifold-compatible data structures, whether it
- * contains the EXT_manifold extension or not.
+ * contains the EXT_mesh_manifold extension or not.
  *
  * @param mesh The Mesh to read.
  * @param attributes An array of attributes representing the order of desired
@@ -105,7 +105,7 @@ export function readMesh(mesh: Mesh, attributes: Attribute[] = []):
   }));
 
   const manifoldPrimitive =
-      mesh.getExtension('EXT_manifold') as ManifoldPrimitive;
+      mesh.getExtension('EXT_mesh_manifold') as ManifoldPrimitive;
 
   let vertPropArray: number[] = [];
   let triVertArray: number[] = [];
@@ -192,7 +192,7 @@ export function readMesh(mesh: Mesh, attributes: Attribute[] = []):
 }
 
 /**
- * Write a Manifold Mesh into a glTF Mesh object, using the EXT_manifold
+ * Write a Manifold Mesh into a glTF Mesh object, using the EXT_mesh_manifold
  * extension to allow for lossless roundtrip of the manifold mesh through the
  * glTF file.
  *
@@ -313,7 +313,7 @@ export function writeMesh(
   });
 
   const manifoldPrimitive = manifoldExtension.createManifoldPrimitive();
-  mesh.setExtension('EXT_manifold', manifoldPrimitive);
+  mesh.setExtension('EXT_mesh_manifold', manifoldPrimitive);
 
   const indices = doc.createAccessor('manifold indices')
                       .setBuffer(buffer)
@@ -368,7 +368,7 @@ export function disposeMesh(mesh: Mesh) {
   }
 
   const manifoldPrimitive =
-      mesh.getExtension('EXT_manifold') as ManifoldPrimitive;
+      mesh.getExtension('EXT_mesh_manifold') as ManifoldPrimitive;
   if (manifoldPrimitive) {
     manifoldPrimitive.getIndices()?.dispose();
     manifoldPrimitive.getMergeIndices()?.dispose();

--- a/bindings/wasm/examples/make-manifold.html
+++ b/bindings/wasm/examples/make-manifold.html
@@ -46,7 +46,7 @@
 <body>
   <p>Load a glTF/GLB model and our <a href="https://github.com/elalish/manifold">Manifold</a> library will attempt to
     merge it into a set of manifold objects. If the model is water-tight, you can download the new GLB which will have
-    our <a href="https://github.com/KhronosGroup/glTF/pull/2286">EXT_manifold</a> extension, thus preserving the
+    our <a href="https://github.com/KhronosGroup/glTF/pull/2286">EXT_mesh_manifold</a> extension, thus preserving the
     manifold data without losing any mesh properties.</p>
   <p> If the View Manifold GLB checkbox is enabled, then some meshes in the model have open edges and don't represent a
     solid object. Check this box to see only the manifold parts, which will also enable them to be downloaded. If the

--- a/bindings/wasm/examples/manifold-gltf.ts
+++ b/bindings/wasm/examples/manifold-gltf.ts
@@ -14,7 +14,7 @@
 
 import {Accessor, Extension, ExtensionProperty, GLTF, IProperty, PropertyType, ReaderContext, WriterContext} from '@gltf-transform/core';
 
-const NAME = 'EXT_manifold';
+const NAME = 'EXT_mesh_manifold';
 const MERGE = 'MERGE';
 
 interface IManifoldPrimitive extends IProperty {


### PR DESCRIPTION
Addressing feedback from https://github.com/KhronosGroup/glTF/pull/2286#issuecomment-1828018627 regarding glTF extension naming conventions. Since I'm pretty sure we're the only ones producing or consuming this extension so far, this feels like a good time to switch. I checked make-manifold and it can successfully read the old `EXT_manifold` files (it ignores the unknown extension, but then merges them to make a manifold and re-exports with `EXT_mesh_manifold`) so this feels pretty minimally invasive. 