### PR TITLE
Java bindings pointer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ python binding documentation:
 
 For more detailed documentation, please refer to the C++ API.
 
+### Java / Clojure
+
+Unofficial java bindings are currently maintained in [a fork](https://github.com/SovereignShop/manifold).
+
+There is also a Clojure [library](https://github.com/SovereignShop/clj-manifold3d).
+
 ### Windows Shenanigans
 
 Windows users should build with `-DBUILD_SHARED_LIBS=OFF`, as enabling shared


### PR DESCRIPTION
Hello,

This just adds a brief mention of Java/clojure bindings in the README.

P.S. I closed a previous MR because commits included the wrong email which seemed to be tripping up the license agreement process.