### PR TITLE
Add Naive Minkowski Sum Implementation

### DIFF
--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -210,6 +210,9 @@ NB_MODULE(manifold3d, m) {
           [](std::vector<Manifold> &ms) { return Manifold::Hull(ms); },
           "Compute the convex hull enveloping a set of manifolds.")
       .def_static(
+          "batch_batch_hull", Manifold::BatchHull,
+          "Compute the convex hulls enveloping multiple sets of manifolds.")
+      .def_static(
           "hull_points",
           [](std::vector<Float3> &pts) {
             std::vector<glm::vec3> vec(pts.size());
@@ -220,6 +223,9 @@ NB_MODULE(manifold3d, m) {
             return Manifold::Hull(vec);
           },
           "Compute the convex hull enveloping a set of 3d points.")
+      .def_static("minkowski", Manifold::Minkowski, nb::arg("a"), nb::arg("b"),
+                  nb::arg("useThreading"),
+                  "Compute the minkowski sum of two manifolds.")
       .def(
           "transform",
           [](Manifold &self, nb::ndarray<float, nb::shape<3, 4>> &mat) {

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -249,6 +249,15 @@ class Manifold {
   Manifold Hull() const;
   static Manifold Hull(const std::vector<Manifold>& manifolds);
   static Manifold Hull(const std::vector<glm::vec3>& pts);
+  static std::vector<Manifold> BatchHull(
+      const std::vector<std::vector<Manifold>>& manifolds);
+  ///@}
+
+  /** @name Minkowski Functions
+   */
+  ///@{
+  static Manifold Minkowski(const Manifold& a, const Manifold& b,
+                            bool useThreading = false);
   ///@}
 
   /** @name Testing hooks

--- a/src/manifold/src/face_op.cpp
+++ b/src/manifold/src/face_op.cpp
@@ -316,4 +316,28 @@ CrossSection Manifold::Impl::Project() const {
 
   return CrossSection(polys).Simplify(precision_);
 }
+
+std::vector<int> Manifold::Impl::ReflexFaces(double tolerance) const {
+  std::unordered_set<int> uniqueReflexFaceSet;
+  for (size_t i = 0; i < halfedge_.size(); i++) {
+    Halfedge halfedge = halfedge_[i];
+    int faceA = halfedge.face;
+    int faceB = halfedge_[halfedge.pairedHalfedge].face;
+    glm::dvec3 tangent =
+        glm::cross((glm::dvec3)faceNormal_[faceA],
+                   (glm::dvec3)vertPos_[halfedge_[i].endVert] -
+                       (glm::dvec3)vertPos_[halfedge_[i].startVert]);
+    double tangentProjection =
+        glm::dot((glm::dvec3)faceNormal_[faceB], tangent);
+    //  If we've found a pair of reflex triangles, add them to the set
+    if (tangentProjection > tolerance) {
+      uniqueReflexFaceSet.insert(faceA);
+      uniqueReflexFaceSet.insert(faceB);
+    }
+  }
+  std::vector<int> uniqueFaces;  // Copy to a vector for indexed access
+  uniqueFaces.insert(uniqueFaces.end(), uniqueReflexFaceSet.begin(),
+                     uniqueReflexFaceSet.end());
+  return uniqueFaces;
+}
 }  // namespace manifold

--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -121,6 +121,7 @@ struct Manifold::Impl {
                             glm::mat3x2 projection) const;
   CrossSection Slice(float height) const;
   CrossSection Project() const;
+  std::vector<int> ReflexFaces(double tolerance = 1e-8) const;
 
   // edge_op.cu
   void SimplifyTopology();

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -784,3 +784,73 @@ TEST(Manifold, EmptyHull) {
       {0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {1, 1, 0}};
   EXPECT_TRUE(Manifold::Hull(coplanar).IsEmpty());
 }
+
+TEST(Manifold, ConvexConvexMinkowski) {
+  Manifold sphere = Manifold::Sphere(0.1, 20);
+  Manifold cube = Manifold::Cube();
+  Manifold sum = Manifold::Minkowski(cube, sphere);
+  EXPECT_FLOAT_EQ(sum.GetProperties().volume, 1.6966598f);
+}
+
+TEST(Manifold, ConvexConvexMinkowskiThreaded) {
+  Manifold sphere = Manifold::Sphere(0.1, 20);
+  Manifold cube = Manifold::Cube();
+  Manifold sum = Manifold::Minkowski(cube, sphere, true);
+  EXPECT_FLOAT_EQ(sum.GetProperties().volume, 1.6966598f);
+}
+
+TEST(Manifold, NonConvexConvexMinkowski) {
+  Manifold sphere = Manifold::Sphere(0.6, 20);
+  Manifold cube = Manifold::Cube({1.0, 1.0, 1.0}, true);
+  Manifold nonConvex = cube - sphere;
+  Manifold sum = Manifold::Minkowski(nonConvex, Manifold::Sphere(0.1, 20));
+  EXPECT_FLOAT_EQ(sum.GetProperties().volume, 1.0686193f);
+}
+
+TEST(Manifold, NonConvexConvexMinkowskiThreaded) {
+  Manifold sphere = Manifold::Sphere(0.6, 20);
+  Manifold cube = Manifold::Cube({1.0, 1.0, 1.0}, true);
+  Manifold nonConvex = cube - sphere;
+  Manifold sum = Manifold::Minkowski(nonConvex, Manifold::Sphere(0.1, 20), true);
+  EXPECT_FLOAT_EQ(sum.GetProperties().volume, 1.0686193f);
+}
+
+TEST(Manifold, NonConvexNonConvexMinkowski) {
+  Manifold smallCube = Manifold::Cube({0.1, 0.1, 0.1}, true);
+  std::vector<glm::vec3> verts = smallCube.GetMesh().vertPos;
+  Manifold star = Manifold::Manifold();
+  for (glm::vec3 point :
+       {glm::vec3(0.2, 0.0, 0.0), glm::vec3(-0.2, 0.0, 0.0),
+        glm::vec3(0.0, 0.2, 0.0), glm::vec3(0.0, -0.2, 0.0),
+        glm::vec3(0.0, 0.0, 0.2), glm::vec3(0.0, 0.0, -0.2)}) {
+    verts.push_back(point);
+    star += Manifold::Hull(verts);
+    verts.pop_back();
+  }
+
+  Manifold sphere = Manifold::Sphere(0.6, 20);
+  Manifold cube = Manifold::Cube({1.0, 1.0, 1.0}, true);
+  Manifold nonConvex = cube - sphere;
+  Manifold sum = Manifold::Minkowski(nonConvex, star);
+  EXPECT_FLOAT_EQ(sum.GetProperties().volume, 1.643248);
+}
+
+TEST(Manifold, NonConvexNonConvexMinkowskiThreaded) {
+  Manifold smallCube = Manifold::Cube({0.1, 0.1, 0.1}, true);
+  std::vector<glm::vec3> verts = smallCube.GetMesh().vertPos;
+  Manifold star = Manifold::Manifold();
+  for (glm::vec3 point :
+       {glm::vec3(0.2, 0.0, 0.0), glm::vec3(-0.2, 0.0, 0.0),
+        glm::vec3(0.0, 0.2, 0.0), glm::vec3(0.0, -0.2, 0.0),
+        glm::vec3(0.0, 0.0, 0.2), glm::vec3(0.0, 0.0, -0.2)}) {
+    verts.push_back(point);
+    star += Manifold::Hull(verts);
+    verts.pop_back();
+  }
+
+  Manifold sphere = Manifold::Sphere(0.6, 20);
+  Manifold cube = Manifold::Cube({1.0, 1.0, 1.0}, true);
+  Manifold nonConvex = cube - sphere;
+  Manifold sum = Manifold::Minkowski(nonConvex, star, true);
+  EXPECT_FLOAT_EQ(sum.GetProperties().volume, 1.643248);
+}


### PR DESCRIPTION
This is the minimal code to get the naive minkowksi sum working, with basic affordances for multithreading.
This is essentially the other PR, but without the in-progress experimentation or the controversial `voro++` dependency.

The benefits of the Naive Technique are that:
1) The output mesh topology looks much nicer  without any need for surface simplification.
2) It doesn't need any additional dependencies.

The drawbacks to the Naive Technique are that:
1) Sometimes, it's a bit slower than the general technique (especially for Non-Convex/Non-Convex).
2) Sometimes, it appears to run out of memory when performing the boolean (especially during Non-Convex/Non-Convex).

There are two basic versions of the function, one with significant threading and the other without.   
I expect we'll consolidate to one or the other as their respective pros/cons make themselves apparent; the speed appears to be pretty comparable on my windows machine (but perhaps that's not true on Linux?).