### PR TITLE
Install libpolygon

### DIFF
--- a/src/polygon/CMakeLists.txt
+++ b/src/polygon/CMakeLists.txt
@@ -26,3 +26,14 @@ target_link_libraries( ${PROJECT_NAME}
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
+  COMPONENT runtime
+)
+install(
+  DIRECTORY include/
+  DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/manifold
+  COMPONENT devel
+)


### PR DESCRIPTION
libmanifold depends on libpolygon, if installed it needs libpolygon.
