### PR TITLE
[python] add MeshGL::Merge() to python API

### DIFF
--- a/bindings/python/examples/all_apis.py
+++ b/bindings/python/examples/all_apis.py
@@ -102,6 +102,7 @@ def all_manifold():
     e = m.status()
     m = Manifold.tetrahedron()
     mesh = m.to_mesh()
+    ok = mesh.merge()
     m = m.transform([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]])
     m = m.translate((0, 0, 0))
     m = m.trim_by_plane((0, 0, 1), 0)

--- a/bindings/python/gen_docs.py
+++ b/bindings/python/gen_docs.py
@@ -89,6 +89,7 @@ def select_functions(s):
 
 collect(f"{base}/src/manifold/src/manifold.cpp", lambda s: method_re.search(s))
 collect(f"{base}/src/manifold/src/constructors.cpp", lambda s: method_re.search(s))
+collect(f"{base}/src/manifold/src/sort.cpp", lambda s: method_re.search(s))
 collect(
     f"{base}/src/cross_section/src/cross_section.cpp", lambda s: method_re.search(s)
 )

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -538,7 +538,8 @@ NB_MODULE(manifold3d, m) {
           ":param level: You can inset your Mesh by using a positive value, or "
           "outset it with a negative value."
           ":return Mesh: This mesh is guaranteed to be manifold."
-          "Use Manifold.from_mesh(mesh) to create a Manifold");
+          "Use Manifold.from_mesh(mesh) to create a Manifold")
+      .def("merge", &MeshGL::Merge, mesh_gl__merge);
 
   nb::enum_<Manifold::Error>(m, "Error")
       .value("NoError", Manifold::Error::NoError)


### PR DESCRIPTION
Small diff to add MeshGL::Merge to python API, so .stl import can be done via python API