### PR TITLE
[FEAT] Add Sweep Operation

### DIFF
--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -120,7 +120,7 @@ ManifoldManifold *manifold_hull_pts(void *mem, ManifoldVec3 *ps, size_t length);
 // Sweeps
 
 ManifoldManifold *manifold_sweep(void *mem, ManifoldManifold *m, float x,
-                                     float y, float z);
+                                 float y, float z);
 
 // Manifold Transformations
 

--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -117,6 +117,11 @@ ManifoldManifold *manifold_hull(void *mem, ManifoldManifold *m);
 ManifoldManifold *manifold_batch_hull(void *mem, ManifoldManifoldVec *ms);
 ManifoldManifold *manifold_hull_pts(void *mem, ManifoldVec3 *ps, size_t length);
 
+// Sweeps
+
+ManifoldManifold *manifold_sweep(void *mem, ManifoldManifold *m, float x,
+                                     float y, float z);
+
 // Manifold Transformations
 
 ManifoldManifold *manifold_translate(void *mem, ManifoldManifold *m, float x,

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -222,6 +222,13 @@ ManifoldManifold *manifold_hull_pts(void *mem, ManifoldVec3 *ps,
   return to_c(new (mem) Manifold(hulled));
 }
 
+ManifoldManifold *manifold_sweep(void *mem, ManifoldManifold *m, float x,
+                                 float y, float z) {
+  auto v = glm::vec3(x, y, z);
+  auto swept = from_c(m)->Sweep(v);
+  return to_c(new (mem) Manifold(swept));
+}
+
 ManifoldManifold *manifold_translate(void *mem, ManifoldManifold *m, float x,
                                      float y, float z) {
   auto v = glm::vec3(x, y, z);

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -154,6 +154,21 @@ NB_MODULE(manifold3d, m) {
           },
           "Compute the convex hull enveloping a set of 3d points.")
       .def(
+          "sweep",
+          [](Manifold &self, float x = 0.0f, float y = 0.0f, float z = 0.0f) {
+            return self.Sweep(glm::vec3(x, y, z));
+          },
+          nb::arg("x") = 0.0f, nb::arg("y") = 0.0f, nb::arg("z") = 0.0f,
+          "Sweep this Manifold through space."
+          "\n\n"
+          ":param x: X axis translation. (default 0.0).\n"
+          ":param y: Y axis translation. (default 0.0).\n"
+          ":param z: Z axis translation. (default 0.0).")
+      .def("sweep", &Manifold::Sweep, nb::arg("t"),
+           "Sweep this Manifold through space."
+           "\n\n"
+           ":param v: The vector to add to every vertex.")
+      .def(
           "transform",
           [](Manifold &self, nb::ndarray<float, nb::shape<3, 4>> &mat) {
             if (mat.ndim() != 2 || mat.shape(0) != 3 || mat.shape(1) != 4)

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -139,6 +139,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("_SplitByPlane", &man_js::SplitByPlane)
       .function("_TrimByPlane", &Manifold::TrimByPlane)
       .function("hull", select_overload<Manifold() const>(&Manifold::Hull))
+      .function("sweep", select_overload<Manifold() const>(&Manifold::Sweep))
       .function("_GetMeshJS", &js::GetMeshJS)
       .function("refine", &Manifold::Refine)
       .function("_Warp", &man_js::Warp)

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -139,7 +139,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("_SplitByPlane", &man_js::SplitByPlane)
       .function("_TrimByPlane", &Manifold::TrimByPlane)
       .function("hull", select_overload<Manifold() const>(&Manifold::Hull))
-      .function("sweep", select_overload<Manifold() const>(&Manifold::Sweep))
+      .function("sweep", &Manifold::Sweep)
       .function("_GetMeshJS", &js::GetMeshJS)
       .function("refine", &Manifold::Refine)
       .function("_Warp", &man_js::Warp)

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -244,6 +244,10 @@ Module.setup = function() {
     return out;
   };
 
+  Module.Manifold.prototype.sweep = function(...vec) {
+    return this.sweep(vararg2vec3(vec));
+  };
+
   Module.Manifold.prototype.translate = function(...vec) {
     return this._Translate(vararg2vec3(vec));
   };

--- a/bindings/wasm/helpers.cpp
+++ b/bindings/wasm/helpers.cpp
@@ -190,7 +190,9 @@ Manifold IntersectionN(const std::vector<Manifold>& manifolds) {
 Manifold Sweep(Manifold& manifold, const val& v) {
   std::vector<float> array = convertJSArrayToNumberVector<float>(v);
   glm::vec3 offset;
-  offset[0] = array[0]; offset[1] = array[1]; offset[2] = array[2];
+  offset[0] = array[0];
+  offset[1] = array[1];
+  offset[2] = array[2];
   return manifold.Sweep(offset);
 }
 

--- a/bindings/wasm/helpers.cpp
+++ b/bindings/wasm/helpers.cpp
@@ -187,6 +187,13 @@ Manifold IntersectionN(const std::vector<Manifold>& manifolds) {
   return Manifold::BatchBoolean(manifolds, OpType::Intersect);
 }
 
+Manifold Sweep(Manifold& manifold, const val& v) {
+  std::vector<float> array = convertJSArrayToNumberVector<float>(v);
+  glm::vec3 offset;
+  offset[0] = array[0]; offset[1] = array[1]; offset[2] = array[2];
+  return manifold.Sweep(offset);
+}
+
 Manifold Transform(Manifold& manifold, const val& mat) {
   std::vector<float> array = convertJSArrayToNumberVector<float>(mat);
   glm::mat4x3 matrix;

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -698,6 +698,16 @@ export class Manifold {
    */
   static hull(points: (Manifold|Vec3)[]): Manifold;
 
+  // Sweeps
+
+  /**
+   * Sweep this Manifold through space.
+   *
+   * @param v The vector to add to every vertex.
+   */
+  sweep(v: Vec3): Manifold;
+  sweep(x: number, y?: number, z?: number): Manifold;
+
   // Topological Operations
 
   /**

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -238,6 +238,8 @@ class Manifold {
   static Manifold Hull(const std::vector<Manifold>& manifolds);
   static Manifold Hull(const std::vector<glm::vec3>& pts);
 
+  Manifold Sweep(glm::vec3) const;
+
   /** @name Testing hooks
    *  These are just for internal testing.
    */

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -845,7 +845,7 @@ Manifold Manifold::Sweep(glm::vec3 v) const {
       glm::vec3 normal = glm::cross(
           mesh.vertPos[mesh.triVerts[i].y] - mesh.vertPos[mesh.triVerts[i].x],
           mesh.vertPos[mesh.triVerts[i].z] - mesh.vertPos[mesh.triVerts[i].x]);
-      if (glm::dot(normal, v) > -0.0001f) { // Only Sweep Forward Triangles
+      if (glm::dot(normal, v) > -0.0001f) {  // Only Sweep Forward Triangles
         Manifold sweptTriangle = Hull({
             mesh.vertPos[mesh.triVerts[i].x],
             mesh.vertPos[mesh.triVerts[i].y],

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -759,3 +759,12 @@ TEST(Manifold, EmptyHull) {
       {0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {1, 1, 0}};
   EXPECT_TRUE(Manifold::Hull(coplanar).IsEmpty());
 }
+
+TEST(Manifold, SweptCube) {
+  std::vector<glm::vec3> cubePts = {
+      {0, 0, 0},       {1, 0, 0},   {0, 1, 0},      {0, 0, 1},  // corners
+      {1, 1, 0},       {0, 1, 1},   {1, 0, 1},      {1, 1, 1},  // corners
+  };
+  auto sweptCube = Manifold::Hull(cubePts).Sweep({1, 0, 0});
+  EXPECT_FLOAT_EQ(sweptCube.GetProperties().volume, 2);
+}

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -762,8 +762,8 @@ TEST(Manifold, EmptyHull) {
 
 TEST(Manifold, SweptCube) {
   std::vector<glm::vec3> cubePts = {
-      {0, 0, 0},       {1, 0, 0},   {0, 1, 0},      {0, 0, 1},  // corners
-      {1, 1, 0},       {0, 1, 1},   {1, 0, 1},      {1, 1, 1},  // corners
+      {0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {0, 0, 1},  // corners
+      {1, 1, 0}, {0, 1, 1}, {1, 0, 1}, {1, 1, 1},  // corners
   };
   auto sweptCube = Manifold::Hull(cubePts).Sweep({1, 0, 0});
   EXPECT_FLOAT_EQ(sweptCube.GetProperties().volume, 2);

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -768,3 +768,10 @@ TEST(Manifold, SweptCube) {
   auto sweptCube = Manifold::Hull(cubePts).Sweep({1, 0, 0});
   EXPECT_FLOAT_EQ(sweptCube.GetProperties().volume, 2);
 }
+
+TEST(Manifold, SweptComplex) {
+  auto sphere = Manifold::Sphere(0.6, 20);
+  auto cube = Manifold::Cube({1.0, 1.0, 1.0}, true);
+  auto sweptShape = (cube - sphere).Sweep({0.1, 0.3, 0.1});
+  EXPECT_FLOAT_EQ(sweptShape.GetProperties().volume, 0.7779319882392883);
+}


### PR DESCRIPTION
This PR is an attempt to break out a successful experiment from Python.
https://github.com/elalish/manifold/issues/192#issuecomment-1823327943

- Does this make sense to move to Impl with parallel for-loops?
- Should I add full transform (translation/rotation/scale) variant with a `$fn` for more interesting sweep trajectories?
- Maybe Catmull-Rom Spline Interpolation between Segments? (Could also be left to the user)