### PR TITLE
Smooth By Normals

### DIFF
--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -139,6 +139,8 @@ ManifoldManifold *manifold_mirror(void *mem, ManifoldManifold *m, float nx,
                                   float ny, float nz);
 ManifoldManifold *manifold_warp(void *mem, ManifoldManifold *m,
                                 ManifoldVec3 (*fun)(float, float, float));
+ManifoldManifold *manifold_smooth_by_normals(void *mem, ManifoldManifold *m,
+                                             int normalIdx);
 ManifoldManifold *manifold_smooth_out(void *mem, ManifoldManifold *m,
                                       float minSharpAngle, float minSmoothness);
 ManifoldManifold *manifold_refine(void *mem, ManifoldManifold *m, int refine);

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -300,6 +300,12 @@ ManifoldMeshGL *manifold_level_set_seq_context(
   return level_set_context(mem, sdf, bounds, edge_length, level, true, ctx);
 }
 
+ManifoldManifold *manifold_smooth_by_normals(void *mem, ManifoldManifold *m,
+                                             int normalIdx) {
+  auto smoothed = from_c(m)->SmoothByNormals(normalIdx);
+  return to_c(new (mem) Manifold(smoothed));
+}
+
 ManifoldManifold *manifold_smooth_out(void *mem, ManifoldManifold *m,
                                       float minSharpAngle,
                                       float minSmoothness) {

--- a/bindings/python/examples/all_apis.py
+++ b/bindings/python/examples/all_apis.py
@@ -70,6 +70,7 @@ def all_manifold():
     b = m.bounding_box()
     m = m.calculate_curvature(4, 5)
     m = m.calculate_normals(0)
+    m = m.smooth_by_normals(0)
     m = Manifold.compose([m, m.translate((5, 0, 0))])
     m = Manifold.cube((1, 1, 1))
     m = Manifold.cylinder(1, 1)

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -107,7 +107,7 @@ struct nb::detail::type_caster<glm::mat<C, R, T, Q>> {
   static handle from_cpp(glm_type mat, rv_policy policy,
                          cleanup_list *cleanup) noexcept {
     T *buffer = new T[R * C];
-    nb::capsule mem_mgr(buffer, [](void *p) noexcept { delete[](T *) p; });
+    nb::capsule mem_mgr(buffer, [](void *p) noexcept { delete[] (T *)p; });
     for (int i = 0; i < R; i++) {
       for (int j = 0; j < C; j++) {
         // py is (Rows, Cols), glm is (Cols, Rows)
@@ -154,7 +154,7 @@ struct nb::detail::type_caster<std::vector<glm::vec<N, T, Q>>> {
                          cleanup_list *cleanup) noexcept {
     size_t num_vec = vec.size();
     T *buffer = new T[num_vec * N];
-    nb::capsule mem_mgr(buffer, [](void *p) noexcept { delete[](T *) p; });
+    nb::capsule mem_mgr(buffer, [](void *p) noexcept { delete[] (T *)p; });
     for (int i = 0; i < num_vec; i++) {
       for (int j = 0; j < N; j++) {
         buffer[i * N + j] = vec[i][j];
@@ -318,6 +318,8 @@ NB_MODULE(manifold3d, m) {
       .def("calculate_normals", &Manifold::CalculateNormals,
            nb::arg("normal_idx"), nb::arg("min_sharp_angle") = 60,
            manifold__calculate_normals__normal_idx__min_sharp_angle)
+      .def("smooth_by_normals", &Manifold::SmoothByNormals,
+           nb::arg("normal_idx") manifold__smooth_by_normals__normal_idx)
       .def("smooth_out", &Manifold::SmoothOut, nb::arg("min_sharp_angle") = 60,
            nb::arg("min_smoothness") = 0,
            manifold__smooth_out__min_sharp_angle__min_smoothness)

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -319,7 +319,7 @@ NB_MODULE(manifold3d, m) {
            nb::arg("normal_idx"), nb::arg("min_sharp_angle") = 60,
            manifold__calculate_normals__normal_idx__min_sharp_angle)
       .def("smooth_by_normals", &Manifold::SmoothByNormals,
-           nb::arg("normal_idx") manifold__smooth_by_normals__normal_idx)
+           nb::arg("normal_idx"), manifold__smooth_by_normals__normal_idx)
       .def("smooth_out", &Manifold::SmoothOut, nb::arg("min_sharp_angle") = 60,
            nb::arg("min_smoothness") = 0,
            manifold__smooth_out__min_sharp_angle__min_smoothness)

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -107,7 +107,7 @@ struct nb::detail::type_caster<glm::mat<C, R, T, Q>> {
   static handle from_cpp(glm_type mat, rv_policy policy,
                          cleanup_list *cleanup) noexcept {
     T *buffer = new T[R * C];
-    nb::capsule mem_mgr(buffer, [](void *p) noexcept { delete[] (T *)p; });
+    nb::capsule mem_mgr(buffer, [](void *p) noexcept { delete[](T *) p; });
     for (int i = 0; i < R; i++) {
       for (int j = 0; j < C; j++) {
         // py is (Rows, Cols), glm is (Cols, Rows)
@@ -154,7 +154,7 @@ struct nb::detail::type_caster<std::vector<glm::vec<N, T, Q>>> {
                          cleanup_list *cleanup) noexcept {
     size_t num_vec = vec.size();
     T *buffer = new T[num_vec * N];
-    nb::capsule mem_mgr(buffer, [](void *p) noexcept { delete[] (T *)p; });
+    nb::capsule mem_mgr(buffer, [](void *p) noexcept { delete[](T *) p; });
     for (int i = 0; i < num_vec; i++) {
       for (int j = 0; j < N; j++) {
         buffer[i * N + j] = vec[i][j];

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -144,6 +144,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("_GetMeshJS", &js::GetMeshJS)
       .function("refine", &Manifold::Refine)
       .function("refineToLength", &Manifold::RefineToLength)
+      .function("smoothByNormals", &Manifold::SmoothByNormals)
       .function("smoothOut", &Manifold::SmoothOut)
       .function("_Warp", &man_js::Warp)
       .function("_SetProperties", &man_js::SetProperties)

--- a/bindings/wasm/examples/public/examples.js
+++ b/bindings/wasm/examples/public/examples.js
@@ -221,7 +221,7 @@ export const examples = {
       const radius = 30;
       const offset = 20;
       const wiggles = 12;
-      const sharpness = 0.8;
+      const sharpness = 0.6;
       const n = 50;
 
       const positions = [];

--- a/bindings/wasm/examples/worker.test.js
+++ b/bindings/wasm/examples/worker.test.js
@@ -116,8 +116,8 @@ suite('Examples', () => {
   test('Scallop', async () => {
     const result = await runExample('Scallop');
     expect(result.genus).to.equal(0, 'Genus');
-    expect(result.volume).to.be.closeTo(41100, 100, 'Volume');
-    expect(result.surfaceArea).to.be.closeTo(7822, 10, 'Surface Area');
+    expect(result.volume).to.be.closeTo(41500, 100, 'Volume');
+    expect(result.surfaceArea).to.be.closeTo(7880, 10, 'Surface Area');
   });
 
   test('Torus Knot', async () => {

--- a/bindings/wasm/examples/worker.test.js
+++ b/bindings/wasm/examples/worker.test.js
@@ -117,7 +117,7 @@ suite('Examples', () => {
     const result = await runExample('Scallop');
     expect(result.genus).to.equal(0, 'Genus');
     expect(result.volume).to.be.closeTo(41100, 100, 'Volume');
-    expect(result.surfaceArea).to.be.closeTo(7790, 10, 'Surface Area');
+    expect(result.surfaceArea).to.be.closeTo(7822, 10, 'Surface Area');
   });
 
   test('Torus Knot', async () => {

--- a/bindings/wasm/examples/worker.ts
+++ b/bindings/wasm/examples/worker.ts
@@ -71,6 +71,7 @@ const manifoldMemberFunctions = [
   'mirror',
   'calculateCurvature',
   'calculateNormals',
+  'smoothByNormals',
   'smoothOut',
   'refine',
   'refineToLength',

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -562,7 +562,20 @@ export class Manifold {
   /**
    * Smooths out the Manifold by filling in the halfedgeTangent vectors. The
    * geometry will remain unchanged until Refine or RefineToLength is called to
-   * interpolate the surface.
+   * interpolate the surface. This version uses the supplied vertex normal
+   * properties to define the tangent vectors.
+   *
+   * @param normalIdx The first property channel of the normals. NumProp must be
+   * at least normalIdx + 3. Any vertex where multiple normals exist and don't
+   * agree will result in a sharp edge.
+   */
+  smoothByNormals(normalIdx: number): Manifold;
+
+  /**
+   * Smooths out the Manifold by filling in the halfedgeTangent vectors. The
+   * geometry will remain unchanged until Refine or RefineToLength is called to
+   * interpolate the surface. This version uses the geometry of the triangles
+   * and pseudo-normals to define the tangent vectors.
    *
    * @param minSharpAngle degrees, default 60. Any edges with angles greater
    * than this value will remain sharp. The rest will be smoothed to G1

--- a/samples/src/scallop.cpp
+++ b/samples/src/scallop.cpp
@@ -25,7 +25,7 @@ Manifold Scallop() {
   constexpr float radius = 3;
   constexpr float offset = 2;
   constexpr int wiggles = 12;
-  constexpr float sharpness = 0.8;
+  constexpr float sharpness = 0.6;
 
   Mesh scallop;
   std::vector<Smoothness> sharpenedEdges;

--- a/src/manifold/include/manifold.h
+++ b/src/manifold/include/manifold.h
@@ -245,6 +245,7 @@ class Manifold {
       int, std::function<void(float*, glm::vec3, const float*)>) const;
   Manifold CalculateCurvature(int gaussianIdx, int meanIdx) const;
   Manifold CalculateNormals(int normalIdx, float minSharpAngle = 60) const;
+  Manifold SmoothByNormals(int normalIdx) const;
   Manifold SmoothOut(float minSharpAngle = 60, float minSmoothness = 0) const;
   Manifold Refine(int) const;
   Manifold RefineToLength(float) const;

--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -137,6 +137,7 @@ struct Manifold::Impl {
   void SplitPinchedVerts();
 
   // smoothing.cu
+  glm::vec3 GetNormal(int halfedge, int normalIdx) const;
   std::vector<Smoothness> UpdateSharpenedEdges(
       const std::vector<Smoothness>&) const;
   Vec<bool> FlatFaces() const;
@@ -144,6 +145,7 @@ struct Manifold::Impl {
   std::vector<Smoothness> SharpenEdges(float minSharpAngle,
                                        float minSmoothness) const;
   void SetNormals(int normalIdx, float minSharpAngle);
+  void CreateTangents(int normalIdx);
   void CreateTangents(std::vector<Smoothness>);
   Vec<Barycentric> Subdivide(std::function<int(glm::vec3)>);
   void Refine(std::function<int(glm::vec3)>);

--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -66,6 +66,29 @@ struct Manifold::Impl {
        const std::vector<float>& propertyTolerance = {},
        bool hasFaceIDs = false);
 
+  inline void ForVert(int halfedge, std::function<void(int halfedge)> func) {
+    int current = halfedge;
+    do {
+      func(current);
+      current = NextHalfedge(halfedge_[current].pairedHalfedge);
+    } while (current != halfedge);
+  }
+
+  template <typename T>
+  void ForVert(int halfedge, std::function<T(int halfedge)> transform,
+               std::function<void(int halfedge, const T& here, const T& next)>
+                   binaryOp) {
+    T here = transform(halfedge);
+    int current = halfedge;
+    do {
+      const int nextHalfedge = NextHalfedge(halfedge_[current].pairedHalfedge);
+      const T next = transform(nextHalfedge);
+      binaryOp(current, here, next);
+      here = next;
+      current = nextHalfedge;
+    } while (current != halfedge);
+  }
+
   void CreateFaces(const std::vector<float>& propertyTolerance = {});
   void RemoveUnreferencedVerts(Vec<glm::ivec3>& triVerts);
   void InitializeOriginal();

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -661,8 +661,8 @@ Manifold Manifold::CalculateCurvature(int gaussianIdx, int meanIdx) const {
  *
  * @param normalIdx The property channel in which to store the X
  * values of the normals. The X, Y, and Z channels will be sequential. The
- * property set will be automatically expanded to include up through normalIdx
- * + 2.
+ * property set will be automatically expanded such that NumProp will be at
+ * least normalIdx + 3.
  *
  * @param minSharpAngle Any edges with angles greater than this value will
  * remain sharp, getting different normal vector properties on each side of the
@@ -679,7 +679,26 @@ Manifold Manifold::CalculateNormals(int normalIdx, float minSharpAngle) const {
 /**
  * Smooths out the Manifold by filling in the halfedgeTangent vectors. The
  * geometry will remain unchanged until Refine or RefineToLength is called to
- * interpolate the surface.
+ * interpolate the surface. This version uses the supplied vertex normal
+ * properties to define the tangent vectors.
+ *
+ * @param normalIdx The first property channel of the normals. NumProp must be
+ * at least normalIdx + 3. Any vertex where multiple normals exist and don't
+ * agree will result in a sharp edge.
+ */
+Manifold Manifold::SmoothByNormals(int normalIdx) const {
+  auto pImpl = std::make_shared<Impl>(*GetCsgLeafNode().GetImpl());
+  if (!IsEmpty()) {
+    pImpl->CreateTangents(normalIdx);
+  }
+  return Manifold(std::make_shared<CsgLeafNode>(pImpl));
+}
+
+/**
+ * Smooths out the Manifold by filling in the halfedgeTangent vectors. The
+ * geometry will remain unchanged until Refine or RefineToLength is called to
+ * interpolate the surface. This version uses the geometry of the triangles and
+ * pseudo-normals to define the tangent vectors.
  *
  * @param minSharpAngle degrees, default 60. Any edges with angles greater than
  * this value will remain sharp. The rest will be smoothed to G1 continuity,

--- a/src/manifold/src/smoothing.cpp
+++ b/src/manifold/src/smoothing.cpp
@@ -858,7 +858,8 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
     } else {  // Sharpen vertex uniformly
       int current = first;
       do {
-        halfedgeTangent_[current] = glm::vec4(0);
+        halfedgeTangent_[current] =
+            glm::vec4(0, 0, 0, halfedgeTangent_[current].w);
         current = NextHalfedge(halfedge_[current].pairedHalfedge);
       } while (current != first);
     }

--- a/src/manifold/src/smoothing.cpp
+++ b/src/manifold/src/smoothing.cpp
@@ -851,15 +851,13 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
 
       ForVert(first, [this, first, second](int current) {
         if (current != first && current != second) {
-          halfedgeTangent_[current] =
-              glm::vec4(0, 0, 0, halfedgeTangent_[current].w);
+          halfedgeTangent_[current] = glm::vec4(0);
         }
       });
     } else {  // Sharpen vertex uniformly
       int current = first;
       do {
-        halfedgeTangent_[current] =
-            glm::vec4(0, 0, 0, halfedgeTangent_[current].w);
+        halfedgeTangent_[current] = glm::vec4(0);
         current = NextHalfedge(halfedge_[current].pairedHalfedge);
       } while (current != first);
     }
@@ -952,8 +950,7 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges) {
       auto SmoothHalf = [&](int first, int last, float smoothness) {
         int current = NextHalfedge(halfedge_[first].pairedHalfedge);
         while (current != last) {
-          tangent[current] = glm::vec4(smoothness * glm::vec3(tangent[current]),
-                                       tangent[current].w);
+          tangent[current] = smoothness * tangent[current];
           current = NextHalfedge(halfedge_[current].pairedHalfedge);
         }
       };
@@ -973,8 +970,7 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges) {
       const int start = vert[0].first.halfedge;
       int current = start;
       do {
-        tangent[current] = glm::vec4(smoothness * glm::vec3(tangent[current]),
-                                     tangent[current].w);
+        tangent[current] = smoothness * tangent[current];
         current = NextHalfedge(halfedge_[current].pairedHalfedge);
       } while (current != start);
     }

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -395,6 +395,25 @@ TEST(Manifold, SmoothSphere) {
   }
 }
 
+TEST(Manifold, SmoothNormals) {
+  Manifold cylinder = Manifold::Cylinder(10, 5, 5, 8);
+  Manifold out = cylinder.SmoothOut().RefineToLength(0.1);
+  MeshGL test = cylinder.CalculateNormals(0).GetMeshGL();
+  Dump(test.vertProperties);
+
+  Manifold byNormals =
+      cylinder.CalculateNormals(0).SmoothByNormals(0).RefineToLength(0.1);
+  auto outProp = out.GetProperties();
+  auto byNormalsProp = byNormals.GetProperties();
+  EXPECT_FLOAT_EQ(outProp.volume, byNormalsProp.volume);
+  EXPECT_FLOAT_EQ(outProp.surfaceArea, byNormalsProp.surfaceArea);
+
+#ifdef MANIFOLD_EXPORT
+  if (options.exportModels)
+    ExportMesh("smoothCylinder.glb", byNormals.GetMesh(), {});
+#endif
+}
+
 TEST(Manifold, ManualSmooth) {
   // Unit Octahedron
   const Mesh oct = Manifold::Sphere(1, 4).GetMesh();

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -398,15 +398,12 @@ TEST(Manifold, SmoothSphere) {
 TEST(Manifold, SmoothNormals) {
   Manifold cylinder = Manifold::Cylinder(10, 5, 5, 8);
   Manifold out = cylinder.SmoothOut().RefineToLength(0.1);
-  MeshGL test = cylinder.CalculateNormals(0).GetMeshGL();
-  Dump(test.vertProperties);
-
   Manifold byNormals =
       cylinder.CalculateNormals(0).SmoothByNormals(0).RefineToLength(0.1);
   auto outProp = out.GetProperties();
   auto byNormalsProp = byNormals.GetProperties();
-  EXPECT_FLOAT_EQ(outProp.volume, byNormalsProp.volume);
-  EXPECT_FLOAT_EQ(outProp.surfaceArea, byNormalsProp.surfaceArea);
+  EXPECT_NEAR(outProp.volume, byNormalsProp.volume, 0.5);
+  EXPECT_NEAR(outProp.surfaceArea, byNormalsProp.surfaceArea, 0.1);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels)

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -347,8 +347,8 @@ TEST(Manifold, SmoothFlat) {
   Manifold cone = Manifold::Cylinder(5, 10, 5).SmoothOut().CalculateNormals(0);
   Manifold smooth = cone.RefineToLength(0.1);
   auto prop = smooth.GetProperties();
-  EXPECT_NEAR(prop.volume, 1105, 1);
-  EXPECT_NEAR(prop.surfaceArea, 759, 1);
+  EXPECT_NEAR(prop.volume, 1157, 1);
+  EXPECT_NEAR(prop.surfaceArea, 779, 1);
 
 #ifdef MANIFOLD_EXPORT
   ExportOptions options2;
@@ -402,8 +402,8 @@ TEST(Manifold, SmoothNormals) {
       cylinder.CalculateNormals(0).SmoothByNormals(0).RefineToLength(0.1);
   auto outProp = out.GetProperties();
   auto byNormalsProp = byNormals.GetProperties();
-  EXPECT_NEAR(outProp.volume, byNormalsProp.volume, 0.5);
-  EXPECT_NEAR(outProp.surfaceArea, byNormalsProp.surfaceArea, 0.1);
+  EXPECT_FLOAT_EQ(outProp.volume, byNormalsProp.volume);
+  EXPECT_FLOAT_EQ(outProp.surfaceArea, byNormalsProp.surfaceArea);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels)

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -121,7 +121,7 @@ TEST(Samples, Scallop) {
   CheckNormals(scallop);
   auto prop = scallop.GetProperties();
   EXPECT_NEAR(prop.volume, 41.1, 0.1);
-  EXPECT_NEAR(prop.surfaceArea, 77.9, 0.1);
+  EXPECT_NEAR(prop.surfaceArea, 78.2, 0.1);
   CheckGL(scallop);
 
 #ifdef MANIFOLD_EXPORT

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -120,8 +120,8 @@ TEST(Samples, Scallop) {
       3, colorCurvature);
   CheckNormals(scallop);
   auto prop = scallop.GetProperties();
-  EXPECT_NEAR(prop.volume, 41.1, 0.1);
-  EXPECT_NEAR(prop.surfaceArea, 78.2, 0.1);
+  EXPECT_NEAR(prop.volume, 41.5, 0.1);
+  EXPECT_NEAR(prop.surfaceArea, 78.8, 0.1);
   CheckGL(scallop);
 
 #ifdef MANIFOLD_EXPORT


### PR DESCRIPTION
Follow-on to #771, that allows smoothing based on input normal properties. Has the convenient side effect of making a solid test since we now have two different paths to create the same type of smoothing, in the case of sharp edges. 

I also added `ForVert`, which I think is a good start toward addressing #775. 