### PR TITLE
Changes that support piecad.

### DIFF
--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -387,6 +387,17 @@ NB_MODULE(manifold3d, m) {
       .def_static("tetrahedron", &Manifold::Tetrahedron, manifold__tetrahedron)
       .def_static("cube", &Manifold::Cube, nb::arg("size") = glm::vec3{1, 1, 1},
                   nb::arg("center") = false, manifold__cube__size__center)
+      .def_static("create_from_verts_and_triangles",
+                  &Manifold::CreateFromVertsAndTriangles, nb::arg("verts"),
+                  nb::arg("triangles"),
+                  manifold__create_from_verts_and_triangles__verts__triangles)
+      .def_static(
+          "extrude_transforming", &Manifold::ExtrudeTransforming,
+          nb::arg("crossSection"), nb::arg("height"),
+          nb::arg("n_divisions") = 0, nb::arg("twist_degrees") = 0.0f,
+          nb::arg("scale_top") = std::make_tuple(1.0f, 1.0f),
+          nb::arg("initial_z") = 0.0f, nb::arg("is_convex") = false,
+          manifold__extrude_transforming__cross_section__height__n_divisions__twist_degrees__scale_top__initial_z__is_convex)
       .def_static(
           "extrude", &Manifold::Extrude, nb::arg("crossSection"),
           nb::arg("height"), nb::arg("n_divisions") = 0,
@@ -681,11 +692,19 @@ NB_MODULE(manifold3d, m) {
       .def("revolve", &Manifold::Revolve, nb::arg("circular_segments") = 0,
            nb::arg("revolve_degrees") = 360.0,
            manifold__revolve__cross_section__circular_segments__revolve_degrees)
-
+      .def_static("create_from_polygons_unchecked",
+                  &CrossSection::CreateFromPolygonsUnchecked,
+                  nb::arg("polygons"),
+                  cross_section__create_from_polygons_unchecked__polygons)
       .def_static("square", &CrossSection::Square, nb::arg("size"),
                   nb::arg("center") = false,
                   cross_section__square__size__center)
       .def_static("circle", &CrossSection::Circle, nb::arg("radius"),
                   nb::arg("circular_segments") = 0,
-                  cross_section__circle__radius__circular_segments);
+                  cross_section__circle__radius__circular_segments)
+      .def_static(
+          "rounded_rectangle", &CrossSection::RoundedRectangle, nb::arg("size"),
+          nb::arg("radius"), nb::arg("circular_segments") = 0,
+          nb::arg("center") = false,
+          cross_section__rounded_rectangle__size__radius__circular_segments__center);
 }

--- a/src/cross_section/include/cross_section.h
+++ b/src/cross_section/include/cross_section.h
@@ -74,6 +74,11 @@ class CrossSection {
   CrossSection(const Polygons& contours,
                FillRule fillrule = FillRule::Positive);
   CrossSection(const Rect& rect);
+  static CrossSection CreateFromPolygonsUnchecked(
+      std::vector<std::vector<glm::vec2>> paths);
+  static CrossSection RoundedRectangle(const glm::vec2 size, float radius,
+                                       int circularSegments = 0,
+                                       bool center = false);
   static CrossSection Square(const glm::vec2 dims, bool center = false);
   static CrossSection Circle(float radius, int circularSegments = 0);
   ///@}

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -146,9 +146,17 @@ class Manifold {
                            float radiusHigh = -1.0f, int circularSegments = 0,
                            bool center = false);
   static Manifold Sphere(float radius, int circularSegments = 0);
+  static Manifold CreateFromVertsAndTriangles(
+      std::vector<glm::vec3> verts, std::vector<glm::ivec3> triangles);
   static Manifold Extrude(const CrossSection& crossSection, float height,
                           int nDivisions = 0, float twistDegrees = 0.0f,
                           glm::vec2 scaleTop = glm::vec2(1.0f));
+  static Manifold ExtrudeTransforming(const CrossSection& crossSection,
+                                      float height, int nDivisions = 0,
+                                      float twistDegrees = 0.0f,
+                                      glm::vec2 scaleTop = glm::vec2(1.0f),
+                                      float initialZ = 0.0f,
+                                      bool isConvex = false);
   static Manifold Revolve(const CrossSection& crossSection,
                           int circularSegments = 0,
                           float revolveDegrees = 360.0f);


### PR DESCRIPTION
This pull request contains several things I've worked on when experimenting
with improving Manifold's support for Python and especially 2d objects.
These are the ones that have provided the most speed improvments.


NOTE: in benchmarks `_mo_` indicates a direct test of Manifold objects from Python.

<details><summary>Benchmarks overview.</summary>

```
Benchmark Name (times are means in us)             Current         New
---
test_mo_square                                        0.69        0.71
test_mo_circle_10                                     1.05        1.02
test_mo_rounded_rectangle                                -        1.17
test_mo_circle_100                                    4.94        4.74
test_mo_cube                                          5.64        5.44
test_cube_from_create_from_verts_and_triangles       18.90        8.23
test_rounded_rectangle                               14.74        9.09
test_mo_cylinder_100_centered                       521.90      161.38
test_mo_cylinder_100                                283.59      161.54
test_extrude_transforming_circle_100_fan                 -      155.68
test_extrude_transforming_circle_100_earcut              -      276.72

```
</details>

## One

The number one issue is extrusion speed. Manifold uses an earcut derivative,
which like earcut, is rather slow.

As you can see, currently, cylinders are extruded and centered cylinders are just sad.

```
Benchmark Name (times are means in us)             Current         New
---
test_mo_cylinder_100_centered                       521.90      161.38
test_mo_cylinder_100                                283.59      161.54
test_extrude_transforming_circle_100_fan                 -      155.68
test_extrude_transforming_circle_100_earcut              -      276.72
```

I fixed this issue by making a function called ExtrudeTransforming, which
contains all the code from Extrude, with two additions.

One, if you set isConvex to true, then fan triangulation is used.

Two, I added initialZ, which allows one to use extrude to properly handle centering the cylinder.

The Extrude routine is now just a call to ExtrudeTransforming without the two new arguments.
Leaving Manifold's API the same.

The two `test_extrude_trans..." test are tests ONLY of extrude time, not circle creation time.
It shows clearly how much time is wasted when unnecessarily using earcut.

## Two

The second issue is the unnecessary overhead that is endured by Python programs needing to
make primitives.

```
Benchmark Name (times are means in us)             Current         New
---
test_rounded_rectangle                               14.74        9.09
test_cube_from_create_from_verts_and_triangles       18.90        8.23
```

The new versions skip Unions (2D) and use a very cut down Extrude called CreateFromVertsAndTriangles,
that simply pases through the verts and triangles (3D).

(The CrossSection addition is called CreateFromPolygonsUnchecked.)


## Three

The third issue issue isn't really an issue, it's just that a built in RoundedRectangle works much faster.
RoundedRectangles cannot be scaled without deforming the corners, so I cache (by circularSegments)
the unit trig ops and it works about as fast as scaling a unit circle does.

```
Benchmark Name (times are means in us)             Current         New
---
test_mo_rounded_rectangle                                -        1.17
```

Compare that against the Python versions:

```
test_rounded_rectangle                               14.74        9.09
```