### PR TITLE
CI: use GCC 14 in Linux build

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -59,11 +59,11 @@ jobs:
         mkdir build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} -DCODE_COVERAGE=ON .. && make
-        lcov --capture --gcov-tool gcov-${{ matrix.gcc }} --initial --directory . --output-file ./code_coverage_init.info
+        lcov --capture --gcov-tool gcov-${{ matrix.gcc }} --ignore-errors mismatch --initial --directory . --output-file ./code_coverage_init.info
         cd test
         ./manifold_test
         cd ../
-        lcov --capture --gcov-tool gcov-${{ matrix.gcc }} --directory . --output-file ./code_coverage_test.info
+        lcov --capture --gcov-tool gcov-${{ matrix.gcc }} --ignore-errors mismatch --directory . --output-file ./code_coverage_test.info
         lcov --add-tracefile ./code_coverage_init.info --add-tracefile ./code_coverage_test.info --output-file ./code_coverage_total.info
         lcov --remove ./code_coverage_total.info '/usr/*' '*/third_party/*' '*/test/*' '*/extras/*' '*/bindings/*' --output-file ./code_coverage.info
         cd ../

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -16,14 +16,21 @@ jobs:
     strategy:
       matrix:
         parallel_backend: [NONE, TBB]
-    runs-on: ubuntu-22.04
+        gcc: [13, 14]
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc-${{ matrix.gcc }}
+      CXX: g++-${{ matrix.gcc }}
     if: github.event.pull_request.draft == false
     steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
     - name: Install dependencies
       run: |
-        sudo apt-get -y update
-        DEBIAN_FRONTEND=noninteractive sudo apt install -y libglm-dev libgtest-dev libassimp-dev git libtbb-dev libthrust-dev pkg-config libpython3-dev python3 python3-distutils python3-pip lcov
-        pip install trimesh pytest
+        sudo apt-get update
+        sudo apt-get install libglm-dev libgtest-dev libassimp-dev git libtbb-dev libthrust-dev pkg-config libpython3-dev lcov
+        python -m pip install -U trimesh pytest
     - uses: actions/checkout@v4
       with:
         submodules: recursive
@@ -52,11 +59,11 @@ jobs:
         mkdir build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} -DCODE_COVERAGE=ON .. && make
-        lcov --capture --initial --directory . --output-file ./code_coverage_init.info
+        lcov --capture --gcov-tool gcov-${{ matrix.gcc }} --initial --directory . --output-file ./code_coverage_init.info
         cd test
         ./manifold_test
         cd ../
-        lcov --capture --directory . --output-file ./code_coverage_test.info
+        lcov --capture --gcov-tool gcov-${{ matrix.gcc }} --directory . --output-file ./code_coverage_test.info
         lcov --add-tracefile ./code_coverage_init.info --add-tracefile ./code_coverage_test.info --output-file ./code_coverage_total.info
         lcov --remove ./code_coverage_total.info '/usr/*' '*/third_party/*' '*/test/*' '*/extras/*' '*/bindings/*' --output-file ./code_coverage.info
         cd ../


### PR DESCRIPTION
Ubuntu 24.04 packages GCC 13. GitHub add GCC 14 to their runner.

--- 

There are now some CMake issues to sort out with the Clipper2 snapshot!

```
CMake Error: install(EXPORT "manifoldTargets" ...) includes target "cross_section" which requires target "Clipper2" that is not in this export set, but in multiple other export sets: lib/cmake/clipper2/Clipper2Targets.cmake, share/clipper2/clipper2Targets.cmake.
An exported target cannot depend upon another target which is exported multiple times. Consider consolidating the exports of the "Clipper2" target to a single export.
-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

