### PR TITLE
Fix PyPI again

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-latest, macos-latest]
+      fail-fast: false
     steps:
       - run: |
           git config --global submodule.fetchJobs 8

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-22.04, windows-2019, macos-latest]
       fail-fast: false
     steps:
       - run: |

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-2019, macos-latest]
-      fail-fast: false
     steps:
       - run: |
           git config --global submodule.fetchJobs 8

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -11,3 +11,4 @@
 1. Check the Actions and verify that both PyPI and npm publishing actions ran successfully.
 1. Verify the npm [package](https://www.npmjs.com/package/manifold-3d?activeTab=code) looks good - unpacked size should be close to 1MB.
 1. Verify PyPI [package](https://pypi.org/project/manifold3d/#files) looks good - a bunch of built distributions ranging from ~600kB to ~1.1MB.
+1. If there's a problem with release deployment, the release workflows can be triggered separately, manually for any branch, under the Actions tab.


### PR DESCRIPTION
This is the actual fix - v2.5 has already been deployed to PyPI using this branch, since the build_wheels action workflow can be run manually from any branch. 