### PR TITLE
Update glm to 1.0.1

### DIFF
--- a/manifoldDeps.cmake
+++ b/manifoldDeps.cmake
@@ -47,7 +47,7 @@ if(NOT glm_FOUND)
     set(GLM_BUILD_INSTALL "ON" CACHE STRING "")
     FetchContent_Declare(glm
         GIT_REPOSITORY https://github.com/g-truc/glm.git
-        GIT_TAG b06b775c1c80af51a1183c0e167f9de3b2351a79
+        GIT_TAG 1.0.1
         GIT_PROGRESS TRUE
     )
     FetchContent_MakeAvailable(glm)

--- a/src/manifold/src/smoothing.cpp
+++ b/src/manifold/src/smoothing.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/quaternion.hpp>
 
 #include "impl.h"


### PR DESCRIPTION
Not a massive step forward but takes us past the errors for GTX extensions, unless `GLM_ENABLE_EXPERIMENTAL` is defined, as we fixed in 0b7ee87489a7.

Hopefully this will demonstrate a newer instance of that.
