### PR TITLE
Fixed backward zebra polygon

### DIFF
--- a/test/polygon_test.cpp
+++ b/test/polygon_test.cpp
@@ -56,20 +56,18 @@ Polygons Duplicate(Polygons polys) {
 }
 
 void TestPoly(const Polygons &polys, int expectedNumTri,
-              float precision = -1.0f, bool onlyBasic = false) {
+              float precision = -1.0f) {
   PolygonParams().verbose = options.params.verbose;
 
   std::vector<glm::ivec3> triangles;
   EXPECT_NO_THROW(triangles = Triangulate(polys, precision));
   EXPECT_EQ(triangles.size(), expectedNumTri) << "Basic";
 
-  if (!onlyBasic) {
-    EXPECT_NO_THROW(triangles = Triangulate(Turn180(polys), precision));
-    EXPECT_EQ(triangles.size(), expectedNumTri) << "Turn 180";
+  EXPECT_NO_THROW(triangles = Triangulate(Turn180(polys), precision));
+  EXPECT_EQ(triangles.size(), expectedNumTri) << "Turn 180";
 
-    EXPECT_NO_THROW(triangles = Triangulate(Duplicate(polys), precision));
-    EXPECT_EQ(triangles.size(), 2 * expectedNumTri) << "Duplicate";
-  }
+  EXPECT_NO_THROW(triangles = Triangulate(Duplicate(polys), precision));
+  EXPECT_EQ(triangles.size(), 2 * expectedNumTri) << "Duplicate";
 
   PolygonParams().verbose = false;
 }

--- a/test/zebra.cpp
+++ b/test/zebra.cpp
@@ -62639,7 +62639,7 @@ TEST(Polygon, Zebra) {
       {5.59076977, 14.00315},    //
       {5.59097004, 14.00315},    //
   });
-  TestPoly(polys, 62597, -1, true);
+  TestPoly(polys, 62597);
 }
 
 TEST(Polygon, Zebra1) {


### PR DESCRIPTION
Follow-on to #832 - now the Zebra works upside-down and backwards too. @kintel this uncovered 2 more bugs, now fixed. 