### PR TITLE
[thrust] cuda/std/detail/libcxx/include/tuple error: call of overloaded swap() is ambiguous

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -29,8 +29,18 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install libglm-dev libgtest-dev libassimp-dev git libtbb-dev libthrust-dev pkg-config libpython3-dev lcov
+        sudo apt-get install libglm-dev libgtest-dev libassimp-dev git libtbb-dev pkg-config libpython3-dev lcov ninja-build
         python -m pip install -U trimesh pytest
+    - name: Install CCCL
+      run: |
+        wget -nv https://github.com/NVIDIA/cccl/archive/main.zip
+        zipinfo -hz main.zip
+        unzip -q main.zip
+        cd cccl-main
+        mkdir build
+        cd build
+        cmake .. -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DCCCL_ENABLE_LIBCUDACXX=OFF -Dlibcudacxx_ENABLE_INSTALL_RULES=ON -DCCCL_ENABLE_CUB=OFF -DCUB_ENABLE_INSTALL_RULES=ON -DCCCL_ENABLE_THRUST=OFF -DTHRUST_ENABLE_INSTALL_RULES=ON -DCCCL_ENABLE_TESTING=OFF
+        sudo ninja install
     - uses: actions/checkout@v4
       with:
         submodules: recursive
@@ -79,187 +89,3 @@ jobs:
         sudo cmake --install .
         cd ..
         ./test-cmake.sh
-
-  build_cbind:
-    timeout-minutes: 30
-    runs-on: ubuntu-22.04
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: Install dependencies
-      run: |
-        sudo apt-get -y update
-        DEBIAN_FRONTEND=noninteractive sudo apt install -y libgtest-dev libglm-dev libassimp-dev git libtbb-dev pkg-config libpython3-dev python3 python3-distutils python3-pip
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - uses: jwlawson/actions-setup-cmake@v2
-    - name: Build C bindings with TBB
-      run: |
-        mkdir build
-        cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PYBIND=ON -DMANIFOLD_DEBUG=ON -DMANIFOLD_CBIND=ON -DMANIFOLD_PAR=TBB .. && make
-    - name: Test ${{matrix.parallel_backend}}
-      run: |
-        cd build/test
-        ./manifold_test --gtest_filter=CBIND.*
-
-  build_wasm:
-    timeout-minutes: 30
-    runs-on: ubuntu-22.04
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: Install dependencies
-      run: |
-        sudo apt-get -y update
-        DEBIAN_FRONTEND=noninteractive sudo apt install -y nodejs libglm-dev 
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - name: Setup WASM
-      run: |
-        # setup emscripten
-        git clone https://github.com/emscripten-core/emsdk.git
-        cd emsdk
-        ./emsdk install 3.1.45
-        ./emsdk activate 3.1.45
-    - uses: jwlawson/actions-setup-cmake@v2
-    - name: Build WASM
-      run: |
-        source ./emsdk/emsdk_env.sh
-        mkdir build
-        cd build
-        emcmake cmake -DCMAKE_BUILD_TYPE=Release .. && emmake make
-    - name: Test WASM
-      run: |
-        cd build/test
-        node ./manifold_test.js
-    - name: Test examples
-      run: |
-        cd bindings/wasm/examples
-        npm ci
-        npm run build
-        npm test
-        cp ../manifold.* ./dist/
-    - name: Upload WASM files
-      uses: actions/upload-artifact@v4
-      with:
-        name: wasm
-        path: bindings/wasm/examples/dist/
-        retention-days: 90
-        overwrite: true
-
-  build_windows:
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        parallel_backend: [NONE, TBB]
-      max-parallel: 1
-    runs-on: windows-2019
-    if: github.event.pull_request.draft == false
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - uses: jwlawson/actions-setup-cmake@v2
-    - uses: ilammy/msvc-dev-cmd@v1
-    - name: Build ${{matrix.backend}}
-      shell: powershell
-      run: |
-        cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DMANIFOLD_DEBUG=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} -A x64 -B build
-        cd build
-        cmake --build . --target ALL_BUILD --config Release
-    - name: Test ${{matrix.parallel_backend}}
-      shell: bash
-      run: |
-        cd build/bin/Release
-        ./manifold_test.exe
-        cd ../../
-    - name: test cmake consumer
-      run: |
-        cd build
-        cmake --install .
-        cd ..
-        ./test-cmake.sh
-
-  build_mxe:
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        parallel_backend: [NONE, TBB]
-      max-parallel: 1
-    runs-on: ubuntu-latest
-    container: openscad/mxe-x86_64-gui:latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - name: Build
-      run: |
-        mkdir build
-        cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PYBIND=OFF -DMANIFOLD_DEBUG=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} .. && make
-    - name: Test
-      run: |
-        cd build/test
-        ./manifold_test
-
-  build_mac:
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        parallel_backend: [NONE, TBB]
-    runs-on: macos-latest
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: Install common dependencies
-      run: |
-        brew install pkg-config googletest assimp
-        pip install trimesh pytest
-    - name: Install TBB
-      if: matrix.parallel_backend == 'TBB'
-      run: brew install tbb
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - uses: jwlawson/actions-setup-cmake@v2
-    - name: Build
-      run: |
-        mkdir build
-        cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_DEBUG=ON -DMANIFOLD_PYBIND=ON -DMANIFOLD_EXPORT=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} .. && make
-    - name: Test
-      run: |
-        cd build/test
-        ./manifold_test
-        cd ../../
-    - name: test cmake consumer
-      run: |
-        cd build
-        sudo cmake --install .
-        cd ..
-        ./test-cmake.sh
-
-  build_nix:
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        variant: [none, tbb, js]
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - uses: cachix/install-nix-action@v22
-    - run: nix build -L '.?submodules=1#manifold-${{matrix.variant}}'
-
-  build_nix_python:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - uses: cachix/install-nix-action@v22
-    - run: nix build -L '.?submodules=1#manifold3d'


