### PR TITLE
CrossSection::Compose was accidently left out of Python API.

### DIFF
--- a/bindings/python/examples/all_apis.py
+++ b/bindings/python/examples/all_apis.py
@@ -22,6 +22,7 @@ def all_cross_section():
     c = CrossSection.batch_hull([c, c.translate((1, 0))])
     b = c.bounds()
     c = CrossSection.circle(1)
+    c = CrossSection.compose([c, c.translate((1, 0))])
     cs = c.decompose()
     m = c.extrude(1)
     c = c.hull()

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -648,6 +648,8 @@ NB_MODULE(manifold3d, m) {
           [](std::vector<glm::vec2> pts) { return CrossSection::Hull(pts); },
           nb::arg("pts"), cross_section__hull__pts)
       .def("decompose", &CrossSection::Decompose, cross_section__decompose)
+      .def_static("compose", &CrossSection::Compose, nb::arg("cross_sections"),
+                  cross_section__compose__cross_sections)
       .def("to_polygons", &CrossSection::ToPolygons, cross_section__to_polygons)
       .def(
           "extrude", &Manifold::Extrude, nb::arg("height"),


### PR DESCRIPTION
@pca006132 fixed the nanobind issue, so this works now too!