### PR TITLE
Fix `Manifold.prototype.{split,splitByPlane,rotate}` JavaScript bindings functions

### DIFF
--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -248,8 +248,12 @@ Module.setup = function() {
     return this._Translate(vararg2vec3(vec));
   };
 
-  Module.Manifold.prototype.rotate = function(vec) {
-    return this._Rotate(...vec);
+  Module.Manifold.prototype.rotate = function(xOrVec, y, z) {
+    if (Array.isArray(xOrVec)) {
+      return this._Rotate(...xOrVec);
+    } else {
+      return this._Rotate(xOrVec, y || 0, z || 0);
+    }
   };
 
   Module.Manifold.prototype.scale = function(vec) {
@@ -269,14 +273,14 @@ Module.setup = function() {
   };
 
   Module.Manifold.prototype.split = function(manifold) {
-    const vec = this._split(manifold);
+    const vec = this._Split(manifold);
     const result = fromVec(vec);
     vec.delete();
     return result;
   };
 
   Module.Manifold.prototype.splitByPlane = function(normal, offset = 0.) {
-    const vec = this._splitByPlane(vararg2vec3([normal]), offset);
+    const vec = this._SplitByPlane(vararg2vec3([normal]), offset);
     const result = fromVec(vec);
     vec.delete();
     return result;

--- a/bindings/wasm/examples/public/examples.js
+++ b/bindings/wasm/examples/public/examples.js
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/** @type {import("../../manifold-encapsulated-types")["Manifold"]} */
+const Manifold = globalThis.Manifold;
+
 export const examples = {
   functions: {
     Intro: function() {
@@ -536,7 +539,37 @@ export const examples = {
         0, 0, size / Math.sqrt(2)
       ]);
       return result;
-    }
+    },
+
+    Split: function() {
+      // This example shows how you can use the .split method to performs
+      // a subtraction and an intersection at once
+      const {tetrahedron, sphere} = Manifold;
+      const box = tetrahedron().scale(100);
+      const ball = sphere(90, 100);
+
+      const [inside, outside] = box.split(ball);
+
+      const rootNode = new GLTFNode();
+
+      const outsideNode = new GLTFNode(rootNode);
+      outsideNode.manifold = outside;
+
+      const insideNode = new GLTFNode(rootNode);
+      insideNode.scale = (t) => (t = t * 0.8 + 0.2, [t, t, t]);
+      insideNode.material = {
+        metallic: 0,
+        baseColorFactor: [0, 0.3, 1.0],
+        roughness: 1
+      };
+      insideNode.manifold = inside;
+
+      globalDefaults.animationLength = 3;  // seconds
+      globalDefaults.animationMode = 'ping-pong';
+
+      const result = outside;
+      return result;
+    },
   },
 
   functionBodies: new Map()

--- a/bindings/wasm/examples/public/examples.js
+++ b/bindings/wasm/examples/public/examples.js
@@ -131,7 +131,7 @@ export const examples = {
       // Demonstrates how at 90-degree intersections, the sphere and cylinder
       // facets match up perfectly, for any choice of global resolution
       // parameters.
-      const {sphere, cylinder, union} = Manifold;
+      const {sphere, cylinder, union, cube} = Manifold;
 
       function roundedFrame(edgeLength, radius, circularSegments = 0) {
         const edge = cylinder(edgeLength, radius, -1, circularSegments);
@@ -155,6 +155,30 @@ export const examples = {
       setMinCircularAngle(3);
       setMinCircularEdgeLength(0.5);
       const result = roundedFrame(100, 10);
+      // Demonstrate how you can use the .split method to performs
+      // a subtraction and an intersection at once
+      const [inside, outside] = result.split(cube(100, true));
+
+      const rootNode = new GLTFNode();
+
+      const outsideNode = new GLTFNode(rootNode);
+      outsideNode.manifold = outside;
+
+      const insideNode = new GLTFNode(rootNode);
+      insideNode.scale = (t) => {
+        const isInsideVisible = t < 0.5;
+        return isInsideVisible ? [1, 1, 1] : [0, 0, 0];
+      };
+      insideNode.material = {
+        metallic: 1,
+        baseColorFactor: [1, 1, .3],
+        roughness: .5,
+      };
+      insideNode.manifold = inside;
+
+      globalDefaults.animationLength = 3;  // seconds
+      globalDefaults.animationMode = 'ping-pong';
+
       return result;
     },
 
@@ -539,37 +563,7 @@ export const examples = {
         0, 0, size / Math.sqrt(2)
       ]);
       return result;
-    },
-
-    Split: function() {
-      // This example shows how you can use the .split method to performs
-      // a subtraction and an intersection at once
-      const {tetrahedron, sphere} = Manifold;
-      const box = tetrahedron().scale(100);
-      const ball = sphere(90, 100);
-
-      const [inside, outside] = box.split(ball);
-
-      const rootNode = new GLTFNode();
-
-      const outsideNode = new GLTFNode(rootNode);
-      outsideNode.manifold = outside;
-
-      const insideNode = new GLTFNode(rootNode);
-      insideNode.scale = (t) => (t = t * 0.8 + 0.2, [t, t, t]);
-      insideNode.material = {
-        metallic: 0,
-        baseColorFactor: [0, 0.3, 1.0],
-        roughness: 1
-      };
-      insideNode.manifold = inside;
-
-      globalDefaults.animationLength = 3;  // seconds
-      globalDefaults.animationMode = 'ping-pong';
-
-      const result = outside;
-      return result;
-    },
+    }
   },
 
   functionBodies: new Map()

