### PR TITLE
remove simplify from warp

### DIFF
--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -737,7 +737,6 @@ void Manifold::Impl::WarpBatch(
   CalculateNormals();
   SetPrecision();
   CreateFaces();
-  SimplifyTopology();
   Finish();
 }
 

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -629,7 +629,6 @@ Manifold Manifold::SetProperties(
 
   pImpl->meshRelation_.numProp = numProp;
   pImpl->CreateFaces();
-  pImpl->SimplifyTopology();
   pImpl->Finish();
   return Manifold(std::make_shared<CsgLeafNode>(pImpl));
 }

--- a/src/manifold/src/properties.cpp
+++ b/src/manifold/src/properties.cpp
@@ -372,7 +372,6 @@ void Manifold::Impl::CalculateCurvature(int gaussianIdx, int meanIdx) {
                         numProp, gaussianIdx, meanIdx}));
 
   CreateFaces();
-  SimplifyTopology();
   Finish();
 }
 


### PR DESCRIPTION
Fixes #673 

This simplification was added after someone found duplicate verts when warping a cylinder into a cone, but based on further discussion, it seems that does more harm than good. This PR also removes `Simplify` from `SetProperties` and `CalculateCurvature` - in those cases there was almost no chance it could simplify anything anyway. Now `Simplify` is only called by the Boolean ops, `AsOriginal`, and mesh import. 

For now I'm not adding `Simplify` to the public API, mostly because I would rather have a better one that can collapse larger triangles accurately, rather than just removing degenerates like mine does. For now if you need `Simplify` you can call `AsOriginal`, or if you need to maintain IDs, you can create a new Manifold from `GetMeshGL`. 