### PR TITLE
Set import library for Clipper2 target when using system version

### DIFF
--- a/manifoldDeps.cmake
+++ b/manifoldDeps.cmake
@@ -14,6 +14,10 @@ if(Clipper2_FOUND)
     add_library(Clipper2 SHARED IMPORTED)
     set_property(TARGET Clipper2 PROPERTY
         IMPORTED_LOCATION ${Clipper2_LINK_LIBRARIES})
+    if(WIN32)
+        set_property(TARGET Clipper2 PROPERTY
+            IMPORTED_IMPLIB ${Clipper2_LINK_LIBRARIES})
+    endif()
     target_include_directories(Clipper2 INTERFACE ${Clipper2_INCLUDE_DIRS})
 else()
     message(STATUS "clipper2 not found, downloading from source")


### PR DESCRIPTION
On Windows, the import library is also needed to link against the Clipper2 DLL, and that must be specified using a different target property.

We noticed this when building manifold in Julia on Windows: https://github.com/JuliaPackaging/Yggdrasil/pull/8712#issuecomment-2122763024