### PR TITLE
Fix to 2D HullImpl problem.

### DIFF
--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -187,7 +187,7 @@ C2::PathD HullImpl(SimplePolygon& pts) {
     lower.push_back(pts[i]);
   }
   auto upper = std::vector<glm::vec2>{};
-  for (int i = len-1; i >= 0; i--) {
+  for (int i = len - 1; i >= 0; i--) {
     auto sz = upper.size();
     while (sz >= 2 && Cross(upper[sz - 2], upper[sz - 1], pts[i]) <= 0) {
       upper.pop_back();
@@ -204,7 +204,7 @@ C2::PathD HullImpl(SimplePolygon& pts) {
     path[i] = v2_to_pd(lower[i]);
   }
   auto llen = lower.size();
-	int sz = upper.size(); // "fix" -Waggressive-loop-optimizations warning.
+  int sz = upper.size();  // "fix" -Waggressive-loop-optimizations warning.
   for (int i = 0; i < sz; i++) {
     path[i + llen] = v2_to_pd(upper[i]);
   }

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -163,8 +163,12 @@ bool V2Lesser(glm::vec2 a, glm::vec2 b) {
   return a.x < b.x;
 }
 
-double Cross(glm::vec2 a, glm::vec2 b, glm::vec2 c) {
-  return (a.x - c.x) * (b.y - c.y) - (a.y - c.y) * (b.x - c.x);
+void HullBacktrack(const glm::vec2& pt, std::vector<glm::vec2>& stack) {
+  auto sz = stack.size();
+  while (sz >= 2 && CCW(stack[sz - 2], stack[sz - 1], pt, 1e-18) <= 0) {
+    stack.pop_back();
+    sz = stack.size();
+  }
 }
 
 // Based on method described here:
@@ -179,20 +183,12 @@ C2::PathD HullImpl(SimplePolygon& pts) {
 
   auto lower = std::vector<glm::vec2>{};
   for (int i = 0; i < len; i++) {
-    auto sz = lower.size();
-    while (sz >= 2 && Cross(lower[sz - 2], lower[sz - 1], pts[i]) <= 0) {
-      lower.pop_back();
-      sz = lower.size();
-    }
+    HullBacktrack(pts[i], lower);
     lower.push_back(pts[i]);
   }
   auto upper = std::vector<glm::vec2>{};
   for (int i = len - 1; i >= 0; i--) {
-    auto sz = upper.size();
-    while (sz >= 2 && Cross(upper[sz - 2], upper[sz - 1], pts[i]) <= 0) {
-      upper.pop_back();
-      sz = upper.size();
-    }
+    HullBacktrack(pts[i], upper);
     upper.push_back(pts[i]);
   }
 

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -165,7 +165,7 @@ bool V2Lesser(glm::vec2 a, glm::vec2 b) {
 
 void HullBacktrack(const glm::vec2& pt, std::vector<glm::vec2>& stack) {
   auto sz = stack.size();
-  while (sz >= 2 && CCW(stack[sz - 2], stack[sz - 1], pt, 1e-18) <= 0) {
+  while (sz >= 2 && CCW(stack[sz - 2], stack[sz - 1], pt, 0.0f) <= 0.0f) {
     stack.pop_back();
     sz = stack.size();
   }

--- a/src/cross_section/src/cross_section.cpp
+++ b/src/cross_section/src/cross_section.cpp
@@ -163,50 +163,50 @@ bool V2Lesser(glm::vec2 a, glm::vec2 b) {
   return a.x < b.x;
 }
 
-double Cross(glm::vec2 a, glm::vec2 b) { return a.x * b.y - a.y * b.x; }
-
-double SquaredDistance(glm::vec2 a, glm::vec2 b) {
-  auto d = a - b;
-  return glm::dot(d, d);
-}
-
-bool IsCw(glm::vec2 a, glm::vec2 b, glm::vec2 c) {
-  double lhs = Cross(a - c, b - c);
-  double rhs = 1e-18 * SquaredDistance(a, c) * SquaredDistance(b, c);
-  return lhs * std::abs(lhs) <= rhs;
-}
-
-void HullBacktrack(const SimplePolygon& pts, const int idx,
-                   std::vector<int>& keep, const int hold) {
-  const int stop = keep.size() - hold;
-  int i = 0;
-  while (i < stop && !IsCw(pts[idx], pts[keep[keep.size() - 1]],
-                           pts[keep[keep.size() - 2]])) {
-    keep.pop_back();
-    i++;
-  }
+double Cross(glm::vec2 a, glm::vec2 b, glm::vec2 c) {
+  return (a.x - c.x) * (b.y - c.y) - (a.y - c.y) * (b.x - c.x);
 }
 
 // Based on method described here:
 // https://www.hackerearth.com/practice/math/geometry/line-sweep-technique/tutorial/
+// Changed to follow:
+// https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain
+// This is the same algorithm (Andrew, also called Montone Chain).
 C2::PathD HullImpl(SimplePolygon& pts) {
   int len = pts.size();
   if (len < 3) return C2::PathD();  // not enough points to create a polygon
   std::sort(pts.begin(), pts.end(), V2Lesser);
-  auto keep = std::vector<int>{0, 1};
-  for (int i = 2; i < len; i++) {
-    HullBacktrack(pts, i, keep, 1);
-    keep.push_back(i);
+
+  auto lower = std::vector<glm::vec2>{};
+  for (int i = 0; i < len; i++) {
+    auto sz = lower.size();
+    while (sz >= 2 && Cross(lower[sz - 2], lower[sz - 1], pts[i]) <= 0) {
+      lower.pop_back();
+      sz = lower.size();
+    }
+    lower.push_back(pts[i]);
   }
-  int nLower = keep.size();
-  for (int i = 0; i < len - 1; i++) {
-    int idx = len - 2 - i;
-    HullBacktrack(pts, idx, keep, nLower);
-    if (idx > 0) keep.push_back(idx);
+  auto upper = std::vector<glm::vec2>{};
+  for (int i = len-1; i >= 0; i--) {
+    auto sz = upper.size();
+    while (sz >= 2 && Cross(upper[sz - 2], upper[sz - 1], pts[i]) <= 0) {
+      upper.pop_back();
+      sz = upper.size();
+    }
+    upper.push_back(pts[i]);
   }
-  auto path = C2::PathD(keep.size());
-  for (int i = 0; i < keep.size(); i++) {
-    path[i] = v2_to_pd(pts[keep[i]]);
+
+  upper.pop_back();
+  lower.pop_back();
+
+  auto path = C2::PathD(lower.size() + upper.size());
+  for (int i = 0; i < lower.size(); i++) {
+    path[i] = v2_to_pd(lower[i]);
+  }
+  auto llen = lower.size();
+	int sz = upper.size(); // "fix" -Waggressive-loop-optimizations warning.
+  for (int i = 0; i < sz; i++) {
+    path[i + llen] = v2_to_pd(upper[i]);
   }
   return path;
 }


### PR DESCRIPTION
Fixes #728 

I did a refactor of the current Andrew/Monotone Chain algorithm,
using [this reference](https://en.wikibooks.org/wiki/Algorithm_Implementation/Geometry/Convex_hull/Monotone_chain)
I think the main problem was in the old check of the turn direction.
At least in my python timings for rounded_rectangle, the new version is slightly faster.
