### PR TITLE
Install headers into manifold subdirectory

### DIFF
--- a/meshIO/CMakeLists.txt
+++ b/meshIO/CMakeLists.txt
@@ -17,7 +17,7 @@ project(meshIO)
 add_library(${PROJECT_NAME} src/meshIO.cpp)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/${CMAKE_PROJECT_NAME}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 
 target_link_libraries(${PROJECT_NAME}
@@ -29,4 +29,4 @@ target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 
 install(TARGETS ${PROJECT_NAME} EXPORT manifoldTargets)
-install(FILES include/meshIO.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES include/meshIO.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_PROJECT_NAME})

--- a/src/collider/CMakeLists.txt
+++ b/src/collider/CMakeLists.txt
@@ -17,7 +17,7 @@ project (collider)
 file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
 add_library(${PROJECT_NAME} OBJECT ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/${CMAKE_PROJECT_NAME}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 target_link_libraries(${PROJECT_NAME} PUBLIC utilities)
 target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
@@ -26,4 +26,4 @@ target_compile_features(${PROJECT_NAME}
     PUBLIC cxx_std_17
 )
 install(TARGETS ${PROJECT_NAME} EXPORT manifoldTargets)
-install(FILES include/collider.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES include/collider.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_PROJECT_NAME})

--- a/src/cross_section/CMakeLists.txt
+++ b/src/cross_section/CMakeLists.txt
@@ -16,7 +16,7 @@ project (cross_section)
 file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
 add_library(${PROJECT_NAME} OBJECT ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/${CMAKE_PROJECT_NAME}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 target_link_libraries(${PROJECT_NAME}
     PUBLIC utilities
@@ -26,4 +26,4 @@ target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 
 install(TARGETS ${PROJECT_NAME} EXPORT manifoldTargets)
-install(FILES include/cross_section.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES include/cross_section.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_PROJECT_NAME})

--- a/src/manifold/CMakeLists.txt
+++ b/src/manifold/CMakeLists.txt
@@ -18,7 +18,7 @@ file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
 add_library(${PROJECT_NAME} ${SOURCE_FILES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/${CMAKE_PROJECT_NAME}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 target_link_libraries(${PROJECT_NAME}
     PUBLIC utilities cross_section sdf
@@ -32,4 +32,4 @@ target_compile_features(${PROJECT_NAME}
 )
 
 install(TARGETS ${PROJECT_NAME} EXPORT manifoldTargets)
-install(FILES include/manifold.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES include/manifold.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_PROJECT_NAME})

--- a/src/polygon/CMakeLists.txt
+++ b/src/polygon/CMakeLists.txt
@@ -17,7 +17,7 @@ project (polygon)
 file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
 add_library(${PROJECT_NAME} OBJECT ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/${CMAKE_PROJECT_NAME}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 target_link_libraries(${PROJECT_NAME} PUBLIC utilities)
 
@@ -25,4 +25,4 @@ target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 
 install(TARGETS ${PROJECT_NAME} EXPORT manifoldTargets)
-install(FILES include/polygon.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES include/polygon.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_PROJECT_NAME})

--- a/src/sdf/CMakeLists.txt
+++ b/src/sdf/CMakeLists.txt
@@ -16,10 +16,10 @@ project(sdf)
 
 add_library(${PROJECT_NAME} OBJECT src/sdf.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/${CMAKE_PROJECT_NAME}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 target_link_libraries(${PROJECT_NAME} PUBLIC utilities)
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
 install(TARGETS ${PROJECT_NAME} EXPORT manifoldTargets)
-install(FILES include/sdf.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES include/sdf.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_PROJECT_NAME})

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -57,7 +57,7 @@ else()
 endif()
 
 target_include_directories(${PROJECT_NAME} INTERFACE
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:include/${CMAKE_PROJECT_NAME}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 target_link_libraries(${PROJECT_NAME} INTERFACE glm::glm)
 
@@ -82,4 +82,4 @@ endif()
 target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
 
 install(TARGETS ${PROJECT_NAME} EXPORT manifoldTargets)
-install(FILES include/public.h include/vec_view.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES include/public.h include/vec_view.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${CMAKE_PROJECT_NAME})


### PR DESCRIPTION
Basically this goes back to the way things were. I think it addresses #701 OK, don't know if there are other ideas.

```
/usr/include/manifold/meshIO.h
/usr/include/manifold/sdf.h
/usr/include/manifold/manifold.h
/usr/include/manifold/polygon.h
/usr/include/manifold/cross_section.h
/usr/include/manifold/collider.h
/usr/include/manifold/vec_view.h
/usr/include/manifold/public.h
```

Because of the CMake config files I am able to build OpenSCAD (modified to use `find_package(manifold)`) with either master or this PR.
