### PR TITLE
add WarpBatch - array process warp with single callback

### DIFF
--- a/bindings/python/examples/torus_knot.py
+++ b/bindings/python/examples/torus_knot.py
@@ -1,0 +1,88 @@
+# %%
+import numpy as np
+from manifold3d import *
+
+# Creates a classic torus knot, defined as a string wrapping periodically
+# around the surface of an imaginary donut. If p and q have a common
+# factor then you will get multiple separate, interwoven knots. This is
+# an example of using the warp() method, thus avoiding any direct
+# handling of triangles.
+
+
+def run():
+    # The number of times the thread passes through the donut hole.
+    p = 1
+    # The number of times the thread circles the donut.
+    q = 3
+    # Radius of the interior of the imaginary donut.
+    majorRadius = 25
+    # Radius of the small cross-section of the imaginary donut.
+    minorRadius = 10
+    # Radius of the small cross-section of the actual object.
+    threadRadius = 3.75
+    # Number of linear segments making up the threadRadius circle. Default is
+    # getCircularSegments(threadRadius).
+    circularSegments = -1
+    # Number of segments along the length of the knot. Default makes roughly
+    # square facets.
+    linearSegments = -1
+
+    # These default values recreate Matlab Knot by Emmett Lalish:
+    # https://www.thingiverse.com/thing:7080
+
+    kLoops = np.gcd(p, q)
+    pk = p / kLoops
+    qk = q / kLoops
+    n = (
+        circularSegments
+        if circularSegments > 2
+        else get_circular_segments(threadRadius)
+    )
+    m = linearSegments if linearSegments > 2 else n * qk * majorRadius / threadRadius
+
+    offset = 2
+    circle = CrossSection.circle(1, n).translate([offset, 0])
+
+    def ax_rotate(x, theta):
+        a, b = (x + 1) % 3, (x + 2) % 3
+        s, c = np.sin(theta), np.cos(theta)
+        m = np.zeros((len(theta), 4, 4), dtype=np.float32)
+        m[:, a, a], m[:, a, b] = c, s
+        m[:, b, a], m[:, b, b] = -s, c
+        m[:, x, x], m[:, 3, 3] = 1, 1
+        return m
+
+    def func(pts):
+        npts = pts.shape[0]
+        x, y, z = pts[:, 0], pts[:, 1], pts[:, 2]
+        psi = qk * np.arctan2(x, y)
+        theta = psi * pk / qk
+        x1 = np.sqrt(x * x + y * y)
+        phi = np.arctan2(x1 - offset, z)
+
+        v = np.zeros((npts, 4), dtype=np.float32)
+        v[:, 0] = threadRadius * np.cos(phi)
+        v[:, 2] = threadRadius * np.sin(phi)
+        v[:, 3] = 1
+        r = majorRadius + minorRadius * np.cos(theta)
+
+        m1 = ax_rotate(0, -np.arctan2(pk * minorRadius, qk * r))
+        m1[:, 3, 0] = minorRadius
+        m2 = ax_rotate(1, theta)
+        m2[:, 3, 0] = majorRadius
+        m3 = ax_rotate(2, psi)
+
+        v = v[:, None, :] @ (m1 @ m2 @ m3)
+        return v[:, 0, :3]
+
+    def func_single(v):
+        pts = np.array(v)[None, :]
+        pts = func(pts)
+        return tuple(pts[0])
+
+    return circle.revolve(int(m)).warp_batch(func)
+    # return circle.revolve(int(m)).warp(func_single)
+
+
+if __name__ == "__main__":
+    run()

--- a/src/cross_section/include/cross_section.h
+++ b/src/cross_section/include/cross_section.h
@@ -21,6 +21,7 @@
 #include "glm/ext/matrix_float3x2.hpp"
 #include "glm/ext/vector_float2.hpp"
 #include "public.h"
