### PR TITLE
Fix manifold3d module being built again in the install phase

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory(third_party)
 nanobind_add_module(
   manifold3d
   NB_STATIC STABLE_ABI LTO
+  autogen_docstrings.inl
   manifold3d.cpp)
 target_link_libraries(manifold3d PRIVATE manifold sdf polygon)
 target_compile_options(manifold3d PRIVATE ${MANIFOLD_FLAGS} -DMODULE_NAME=manifold3d)
@@ -25,15 +26,12 @@ target_compile_features(manifold3d PUBLIC cxx_std_17)
 set_target_properties(manifold3d PROPERTIES OUTPUT_NAME "manifold3d")
 
 message(Python_EXECUTABLE = ${Python_EXECUTABLE})
-add_custom_target(
-  autogen_docstrings
-  ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_docs.py
+add_custom_command(
+  OUTPUT autogen_docstrings.inl
+  COMMAND ${Python_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/gen_docs.py
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  BYPRODUCTS autogen_docstrings.inl
 )
 target_include_directories(manifold3d PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-add_dependencies(autogen_docstrings manifold sdf polygon)
-add_dependencies(manifold3d autogen_docstrings)
 
 if(SKBUILD)
 install(


### PR DESCRIPTION
With add_custom_target() "the target has no output file and is always considered out of date".