### PR TITLE
Optimize triangulator with collider

### DIFF
--- a/src/collider/include/collider.h
+++ b/src/collider/include/collider.h
@@ -30,6 +30,7 @@ class Collider {
   template <const bool selfCollision = false, const bool inverted = false,
             typename T>
   SparseIndices Collisions(const VecView<const T>& queriesIn) const;
+  static uint32_t MortonCode(glm::vec3 position, Box bBox);
 
  private:
   Vec<Box> nodeBBox_;

--- a/src/collider/src/collider.cpp
+++ b/src/collider/src/collider.cpp
@@ -382,6 +382,18 @@ bool Collider::Transform(glm::mat4x3 transform) {
   return axisAligned;
 }
 
+/**
+ * Calculate the 32-bit Morton code of a position within a bounding box.
+ */
+uint32_t Collider::MortonCode(glm::vec3 position, Box bBox) {
+  glm::vec3 xyz = (position - bBox.min) / (bBox.max - bBox.min);
+  xyz = glm::min(glm::vec3(1023.0f), glm::max(glm::vec3(0.0f), 1024.0f * xyz));
+  uint32_t x = SpreadBits3(static_cast<uint32_t>(xyz.x));
+  uint32_t y = SpreadBits3(static_cast<uint32_t>(xyz.y));
+  uint32_t z = SpreadBits3(static_cast<uint32_t>(xyz.z));
+  return x * 4 + y * 2 + z;
+}
+
 template SparseIndices Collider::Collisions<true, false, Box>(
     const VecView<const Box>&) const;
 
@@ -399,13 +411,4 @@ template SparseIndices Collider::Collisions<false, true, Box>(
 
 template SparseIndices Collider::Collisions<false, true, glm::vec3>(
     const VecView<const glm::vec3>&) const;
-
-uint32_t Collider::MortonCode(glm::vec3 position, Box bBox) {
-  glm::vec3 xyz = (position - bBox.min) / (bBox.max - bBox.min);
-  xyz = glm::min(glm::vec3(1023.0f), glm::max(glm::vec3(0.0f), 1024.0f * xyz));
-  uint32_t x = SpreadBits3(static_cast<uint32_t>(xyz.x));
-  uint32_t y = SpreadBits3(static_cast<uint32_t>(xyz.y));
-  uint32_t z = SpreadBits3(static_cast<uint32_t>(xyz.z));
-  return x * 4 + y * 2 + z;
-}
 }  // namespace manifold

--- a/src/manifold/src/sort.cpp
+++ b/src/manifold/src/sort.cpp
@@ -48,25 +48,12 @@ struct Extrema : public thrust::binary_function<Halfedge, Halfedge, Halfedge> {
   }
 };
 
-uint32_t SpreadBits3(uint32_t v) {
-  v = 0xFF0000FFu & (v * 0x00010001u);
-  v = 0x0F00F00Fu & (v * 0x00000101u);
-  v = 0xC30C30C3u & (v * 0x00000011u);
-  v = 0x49249249u & (v * 0x00000005u);
-  return v;
-}
-
 uint32_t MortonCode(glm::vec3 position, Box bBox) {
   // Unreferenced vertices are marked NaN, and this will sort them to the end
   // (the Morton code only uses the first 30 of 32 bits).
   if (isnan(position.x)) return kNoCode;
 
-  glm::vec3 xyz = (position - bBox.min) / (bBox.max - bBox.min);
-  xyz = glm::min(glm::vec3(1023.0f), glm::max(glm::vec3(0.0f), 1024.0f * xyz));
-  uint32_t x = SpreadBits3(static_cast<uint32_t>(xyz.x));
-  uint32_t y = SpreadBits3(static_cast<uint32_t>(xyz.y));
-  uint32_t z = SpreadBits3(static_cast<uint32_t>(xyz.z));
-  return x * 4 + y * 2 + z;
+  return Collider::MortonCode(position, bBox);
 }
 
 struct Morton {

--- a/src/polygon/CMakeLists.txt
+++ b/src/polygon/CMakeLists.txt
@@ -15,7 +15,7 @@
 project (polygon)
 
 file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
-add_library(${PROJECT_NAME} OBJECT ${SOURCE_FILES})
+add_library(${PROJECT_NAME} ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<INSTALL_INTERFACE:include/${CMAKE_PROJECT_NAME}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)

--- a/src/polygon/CMakeLists.txt
+++ b/src/polygon/CMakeLists.txt
@@ -19,7 +19,10 @@ add_library(${PROJECT_NAME} OBJECT ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<INSTALL_INTERFACE:include/${CMAKE_PROJECT_NAME}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
-target_link_libraries(${PROJECT_NAME} PUBLIC utilities)
+target_link_libraries(${PROJECT_NAME} 
+    PUBLIC utilities 
+    PRIVATE collider
+)
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${MANIFOLD_FLAGS})
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)