--- a/bindings/wasm/examples/worker.test.js
+++ b/bindings/wasm/examples/worker.test.js
@@ -102,8 +102,8 @@ suite('Examples', () => {
   test('Rounded Frame', async () => {
     const result = await runExample('Rounded Frame');
     expect(result.genus).to.equal(5, 'Genus');
-    expect(result.volume).to.be.closeTo(353706, 10, 'Volume');
-    expect(result.surfaceArea).to.be.closeTo(68454, 1, 'Surface Area');
+    expect(result.volume).to.be.closeTo(270807, 10, 'Volume');
+    expect(result.surfaceArea).to.be.closeTo(74599, 1, 'Surface Area');
   });
 
   test('Heart', async () => {
@@ -146,12 +146,5 @@ suite('Examples', () => {
     expect(result.genus).to.equal(15, 'Genus');
     expect(result.volume).to.be.closeTo(4167, 1, 'Volume');
     expect(result.surfaceArea).to.be.closeTo(5642, 1, 'Surface Area');
-  });
-
-  test('Split', async () => {
-    const result = await runExample('Split');
-    expect(result.genus).to.equal(3, 'Genus');
-    expect(result.volume).to.be.closeTo(651871, 1, 'Volume');
-    expect(result.surfaceArea).to.be.closeTo(107690, 1, 'Surface Area');
   });
 });

--- a/bindings/wasm/examples/worker.test.js
+++ b/bindings/wasm/examples/worker.test.js
@@ -147,4 +147,11 @@ suite('Examples', () => {
     expect(result.volume).to.be.closeTo(4167, 1, 'Volume');
     expect(result.surfaceArea).to.be.closeTo(5642, 1, 'Surface Area');
   });
+
+  test('Split', async () => {
+    const result = await runExample('Split');
+    expect(result.genus).to.equal(3, 'Genus');
+    expect(result.volume).to.be.closeTo(651871, 1, 'Volume');
+    expect(result.surfaceArea).to.be.closeTo(107690, 1, 'Surface Area');
+  });
 });


### PR DESCRIPTION
The `Manifold.prototype.split` was incorrectly calling `this._split` instead of `this._Split`. Emscripten bindings export `_Split` with capital "S": https://github.com/elalish/manifold/blob/master/bindings/wasm/bindings.cpp#L138

Similar problem was present for the `Manifold.prototype.splitByPlane`. This PR fixes that as well

`Manifold.prototype.rotate` was broken in a different way: it only accepted 3d vectors in a form of an array of three numbers. However the TypeScript types suggest you can also call this method with three parameters.