### PR TITLE
v2.3

### DIFF
--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manifold-3d",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Geometry library for topological robustness",
   "main": "manifold.js",
   "files": [

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
             }: pkgs.stdenv.mkDerivation {
               inherit doCheck;
               pname = "manifold-${parallel-backend}";
-              version = "2.2.2";
+              version = "2.3.0";
               src = self;
               nativeBuildInputs = (with pkgs; [
                 cmake
@@ -104,7 +104,7 @@
               parallelBackends)) // {
             manifold-js = pkgs.buildEmscriptenPackage {
               name = "manifold-js";
-              version = "2.2.2";
+              version = "2.3.0";
               src = self;
               nativeBuildInputs = (with pkgs; [ cmake python39 ]);
               buildInputs = [ pkgs.nodejs ];
@@ -135,7 +135,7 @@
             # but how should we make it work with other python versions?
             manifold3d = with pkgs.python3Packages; buildPythonPackage {
               pname = "manifold3d";
-              version = "2.2.2";
+              version = "2.3.0";
               src = self;
               propagatedBuildInputs = [
                 numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "manifold3d"
-version = "2.2.2"
+version = "2.3.0"
 authors = [
   { name="Emmett Lalish", email="elalish@gmail.com" },
 ]


### PR DESCRIPTION
## New Features
- Added `Project` function for 3D -> 2D. #638 (@elalish)
- Added `Slice` function for 3D -> 2D. #644 (@elalish)

## Bindings
- Add missing parameters to Python bindings. #646, #647 (@wrongbad)
- Updated Python bindings to use numpy universally. #650, #656 (@wrongbad)

## Bug Fixes
- Spec-compliant 3MF output for ManifoldCAD.org. #626, #627 (@pca006132)
- Fixed a couple of triangulator errors. #633 (@elalish)
- Improved our precision calculations, fixed collider. #635 (@elalish)
- Switched the order of rotation and scale in `Extrude` to match OpenSCAD. #642 (@pca006132)
- Make `Warp` no longer simplify. #677 (@elalish)
- Fixed `Revolve`. #682, #684 (@elalish)

## Performance Improvements
- Added `WarpBatch` for better binding efficiency. #651 (@wrongbad)

## Build/CI Updates
- Cleanup warnings, improved Tracy support. #640 (@pca006132)
- Added a formatting script. #660 (@pca006132)
- Build Python docs automatically. #665 (@wrongbad)

## Examples
- Updated tetrahedron puzzle example. #625 (@elalish)
- Added a [Python Colab Example](https://colab.research.google.com/drive/1VxrFYHPSHZgUbl9TeWzCeovlpXrPQ5J5?usp=sharing), functionally akin to ManifoldCAD.org. #648 (@elalish)

## [ManifoldCAD.org](https://manifoldcad.org/)
- Added glTF animation support. #624, #637 (@elalish)
- Updated glTF export for official [EXT_mesh_manifold](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Vendor/EXT_mesh_manifold) extension. #630 (@elalish)
- Enable hash params to point a URL directly to a particular example. #643 (@pca006132)