--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -413,10 +413,9 @@ class EarClip {
       return -precision - scale * glm::dot(diff, diff);
     }
 
-    // This is the O(n^2) part of the algorithm, checking this ear against every
-    // Vert to ensure none are inside. It may be possible to improve performance
-    // by using the Collider to get it down to nlogn or doing some
-    // parallelization, but that may be more trouble than it's worth.
+    // This is the expensive part of the algorithm, checking this ear against
+    // every Vert to ensure none are inside. The Collider brings the total
+    // triangulator cost down from O(n^2) to O(nlogn) for most large polygons.
     //
     // Think of a cost as vaguely a distance metric - 0 is right on the edge of
     // being invalid. cost > precision is definitely invalid. Cost < -precision
@@ -758,6 +757,9 @@ class EarClip {
     }
   }
 
+  // Create a collider of all vertices in this polygon, each expanded by
+  // precision_. Each ear uses this BVH to quickly find a subset of vertices to
+  // check for cost.
   IdxCollider VertCollider(VertItr start) const {
     Vec<Box> vertBox;
     Vec<uint32_t> vertMorton;

--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -762,13 +762,16 @@ class EarClip {
     Vec<VertItr> itr;
     const Box box(glm::vec3(bBox_.min, 0), glm::vec3(bBox_.max, 0));
 
-    Loop(start, [&vertBox, &vertMorton, &itr, &box](VertItr v) {
+    Loop(start, [&vertBox, &vertMorton, &itr, &box, this](VertItr v) {
       itr.push_back(v);
       const glm::vec3 pos(v->pos, 0);
-      vertBox.push_back({});
-      vertBox.back().Union(pos);
+      vertBox.push_back({pos - precision_, pos + precision_});
       vertMorton.push_back(Collider::MortonCode(pos, box));
     });
+
+    if (itr.empty()) {
+      return {Collider(), itr};
+    }
 
     stable_sort(autoPolicy(itr.size()),
                 zip(vertMorton.begin(), vertBox.begin(), itr.begin()),
@@ -787,6 +790,11 @@ class EarClip {
     ZoneScoped;
 
     const IdxCollider vertCollider = VertCollider(start);
+
+    if (vertCollider.itr.empty()) {
+      PRINT("Empty poly");
+      return;
+    }
 
     // A simple polygon always creates two fewer triangles than it has verts.
     int numTri = -2;


### PR DESCRIPTION
Fixes #723, or so's the hope. ~~Does anyone have a good polygon to contribute to a `TEST` that would make clear the performance improvement?~~ 35x improvement on #831 without degrading our other test times, so I think we're good! And this is just the simple version: using our 3D collider for 2D boxes. Could probably be sped up a bit more with a templatized Collider, though I'm not sure it's worth the trouble. 

@pca006132 ~~I seem to be hitting a linker error - I told CMake to link to `collider`, but apparently that's not good enough? I'm guessing it's just a line I forgot somewhere.~~