### PR TITLE
Install Python module into site-packages

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -44,7 +44,7 @@ install(
 else()
 install(
   TARGETS manifold3d
-  LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
+  LIBRARY DESTINATION ${Python_SITEARCH}
   COMPONENT bindings
 )
 endif()

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,10 @@
                 "-DFETCHCONTENT_SOURCE_DIR_THRUST=${thrust-src}"
                 "-DMANIFOLD_PAR=${pkgs.lib.strings.toUpper parallel-backend}"
               ];
+              prePatch = ''
+                substituteInPlace bindings/python/CMakeLists.txt \
+                  --replace 'DESTINATION ''${Python_SITEARCH}' 'DESTINATION "${placeholder "out"}/${pkgs.python3.sitePackages}"'
+              '';
               checkPhase = ''
                 cd test
                 ./manifold_test


### PR DESCRIPTION
Allows `import manifold3d` to work from the REPL or a script using the installed system interpreter.
