### PR TITLE
python/gen_docs.py tidy-up

### DIFF
--- a/bindings/python/gen_docs.py
+++ b/bindings/python/gen_docs.py
@@ -1,5 +1,4 @@
 from os.path import dirname
-from hashlib import md5
 import re
 
 base = dirname(dirname(dirname(__file__)))
@@ -98,7 +97,7 @@ collect(f"{base}/src/utilities/include/public.h", select_functions)
 
 comments = dict(sorted(comments.items()))
 
-gen_h = f"autogen_docstrings.inl"
+gen_h = "autogen_docstrings.inl"
 with open(gen_h, "w") as f:
     f.write("#pragma once\n\n")
     f.write("// --- AUTO GENERATED ---\n")

--- a/bindings/python/gen_docs.py
+++ b/bindings/python/gen_docs.py
@@ -18,12 +18,12 @@ def python_param_modifier(comment):
 
 
 def method_key(name):
-    name = re.sub("\+", "_plus", name)
-    name = re.sub("\-", "_minus", name)
-    name = re.sub("\^", "_xor", name)
-    name = re.sub("\=", "_eq", name)
-    name = re.sub("\:", "_", name)
-    name = re.sub("\~", "destroy_", name)
+    name = re.sub(r"\+", "_plus", name)
+    name = re.sub(r"\-", "_minus", name)
+    name = re.sub(r"\^", "_xor", name)
+    name = re.sub(r"\=", "_eq", name)
+    name = re.sub(r"\:", "_", name)
+    name = re.sub(r"\~", "destroy_", name)
     return name
 
 


### PR DESCRIPTION
Resolve Python 3.12 invalid escape sequence warnings.

Remove unused code.
