### PR TITLE
Add manifold_meshgl_merge to c bindings

### DIFF
--- a/bindings/c/include/manifoldc.h
+++ b/bindings/c/include/manifoldc.h
@@ -51,6 +51,7 @@ ManifoldMeshGL *manifold_meshgl_w_tangents(void *mem, float *vert_props,
                                            float *halfedge_tangent);
 ManifoldMeshGL *manifold_get_meshgl(void *mem, ManifoldManifold *m);
 ManifoldMeshGL *manifold_meshgl_copy(void *mem, ManifoldMeshGL *m);
+ManifoldMeshGL *manifold_meshgl_merge(void *mem, ManifoldMeshGL *m);
 
 // SDF
 // By default, the execution policy (sequential or parallel) of

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -417,6 +417,15 @@ ManifoldMeshGL *manifold_meshgl_copy(void *mem, ManifoldMeshGL *m) {
   return to_c(new (mem) MeshGL(*from_c(m)));
 }
 
+ManifoldMeshGL *manifold_meshgl_merge(void *mem, ManifoldMeshGL *m) {
+  auto duplicate = new (mem) MeshGL(*from_c(m));
+  if (duplicate->Merge()) {
+    return to_c(duplicate);
+  }
+  delete duplicate;
+  return m;
+}
+
 int manifold_meshgl_num_prop(ManifoldMeshGL *m) { return from_c(m)->numProp; }
 int manifold_meshgl_num_vert(ManifoldMeshGL *m) { return from_c(m)->NumVert(); }
 int manifold_meshgl_num_tri(ManifoldMeshGL *m) { return from_c(m)->NumTri(); }


### PR DESCRIPTION
Add manifold_meshgl_merge to call MeshGL::Merge() on a duplicate mesh via the c bindings