### PR DESCRIPTION
**not for merging** - to demonstrate compiling with CCCL.

Since 0577aabe7f compiling with recent CCCL fails, with GCC 13:

```
/home/runner/work/manifold/manifold/src/polygon/src/polygon.cpp:844:16:   required from here
/usr/include/cuda/std/detail/libcxx/include/tuple:208:7: error: call of overloaded ‘swap(__gnu_cxx::__normal_iterator<{anonymous}::EarClip::Vert*, std::vector<{anonymous}::EarClip::Vert> >&, __gnu_cxx::__normal_iterator<{anonymous}::EarClip::Vert*, std::vector<{anonymous}::EarClip::Vert> >&)’ is ambiguous
  208 |   swap(__x.get(), __y.get());
      |   ~~~~^~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/cuda/std/__functional/hash.h:36,
                 from /usr/include/cuda/std/detail/libcxx/include/utility:24,
                 from /usr/include/cuda/std/utility:26,
                 from /usr/include/thrust/pair.h:33,
                 from /usr/include/thrust/binary_search.h:33:
/usr/include/cuda/std/__utility/swap.h:35:81: note: candidate: ‘constexpr cuda::std::__4::__swap_result_t<_Tp> cuda::std::__4::swap(_Tp&, _Tp&) [with _Tp = __gnu_cxx::__normal_iterator<{anonymous}::EarClip::Vert*, std::vector<{anonymous}::EarClip::Vert> >; __swap_result_t<_Tp> = void]’
   35 | inline _LIBCUDACXX_INLINE_VISIBILITY _CCCL_CONSTEXPR_CXX14 __swap_result_t<_Tp> swap(_Tp& __x, _Tp& __y) noexcept(
      |                                                                                 ^~~~
In file included from /usr/include/c++/13/bits/stl_function.h:60,
                 from /usr/include/c++/13/functional:49,
                 from /home/runner/work/manifold/manifold/src/polygon/include/polygon.h:16,
                 from /home/runner/work/manifold/manifold/src/polygon/src/polygon.cpp:15:
/usr/include/c++/13/bits/move.h:189:5: note: candidate: ‘std::_Require<std::__not_<std::__is_tuple_like<_Tp> >, std::is_move_constructible<_Tp>, std::is_move_assignable<_Tp> > std::swap(_Tp&, _Tp&) [with _Tp = __gnu_cxx::__normal_iterator<{anonymous}::EarClip::Vert*, vector<{anonymous}::EarClip::Vert> >; _Require<__not_<__is_tuple_like<_Tp> >, is_move_constructible<_Tp>, is_move_assignable<_Tp> > = void]’
  189 |     swap(_Tp& __a, _Tp& __b)
      |     ^~~~
make[2]: *** [src/polygon/CMakeFiles/polygon.dir/build.make:79: src/polygon/CMakeFiles/polygon.dir/src/polygon.cpp.o] Error 1
```

I guess that is a result of `Replace thrust::tuple implementation with cuda::std::tuple`  https://github.com/NVIDIA/cccl/commit/61c1fd043ac0942805bab97429fdf72242182314
which has caused other problems https://github.com/NVIDIA/cccl/commit/78a61a278cdc6e072f6b93629a062eb01f4f04d9
so their problem, but a bit outside my knowledge to understand what we would want.

