### PR TITLE
Added Project()

### DIFF
--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -234,9 +234,19 @@ class Manifold {
   Manifold TrimByPlane(glm::vec3 normal, float originOffset) const;
   ///@}
 
+  /** @name 2D from 3D
+   */
+  ///@{
+  CrossSection Project() const;
+  ///@}
+
+  /** @name Convex hull
+   */
+  ///@{
   Manifold Hull() const;
   static Manifold Hull(const std::vector<Manifold>& manifolds);
   static Manifold Hull(const std::vector<glm::vec3>& pts);
+  ///@}
 
   /** @name Testing hooks
    *  These are just for internal testing.

--- a/src/manifold/src/face_op.cpp
+++ b/src/manifold/src/face_op.cpp
@@ -193,8 +193,9 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
 }
 
 /**
- * For the input face index, return a set of 2D polygons formed by the input
- * projection of the vertices.
+ * Returns a set of 2D polygons formed by the input projection of the vertices
+ * of the list of Halfedges, which must be an even-manifold, meaning each vert
+ * must be referenced the same number of times as a startVert and endVert.
  */
 PolygonsIdx Manifold::Impl::Face2Polygons(VecView<Halfedge>::IterC start,
                                           VecView<Halfedge>::IterC end,

--- a/src/manifold/src/face_op.cpp
+++ b/src/manifold/src/face_op.cpp
@@ -250,6 +250,6 @@ CrossSection Manifold::Impl::Project() const {
     polys.push_back(simple);
   }
 
-  return CrossSection(polys);
+  return CrossSection(polys).Simplify(precision_);
 }
 }  // namespace manifold

