### PR TITLE
Create a release file containing submodules

### DIFF
--- a/.github/workflows/release_file.yml
+++ b/.github/workflows/release_file.yml
@@ -1,0 +1,31 @@
+name: Release File
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  upload_archive:
+    name: Upload archive
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          ref=${{ github.ref_name }}
+          echo "release_name=manifold-${ref#v}" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+        with:
+          path: ${{ env.release_name }}
+          submodules: recursive
+      - name: Build archive
+        run: >
+          tar --exclude=".git*" -cz ${{ env.release_name }} -f ${{ env.release_name }}.tar.gz
+      - name: Log checksum
+        run: >
+          sha256sum ${{ env.release_name }}.tar.gz
+      - name: Add file to release
+        run: |
+          cd ${{ env.release_name }} || exit 1
+          gh release upload ${{ github.ref_name }} ../${{ env.release_name }}.tar.gz
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Fixes #783

This does assume the release tag starts with v. If this workflow checked and then exited without creating a file that could be a problem.
