### PR TITLE
Smoothing fixes

### DIFF
--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -178,6 +178,7 @@ struct Manifold::Impl {
   std::vector<Smoothness> SharpenEdges(float minSharpAngle,
                                        float minSmoothness) const;
   void SetNormals(int normalIdx, float minSharpAngle);
+  void LinearizeFlatTangents();
   void CreateTangents(int normalIdx);
   void CreateTangents(std::vector<Smoothness>);
   Vec<Barycentric> Subdivide(std::function<int(glm::vec3)>);

--- a/src/manifold/src/smoothing.cpp
+++ b/src/manifold/src/smoothing.cpp
@@ -1517,6 +1517,7 @@ void Manifold::Impl::Refine(std::function<int(glm::vec3)> edgeDivisions) {
     // being non-coplanar, and hence not being related to the original faces.
     meshRelation_.originalID = ReserveIDs(1);
     InitializeOriginal();
+    CreateFaces();
   }
 
   halfedgeTangent_.resize(0);

--- a/src/manifold/src/smoothing.cpp
+++ b/src/manifold/src/smoothing.cpp
@@ -966,7 +966,7 @@ void Manifold::Impl::SetNormals(int normalIdx, float minSharpAngle) {
               group.push_back(normals.size() - 1);
               float dot = glm::dot(here.edgeVec, next.edgeVec);
               const float phi =
-                  dot >= 1 ? 0
+                  dot >= 1 ? kTolerance
                            : (dot <= -1 ? glm::pi<float>() : glm::acos(dot));
               normals.back() += faceNormal_[next.face] * phi;
             });

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -358,12 +358,13 @@ TEST(Manifold, RefineQuads) {
   auto prop = cylinder.GetProperties();
   EXPECT_NEAR(prop.volume, 2 * glm::pi<float>(), 0.003);
   EXPECT_NEAR(prop.surfaceArea, 6 * glm::pi<float>(), 0.0003);
+  MeshGL out = cylinder.GetMeshGL();
+  CheckGL(out);
 
 #ifdef MANIFOLD_EXPORT
   ExportOptions options2;
   options2.mat.colorChannels = {3, 4, 5, -1};
-  if (options.exportModels)
-    ExportMesh("refinedCylinder.glb", cylinder.GetMeshGL(), options2);
+  if (options.exportModels) ExportMesh("refinedCylinder.glb", out, options2);
 #endif
 }
 
@@ -373,14 +374,15 @@ TEST(Manifold, SmoothFlat) {
   auto prop = smooth.GetProperties();
   EXPECT_NEAR(prop.volume, 1159.02, 0.01);
   EXPECT_NEAR(prop.surfaceArea, 771.45, 0.01);
+  MeshGL out = smooth.GetMeshGL();
+  CheckGL(out);
 
 #ifdef MANIFOLD_EXPORT
   ExportOptions options2;
   options2.faceted = false;
   options2.mat.normalChannels = {3, 4, 5};
   options2.mat.roughness = 0;
-  if (options.exportModels)
-    ExportMesh("smoothCone.glb", smooth.GetMeshGL(), options2);
+  if (options.exportModels) ExportMesh("smoothCone.glb", out, options2);
 #endif
 }
 

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -357,12 +357,24 @@ TEST(Manifold, RefineQuads) {
   EXPECT_EQ(cylinder.NumTri(), 16892);
   auto prop = cylinder.GetProperties();
   EXPECT_NEAR(prop.volume, 2 * glm::pi<float>(), 0.003);
-  EXPECT_NEAR(prop.surfaceArea, 6 * glm::pi<float>(), 0.0003);
-  MeshGL out = cylinder.GetMeshGL();
+  EXPECT_NEAR(prop.surfaceArea, 6 * glm::pi<float>(), 0.004);
+  const MeshGL out = cylinder.GetMeshGL();
   CheckGL(out);
+
+  const MeshGL baseline = WithPositionColors(cylinder);
+  float maxDiff = 0;
+  for (int i = 0; i < out.vertProperties.size(); ++i) {
+    maxDiff = glm::max(
+        maxDiff, glm::abs(out.vertProperties[i] - baseline.vertProperties[i]));
+  }
+  // This has a wide tolerance because the triangle colors on the ends are still
+  // being stretched out into circular arcs, which introduces unavoidable error.
+  EXPECT_LE(maxDiff, 0.07);
 
 #ifdef MANIFOLD_EXPORT
   ExportOptions options2;
+  options2.mat.metalness = 0;
+  options2.mat.roughness = 0.5;
   options2.mat.colorChannels = {3, 4, 5, -1};
   if (options.exportModels) ExportMesh("refinedCylinder.glb", out, options2);
 #endif
@@ -372,8 +384,8 @@ TEST(Manifold, SmoothFlat) {
   Manifold cone = Manifold::Cylinder(5, 10, 5, 12).SmoothOut();
   Manifold smooth = cone.RefineToLength(0.1).CalculateNormals(0);
   auto prop = smooth.GetProperties();
-  EXPECT_NEAR(prop.volume, 1159.02, 0.01);
-  EXPECT_NEAR(prop.surfaceArea, 771.45, 0.01);
+  EXPECT_NEAR(prop.volume, 1142.9, 0.01);
+  EXPECT_NEAR(prop.surfaceArea, 764.28, 0.01);
   MeshGL out = smooth.GetMeshGL();
   CheckGL(out);
 

--- a/test/test.h
+++ b/test/test.h
@@ -57,6 +57,7 @@ MeshGL WithPositionColors(const Manifold& in);
 MeshGL WithNormals(const Manifold& in);
 float GetMaxProperty(const MeshGL& mesh, int channel);
 float GetMinProperty(const MeshGL& mesh, int channel);
+void CheckFinite(const MeshGL& mesh);
 void Identical(const Mesh& mesh1, const Mesh& mesh2);
 void RelatedGL(const Manifold& out, const std::vector<MeshGL>& originals,
                bool checkNormals = false, bool updateNormals = false);

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -305,6 +305,18 @@ float GetMinProperty(const MeshGL& mesh, int channel) {
   return min;
 }
 
+void CheckFinite(const MeshGL& mesh) {
+  for (float v : mesh.vertProperties) {
+    ASSERT_TRUE(isfinite(v));
+  }
+  for (float v : mesh.runTransform) {
+    ASSERT_TRUE(isfinite(v));
+  }
+  for (float v : mesh.halfedgeTangent) {
+    ASSERT_TRUE(isfinite(v));
+  }
+}
+
 void Identical(const Mesh& mesh1, const Mesh& mesh2) {
   ASSERT_EQ(mesh1.vertPos.size(), mesh2.vertPos.size());
   for (int i = 0; i < mesh1.vertPos.size(); ++i)
@@ -455,6 +467,7 @@ void CheckGL(const Manifold& manifold) {
     EXPECT_EQ(meshGL.runTransform.size(), 12 * meshGL.runOriginalID.size());
   }
   EXPECT_EQ(meshGL.faceID.size(), meshGL.NumTri());
+  CheckFinite(meshGL);
 }
 
 #ifdef MANIFOLD_EXPORT


### PR DESCRIPTION
Fixed a few problems I noticed while I was working on smoothing quads. The biggest one is linearizing the parameterization near sharp corners - weight = 0 causes the parameterization to become quadratic, which makes really noticeable artifacts on flat faces with color gradients.