### PR TITLE
fix default partial revolve segments

### DIFF
--- a/src/manifold/src/constructors.cpp
+++ b/src/manifold/src/constructors.cpp
@@ -352,9 +352,10 @@ Manifold Manifold::Revolve(const CrossSection& crossSection,
   }
   const bool isFullRevolution = revolveDegrees == 360.0f;
 
-  const int nDivisions = circularSegments > 2
-                             ? circularSegments
-                             : Quality::GetCircularSegments(radius);
+  const int nDivisions =
+      circularSegments > 2
+          ? circularSegments
+          : Quality::GetCircularSegments(radius) * revolveDegrees / 360;
 
   auto pImpl_ = std::make_shared<Impl>();
   auto& vertPos = pImpl_->vertPos_;

--- a/src/manifold/src/constructors.cpp
+++ b/src/manifold/src/constructors.cpp
@@ -333,8 +333,9 @@ Manifold Manifold::Revolve(const CrossSection& crossSection,
   }
 
   const Rect bounds = crossSection.Bounds();
+  const float radius = bounds.max.x;
 
-  if (bounds.max.x <= 0) {
+  if (radius <= 0) {
     return Invalid();
   } else if (bounds.min.x < 0) {
     // Take the x>=0 slice.
@@ -344,13 +345,6 @@ Manifold Manifold::Revolve(const CrossSection& crossSection,
         {{0.0, min.y}, {max.x, min.y}, {max.x, max.y}, {0.0, max.y}});
 
     polygons = (crossSection ^ posBoundingBox).ToPolygons();
-  }
-
-  float radius = 0.0f;
-  for (const auto& poly : polygons) {
-    for (const auto& vert : poly) {
-      radius = fmax(radius, vert.x);
-    }
   }
 
   if (revolveDegrees > 360.0f) {
@@ -390,14 +384,14 @@ Manifold Manifold::Revolve(const CrossSection& crossSection,
 
       if (!isFullRevolution) startPoses.push_back(startPosIndex);
 
+      const glm::vec2 currPolyVertex = poly[polyVert];
+      const glm::vec2 prevPolyVertex =
+          poly[polyVert == 0 ? poly.size() - 1 : polyVert - 1];
+
       const int prevStartPosIndex =
           startPosIndex +
-          (polyVert == 0 ? nRevolveAxisVerts + (nSlices * nPosVerts) - nSlices
-           : poly[polyVert - 1].x == 0.0 ? -1
-                                         : -nSlices);
-      glm::vec2 currPolyVertex = poly[polyVert];
-      glm::vec2 prevPolyVertex =
-          poly[polyVert == 0 ? poly.size() - 1 : polyVert - 1];
+          (polyVert == 0 ? nRevolveAxisVerts + (nSlices * nPosVerts) : 0) +
+          (prevPolyVertex.x == 0.0 ? -1 : -nSlices);
 
       for (int slice = 0; slice < nSlices; ++slice) {
         const float phi = slice * dPhi;

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -232,6 +232,14 @@ TEST(Manifold, Revolve2) {
   EXPECT_NEAR(prop.surfaceArea, 96.0f * glm::pi<float>(), 1.0f);
 }
 
+TEST(Manifold, Revolve3) {
+  CrossSection circle = CrossSection::Circle(1, 32);
+  Manifold sphere = Manifold::Revolve(circle, 32);
+  auto prop = sphere.GetProperties();
+  EXPECT_NEAR(prop.volume, 4.0f / 3.0f * glm::pi<float>(), 0.1);
+  EXPECT_NEAR(prop.surfaceArea, 4 * glm::pi<float>(), 0.15);
+}
+
 TEST(Manifold, PartialRevolveOnYAxis) {
   Polygons polys = SquareHole(2.0f);
   Polygons offsetPolys = SquareHole(10.0f);


### PR DESCRIPTION
I noticed that with partial revolves, the segments were getting more dense as the angle got smaller. This keeps it more in line with our global concepts of minAngle and minLength.