### PR TITLE
fix sdist submodule

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -31,12 +31,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0  # Optional, use if you use setuptools_scm
-        submodules: true  # Optional, use if you have submodules
-
+        submodules: recursive
     - name: Build SDist
       run: pipx run build --sdist
-
     - uses: actions/upload-artifact@v3
       with:
         path: dist/*.tar.gz


### PR DESCRIPTION
Currently `make_sdist` action is not pulling submodules recursively, causing #706.