### PR TITLE
add formatting script

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -17,7 +17,7 @@ jobs:
         source: '.'
         exclude: '*/third_party'
         extensions: 'h,cpp,js,ts,html'
-        clangFormatVersion: 12
+        clangFormatVersion: 11
     - uses: psf/black@stable
       with:
         options: "--check --verbose"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ For more detailed documentation, please refer to the C++ API.
 
 Contributions are welcome! A lower barrier contribution is to simply make a PR that adds a test, especially if it repros an issue you've found. Simply name it prepended with DISABLED_, so that it passes the CI. That will be a very strong signal to me to fix your issue. However, if you know how to fix it yourself, then including the fix in your PR would be much appreciated!
 
+### Formatting
+
+There is a formatting script `format.sh` that automatically formats everything.
+It requires clang-format 14 and black formatter for python.
+
 ### Profiling
 
 There is now basic support for the [Tracy profiler](https://github.com/wolfpld/tracy) for our tests.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,10 @@ Contributions are welcome! A lower barrier contribution is to simply make a PR t
 ### Formatting
 
 There is a formatting script `format.sh` that automatically formats everything.
-It requires clang-format 14 and black formatter for python.
+It requires clang-format 11 and black formatter for python.
+
+If you have clang-format installed but without clang-11, you can specify the
+clang-format executable by setting the `CLANG_FORMAT` environment variable.
 
 ### Profiling
 

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+shopt -s extglob
+CLANG_FORMAT=$(dirname $(which clang-14))/clang-format
+
+$CLANG_FORMAT -i extras/*.cpp
+$CLANG_FORMAT -i meshIO/**/*.{h,cpp}
+$CLANG_FORMAT -i samples/**/*.{h,cpp}
+$CLANG_FORMAT -i test/*.{h,cpp}
+$CLANG_FORMAT -i bindings/*/*.cpp
+$CLANG_FORMAT -i bindings/c/include/*.h
+$CLANG_FORMAT -i bindings/wasm/**/*.{js,ts,html}
+$CLANG_FORMAT -i src/!(third_party)/*/*.{h,cpp}
+black bindings/python/examples/*.py

--- a/format.sh
+++ b/format.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 shopt -s extglob
-CLANG_FORMAT=$(dirname $(which clang-14))/clang-format
+if [ -z "$CLANG_FORMAT" ]; then
+CLANG_FORMAT=$(dirname $(which clang-11))/clang-format
+fi
 
 $CLANG_FORMAT -i extras/*.cpp
 $CLANG_FORMAT -i meshIO/**/*.{h,cpp}


### PR DESCRIPTION
This also fix the version for clang-format to 14. I think this script should work for other distros if they have clang-14 installed, would be nice if someone can help me test it.