--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -115,8 +115,10 @@ struct Manifold::Impl {
 
   // face_op.cu
   void Face2Tri(const Vec<int>& faceEdge, const Vec<TriRef>& halfedgeRef);
-  PolygonsIdx Face2Polygons(int face, glm::mat3x2 projection,
-                            const Vec<int>& faceEdge) const;
+  PolygonsIdx Face2Polygons(VecView<Halfedge>::IterC start,
+                            VecView<Halfedge>::IterC end,
+                            glm::mat3x2 projection) const;
+  CrossSection Project() const;
 
   // edge_op.cu
   void SimplifyTopology();

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -777,6 +777,14 @@ Manifold Manifold::TrimByPlane(glm::vec3 normal, float originOffset) const {
   return *this ^ Halfspace(BoundingBox(), normal, originOffset);
 }
 
+/**
+ * Returns a cross section representing the projection of this object onto the
+ * X-Y plane.
+ */
+CrossSection Manifold::Project() const {
+  return GetCsgLeafNode().GetImpl()->Project();
+}
+
 ExecutionParams& ManifoldParams() { return manifoldParams; }
 
 /**

--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -582,6 +582,8 @@ class EarClip {
   // Find the actual rightmost starts after degenerate removal. Also calculate
   // the polygon bounding boxes.
   void FindStart(VertItr first) {
+    const glm::vec2 origin = first->pos;
+
     VertItr start = first;
     float maxX = -std::numeric_limits<float>::infinity();
     Rect bBox;
@@ -591,7 +593,8 @@ class EarClip {
 
     auto AddPoint = [&](VertItr v) {
       bBox.Union(v->pos);
-      const double area1 = glm::determinant(glm::dmat2(v->pos, v->right->pos));
+      const double area1 =
+          glm::determinant(glm::dmat2(v->pos - origin, v->right->pos - origin));
       const double t1 = area + area1;
       areaCompensation += (area - t1) + area1;
       area = t1;

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -182,11 +182,25 @@ TEST(Samples, Frame) {
 TEST(Samples, Bracelet) {
   Manifold bracelet = StretchyBracelet();
   CheckNormals(bracelet);
-  EXPECT_LE(bracelet.NumDegenerateTris(), 22);
+  EXPECT_EQ(bracelet.NumDegenerateTris(), 0);
   EXPECT_EQ(bracelet.Genus(), 1);
   CheckGL(bracelet);
+
+  CrossSection projection = bracelet.Project();
+  Rect rect = projection.Bounds();
+  Box box = bracelet.BoundingBox();
+  EXPECT_EQ(rect.min.x, box.min.x);
+  EXPECT_EQ(rect.min.y, box.min.y);
+  EXPECT_EQ(rect.max.x, box.max.x);
+  EXPECT_EQ(rect.max.y, box.max.y);
+  EXPECT_NEAR(projection.Area(), 649, 1);
+
 #ifdef MANIFOLD_EXPORT
-  if (options.exportModels) ExportMesh("bracelet.glb", bracelet.GetMesh(), {});
+  if (options.exportModels) {
+    ExportMesh("bracelet.glb", bracelet.GetMesh(), {});
+    ExportMesh("bracelet_projection.glb",
+               Manifold::Extrude(projection, 15).GetMesh(), {});
+  }
 #endif
 }
 
@@ -237,9 +251,20 @@ TEST(Samples, Sponge4) {
   EXPECT_EQ(cutSponge.first.Genus(), 13394);
   EXPECT_EQ(cutSponge.second.Genus(), 13394);
 
+  CrossSection projection = cutSponge.first.Project();
+  Rect rect = projection.Bounds();
+  Box box = cutSponge.first.BoundingBox();
+  EXPECT_EQ(rect.min.x, box.min.x);
+  EXPECT_EQ(rect.min.y, box.min.y);
+  EXPECT_EQ(rect.max.x, box.max.x);
+  EXPECT_EQ(rect.max.y, box.max.y);
+  EXPECT_NEAR(projection.Area(), 0.535, 0.001);
+
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) {
     ExportMesh("mengerHalf.glb", cutSponge.first.GetMesh(), {});
+    ExportMesh("mengerHalf_projection.glb",
+               Manifold::Extrude(projection, 1).GetMesh(), {});
 
     const Mesh out = sponge.GetMesh();
     ExportOptions options;

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -194,13 +194,13 @@ TEST(Samples, Bracelet) {
   EXPECT_EQ(rect.max.x, box.max.x);
   EXPECT_EQ(rect.max.y, box.max.y);
   EXPECT_NEAR(projection.Area(), 649, 1);
+  EXPECT_EQ(projection.NumContour(), 2);
+  Manifold extrusion = Manifold::Extrude(projection, 1);
+  EXPECT_EQ(extrusion.NumDegenerateTris(), 0);
+  EXPECT_EQ(extrusion.Genus(), 1);
 
 #ifdef MANIFOLD_EXPORT
-  if (options.exportModels) {
-    ExportMesh("bracelet.glb", bracelet.GetMesh(), {});
-    ExportMesh("bracelet_projection.glb",
-               Manifold::Extrude(projection, 15).GetMesh(), {});
-  }
+  if (options.exportModels) ExportMesh("bracelet.glb", bracelet.GetMesh(), {});
 #endif
 }
 
@@ -259,12 +259,13 @@ TEST(Samples, Sponge4) {
   EXPECT_EQ(rect.max.x, box.max.x);
   EXPECT_EQ(rect.max.y, box.max.y);
   EXPECT_NEAR(projection.Area(), 0.535, 0.001);
+  Manifold extrusion = Manifold::Extrude(projection, 1);
+  EXPECT_EQ(extrusion.NumDegenerateTris(), 0);
+  EXPECT_EQ(extrusion.Genus(), 502);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) {
     ExportMesh("mengerHalf.glb", cutSponge.first.GetMesh(), {});
-    ExportMesh("mengerHalf_projection.glb",
-               Manifold::Extrude(projection, 1).GetMesh(), {});
 
     const Mesh out = sponge.GetMesh();
     ExportOptions options;


### PR DESCRIPTION
Addresses one part of #426 

Pretty simple algorithm. However, I'm getting lots of micro holes in the bracelet projection, probably from rounding errors, which are messing up the triangulation. I haven't determined if the CrossSection is actually epsilon-valid, and either way, I'm surprised that Clipper's positive fill rule isn't getting rid of them. 