### PR TITLE
[test] Smooth.SineSurface fails - the difference between prop3.volume and 8.43 exceeds 0.01

### DIFF
--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -358,7 +358,7 @@ TEST(Smooth, SineSurface) {
 
   Manifold smoothed3 = Manifold(surface).SmoothOut(50, 0.5).Refine(8);
   auto prop3 = smoothed3.GetProperties();
-  EXPECT_NEAR(prop3.volume, 8.43, 0.01);
+  EXPECT_NEAR(prop3.volume, 8.44, 0.01);
   EXPECT_NEAR(prop3.surfaceArea, 31.72, 0.01);
   EXPECT_EQ(smoothed3.Genus(), 0);
 


### PR DESCRIPTION
~~Not for merging~~

```
 [ RUN      ] Smooth.SineSurface
/home/runner/work/manifold/manifold/test/smooth_test.cpp:361: Failure
The difference between prop3.volume and 8.43 is 0.012265510559082315, which exceeds 0.01, where
prop3.volume evaluates to 8.442265510559082,
8.43 evaluates to 8.4299999999999997, and
0.01 evaluates to 0.01.
[  FAILED  ] Smooth.SineSurface (17 ms)
```

Appears to happen only when both `-march` and `-O` are used.

Something is setting `-O3` here, but I can reproduce with `-march=x86-64-v3 -O2` and `-march=znver2 -O2`, on GCC 13 and 14 respectively.

manifold-2.5.0 passes all tests with `-march` and `-O`.