+#include "vec_view.h"
 
 namespace manifold {
 
@@ -97,6 +98,8 @@ class CrossSection {
   CrossSection Mirror(const glm::vec2 ax) const;
   CrossSection Transform(const glm::mat3x2& m) const;
   CrossSection Warp(std::function<void(glm::vec2&)> warpFunc) const;
+  CrossSection WarpBatch(
+      std::function<void(VecView<glm::vec2>)> warpFunc) const;
   CrossSection Simplify(double epsilon = 1e-6) const;
 
   // Adapted from Clipper2 docs:

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -18,6 +18,7 @@
 
 #include "cross_section.h"
 #include "public.h"
+#include "vec_view.h"
 
 namespace manifold {
 
@@ -206,6 +207,7 @@ class Manifold {
   Manifold Transform(const glm::mat4x3&) const;
   Manifold Mirror(glm::vec3) const;
   Manifold Warp(std::function<void(glm::vec3&)>) const;
+  Manifold WarpBatch(std::function<void(VecView<glm::vec3>)>) const;
   Manifold SetProperties(
       int, std::function<void(float*, glm::vec3, const float*)>) const;
   Manifold CalculateCurvature(int gaussianIdx, int meanIdx) const;

--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -76,6 +76,7 @@ struct Manifold::Impl {
   void Update();
   void MarkFailure(Error status);
   void Warp(std::function<void(glm::vec3&)> warpFunc);
+  void WarpBatch(std::function<void(VecView<glm::vec3>)> warpFunc);
   Impl Transform(const glm::mat4x3& transform) const;
   SparseIndices EdgeCollisions(const Impl& B, bool inverted = false) const;
   SparseIndices VertexCollisionsZ(VecView<const glm::vec3> vertsIn,

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -570,6 +570,20 @@ Manifold Manifold::Warp(std::function<void(glm::vec3&)> warpFunc) const {
 }
 
 /**
+ * Same as Manifold::Warp but calls warpFunc with with
+ * a VecView which is roughly equivalent to std::span
+ * pointing to all vec3 elements to be modified in-place
+ *
+ * @param warpFunc A function that modifies multiple vertex positions.
+ */
+Manifold Manifold::WarpBatch(
+    std::function<void(VecView<glm::vec3>)> warpFunc) const {
+  auto pImpl = std::make_shared<Impl>(*GetCsgLeafNode().GetImpl());
+  pImpl->WarpBatch(warpFunc);
+  return Manifold(std::make_shared<CsgLeafNode>(pImpl));
+}
+
+/**
  * Create a new copy of this manifold with updated vertex properties by
  * supplying a function that takes the existing position and properties as
  * input. You may specify any number of output properties, allowing creation and

--- a/src/utilities/include/vec.h
+++ b/src/utilities/include/vec.h
@@ -24,6 +24,7 @@
 // #include "optional_assert.h"
 #include "par.h"
 #include "public.h"
+#include "vec_view.h"
 
 namespace manifold {
 
@@ -32,100 +33,6 @@ namespace manifold {
  */
 template <typename T>
 class Vec;
-
-/**
- * View for Vec, can perform offset operation.
- * This will be invalidated when the original vector is dropped or changes
- * length.
- */
-template <typename T>
-class VecView {
- public:
-  using Iter = T *;
-  using IterC = const T *;
-
-  VecView(T *ptr_, int size_) : ptr_(ptr_), size_(size_) {}
-
-  VecView(const VecView &other) {
-    ptr_ = other.ptr_;
-    size_ = other.size_;
-  }
-
-  VecView &operator=(const VecView &other) {
-    ptr_ = other.ptr_;
-    size_ = other.size_;
-    return *this;
-  }
-
-  // allows conversion to a const VecView
-  operator VecView<const T>() const { return {ptr_, size_}; }
-
-  inline const T &operator[](int i) const {
-    if (i < 0 || i >= size_) throw std::out_of_range("Vec out of range");
-    return ptr_[i];
-  }
-
-  inline T &operator[](int i) {
-    if (i < 0 || i >= size_) throw std::out_of_range("Vec out of range");
-    return ptr_[i];
-  }
-
-  IterC cbegin() const { return ptr_; }
-  IterC cend() const { return ptr_ + size_; }
-
-  IterC begin() const { return cbegin(); }
-  IterC end() const { return cend(); }
-
-  Iter begin() { return ptr_; }
-  Iter end() { return ptr_ + size_; }
-
-  const T &front() const {
-    if (size_ == 0)
-      throw std::out_of_range("attempt to take the front of an empty vector");
-    return ptr_[0];
-  }
-
-  const T &back() const {
-    if (size_ == 0)
-      throw std::out_of_range("attempt to take the back of an empty vector");
-    return ptr_[size_ - 1];
-  }
-
-  T &front() {
-    if (size_ == 0)
-      throw std::out_of_range("attempt to take the front of an empty vector");
-    return ptr_[0];
-  }
-
-  T &back() {
-    if (size_ == 0)
-      throw std::out_of_range("attempt to take the back of an empty vector");
-    return ptr_[size_ - 1];
-  }
-
-  int size() const { return size_; }
-
-  bool empty() const { return size_ == 0; }
-
-#ifdef MANIFOLD_DEBUG
-  void Dump() {
-    std::cout << "Vec = " << std::endl;
-    for (int i = 0; i < size(); ++i) {
-      std::cout << i << ", " << ptr_[i] << ", " << std::endl;
-    }
-    std::cout << std::endl;
-  }
-#endif
-
- protected:
-  T *ptr_ = nullptr;
-  int size_ = 0;
-
-  VecView() = default;
-  friend class Vec<T>;
-  friend class Vec<typename std::remove_const<T>::type>;
-  friend class VecView<typename std::remove_const<T>::type>;
-};
 
 /*
  * Specialized vector implementation with multithreaded fill and uninitialized

--- a/src/utilities/include/vec_view.h
+++ b/src/utilities/include/vec_view.h
@@ -1,0 +1,112 @@
+// Copyright 2023 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <stdexcept>
+
+namespace manifold {
+
+/**
+ * View for Vec, can perform offset operation.
+ * This will be invalidated when the original vector is dropped or changes
+ * length. Roughly equivalent to std::span<T> from c++20
+ */
+template <typename T>
+class VecView {
+ public:
+  using Iter = T *;
+  using IterC = const T *;
+
+  VecView(T *ptr_, int size_) : ptr_(ptr_), size_(size_) {}
+
+  VecView(const VecView &other) {
+    ptr_ = other.ptr_;
+    size_ = other.size_;
+  }
+
+  VecView &operator=(const VecView &other) {
+    ptr_ = other.ptr_;
+    size_ = other.size_;
+    return *this;
+  }
+
+  // allows conversion to a const VecView
+  operator VecView<const T>() const { return {ptr_, size_}; }
+
+  inline const T &operator[](int i) const {
+    if (i < 0 || i >= size_) throw std::out_of_range("Vec out of range");
+    return ptr_[i];
+  }
+
+  inline T &operator[](int i) {
+    if (i < 0 || i >= size_) throw std::out_of_range("Vec out of range");
+    return ptr_[i];
+  }
+
+  IterC cbegin() const { return ptr_; }
+  IterC cend() const { return ptr_ + size_; }
+
+  IterC begin() const { return cbegin(); }
+  IterC end() const { return cend(); }
+
+  Iter begin() { return ptr_; }
+  Iter end() { return ptr_ + size_; }
+
+  const T &front() const {
+    if (size_ == 0)
+      throw std::out_of_range("attempt to take the front of an empty vector");
+    return ptr_[0];
+  }
+
+  const T &back() const {
+    if (size_ == 0)
+      throw std::out_of_range("attempt to take the back of an empty vector");
+    return ptr_[size_ - 1];
+  }
+
+  T &front() {
+    if (size_ == 0)
+      throw std::out_of_range("attempt to take the front of an empty vector");
+    return ptr_[0];
+  }
+
+  T &back() {
+    if (size_ == 0)
+      throw std::out_of_range("attempt to take the back of an empty vector");
+    return ptr_[size_ - 1];
+  }
+
+  int size() const { return size_; }
+
+  bool empty() const { return size_ == 0; }
+
+#ifdef MANIFOLD_DEBUG
+  void Dump() {
+    std::cout << "Vec = " << std::endl;
+    for (int i = 0; i < size(); ++i) {
+      std::cout << i << ", " << ptr_[i] << ", " << std::endl;
+    }
+    std::cout << std::endl;
+  }
+#endif
+
+ protected:
+  T *ptr_ = nullptr;
+  int size_ = 0;
+
+  VecView() = default;
+};
+
+}  // namespace manifold

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -303,6 +303,23 @@ TEST(Manifold, Warp2) {
   EXPECT_NEAR(propBefore.volume, 321, 1);
 }
 
+TEST(Manifold, WarpBatch) {
+  Manifold shape1 =
+      Manifold::Cube({2, 3, 4}).Warp([](glm::vec3& v) { v.x += v.z * v.z; });
+  auto prop1 = shape1.GetProperties();
+
+  Manifold shape2 =
+      Manifold::Cube({2, 3, 4}).WarpBatch([](VecView<glm::vec3> vecs) {
+        for (glm::vec3& v : vecs) {
+          v.x += v.z * v.z;
+        }
+      });
+  auto prop2 = shape2.GetProperties();
+
+  EXPECT_EQ(prop1.volume, prop2.volume);
+  EXPECT_EQ(prop1.surfaceArea, prop2.surfaceArea);
+}
+
 TEST(Manifold, Smooth) {
   Manifold tet = Manifold::Tetrahedron();
   Manifold smooth = Manifold::Smooth(tet.GetMesh());


### PR DESCRIPTION
I introduce `WarpBatch` for both `Manifold` and `CrossSection`. 

The new callback signature is `void(manifold::VecView<glm::vec3>)` to allow for arbitrary contiguous storage. This moves the per-vertex tight-loop fully into the callback, where math vectorizations can now apply.

This is especially helpful for python users where scalar math is vastly slower, but array math can use compiled libs like numpy.