### PR TITLE
Quaternion smoothing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
       "program": "${workspaceFolder}/build/test/manifold_test",
       "args": [
         "--gtest_break_on_failure",
-        "--gtest_filter=Manifold.RefineQuads"
+        "--gtest_filter=Manifold.SmoothFlat"
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/build/test",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
       "program": "${workspaceFolder}/build/test/manifold_test",
       "args": [
         "--gtest_break_on_failure",
-        "--gtest_filter=Manifold.SmoothFlat"
+        "--gtest_filter=SDF.SineSurface"
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/build/test",

--- a/bindings/wasm/examples/public/examples.js
+++ b/bindings/wasm/examples/public/examples.js
@@ -221,7 +221,7 @@ export const examples = {
       const radius = 30;
       const offset = 20;
       const wiggles = 12;
-      const sharpness = 0.6;
+      const sharpness = 0.8;
       const n = 50;
 
       const positions = [];

--- a/bindings/wasm/examples/worker.test.js
+++ b/bindings/wasm/examples/worker.test.js
@@ -116,8 +116,8 @@ suite('Examples', () => {
   test('Scallop', async () => {
     const result = await runExample('Scallop');
     expect(result.genus).to.equal(0, 'Genus');
-    expect(result.volume).to.be.closeTo(41500, 100, 'Volume');
-    expect(result.surfaceArea).to.be.closeTo(7880, 10, 'Surface Area');
+    expect(result.volume).to.be.closeTo(41400, 100, 'Volume');
+    expect(result.surfaceArea).to.be.closeTo(7770, 10, 'Surface Area');
   });
 
   test('Torus Knot', async () => {

--- a/samples/src/scallop.cpp
+++ b/samples/src/scallop.cpp
@@ -25,7 +25,7 @@ Manifold Scallop() {
   constexpr float radius = 3;
   constexpr float offset = 2;
   constexpr int wiggles = 12;
-  constexpr float sharpness = 0.6;
+  constexpr float sharpness = 0.8;
 
   Mesh scallop;
   std::vector<Smoothness> sharpenedEdges;

--- a/src/manifold/src/impl.h
+++ b/src/manifold/src/impl.h
@@ -180,6 +180,7 @@ struct Manifold::Impl {
   Vec<int> VertFlatFace(const Vec<bool>&) const;
   std::vector<Smoothness> SharpenEdges(float minSharpAngle,
                                        float minSmoothness) const;
+  void SharpenTangent(int halfedge, float smoothness);
   void SetNormals(int normalIdx, float minSharpAngle);
   void LinearizeFlatTangents();
   void CreateTangents(int normalIdx);

--- a/src/manifold/src/smoothing.cpp
+++ b/src/manifold/src/smoothing.cpp
@@ -195,8 +195,9 @@ struct InterpTri {
           impl->halfedgeTangent_[impl->halfedge_[halfedges[1]].pairedHalfedge]};
 
       for (const int i : {0, 1, 2}) {
-        const int j = (i + 1) % 3;
-        const int k = (i + 2) % 3;
+        const int j = Next3(i);
+        const int k = Prev3(i);
+        const float x = uvw[k] / (1 - uvw[i]);
 
         const glm::mat2x4 bezJ = Bezier2Bezier(
             {corners[i], corners[j]}, {tangentR[i], tangentL[j]},
@@ -205,10 +206,10 @@ struct InterpTri {
             Bezier2Bezier({corners[k], corners[i]}, {tangentR[k], tangentL[i]},
                           {tangentL[k], tangentR[i]}, uvw[i], {false, true});
 
-        const glm::mat2x4 bez = CubicBezier2Linear(
-            bezJ[0], bezJ[1], bezK[1], bezK[0], uvw[k] / (1 - uvw[j]));
-        const glm::vec3 p = BezierPoint(bez, uvw[i]);
-        posH += Homogeneous(glm::vec4(p, uvw[i]));
+        const glm::mat2x4 bez =
+            CubicBezier2Linear(bezJ[0], bezJ[1], bezK[1], bezK[0], x);
+        const glm::vec3 p = BezierPoint(bez, x);
+        posH += Homogeneous(glm::vec4(p, uvw[i] * uvw[i]));
       }
     } else {  // quad
       const glm::mat4 tangentsX = {

--- a/src/manifold/src/smoothing.cpp
+++ b/src/manifold/src/smoothing.cpp
@@ -83,7 +83,9 @@ struct InterpTri {
 
   glm::vec4 Homogeneous(glm::vec3 v) const { return glm::vec4(v, 1.0f); }
 
-  glm::vec3 HNormalize(glm::vec4 v) const { return glm::vec3(v) / v.w; }
+  glm::vec3 HNormalize(glm::vec4 v) const {
+    return v.w == 0 ? v : (glm::vec3(v) / v.w);
+  }
 
   glm::vec4 Bezier(glm::vec3 point, glm::vec4 tangent) const {
     return Homogeneous(glm::vec4(point, 0) + tangent);
@@ -103,7 +105,7 @@ struct InterpTri {
   }
 
   glm::vec3 BezierTangent(glm::mat2x4 points) const {
-    return glm::normalize(HNormalize(points[1]) - HNormalize(points[0]));
+    return SafeNormalize(HNormalize(points[1]) - HNormalize(points[0]));
   }
 
   glm::vec3 RotateFromTo(glm::vec3 v, glm::quat start, glm::quat end) const {

--- a/src/manifold/src/smoothing.cpp
+++ b/src/manifold/src/smoothing.cpp
@@ -87,6 +87,10 @@ struct InterpTri {
     return v.w == 0 ? v : (glm::vec3(v) / v.w);
   }
 
+  glm::vec4 Scale(glm::vec4 v, float scale) const {
+    return glm::vec4(scale * glm::vec3(v), v.w);
+  }
+
   glm::vec4 Bezier(glm::vec3 point, glm::vec4 tangent) const {
     return Homogeneous(glm::vec4(point, 0) + tangent);
   }
@@ -172,12 +176,8 @@ struct InterpTri {
     const float scale = glm::length(glm::vec3(bez0[0] - bez1[0])) / flatLen;
 
     const glm::mat2x4 bez = CubicBezier2Linear(
-        bez0[0],
-        Bezier(glm::vec3(bez0[0]),
-               glm::vec4(scale * glm::vec3(bez0[1]), bez0[1].w)),
-        Bezier(glm::vec3(bez1[0]),
-               glm::vec4(scale * glm::vec3(bez1[1]), bez1[1].w)),
-        bez1[0], y);
+        bez0[0], Bezier(glm::vec3(bez0[0]), Scale(bez0[1], scale)),
+        Bezier(glm::vec3(bez1[0]), Scale(bez1[1], scale)), bez1[0], y);
     return BezierPoint(bez, y);
   }
 
@@ -647,7 +647,7 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
   for (int e = 0; e < numHalfedge; ++e) {
     const int vert = halfedge_[e].startVert;
     auto& sharpHalfedge = vertSharpHalfedge[vert];
-    if (sharpHalfedge[0] >= 0 || sharpHalfedge[1] >= 0) continue;
+    if (sharpHalfedge[0] >= 0 && sharpHalfedge[1] >= 0) continue;
 
     int idx = 0;
     // Only used when there is only one.

--- a/src/manifold/src/smoothing.cpp
+++ b/src/manifold/src/smoothing.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <glm/gtx/quaternion.hpp>
+
 #include "impl.h"
 #include "par.h"
 
@@ -104,24 +106,43 @@ struct InterpTri {
     return glm::normalize(HNormalize(points[1]) - HNormalize(points[0]));
   }
 
+  glm::vec3 RotateFromTo(glm::vec3 v, glm::quat start, glm::quat end) const {
+    return end * glm::conjugate(start) * v;
+  }
+
   glm::mat2x4 Bezier2Bezier(const glm::mat2x3& corners,
                             const glm::mat2x4& tangentsX,
-                            const glm::mat2x4& tangentsY, float x) const {
+                            const glm::mat2x4& tangentsY, float x,
+                            const glm::bvec2& pointedEnds) const {
     const glm::mat2x4 bez = CubicBezier2Linear(
         Homogeneous(corners[0]), Bezier(corners[0], tangentsX[0]),
         Bezier(corners[1], tangentsX[1]), Homogeneous(corners[1]), x);
     const glm::vec3 end = BezierPoint(bez, x);
     const glm::vec3 tangent = BezierTangent(bez);
 
+    const glm::mat2x3 nTangentsX(SafeNormalize(glm::vec3(tangentsX[0])),
+                                 -SafeNormalize(glm::vec3(tangentsX[1])));
     const glm::mat2x3 biTangents = {
-        SafeNormalize(OrthogonalTo(glm::vec3(tangentsY[0]),
-                                   SafeNormalize(glm::vec3(tangentsX[0])))),
-        SafeNormalize(OrthogonalTo(glm::vec3(tangentsY[1]),
-                                   -SafeNormalize(glm::vec3(tangentsX[1]))))};
-    const glm::vec3 normal = SafeNormalize(
-        glm::cross(glm::mix(biTangents[0], biTangents[1], x), tangent));
-    const glm::vec3 delta = OrthogonalTo(
-        glm::mix(glm::vec3(tangentsY[0]), glm::vec3(tangentsY[1]), x), normal);
+        SafeNormalize(OrthogonalTo(glm::vec3(tangentsY[0]), nTangentsX[0])),
+        SafeNormalize(OrthogonalTo(glm::vec3(tangentsY[1]), nTangentsX[1]))};
+
+    const glm::quat q0 =
+        glm::quat_cast(glm::mat3(nTangentsX[0], biTangents[0],
+                                 glm::cross(nTangentsX[0], biTangents[0])));
+    const glm::quat q1 =
+        glm::quat_cast(glm::mat3(nTangentsX[1], biTangents[1],
+                                 glm::cross(nTangentsX[1], biTangents[1])));
+    const glm::quat qTmp = glm::slerp(q0, q1, x);
+    const glm::quat q =
+        glm::rotation(qTmp * glm::vec3(1, 0, 0), tangent) * qTmp;
+
+    const glm::vec3 end0 = pointedEnds[0]
+                               ? glm::vec3(0)
+                               : RotateFromTo(glm::vec3(tangentsY[0]), q0, q);
+    const glm::vec3 end1 = pointedEnds[1]
+                               ? glm::vec3(0)
+                               : RotateFromTo(glm::vec3(tangentsY[1]), q1, q);
+    const glm::vec3 delta = glm::mix(end0, end1, x);
     const float deltaW = glm::mix(tangentsY[0].w, tangentsY[1].w, x);
 
     return {Homogeneous(end), Homogeneous(glm::vec4(end + delta, deltaW))};
@@ -131,10 +152,10 @@ struct InterpTri {
                      const glm::mat4& tangentsY, float x, float y) const {
     glm::mat2x4 bez0 =
         Bezier2Bezier({corners[0], corners[1]}, {tangentsX[0], tangentsX[1]},
-                      {tangentsY[0], tangentsY[1]}, x);
+                      {tangentsY[0], tangentsY[1]}, x, {false, false});
     glm::mat2x4 bez1 =
         Bezier2Bezier({corners[2], corners[3]}, {tangentsX[2], tangentsX[3]},
-                      {tangentsY[2], tangentsY[3]}, 1 - x);
+                      {tangentsY[2], tangentsY[3]}, 1 - x, {false, false});
 
     const glm::mat2x4 bez =
         CubicBezier2Linear(bez0[0], bez0[1], bez1[1], bez1[0], y);
@@ -176,20 +197,18 @@ struct InterpTri {
       for (const int i : {0, 1, 2}) {
         const int j = (i + 1) % 3;
         const int k = (i + 2) % 3;
-        const float x = uvw[k] / (1 - uvw[i]);
 
-        const glm::mat2x4 bez =
-            Bezier2Bezier({corners[j], corners[k]}, {tangentR[j], tangentL[k]},
-                          {tangentL[j], tangentR[k]}, x);
+        const glm::mat2x4 bezJ = Bezier2Bezier(
+            {corners[i], corners[j]}, {tangentR[i], tangentL[j]},
+            {tangentL[i], tangentR[j]}, 1 - uvw[i], {true, false});
+        const glm::mat2x4 bezK =
+            Bezier2Bezier({corners[k], corners[i]}, {tangentR[k], tangentL[i]},
+                          {tangentL[k], tangentR[i]}, uvw[i], {false, true});
 
-        const glm::mat2x4 bez1 = CubicBezier2Linear(
-            bez[0], bez[1],
-            // Homogeneous(end), Homogeneous(glm::vec4(end + delta, deltaW)),
-            Bezier(corners[i], glm::mix(tangentR[i], tangentL[i], x)),
-            Homogeneous(corners[i]), uvw[i]);
-        const glm::vec3 p = BezierPoint(bez1, uvw[i]);
-        float w = uvw[j] * uvw[j] * uvw[k] * uvw[k];
-        posH += Homogeneous(glm::vec4(p, w));
+        const glm::mat2x4 bez = CubicBezier2Linear(
+            bezJ[0], bezJ[1], bezK[1], bezK[0], uvw[k] / (1 - uvw[j]));
+        const glm::vec3 p = BezierPoint(bez, uvw[i]);
+        posH += Homogeneous(glm::vec4(p, uvw[i]));
       }
     } else {  // quad
       const glm::mat4 tangentsX = {

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -477,8 +477,9 @@ TEST(Manifold, SineSurface) {
        glm::vec3(0 * glm::pi<float>() - 0.2)},
       1);
   Manifold smoothed = Manifold(surface).SmoothOut(50).Refine(8);
-
-  EXPECT_EQ(smoothed.Status(), Manifold::Error::NoError);
+  auto prop = smoothed.GetProperties();
+  EXPECT_NEAR(prop.volume, 8.08, 0.01);
+  EXPECT_NEAR(prop.surfaceArea, 30.85, 0.01);
   EXPECT_EQ(smoothed.Genus(), 0);
 
 #ifdef MANIFOLD_EXPORT

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -384,8 +384,8 @@ TEST(Manifold, SmoothFlat) {
   Manifold cone = Manifold::Cylinder(5, 10, 5, 12).SmoothOut();
   Manifold smooth = cone.RefineToLength(0.1).CalculateNormals(0);
   auto prop = smooth.GetProperties();
-  EXPECT_NEAR(prop.volume, 1142.9, 0.01);
-  EXPECT_NEAR(prop.surfaceArea, 764.28, 0.01);
+  EXPECT_NEAR(prop.volume, 1144.01, 0.01);
+  EXPECT_NEAR(prop.surfaceArea, 764.55, 0.01);
   MeshGL out = smooth.GetMeshGL();
   CheckGL(out);
 

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -584,15 +584,19 @@ TEST(Manifold, ManualSmooth) {
 }
 
 TEST(Manifold, SmoothMirrored) {
-  const Mesh tet = Manifold::Tetrahedron().GetMesh();
+  const Mesh tet = Manifold::Tetrahedron().Scale({1, 2, 3}).GetMesh();
   Manifold smooth = Manifold::Smooth(tet);
-  Manifold mirror = smooth.Scale({-1, 1, 2}).Refine(10);
-  smooth = smooth.Refine(10).Scale({1, 1, 2});
+  Manifold mirror = smooth.Scale({-2, 2, 2}).Refine(10);
+  smooth = smooth.Refine(10).Scale({2, 2, 2});
 
   auto prop0 = smooth.GetProperties();
   auto prop1 = mirror.GetProperties();
   EXPECT_NEAR(prop0.volume, prop1.volume, 0.1);
   EXPECT_NEAR(prop0.surfaceArea, prop1.surfaceArea, 0.1);
+
+#ifdef MANIFOLD_EXPORT
+  if (options.exportModels) ExportMesh("mirrored.glb", mirror.GetMesh(), {});
+#endif
 }
 
 TEST(Manifold, Csaszar) {

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -334,8 +334,8 @@ TEST(Manifold, Smooth) {
   smooth = smooth.Refine(n);
   ExpectMeshes(smooth, {{2 * n * n + 2, 4 * n * n}});
   auto prop = smooth.GetProperties();
-  EXPECT_NEAR(prop.volume, 17.38, 0.1);
-  EXPECT_NEAR(prop.surfaceArea, 33.38, 0.1);
+  EXPECT_NEAR(prop.volume, 18.7, 0.1);
+  EXPECT_NEAR(prop.surfaceArea, 34.5, 0.1);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) ExportMesh("smoothTet.glb", smooth.GetMesh(), {});
@@ -385,8 +385,8 @@ TEST(Manifold, SmoothFlat) {
   Manifold cone = Manifold::Cylinder(5, 10, 5, 12).SmoothOut();
   Manifold smooth = cone.RefineToLength(0.5).CalculateNormals(0);
   auto prop = smooth.GetProperties();
-  EXPECT_NEAR(prop.volume, 1144.01, 0.01);
-  EXPECT_NEAR(prop.surfaceArea, 764.55, 0.01);
+  EXPECT_NEAR(prop.volume, 1165.77, 0.01);
+  EXPECT_NEAR(prop.surfaceArea, 769.88, 0.01);
   MeshGL out = smooth.GetMeshGL();
   CheckGL(out);
 
@@ -498,8 +498,8 @@ TEST(Manifold, Smooth2Length) {
   smooth = smooth.RefineToLength(0.1);
   ExpectMeshes(smooth, {{85250, 170496}});
   auto prop = smooth.GetProperties();
-  EXPECT_NEAR(prop.volume, 4688, 1);
-  EXPECT_NEAR(prop.surfaceArea, 1369, 1);
+  EXPECT_NEAR(prop.volume, 4842, 1);
+  EXPECT_NEAR(prop.surfaceArea, 1400, 1);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) ExportMesh("smoothCones.glb", smooth.GetMesh(), {});
@@ -557,8 +557,8 @@ TEST(Manifold, ManualSmooth) {
 
   ExpectMeshes(interp, {{40002, 80000}});
   auto prop = interp.GetProperties();
-  EXPECT_NEAR(prop.volume, 3.53, 0.01);
-  EXPECT_NEAR(prop.surfaceArea, 11.39, 0.01);
+  EXPECT_NEAR(prop.volume, 3.55, 0.01);
+  EXPECT_NEAR(prop.surfaceArea, 11.45, 0.01);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) {
@@ -600,8 +600,8 @@ TEST(Manifold, Csaszar) {
   csaszar = csaszar.Refine(100);
   ExpectMeshes(csaszar, {{70000, 140000}});
   auto prop = csaszar.GetProperties();
-  EXPECT_NEAR(prop.volume, 84699, 10);
-  EXPECT_NEAR(prop.surfaceArea, 14796, 10);
+  EXPECT_NEAR(prop.volume, 89873, 10);
+  EXPECT_NEAR(prop.surfaceArea, 15301, 10);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) {

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -116,8 +116,8 @@ TEST(Samples, Scallop) {
       3, colorCurvature);
   CheckNormals(scallop);
   auto prop = scallop.GetProperties();
-  EXPECT_NEAR(prop.volume, 41.1, 0.1);
-  EXPECT_NEAR(prop.surfaceArea, 78.2, 0.1);
+  EXPECT_NEAR(prop.volume, 41.4, 0.1);
+  EXPECT_NEAR(prop.surfaceArea, 77.7, 0.1);
   CheckGL(scallop);
 
 #ifdef MANIFOLD_EXPORT

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -116,8 +116,8 @@ TEST(Samples, Scallop) {
       3, colorCurvature);
   CheckNormals(scallop);
   auto prop = scallop.GetProperties();
-  EXPECT_NEAR(prop.volume, 41.5, 0.1);
-  EXPECT_NEAR(prop.surfaceArea, 78.8, 0.1);
+  EXPECT_NEAR(prop.volume, 41.1, 0.1);
+  EXPECT_NEAR(prop.surfaceArea, 78.2, 0.1);
   CheckGL(scallop);
 
 #ifdef MANIFOLD_EXPORT

--- a/test/sdf_test.cpp
+++ b/test/sdf_test.cpp
@@ -113,19 +113,24 @@ TEST(SDF, Resize) {
 }
 
 TEST(SDF, SineSurface) {
-  Mesh surface(LevelSet(
+  MeshGL surface = LevelSet(
       [](glm::vec3 p) {
         float mid = glm::sin(p.x) + glm::sin(p.y);
-        return (p.z > mid - 0.5 && p.z < mid + 0.5) ? 1 : 0;
+        return (p.z > mid - 0.5 && p.z < mid + 0.5) ? 1 : -1;
       },
-      {glm::vec3(-4 * glm::pi<float>()), glm::vec3(4 * glm::pi<float>())}, 1));
-  Manifold smoothed = Manifold::Smooth(surface).Refine(8);
+      {glm::vec3(-2 * glm::pi<float>() + 0.2),
+       glm::vec3(0 * glm::pi<float>() - 0.2)},
+      1);
+  Manifold smoothed = Manifold(surface).SmoothOut(50).Refine(8);
 
   EXPECT_EQ(smoothed.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(smoothed.Genus(), -2);
+  EXPECT_EQ(smoothed.Genus(), 0);
 
 #ifdef MANIFOLD_EXPORT
-  if (options.exportModels)
-    ExportMesh("sinesurface.glb", smoothed.GetMeshGL(), {});
+  if (options.exportModels) {
+    ExportOptions options2;
+    // options2.mat.colorChannels = {3, 4, 5, -1};
+    ExportMesh("sinesurface.glb", smoothed.GetMeshGL(), options2);
+  }
 #endif
 }

--- a/test/sdf_test.cpp
+++ b/test/sdf_test.cpp
@@ -119,7 +119,7 @@ TEST(SDF, SineSurface) {
         return (p.z > mid - 0.5 && p.z < mid + 0.5) ? 1 : 0;
       },
       {glm::vec3(-4 * glm::pi<float>()), glm::vec3(4 * glm::pi<float>())}, 1));
-  Manifold smoothed = Manifold::Smooth(surface).Refine(2);
+  Manifold smoothed = Manifold::Smooth(surface).Refine(8);
 
   EXPECT_EQ(smoothed.Status(), Manifold::Error::NoError);
   EXPECT_EQ(smoothed.Genus(), -2);

--- a/test/sdf_test.cpp
+++ b/test/sdf_test.cpp
@@ -113,24 +113,19 @@ TEST(SDF, Resize) {
 }
 
 TEST(SDF, SineSurface) {
-  MeshGL surface = LevelSet(
+  Mesh surface(LevelSet(
       [](glm::vec3 p) {
         float mid = glm::sin(p.x) + glm::sin(p.y);
-        return (p.z > mid - 0.5 && p.z < mid + 0.5) ? 1 : -1;
+        return (p.z > mid - 0.5 && p.z < mid + 0.5) ? 1 : 0;
       },
-      {glm::vec3(-2 * glm::pi<float>() + 0.2),
-       glm::vec3(0 * glm::pi<float>() - 0.2)},
-      1);
-  Manifold smoothed = Manifold(surface).SmoothOut(50).Refine(8);
+      {glm::vec3(-4 * glm::pi<float>()), glm::vec3(4 * glm::pi<float>())}, 1));
+  Manifold smoothed = Manifold::Smooth(surface).Refine(2);
 
   EXPECT_EQ(smoothed.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(smoothed.Genus(), 0);
+  EXPECT_EQ(smoothed.Genus(), -2);
 
 #ifdef MANIFOLD_EXPORT
-  if (options.exportModels) {
-    ExportOptions options2;
-    // options2.mat.colorChannels = {3, 4, 5, -1};
-    ExportMesh("sinesurface.glb", smoothed.GetMeshGL(), options2);
-  }
+  if (options.exportModels)
+    ExportMesh("sinesurface.glb", smoothed.GetMeshGL(), {});
 #endif
 }


### PR DESCRIPTION
This fixes a number of bugs introduced with the quad smoothing. By introducing quaternions and some other math, we get significantly better circular interpolation. We can now create exact cylinders and cones, we're getting ~0.5% error on a sphere and torus that start with only a few vertices. I also reverted an earlier change that had the effect of compressing the parameterization a lot, which skewed colors badly. Still more work to do though.