### PR TITLE
added Slice()

### DIFF
--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -111,6 +111,12 @@ ManifoldManifold *manifold_trim_by_plane(void *mem, ManifoldManifold *m,
                                          float normal_x, float normal_y,
                                          float normal_z, float offset);
 
+// 3D to 2D
+
+ManifoldCrossSection *manifold_slice(void *mem, ManifoldManifold *m,
+                                     float height);
+ManifoldCrossSection *manifold_project(void *mem, ManifoldManifold *m);
+
 // Convex Hulls
 
 ManifoldManifold *manifold_hull(void *mem, ManifoldManifold *m);

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -202,6 +202,17 @@ ManifoldManifold *manifold_trim_by_plane(void *mem, ManifoldManifold *m,
   return to_c(new (mem) Manifold(trimmed));
 }
 
+ManifoldCrossSection *manifold_slice(void *mem, ManifoldManifold *m,
+                                     float height) {
+  auto poly = from_c(m)->Slice(height);
+  return to_c(new (mem) CrossSection(poly));
+}
+
+ManifoldCrossSection *manifold_project(void *mem, ManifoldManifold *m) {
+  auto poly = from_c(m)->Project();
+  return to_c(new (mem) CrossSection(poly));
+}
+
 ManifoldManifold *manifold_hull(void *mem, ManifoldManifold *m) {
   auto hulled = from_c(m)->Hull();
   return to_c(new (mem) Manifold(hulled));

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -464,6 +464,19 @@ NB_MODULE(manifold3d, m) {
           "vector from the plane.\n"
           ":param originOffset: The distance of the plane from the origin in "
           "the direction of the normal vector.")
+      .def(
+          "slice",
+          [](Manifold &self, float height) { return self.Slice(height); },
+          nb::arg("height"),
+          "Returns the cross section of this object parallel to the X-Y plane "
+          "at the specified height. Using a height equal to the bottom of the "
+          "bounding box will return the bottom faces, while using a height "
+          "equal to the top of the bounding box will return empty."
+          "\n\n"
+          ":param height: The Z-level of the slice, defaulting to zero.")
+      .def("project", &Manifold::Project,
+           "Returns a cross section representing the projected outline of this "
+           "object onto the X-Y plane.")
       .def("status", &Manifold::Status,
            "Returns the reason for an input Mesh producing an empty Manifold. "
            "This Status only applies to Manifolds newly-created from an input "

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -138,6 +138,8 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("_Split", &man_js::Split)
       .function("_SplitByPlane", &man_js::SplitByPlane)
       .function("_TrimByPlane", &Manifold::TrimByPlane)
+      .function("slice", &Manifold::Slice)
+      .function("project", &Manifold::Project)
       .function("hull", select_overload<Manifold() const>(&Manifold::Hull))
       .function("_GetMeshJS", &js::GetMeshJS)
       .function("refine", &Manifold::Refine)

--- a/bindings/wasm/examples/worker.ts
+++ b/bindings/wasm/examples/worker.ts
@@ -61,7 +61,7 @@ const manifoldStaticFunctions = [
 const manifoldMemberFunctions = [
   'add', 'subtract', 'intersect', 'decompose', 'warp', 'transform', 'translate',
   'rotate', 'scale', 'mirror', 'refine', 'setProperties', 'asOriginal',
-  'trimByPlane', 'split', 'splitByPlane', 'hull'
+  'trimByPlane', 'split', 'splitByPlane', 'slice', 'project', 'hull'
 ];
 // CrossSection static methods (that return a new cross-section)
 const crossSectionStaticFunctions = [

--- a/bindings/wasm/examples/worker.ts
+++ b/bindings/wasm/examples/worker.ts
@@ -95,15 +95,13 @@ function addMembers(
   const cls = module[className];
   const obj = areStatic ? cls : cls.prototype;
   for (const name of methodNames) {
-    if (name != 'cylinder') {
-      const originalFn = obj[name];
-      obj[name] = function(...args: any) {
-        //@ts-ignore
-        const result = originalFn(...args);
-        memoryRegistry.push(result);
-        return result;
-      };
-    }
+    const originalFn = obj[name];
+    obj[name] = function(...args: any) {
+      //@ts-ignore
+      const result = originalFn(...args);
+      memoryRegistry.push(result);
+      return result;
+    };
   }
 }
 

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -685,6 +685,22 @@ export class Manifold {
    */
   trimByPlane(normal: Vec3, originOffset: number): Manifold;
 
+  /**
+   * Returns the cross section of this object parallel to the X-Y plane at the
+   * specified height. Using a height equal to the bottom
+   * of the bounding box will return the bottom faces, while using a height
+   * equal to the top of the bounding box will return empty.
+   *
+   * @param height Z-level of slice.
+   */
+  slice(height: number): CrossSection;
+
+  /**
+   * Returns a cross section representing the projected outline of this object
+   * onto the X-Y plane.
+   */
+  project(): CrossSection;
+
   // Convex Hulls
 
   /**

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -237,6 +237,7 @@ class Manifold {
   /** @name 2D from 3D
    */
   ///@{
+  CrossSection Slice(float height = 0) const;
   CrossSection Project() const;
   ///@}
 

--- a/src/manifold/src/face_op.cpp
+++ b/src/manifold/src/face_op.cpp
@@ -17,8 +17,7 @@
 #define TBB_PREVIEW_CONCURRENT_ORDERED_CONTAINERS 1
 #include <tbb/concurrent_map.h>
 #endif
-#include <map>
-#include <set>
+#include <unordered_set>
 
 #include "impl.h"
 #include "polygon.h"
@@ -235,7 +234,7 @@ CrossSection Manifold::Impl::Slice(float height) const {
   const SparseIndices collisions =
       collider_.Collisions<false, false>(query.cview());
 
-  std::set<int> tris;
+  std::unordered_set<int> tris;
   for (int i = 0; i < collisions.size(); ++i) {
     const int tri = collisions.Get(i, 1);
     float min = std::numeric_limits<float>::infinity();

--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -118,6 +118,7 @@ struct Manifold::Impl {
   PolygonsIdx Face2Polygons(VecView<Halfedge>::IterC start,
                             VecView<Halfedge>::IterC end,
                             glm::mat3x2 projection) const;
+  CrossSection Slice(float height) const;
   CrossSection Project() const;
 
   // edge_op.cu

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -781,15 +781,17 @@ Manifold Manifold::TrimByPlane(glm::vec3 normal, float originOffset) const {
 
 /**
  * Returns the cross section of this object parallel to the X-Y plane at the
- * specified Z height, defaulting to zero.
+ * specified Z height, defaulting to zero. Using a height equal to the bottom of
+ * the bounding box will return the bottom faces, while using a height equal to
+ * the top of the bounding box will return empty.
  */
 CrossSection Manifold::Slice(float height) const {
   return GetCsgLeafNode().GetImpl()->Slice(height);
 }
 
 /**
- * Returns a cross section representing the projection of this object onto the
- * X-Y plane.
+ * Returns a cross section representing the projected outline of this object
+ * onto the X-Y plane.
  */
 CrossSection Manifold::Project() const {
   return GetCsgLeafNode().GetImpl()->Project();

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -780,6 +780,14 @@ Manifold Manifold::TrimByPlane(glm::vec3 normal, float originOffset) const {
 }
 
 /**
+ * Returns the cross section of this object parallel to the X-Y plane at the
+ * specified Z height, defaulting to zero.
+ */
+CrossSection Manifold::Slice(float height) const {
+  return GetCsgLeafNode().GetImpl()->Slice(height);
+}
+
+/**
  * Returns a cross section representing the projection of this object onto the
  * X-Y plane.
  */

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -527,6 +527,14 @@ TEST(Manifold, Transform) {
   Identical(cube.GetMesh(), cube2.GetMesh());
 }
 
+TEST(Manifold, Slice) {
+  Manifold cube = Manifold::Cube();
+  CrossSection bottom = cube.Slice();
+  CrossSection top = cube.Slice(1);
+  EXPECT_EQ(bottom.Area(), 1);
+  EXPECT_EQ(top.Area(), 0);
+}
+
 TEST(Manifold, MeshRelation) {
   Mesh gyroidMesh = Gyroid();
   MeshGL gyroidMeshGL = WithIndexColors(gyroidMesh);

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -199,6 +199,12 @@ TEST(Samples, Bracelet) {
   EXPECT_EQ(extrusion.NumDegenerateTris(), 0);
   EXPECT_EQ(extrusion.Genus(), 1);
 
+  CrossSection slice = bracelet.Slice();
+  EXPECT_EQ(slice.NumContour(), 2);
+  EXPECT_NEAR(slice.Area(), 230.6, 0.1);
+  extrusion = Manifold::Extrude(slice, 1);
+  EXPECT_EQ(extrusion.Genus(), 1);
+
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) ExportMesh("bracelet.glb", bracelet.GetMesh(), {});
 #endif
@@ -216,9 +222,16 @@ TEST(Samples, GyroidModule) {
   const float precision = gyroid.Precision();
   EXPECT_NEAR(bounds.min.z, 0, precision);
   EXPECT_NEAR(bounds.max.z, size * glm::sqrt(2.0f), precision);
+
+  CrossSection slice = gyroid.Slice(5);
+  EXPECT_EQ(slice.NumContour(), 4);
+  EXPECT_NEAR(slice.Area(), 121.9, 0.1);
+  Manifold extrusion = Manifold::Extrude(slice, 1);
+  EXPECT_EQ(extrusion.Genus(), -3);
+
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels)
-    ExportMesh("gyroidModule.gltf", gyroid.GetMesh(), {});
+    ExportMesh("gyroidModule.glb", gyroid.GetMesh(), {});
 #endif
 }
 


### PR DESCRIPTION
Fixes #426 

This gets us proper cross-sections of a Manifold. I gave it a height parameter to make it cheaper to do a stack of slices as a 3D printer might need, rather than having to transform the whole model each time like in OpenSCAD. This will return the bottom face if the height is equal to the bottom of the bounding box, and return empty when at the top of the bounding box. 

~~Now we just need to add the various bindings for this and `Project`.~~ Done