### PR TITLE
added alwaysAsOriginal option

### DIFF
--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -779,8 +779,8 @@ Manifold::Impl Boolean3::Result(OpType op) const {
 
 #ifdef MANIFOLD_DEBUG
   triangulate.Stop();
-  Timer simplify;
-  simplify.Start();
+  Timer finish;
+  finish.Start();
 #endif
 
   if (ManifoldParams().intermediateChecks)
@@ -788,29 +788,22 @@ Manifold::Impl Boolean3::Result(OpType op) const {
 
   CreateProperties(outR, inP_, inQ_);
 
-  UpdateReference(outR, inP_, inQ_, invertQ);
+  if (ManifoldParams().alwaysAsOriginal) {
+    outR.AsOriginal();
+  } else {
+    UpdateReference(outR, inP_, inQ_, invertQ);
+    outR.SimplifyTopology();
+    outR.Finish();
+  }
 
-  outR.SimplifyTopology();
-
-  if (ManifoldParams().intermediateChecks)
-    ASSERT(outR.Is2Manifold(), logicErr, "simplified mesh is not 2-manifold!");
-
-#ifdef MANIFOLD_DEBUG
-  simplify.Stop();
-  Timer sort;
-  sort.Start();
-#endif
-
-  outR.Finish();
   outR.IncrementMeshIDs();
 
 #ifdef MANIFOLD_DEBUG
-  sort.Stop();
+  finish.Stop();
   if (ManifoldParams().verbose) {
     assemble.Print("Assembly");
     triangulate.Print("Triangulation");
-    simplify.Print("Simplification");
-    sort.Print("Sorting");
+    finish.Print("Finishing");
     std::cout << outR.NumVert() << " verts and " << outR.NumTri() << " tris"
               << std::endl;
   }

--- a/src/manifold/src/edge_op.cpp
+++ b/src/manifold/src/edge_op.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "impl.h"
+#include "optional_assert.h"
 #include "par.h"
 
 namespace {
@@ -256,6 +257,9 @@ void Manifold::Impl::SimplifyTopology() {
     std::cout << "found " << numFlagged << " edges to swap" << std::endl;
   }
 #endif
+
+  if (ManifoldParams().intermediateChecks)
+    ASSERT(Is2Manifold(), logicErr, "simplified mesh is not 2-manifold!");
 }
 
 // Deduplicate the given 4-manifold edge by duplicating endVert, thus making the

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -661,6 +661,14 @@ void Manifold::Impl::CreateFaces(const std::vector<float>& propertyTolerance) {
   }
 }
 
+void Manifold::Impl::AsOriginal() {
+  meshRelation_.originalID = ReserveIDs(1);
+  InitializeOriginal();
+  CreateFaces();
+  SimplifyTopology();
+  Finish();
+}
+
 /**
  * Create the halfedge_ data structure from an input triVerts array like Mesh.
  */

--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -69,6 +69,7 @@ struct Manifold::Impl {
   void CreateFaces(const std::vector<float>& propertyTolerance = {});
   void RemoveUnreferencedVerts(Vec<glm::ivec3>& triVerts);
   void InitializeOriginal();
+  void AsOriginal();
   void CreateHalfedges(const Vec<glm::ivec3>& triVerts);
   void CalculateNormals();
   void IncrementMeshIDs();

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -438,11 +438,7 @@ int Manifold::OriginalID() const {
  */
 Manifold Manifold::AsOriginal() const {
   auto newImpl = std::make_shared<Impl>(*GetCsgLeafNode().GetImpl());
-  newImpl->meshRelation_.originalID = ReserveIDs(1);
-  newImpl->InitializeOriginal();
-  newImpl->CreateFaces();
-  newImpl->SimplifyTopology();
-  newImpl->Finish();
+  newImpl->AsOriginal();
   return Manifold(std::make_shared<CsgLeafNode>(newImpl));
 }
 

--- a/src/utilities/include/public.h
+++ b/src/utilities/include/public.h
@@ -615,6 +615,10 @@ struct ExecutionParams {
   bool deterministic = false;
   /// Perform optional but recommended triangle cleanups in SimplifyTopology()
   bool cleanupTriangles = true;
+  /// Speed up Boolean operations by resetting each result to an original,
+  /// allowing more simplification to happen, but losing the relationships to
+  /// input meshes.
+  bool alwaysAsOriginal = false;
 };
 
 #ifdef MANIFOLD_DEBUG


### PR DESCRIPTION
This is more of just a test for now. I'm not a fan of using the `ManifoldParams` - in fact if anyone has a better pattern for those I'm totally open to suggestions. Always felt like a bit of a hack.

I'm finding this cuts the time for `NonConvexNonConvexMinkowski` from #666 by about 10x - from 1206ms to 111ms. It also cleans up the output, dropping the number of verts and tris by about 10x too. I was hoping it would help on other tests with lots of Boolean ops too, but instead I see making about a 10-20% increase in time, maybe from recalculating coplanar faces? I guess it probably only helps if there are lots of coplanar facing being generated. It would be helpful to see more examples of the Minkowski to see if that's actually just unique to this example. 

@zalo - what do you think?