### PR TITLE
example url

### DIFF
--- a/bindings/wasm/examples/editor.js
+++ b/bindings/wasm/examples/editor.js
@@ -207,16 +207,19 @@ function addEdit(button) {
 }
 
 const newButton = document.querySelector('#new');
-function newItem(code) {
-  const name = uniqueName('New Script');
+function newItem(code, scriptName = undefined) {
+  const name = uniqueName(scriptName ?? 'New Script');
   setScript(name, code);
   const nextButton = createDropdownItem(name);
   newButton.insertAdjacentElement('afterend', nextButton.parentElement);
   addEdit(nextButton);
-  nextButton.click();
+  return {
+    button: nextButton,
+    name
+  };
 };
 newButton.onclick = function() {
-  newItem('');
+  newItem('').button.click();
 };
 
 const runButton = document.querySelector('#compile');
@@ -306,17 +309,12 @@ require(['vs/editor/editor.main'], async function() {
   if (window.location.hash.length > 0) {
     const name = unescape(window.location.hash.substring(1));
     switchTo(name);
-  } else if (params.get('url') != null) {
-    console.log(`Fetching ${params.get('url')}`);
+  } else if (params.get('script') != null) {
+    console.log(`Fetching ${params.get('script')}`);
     autoExecute = false;
-    const response = await fetch(params.get('url'));
+    const response = await fetch(params.get('script'));
     const code = await response.text();
-    const name = uniqueName(params.get('name') ?? 'New Script');
-    setScript(name, code);
-    const nextButton = createDropdownItem(name);
-    newButton.insertAdjacentElement('afterend', nextButton.parentElement);
-    addEdit(nextButton);
-    switchTo(name);
+    switchTo(newItem(code, params.get('name')).name);
   } else {
     switchTo(currentName);
     window.location.hash = `#${currentName}`;
@@ -334,7 +332,7 @@ require(['vs/editor/editor.main'], async function() {
     }
     if (isExample) {
       const cursor = editor.getPosition();
-      newItem(editor.getValue());
+      newItem(editor.getValue()).button.click();
       editor.setPosition(cursor);
     }
   });

--- a/bindings/wasm/examples/editor.js
+++ b/bindings/wasm/examples/editor.js
@@ -306,12 +306,12 @@ require(['vs/editor/editor.main'], async function() {
   if (window.location.hash.length > 0) {
     const name = unescape(window.location.hash.substring(1));
     switchTo(name);
-  } else if (params.get("url") != null) {
-    console.log(`Fetching ${params.get("url")}`);
+  } else if (params.get('url') != null) {
+    console.log(`Fetching ${params.get('url')}`);
     autoExecute = false;
-    const response = await fetch(params.get("url"));
+    const response = await fetch(params.get('url'));
     const code = await response.text();
-    const name = uniqueName(params.get("name") ?? "New Script");
+    const name = uniqueName(params.get('name') ?? 'New Script');
     setScript(name, code);
     const nextButton = createDropdownItem(name);
     newButton.insertAdjacentElement('afterend', nextButton.parentElement);

--- a/bindings/wasm/examples/editor.js
+++ b/bindings/wasm/examples/editor.js
@@ -111,6 +111,7 @@ function createDropdownItem(name) {
   button.onclick = function() {
     saveCurrent();
     window.location.hash = `#${label.textContent}`;
+    window.location.search = '';
     switchTo(label.textContent);
   };
   // Stop text input spaces from triggering the button
@@ -301,10 +302,21 @@ require(['vs/editor/editor.main'], async function() {
       addEdit(button);
     }
   }
+  const params = new URLSearchParams(window.location.search);
   if (window.location.hash.length > 0) {
     const name = unescape(window.location.hash.substring(1));
-    if (exampleFunctions.get(name) != null || getScript(name) != null)
-      switchTo(name);
+    switchTo(name);
+  } else if (params.get("url") != null) {
+    console.log(`Fetching ${params.get("url")}`);
+    autoExecute = false;
+    const response = await fetch(params.get("url"));
+    const code = await response.text();
+    const name = uniqueName(params.get("name") ?? "New Script");
+    setScript(name, code);
+    const nextButton = createDropdownItem(name);
+    newButton.insertAdjacentElement('afterend', nextButton.parentElement);
+    addEdit(nextButton);
+    switchTo(name);
   } else {
     switchTo(currentName);
     window.location.hash = `#${currentName}`;

--- a/bindings/wasm/examples/editor.js
+++ b/bindings/wasm/examples/editor.js
@@ -213,10 +213,7 @@ function newItem(code, scriptName = undefined) {
   const nextButton = createDropdownItem(name);
   newButton.insertAdjacentElement('afterend', nextButton.parentElement);
   addEdit(nextButton);
-  return {
-    button: nextButton,
-    name
-  };
+  return {button: nextButton, name};
 };
 newButton.onclick = function() {
   newItem('').button.click();

--- a/bindings/wasm/examples/editor.js
+++ b/bindings/wasm/examples/editor.js
@@ -90,9 +90,9 @@ function switchTo(scriptName) {
     switching = true;
     currentFileElement.textContent = scriptName;
     setScript('currentName', scriptName);
-    const code =
-        exampleFunctions.get(scriptName) ?? getScript(scriptName) ?? '';
     isExample = exampleFunctions.get(scriptName) != null;
+    const code = isExample ? exampleFunctions.get(scriptName).substring(1) :
+                             getScript(scriptName) ?? '';
     editor.setValue(code);
   }
 }
@@ -110,6 +110,7 @@ function createDropdownItem(name) {
 
   button.onclick = function() {
     saveCurrent();
+    window.location.hash = `#${label.textContent}`;
     switchTo(label.textContent);
   };
   // Stop text input spaces from triggering the button
@@ -196,6 +197,7 @@ function addEdit(button) {
       removeScript(label.textContent);
       if (currentFileElement.textContent == label.textContent) {
         switchTo('Intro');
+        window.location.hash = '#Intro';
       }
       const container = button.parentElement;
       container.parentElement.removeChild(container);
@@ -299,7 +301,14 @@ require(['vs/editor/editor.main'], async function() {
       addEdit(button);
     }
   }
-  switchTo(currentName);
+  if (window.location.hash.length > 0) {
+    const name = unescape(window.location.hash.substring(1));
+    if (exampleFunctions.get(name) != null || getScript(name) != null)
+      switchTo(name);
+  } else {
+    switchTo(currentName);
+    window.location.hash = `#${currentName}`;
+  }
 
   if (manifoldInitialized) {
     initializeRun();


### PR DESCRIPTION
1. Allows choosing the script via URL hash, e.g. `#Intro`.
2. Removed the annoying newline at the start of examples.