### PR TITLE
GLM 1.0 compatibility

### DIFF
--- a/src/utilities/include/public.h
+++ b/src/utilities/include/public.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#define GLM_ENABLE_EXPERIMENTAL  // needed for glm/gtx/compatibility.hpp
 #define GLM_FORCE_EXPLICIT_CTOR
 #include <glm/ext/matrix_transform.hpp>
 #include <glm/glm.hpp>


### PR DESCRIPTION
Using glm/gtx/compatibility.hpp without GLM_ENABLE_EXPERIMENTAL has become an error:

```
error: #error "GLM: GLM_GTX_compatibility is an experimental extension
               and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL
	       before including it, if you really want to use it."
```
---

Became an error in:
https://github.com/g-truc/glm/commit/f86092a658ad19bdc3e5a121d18785a582c9a56f#diff-b25c43cdda0d7be5dc5ea91beefb168cc1bd2522d60c7aa9b6c6164c0630e173

I haven't noticed any other effects from defining GLM_ENABLE_EXPERIMENTAL. But...
