### PR TITLE
Improve smooth

### DIFF
--- a/bindings/wasm/examples/worker.test.ts
+++ b/bindings/wasm/examples/worker.test.ts
@@ -83,8 +83,8 @@ suite('Examples', () => {
   test('Scallop', async () => {
     const result = await runExample('Scallop');
     expect(result.genus).to.equal(0, 'Genus');
-    expect(result.volume).to.be.closeTo(40900, 100, 'Volume');
-    expect(result.surfaceArea).to.be.closeTo(7740, 10, 'Surface Area');
+    expect(result.volume).to.be.closeTo(39900, 100, 'Volume');
+    expect(result.surfaceArea).to.be.closeTo(7930, 10, 'Surface Area');
   });
 
   test('Torus Knot', async () => {

--- a/src/manifold/src/smoothing.cpp
+++ b/src/manifold/src/smoothing.cpp
@@ -176,10 +176,10 @@ struct InterpTri {
     const glm::quat qTmp = Slerp(q0, q1, x, longWay);
     const glm::quat q =
         glm::rotation(qTmp * glm::vec3(1, 0, 0), tangent) * qTmp;
-    const glm::vec3 normal = q * glm::vec3(0, 0, 1);
 
-    const glm::vec3 delta = OrthogonalTo(
-        glm::mix(glm::vec3(tangentsY[0]), glm::vec3(tangentsY[1]), x), normal);
+    const glm::vec3 delta =
+        glm::mix(RotateFromTo(glm::vec3(tangentsY[0]), q0, q),
+                 RotateFromTo(glm::vec3(tangentsY[1]), q1, q), x);
     const float deltaW = glm::mix(tangentsY[0].w, tangentsY[1].w, x);
 
     return {Homogeneous(end), glm::vec4(delta, deltaW)};
@@ -248,7 +248,7 @@ struct InterpTri {
             Bezier(corners[i], glm::mix(tangentR[i], tangentL[i], x)),
             Homogeneous(corners[i]), uvw[i]);
         const glm::vec3 p = BezierPoint(bez1, uvw[i]);
-        float w = uvw[j] * uvw[j] * uvw[k] * uvw[k] + 0.0001;
+        float w = uvw[j] * uvw[k];
         posH += Homogeneous(glm::vec4(p, w));
       }
     } else {  // quad

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -116,8 +116,8 @@ TEST(Samples, Scallop) {
       3, colorCurvature);
   CheckNormals(scallop);
   auto prop = scallop.GetProperties();
-  EXPECT_NEAR(prop.volume, 40.5, 0.1);
-  EXPECT_NEAR(prop.surfaceArea, 78.1, 0.1);
+  EXPECT_NEAR(prop.volume, 39.9, 0.1);
+  EXPECT_NEAR(prop.surfaceArea, 79.3, 0.1);
   CheckGL(scallop);
 
 #ifdef MANIFOLD_EXPORT

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -116,8 +116,8 @@ TEST(Samples, Scallop) {
       3, colorCurvature);
   CheckNormals(scallop);
   auto prop = scallop.GetProperties();
-  EXPECT_NEAR(prop.volume, 40.9, 0.1);
-  EXPECT_NEAR(prop.surfaceArea, 77.4, 0.1);
+  EXPECT_NEAR(prop.volume, 40.5, 0.1);
+  EXPECT_NEAR(prop.surfaceArea, 78.1, 0.1);
   CheckGL(scallop);
 
 #ifdef MANIFOLD_EXPORT

--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -30,8 +30,8 @@ TEST(Smooth, Tetrahedron) {
   smooth = smooth.Refine(n);
   ExpectMeshes(smooth, {{2 * n * n + 2, 4 * n * n}});
   auto prop = smooth.GetProperties();
-  EXPECT_NEAR(prop.volume, 18.7, 0.1);
-  EXPECT_NEAR(prop.surfaceArea, 34.5, 0.1);
+  EXPECT_NEAR(prop.volume, 17.4, 0.1);
+  EXPECT_NEAR(prop.surfaceArea, 33.37, 0.1);
 
   MeshGL out = smooth.CalculateCurvature(-1, 0).GetMeshGL();
   float maxMeanCurvature = 0;
@@ -39,7 +39,7 @@ TEST(Smooth, Tetrahedron) {
     maxMeanCurvature =
         glm::max(maxMeanCurvature, glm::abs(out.vertProperties[i]));
   }
-  EXPECT_NEAR(maxMeanCurvature, 2.32, 0.01);
+  EXPECT_NEAR(maxMeanCurvature, 2.48, 0.01);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) ExportMesh("smoothTet.glb", smooth.GetMesh(), {});
@@ -80,8 +80,8 @@ TEST(Smooth, TruncatedCone) {
   Manifold cone = Manifold::Cylinder(5, 10, 5, 12).SmoothOut();
   Manifold smooth = cone.RefineToLength(0.5).CalculateNormals(0);
   auto prop = smooth.GetProperties();
-  EXPECT_NEAR(prop.volume, 1063.61, 0.01);
-  EXPECT_NEAR(prop.surfaceArea, 751.78, 0.01);
+  EXPECT_NEAR(prop.volume, 1060.77, 0.01);
+  EXPECT_NEAR(prop.surfaceArea, 751.11, 0.01);
   MeshGL out = smooth.GetMeshGL();
   CheckGL(out);
 
@@ -103,8 +103,8 @@ TEST(Smooth, ToLength) {
   smooth = smooth.RefineToLength(0.1);
   ExpectMeshes(smooth, {{85250, 170496}});
   auto prop = smooth.GetProperties();
-  EXPECT_NEAR(prop.volume, 4842, 1);
-  EXPECT_NEAR(prop.surfaceArea, 1400, 1);
+  EXPECT_NEAR(prop.volume, 4747, 1);
+  EXPECT_NEAR(prop.surfaceArea, 1381, 1);
 
   MeshGL out = smooth.CalculateCurvature(-1, 0).GetMeshGL();
   float maxMeanCurvature = 0;
@@ -112,7 +112,7 @@ TEST(Smooth, ToLength) {
     maxMeanCurvature =
         glm::max(maxMeanCurvature, glm::abs(out.vertProperties[i]));
   }
-  EXPECT_NEAR(maxMeanCurvature, 1.45, 0.01);
+  EXPECT_NEAR(maxMeanCurvature, 1.97, 0.01);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels)
@@ -122,7 +122,7 @@ TEST(Smooth, ToLength) {
 
 TEST(Smooth, Sphere) {
   int n[5] = {4, 8, 16, 32, 64};
-  float precision[5] = {0.006, 0.003, 0.003, 0.0005, 0.00006};
+  float precision[5] = {0.04, 0.003, 0.003, 0.0005, 0.00006};
   for (int i = 0; i < 5; ++i) {
     Manifold sphere = Manifold::Sphere(1, n[i]);
     // Refine(odd) puts a center point in the triangle, which is the worst case.
@@ -172,8 +172,8 @@ TEST(Smooth, Manual) {
 
   ExpectMeshes(interp, {{40002, 80000}});
   auto prop = interp.GetProperties();
-  EXPECT_NEAR(prop.volume, 3.83, 0.01);
-  EXPECT_NEAR(prop.surfaceArea, 11.95, 0.01);
+  EXPECT_NEAR(prop.volume, 3.75, 0.01);
+  EXPECT_NEAR(prop.surfaceArea, 11.81, 0.01);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) {
@@ -216,8 +216,8 @@ TEST(Smooth, Csaszar) {
   csaszar = csaszar.Refine(100);
   ExpectMeshes(csaszar, {{70000, 140000}});
   auto prop = csaszar.GetProperties();
-  EXPECT_NEAR(prop.volume, 89873, 10);
-  EXPECT_NEAR(prop.surfaceArea, 15301, 10);
+  EXPECT_NEAR(prop.volume, 85070, 10);
+  EXPECT_NEAR(prop.surfaceArea, 12640, 10);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) {
@@ -304,11 +304,11 @@ TEST(Smooth, Torus) {
     glm::vec3 p(v.x, v.y, 0);
     p = glm::normalize(p) * 2.0f;
     float r = glm::length(v - p);
-    ASSERT_NEAR(r, 1, 0.005);
+    ASSERT_NEAR(r, 1, 0.006);
     maxMeanCurvature =
         glm::max(maxMeanCurvature, glm::abs(out.vertProperties[i + 3]));
   }
-  EXPECT_NEAR(maxMeanCurvature, 1.48, 0.01);
+  EXPECT_NEAR(maxMeanCurvature, 1.70, 0.01);
 
 #ifdef MANIFOLD_EXPORT
   ExportOptions options2;
@@ -332,7 +332,7 @@ TEST(Smooth, SineSurface) {
       Manifold(surface).CalculateNormals(0, 50).SmoothByNormals(0).Refine(8);
   auto prop = smoothed.GetProperties();
   EXPECT_NEAR(prop.volume, 7.89, 0.01);
-  EXPECT_NEAR(prop.surfaceArea, 30.61, 0.01);
+  EXPECT_NEAR(prop.surfaceArea, 30.62, 0.01);
   EXPECT_EQ(smoothed.Genus(), 0);
 
   Manifold smoothed1 = Manifold(surface).SmoothOut(50).Refine(8);
@@ -343,14 +343,14 @@ TEST(Smooth, SineSurface) {
 
   Manifold smoothed2 = Manifold(surface).SmoothOut(180, 1).Refine(8);
   auto prop2 = smoothed2.GetProperties();
-  EXPECT_NEAR(prop2.volume, 9.06, 0.01);
-  EXPECT_NEAR(prop2.surfaceArea, 33.81, 0.01);
+  EXPECT_NEAR(prop2.volume, 9.02, 0.01);
+  EXPECT_NEAR(prop2.surfaceArea, 33.54, 0.01);
   EXPECT_EQ(smoothed2.Genus(), 0);
 
   Manifold smoothed3 = Manifold(surface).SmoothOut(50, 0.5).Refine(8);
   auto prop3 = smoothed3.GetProperties();
   EXPECT_NEAR(prop3.volume, 8.46, 0.01);
-  EXPECT_NEAR(prop3.surfaceArea, 31.77, 0.01);
+  EXPECT_NEAR(prop3.surfaceArea, 31.68, 0.01);
   EXPECT_EQ(smoothed3.Genus(), 0);
 
 #ifdef MANIFOLD_EXPORT

--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -30,8 +30,8 @@ TEST(Smooth, Tetrahedron) {
   smooth = smooth.Refine(n);
   ExpectMeshes(smooth, {{2 * n * n + 2, 4 * n * n}});
   auto prop = smooth.GetProperties();
-  EXPECT_NEAR(prop.volume, 17.4, 0.1);
-  EXPECT_NEAR(prop.surfaceArea, 33.37, 0.1);
+  EXPECT_NEAR(prop.volume, 17.0, 0.1);
+  EXPECT_NEAR(prop.surfaceArea, 32.9, 0.1);
 
   MeshGL out = smooth.CalculateCurvature(-1, 0).GetMeshGL();
   float maxMeanCurvature = 0;
@@ -39,7 +39,7 @@ TEST(Smooth, Tetrahedron) {
     maxMeanCurvature =
         glm::max(maxMeanCurvature, glm::abs(out.vertProperties[i]));
   }
-  EXPECT_NEAR(maxMeanCurvature, 2.48, 0.01);
+  EXPECT_NEAR(maxMeanCurvature, 4.73, 0.01);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) ExportMesh("smoothTet.glb", smooth.GetMesh(), {});
@@ -80,8 +80,8 @@ TEST(Smooth, TruncatedCone) {
   Manifold cone = Manifold::Cylinder(5, 10, 5, 12).SmoothOut();
   Manifold smooth = cone.RefineToLength(0.5).CalculateNormals(0);
   auto prop = smooth.GetProperties();
-  EXPECT_NEAR(prop.volume, 1060.77, 0.01);
-  EXPECT_NEAR(prop.surfaceArea, 751.11, 0.01);
+  EXPECT_NEAR(prop.volume, 1062.27, 0.01);
+  EXPECT_NEAR(prop.surfaceArea, 751.46, 0.01);
   MeshGL out = smooth.GetMeshGL();
   CheckGL(out);
 
@@ -103,8 +103,8 @@ TEST(Smooth, ToLength) {
   smooth = smooth.RefineToLength(0.1);
   ExpectMeshes(smooth, {{85250, 170496}});
   auto prop = smooth.GetProperties();
-  EXPECT_NEAR(prop.volume, 4747, 1);
-  EXPECT_NEAR(prop.surfaceArea, 1381, 1);
+  EXPECT_NEAR(prop.volume, 4604, 1);
+  EXPECT_NEAR(prop.surfaceArea, 1356, 1);
 
   MeshGL out = smooth.CalculateCurvature(-1, 0).GetMeshGL();
   float maxMeanCurvature = 0;
@@ -112,7 +112,7 @@ TEST(Smooth, ToLength) {
     maxMeanCurvature =
         glm::max(maxMeanCurvature, glm::abs(out.vertProperties[i]));
   }
-  EXPECT_NEAR(maxMeanCurvature, 1.97, 0.01);
+  EXPECT_NEAR(maxMeanCurvature, 1.67, 0.01);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels)
@@ -172,8 +172,8 @@ TEST(Smooth, Manual) {
 
   ExpectMeshes(interp, {{40002, 80000}});
   auto prop = interp.GetProperties();
-  EXPECT_NEAR(prop.volume, 3.75, 0.01);
-  EXPECT_NEAR(prop.surfaceArea, 11.81, 0.01);
+  EXPECT_NEAR(prop.volume, 3.74, 0.01);
+  EXPECT_NEAR(prop.surfaceArea, 11.78, 0.01);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) {
@@ -216,8 +216,8 @@ TEST(Smooth, Csaszar) {
   csaszar = csaszar.Refine(100);
   ExpectMeshes(csaszar, {{70000, 140000}});
   auto prop = csaszar.GetProperties();
-  EXPECT_NEAR(prop.volume, 85070, 10);
-  EXPECT_NEAR(prop.surfaceArea, 12640, 10);
+  EXPECT_NEAR(prop.volume, 79890, 10);
+  EXPECT_NEAR(prop.surfaceArea, 11950, 10);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) {
@@ -308,7 +308,7 @@ TEST(Smooth, Torus) {
     maxMeanCurvature =
         glm::max(maxMeanCurvature, glm::abs(out.vertProperties[i + 3]));
   }
-  EXPECT_NEAR(maxMeanCurvature, 1.70, 0.01);
+  EXPECT_NEAR(maxMeanCurvature, 1.63, 0.01);
 
 #ifdef MANIFOLD_EXPORT
   ExportOptions options2;
@@ -332,7 +332,7 @@ TEST(Smooth, SineSurface) {
       Manifold(surface).CalculateNormals(0, 50).SmoothByNormals(0).Refine(8);
   auto prop = smoothed.GetProperties();
   EXPECT_NEAR(prop.volume, 7.89, 0.01);
-  EXPECT_NEAR(prop.surfaceArea, 30.62, 0.01);
+  EXPECT_NEAR(prop.surfaceArea, 30.60, 0.01);
   EXPECT_EQ(smoothed.Genus(), 0);
 
   Manifold smoothed1 = Manifold(surface).SmoothOut(50).Refine(8);
@@ -344,13 +344,13 @@ TEST(Smooth, SineSurface) {
   Manifold smoothed2 = Manifold(surface).SmoothOut(180, 1).Refine(8);
   auto prop2 = smoothed2.GetProperties();
   EXPECT_NEAR(prop2.volume, 9.02, 0.01);
-  EXPECT_NEAR(prop2.surfaceArea, 33.54, 0.01);
+  EXPECT_NEAR(prop2.surfaceArea, 33.56, 0.01);
   EXPECT_EQ(smoothed2.Genus(), 0);
 
   Manifold smoothed3 = Manifold(surface).SmoothOut(50, 0.5).Refine(8);
   auto prop3 = smoothed3.GetProperties();
   EXPECT_NEAR(prop3.volume, 8.46, 0.01);
-  EXPECT_NEAR(prop3.surfaceArea, 31.68, 0.01);
+  EXPECT_NEAR(prop3.surfaceArea, 31.66, 0.01);
   EXPECT_EQ(smoothed3.Genus(), 0);
 
 #ifdef MANIFOLD_EXPORT


### PR DESCRIPTION
This robustifies the smoothing algorithm, ensuring it doesn't create knots and cusps even when faced with extreme dihedral angles. It also makes most of the shapes I've tried look better - more spherical, fewer wiggles. It's very much a tradeoffs game, but I feel good that our most extreme example (Csaszar) now works reasonably well, and Scallop looks better too.