### PR TITLE
Clear compiler warning from BSD.

### DIFF
--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -317,7 +317,7 @@ Manifold::Impl CsgLeafNode::Compose(
     auto &node = nodes[i];
     const int offset = i * Manifold::Impl::meshIDCounter_;
 
-    for (const auto & pair : node->pImpl_->meshRelation_.meshIDtransform) {
+    for (const auto &pair : node->pImpl_->meshRelation_.meshIDtransform) {
       combined.meshRelation_.meshIDtransform[pair.first + offset] = pair.second;
     }
   }

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -317,7 +317,7 @@ Manifold::Impl CsgLeafNode::Compose(
     auto &node = nodes[i];
     const int offset = i * Manifold::Impl::meshIDCounter_;
 
-    for (const auto pair : node->pImpl_->meshRelation_.meshIDtransform) {
+    for (const auto & pair : node->pImpl_->meshRelation_.meshIDtransform) {
       combined.meshRelation_.meshIDtransform[pair.first + offset] = pair.second;
     }
   }


### PR DESCRIPTION
Clear clang 16 compiler error encountered on GhostBSD: Fixes https://github.com/elalish/manifold/issues/840