### PR TITLE
custom parallel algorithms based on tbb

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -17,7 +17,7 @@ jobs:
         source: '.'
         exclude: '*/third_party'
         extensions: 'h,cpp,js,ts,html'
-        clangFormatVersion: 11
+        clangFormatVersion: 15
     - uses: psf/black@stable
       with:
         options: "--check --verbose"

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -107,7 +107,7 @@ struct nb::detail::type_caster<glm::mat<C, R, T, Q>> {
   static handle from_cpp(glm_type mat, rv_policy policy,
                          cleanup_list *cleanup) noexcept {
     T *buffer = new T[R * C];
-    nb::capsule mem_mgr(buffer, [](void *p) noexcept { delete[](T *) p; });
+    nb::capsule mem_mgr(buffer, [](void *p) noexcept { delete[] (T *)p; });
     for (int i = 0; i < R; i++) {
       for (int j = 0; j < C; j++) {
         // py is (Rows, Cols), glm is (Cols, Rows)
@@ -154,7 +154,7 @@ struct nb::detail::type_caster<std::vector<glm::vec<N, T, Q>>> {
                          cleanup_list *cleanup) noexcept {
     size_t num_vec = vec.size();
     T *buffer = new T[num_vec * N];
-    nb::capsule mem_mgr(buffer, [](void *p) noexcept { delete[](T *) p; });
+    nb::capsule mem_mgr(buffer, [](void *p) noexcept { delete[] (T *)p; });
     for (size_t i = 0; i < num_vec; i++) {
       for (int j = 0; j < N; j++) {
         buffer[i * N + j] = vec[i][j];

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(perfTest manifold)
 target_compile_options(perfTest PRIVATE ${MANIFOLD_FLAGS})
 target_compile_features(perfTest PUBLIC cxx_std_17)
 
-if(MANIFOLD_PAR STREQUAL "TBB")
+if(MANIFOLD_PAR STREQUAL "TBB" AND NOT MSVC)
   add_executable(stlTest stl_test.cpp)
   target_link_libraries(stlTest utilities)
   target_compile_options(stlTest PRIVATE ${MANIFOLD_FLAGS})

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(perfTest manifold)
 target_compile_options(perfTest PRIVATE ${MANIFOLD_FLAGS})
 target_compile_features(perfTest PUBLIC cxx_std_17)
 
-if(MANIFOLD_PAR STREQUAL "T")
+if(MANIFOLD_PAR STREQUAL "TBB")
   add_executable(stlTest stl_test.cpp)
   target_link_libraries(stlTest utilities)
   target_compile_options(stlTest PRIVATE ${MANIFOLD_FLAGS})

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -19,11 +19,12 @@ target_link_libraries(perfTest manifold)
 target_compile_options(perfTest PRIVATE ${MANIFOLD_FLAGS})
 target_compile_features(perfTest PUBLIC cxx_std_17)
 
-add_executable(stlTest stl_test.cpp)
-target_link_libraries(stlTest utilities)
-target_compile_options(stlTest PRIVATE ${MANIFOLD_FLAGS})
-target_compile_features(stlTest PUBLIC cxx_std_17)
-
+if(MANIFOLD_PAR STREQUAL "T")
+  add_executable(stlTest stl_test.cpp)
+  target_link_libraries(stlTest utilities)
+  target_compile_options(stlTest PRIVATE ${MANIFOLD_FLAGS})
+  target_compile_features(stlTest PUBLIC cxx_std_17)
+endif()
 
 add_executable(largeSceneTest large_scene_test.cpp)
 target_link_libraries(largeSceneTest manifold)

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -19,6 +19,12 @@ target_link_libraries(perfTest manifold)
 target_compile_options(perfTest PRIVATE ${MANIFOLD_FLAGS})
 target_compile_features(perfTest PUBLIC cxx_std_17)
 
+add_executable(stlTest stl_test.cpp)
+target_link_libraries(stlTest utilities)
+target_compile_options(stlTest PRIVATE ${MANIFOLD_FLAGS})
+target_compile_features(stlTest PUBLIC cxx_std_17)
+
+
 add_executable(largeSceneTest large_scene_test.cpp)
 target_link_libraries(largeSceneTest manifold)
 target_compile_options(largeSceneTest PRIVATE ${MANIFOLD_FLAGS})

--- a/extras/stl_test.cpp
+++ b/extras/stl_test.cpp
@@ -95,7 +95,11 @@ struct copy {  // 25.7.1
     std::vector<double> v1, v2;
     return measure(
         [&] {
-          v1 = std::vector<double>(size, 42.);
+          std::mt19937 mt{42};
+          std::uniform_real_distribution<double> dist{0., 1.};
+          v1 = std::vector<double>(size);
+          std::generate(std::begin(v1), std::end(v1),
+                        [&dist, &mt] { return dist(mt); });
           v2 = std::vector<double>(size);
         },
         [&] {

--- a/extras/stl_test.cpp
+++ b/extras/stl_test.cpp
@@ -7,8 +7,6 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdio>
-#include <execution>
-#include <iostream>
 #include <random>
 #include <vector>
 
@@ -600,4 +598,3 @@ int main() {
     printf("\n");
   }
 }
-

--- a/extras/stl_test.cpp
+++ b/extras/stl_test.cpp
@@ -1,0 +1,603 @@
+// benchmark from https://github.com/mikekazakov/pstld/tree/master
+// extended with more sort options
+#include <cxxabi.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdio>
+#include <execution>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include "par.h"
+
+static constexpr size_t g_Iterations = 5;
+static constexpr size_t g_IterationsDiscard = 1;
+static constexpr size_t g_Sizes[] = {1'000, 10'000, 100'000, 1'000'000,
+                                     10'000'000};
+
+template <class Tp>
+inline void noopt(Tp const &value) {
+  asm volatile("" : : "r,m"(value) : "memory");
+}
+
+template <class Tp>
+inline void noopt(Tp &value) {
+  asm volatile("" : "+r,m"(value) : : "memory");
+}
+
+template <class Setup, class Work, class Cleanup>
+std::chrono::high_resolution_clock::duration measure(Setup setup, Work work,
+                                                     Cleanup cleanup) {
+  std::array<std::chrono::high_resolution_clock::duration, g_Iterations> runs;
+  for (size_t i = 0; i != g_Iterations; ++i) {
+    setup();
+    const auto start = std::chrono::high_resolution_clock::now();
+    work();
+    const auto end = std::chrono::high_resolution_clock::now();
+    cleanup();
+    runs[i] = end - start;
+  }
+  std::sort(runs.begin(), runs.end());
+  return std::accumulate(runs.begin() + g_IterationsDiscard,
+                         runs.end() - g_IterationsDiscard,
+                         std::chrono::high_resolution_clock::duration{});
+}
+
+template <class Setup, class Work>
+std::chrono::high_resolution_clock::duration measure(Setup setup, Work work) {
+  return measure(setup, work, [] {});
+}
+
+namespace benchmarks {
+template <auto Policy>
+struct all_of {  // 25.6.1
+  auto operator()(size_t size) {
+    std::vector<double> v;
+    return measure([&] { v = std::vector<double>(size, 42.); },
+                   [&] {
+                     noopt(manifold::all_of(Policy, v.begin(), v.end(),
+                                            [](auto e) { return e < 50.; }));
+                   });
+  }
+};
+
+template <auto Policy>
+struct for_each {  // 25.6.4
+  auto operator()(size_t size) {
+    std::vector<double> v;
+    return measure([&] { v = std::vector<double>(size, 42.); },
+                   [&] {
+                     manifold::for_each(Policy, v.begin(), v.end(),
+                                        [](auto &e) { e += 1.; });
+                     noopt(v);
+                   });
+  }
+};
+
+template <auto Policy>
+struct count {  // 25.6.9
+  auto operator()(size_t size) {
+    std::vector<double> v;
+    return measure(
+        [&] { v = std::vector<double>(size, 42.); },
+        [&] {
+          noopt(manifold::count_if(Policy, v.begin(), v.end(),
+                                   [](double v) { return v == 42.; }));
+        });
+  }
+};
+
+template <auto Policy>
+struct copy {  // 25.7.1
+  auto operator()(size_t size) {
+    std::vector<double> v1, v2;
+    return measure(
+        [&] {
+          v1 = std::vector<double>(size, 42.);
+          v2 = std::vector<double>(size);
+        },
+        [&] {
+          manifold::copy(Policy, v1.begin(), v1.end(), v2.begin());
+          noopt(v2);
+        });
+  }
+};
+
+template <auto Policy>
+struct copy_if_28 {  // 25.7.1
+  auto operator()(size_t size) {
+    std::vector<double> v1, v2;
+    return measure(
+        [&] {
+          std::mt19937 mt{42};
+          std::uniform_real_distribution<double> dist{0., 1.};
+          v1 = std::vector<double>(size, 42.);
+          for (size_t i = 0; i < size; i++)
+            if (dist(mt) <= 0.8) v1[i] = 24;
+          v2 = std::vector<double>(size);
+        },
+        [&] {
+          manifold::copy_if(Policy, v1.begin(), v1.end(), v2.begin(),
+                            [](double v) { return v == 42; });
+          noopt(v2);
+        });
+  }
+};
+
+template <auto Policy>
+struct copy_if_55 {  // 25.7.1
+  auto operator()(size_t size) {
+    std::vector<double> v1, v2;
+    return measure(
+        [&] {
+          std::mt19937 mt{42};
+          std::uniform_real_distribution<double> dist{0., 1.};
+          v1 = std::vector<double>(size, 42.);
+          for (size_t i = 0; i < size; i++)
+            if (dist(mt) <= 0.5) v1[i] = 24;
+          v2 = std::vector<double>(size);
+        },
+        [&] {
+          manifold::copy_if(Policy, v1.begin(), v1.end(), v2.begin(),
+                            [](double v) { return v == 42; });
+          noopt(v2);
+        });
+  }
+};
+
+template <auto Policy>
+struct copy_if_82 {  // 25.7.1
+  auto operator()(size_t size) {
+    std::vector<double> v1, v2;
+    return measure(
+        [&] {
+          std::mt19937 mt{42};
+          std::uniform_real_distribution<double> dist{0., 1.};
+          v1 = std::vector<double>(size, 42.);
+          for (size_t i = 0; i < size; i++)
+            if (dist(mt) <= 0.2) v1[i] = 24;
+          v2 = std::vector<double>(size);
+        },
+        [&] {
+          manifold::copy_if(Policy, v1.begin(), v1.end(), v2.begin(),
+                            [](double v) { return v == 42; });
+          noopt(v2);
+        });
+  }
+};
+
+template <auto Policy>
+struct copy_if_1001 {  // 25.7.1
+  auto operator()(size_t size) {
+    std::vector<double> v1, v2;
+    return measure(
+        [&] {
+          std::mt19937 mt{42};
+          std::uniform_real_distribution<double> dist{0., 1.};
+          v1 = std::vector<double>(size, 42.);
+          for (size_t i = 0; i < size; i++)
+            if (dist(mt) <= 0.01) v1[i] = 24;
+          v2 = std::vector<double>(size);
+        },
+        [&] {
+          manifold::copy_if(Policy, v1.begin(), v1.end(), v2.begin(),
+                            [](double v) { return v == 42; });
+          noopt(v2);
+        });
+  }
+};
+
+template <auto Policy>
+struct fill {  // 25.7.6
+  auto operator()(size_t size) {
+    std::vector<double> v;
+    return measure([&] { v = std::vector<double>(size); },
+                   [&] {
+                     manifold::fill(Policy, v.begin(), v.end(), 42.);
+                     noopt(v);
+                   });
+  }
+};
+
+template <auto Policy>
+struct sort_Rnd {  // 25.8.2.1, semi-random input
+  auto operator()(size_t size) {
+    std::vector<double> v;
+    return measure(
+        [&] {
+          std::mt19937 mt{42};
+          std::uniform_real_distribution<double> dist{0., 1.};
+          v = std::vector<double>(size);
+          std::generate(std::begin(v), std::end(v),
+                        [&dist, &mt] { return dist(mt); });
+        },
+        [&] {
+          manifold::stable_sort(Policy, v.begin(), v.end());
+          noopt(v);
+        });
+  }
+};
+
+template <auto Policy>
+struct sort_Rnd_size {  // 25.8.2.1, semi-random input
+  auto operator()(size_t size) {
+    std::vector<size_t> v;
+    return measure(
+        [&] {
+          std::mt19937 mt{42};
+          std::uniform_int_distribution<size_t> dist{
+              0, std::numeric_limits<size_t>::max()};
+          v = std::vector<size_t>(size);
+          std::generate(std::begin(v), std::end(v),
+                        [&dist, &mt] { return dist(mt); });
+        },
+        [&] {
+          manifold::stable_sort(Policy, v.begin(), v.end());
+          noopt(v);
+        });
+  }
+};
+
+template <auto Policy>
+struct sort_Rnd_size_merge {  // 25.8.2.1, semi-random input
+  auto operator()(size_t size) {
+    std::vector<size_t> v;
+    return measure(
+        [&] {
+          std::mt19937 mt{42};
+          std::uniform_int_distribution<size_t> dist{
+              0, std::numeric_limits<size_t>::max()};
+          v = std::vector<size_t>(size);
+          std::generate(std::begin(v), std::end(v),
+                        [&dist, &mt] { return dist(mt); });
+        },
+        [&] {
+          manifold::stable_sort(Policy, v.begin(), v.end(),
+                                std::less<size_t>());
+          noopt(v);
+        });
+  }
+};
+
+template <auto Policy>
+struct sort_Eq {  // 25.8.2.1, equal input
+  auto operator()(size_t size) {
+    std::vector<double> v;
+    return measure([&] { v = std::vector<double>(size, 42.); },
+                   [&] {
+                     manifold::stable_sort(Policy, v.begin(), v.end());
+                     noopt(v);
+                   });
+  }
+};
+
+template <auto Policy>
+struct sort_Eq_size {  // 25.8.2.1, equal input
+  auto operator()(size_t size) {
+    std::vector<size_t> v;
+    return measure([&] { v = std::vector<size_t>(size, 42); },
+                   [&] {
+                     manifold::stable_sort(Policy, v.begin(), v.end());
+                     noopt(v);
+                   });
+  }
+};
+
+template <auto Policy>
+struct sort_Eq_size_merge {  // 25.8.2.1, equal input
+  auto operator()(size_t size) {
+    std::vector<size_t> v;
+    return measure([&] { v = std::vector<size_t>(size, 42); },
+                   [&] {
+                     manifold::stable_sort(Policy, v.begin(), v.end(),
+                                           std::less<size_t>());
+                     noopt(v);
+                   });
+  }
+};
+
+template <auto Policy>
+struct sort_Asc {  // 25.8.2.1, ascending
+  auto operator()(size_t size) {
+    std::vector<double> v;
+    return measure(
+        [&] {
+          v = std::vector<double>(size);
+          std::iota(v.begin(), v.end(), 0.);
+        },
+        [&] {
+          manifold::stable_sort(Policy, v.begin(), v.end());
+          noopt(v);
+        });
+  }
+};
+
+template <auto Policy>
+struct sort_Asc_size {  // 25.8.2.1, ascending
+  auto operator()(size_t size) {
+    std::vector<size_t> v;
+    return measure(
+        [&] {
+          v = std::vector<size_t>(size);
+          std::iota(v.begin(), v.end(), 0);
+        },
+        [&] {
+          manifold::stable_sort(Policy, v.begin(), v.end());
+          noopt(v);
+        });
+  }
+};
+
+template <auto Policy>
+struct sort_Asc_size_merge {  // 25.8.2.1, ascending
+  auto operator()(size_t size) {
+    std::vector<size_t> v;
+    return measure(
+        [&] {
+          v = std::vector<size_t>(size);
+          std::iota(v.begin(), v.end(), 0);
+        },
+        [&] {
+          manifold::stable_sort(Policy, v.begin(), v.end(),
+                                std::less<size_t>());
+          noopt(v);
+        });
+  }
+};
+
+template <auto Policy>
+struct sort_roughly_Asc {  // 25.8.2.1, ascending + random swaps
+  auto operator()(size_t size) {
+    std::vector<double> v;
+    return measure(
+        [&] {
+          std::mt19937 mt{42};
+          std::uniform_int_distribution<size_t> dist{0, size - 1};
+          v = std::vector<double>(size);
+          std::iota(v.begin(), v.end(), 0.);
+          for (int i = 0; i < std::sqrt(size); i++) {
+            std::swap(v[dist(mt)], v[dist(mt)]);
+          }
+        },
+        [&] {
+          manifold::stable_sort(Policy, v.begin(), v.end());
+          noopt(v);
+        });
+  }
+};
+
+template <auto Policy>
+struct sort_roughly_Asc_size {  // 25.8.2.1, ascending + random swaps
+  auto operator()(size_t size) {
+    std::vector<size_t> v;
+    return measure(
+        [&] {
+          std::mt19937 mt{42};
+          std::uniform_int_distribution<size_t> dist{0, size - 1};
+          v = std::vector<size_t>(size);
+          std::iota(v.begin(), v.end(), 0.);
+          for (int i = 0; i < std::sqrt(size); i++) {
+            std::swap(v[dist(mt)], v[dist(mt)]);
+          }
+        },
+        [&] {
+          manifold::stable_sort(Policy, v.begin(), v.end());
+          noopt(v);
+        });
+  }
+};
+
+template <auto Policy>
+struct sort_roughly_Asc_size_merge {  // 25.8.2.1, ascending + random swaps
+  auto operator()(size_t size) {
+    std::vector<size_t> v;
+    return measure(
+        [&] {
+          std::mt19937 mt{42};
+          std::uniform_int_distribution<size_t> dist{0, size - 1};
+          v = std::vector<size_t>(size);
+          std::iota(v.begin(), v.end(), 0.);
+          for (int i = 0; i < std::sqrt(size); i++) {
+            std::swap(v[dist(mt)], v[dist(mt)]);
+          }
+        },
+        [&] {
+          manifold::stable_sort(Policy, v.begin(), v.end(),
+                                std::less<size_t>());
+          noopt(v);
+        });
+  }
+};
+
+template <auto Policy>
+struct sort_Des {  // 25.8.2.1, descending
+  auto operator()(size_t size) {
+    std::vector<double> v;
+    return measure(
+        [&] {
+          v = std::vector<double>(size);
+          std::generate(v.begin(), v.end(),
+                        [v = std::numeric_limits<double>::max()]() mutable {
+                          return v -= 1.;
+                        });
+        },
+        [&] {
+          manifold::stable_sort(Policy, v.begin(), v.end());
+          noopt(v);
+        });
+  }
+};
+
+template <auto Policy>
+struct sort_Des_size {  // 25.8.2.1, descending
+  auto operator()(size_t size) {
+    std::vector<size_t> v;
+    return measure(
+        [&] {
+          v = std::vector<size_t>(size);
+          std::generate(v.begin(), v.end(),
+                        [v = std::numeric_limits<size_t>::max()]() mutable {
+                          return v -= 1;
+                        });
+        },
+        [&] {
+          manifold::stable_sort(Policy, v.begin(), v.end());
+          noopt(v);
+        });
+  }
+};
+
+template <auto Policy>
+struct sort_Des_size_merge {  // 25.8.2.1, descending
+  auto operator()(size_t size) {
+    std::vector<size_t> v;
+    return measure(
+        [&] {
+          v = std::vector<size_t>(size);
+          std::generate(v.begin(), v.end(),
+                        [v = std::numeric_limits<size_t>::max()]() mutable {
+                          return v -= 1;
+                        });
+        },
+        [&] {
+          manifold::stable_sort(Policy, v.begin(), v.end(),
+                                std::less<size_t>());
+          noopt(v);
+        });
+  }
+};
+
+template <auto Policy>
+struct reduce {  // 25.10.4
+  auto operator()(size_t size) {
+    std::vector<double> v;
+    return measure([&] { v = std::vector<double>(size, 42.); },
+                   [&] {
+                     noopt(manifold::reduce(Policy, v.begin(), v.end(), 0,
+                                            std::plus<double>()));
+                   });
+  }
+};
+
+template <auto Policy>
+struct transform_reduce {  // 25.10.6
+  auto operator()(size_t size) {
+    std::vector<double> v;
+    return measure([&] { v = std::vector<double>(size, 42.); },
+                   [&] {
+                     noopt(manifold::transform_reduce(
+                         Policy, v.begin(), v.end(), 0., std::plus<>{},
+                         [](auto d) { return d + 1.; }));
+                   });
+  }
+};
+
+template <auto Policy>
+struct exclusive_scan {  // 25.10.8
+  auto operator()(size_t size) {
+    std::vector<double> v1, v2;
+    return measure(
+        [&] {
+          v1 = std::vector<double>(size, 1.01);
+          v2 = std::vector<double>(size);
+        },
+        [&] {
+          manifold::exclusive_scan(Policy, v1.begin(), v1.end(), v2.begin(),
+                                   1.02, std::multiplies<>{});
+          noopt(v1);
+        });
+  }
+};
+
+template <class T>
+static std::string demangle() {
+  const char *name = typeid(T).name();
+  char s[1024];
+  size_t len = sizeof(s);
+  int status;
+  std::string norm = abi::__cxa_demangle(name, s, &len, &status);
+  norm.erase(0, std::string_view{"benchmarks::"}.length());
+  norm.erase(norm.find_first_of('<'));
+  return norm;
+}
+
+}  // namespace benchmarks
+
+struct Result {
+  std::string name;
+  std::array<double, std::size(g_Sizes)> speedups;
+};
+
+template <template <auto> class Benchmark>
+Result record() {
+  auto micro = [](auto d) {
+    return std::chrono::duration_cast<
+               std::chrono::duration<double, std::micro>>(d)
+        .count();
+  };
+  using Seq = Benchmark<manifold::ExecutionPolicy::Seq>;
+  using Par = Benchmark<manifold::ExecutionPolicy::Par>;
+  Result r;
+  r.name = benchmarks::demangle<Seq>();
+  for (size_t i = 0; i != std::size(g_Sizes); ++i)
+    r.speedups[i] = micro(Seq{}(g_Sizes[i])) / micro(Par{}(g_Sizes[i]));
+  return r;
+}
+
+int main() {
+  std::vector<Result> results;
+  results.emplace_back(record<benchmarks::all_of>());
+  results.emplace_back(record<benchmarks::for_each>());
+  results.emplace_back(record<benchmarks::count>());
+  results.emplace_back(record<benchmarks::copy>());
+  results.emplace_back(record<benchmarks::copy_if_28>());
+  results.emplace_back(record<benchmarks::copy_if_55>());
+  results.emplace_back(record<benchmarks::copy_if_82>());
+  results.emplace_back(record<benchmarks::copy_if_1001>());
+  results.emplace_back(record<benchmarks::fill>());
+  results.emplace_back(record<benchmarks::sort_Rnd>());
+  results.emplace_back(record<benchmarks::sort_Rnd_size>());
+  results.emplace_back(record<benchmarks::sort_Rnd_size_merge>());
+  results.emplace_back(record<benchmarks::sort_Eq>());
+  // we optimized it to a copy...
+  // results.emplace_back(record<benchmarks::sort_Eq_size>());
+  results.emplace_back(record<benchmarks::sort_Eq_size_merge>());
+  results.emplace_back(record<benchmarks::sort_Asc>());
+  // optimized to a copy as well
+  // results.emplace_back(record<benchmarks::sort_Asc_size>());
+  results.emplace_back(record<benchmarks::sort_Asc_size_merge>());
+  results.emplace_back(record<benchmarks::sort_roughly_Asc>());
+  results.emplace_back(record<benchmarks::sort_roughly_Asc_size>());
+  results.emplace_back(record<benchmarks::sort_roughly_Asc_size_merge>());
+  results.emplace_back(record<benchmarks::sort_Des>());
+  results.emplace_back(record<benchmarks::sort_Des_size>());
+  results.emplace_back(record<benchmarks::sort_Des_size_merge>());
+  results.emplace_back(record<benchmarks::reduce>());
+  results.emplace_back(record<benchmarks::transform_reduce>());
+  results.emplace_back(record<benchmarks::exclusive_scan>());
+
+  const auto max_name_len =
+      std::max_element(results.begin(), results.end(), [](auto &a, auto &b) {
+        return a.name.length() < b.name.length();
+      })->name.length();
+
+  printf("%*s", int(max_name_len + 1), "");
+  for (auto s : g_Sizes) {
+    if (s >= 1'000'000)
+      printf("%4luM ", s / 1'000'000);
+    else if (s >= 1'000)
+      printf("%4luK ", s / 1'000);
+  }
+  printf("\n");
+
+  for (auto &r : results) {
+    printf("%-*s ", int(max_name_len), r.name.c_str());
+    for (auto v : r.speedups) printf("%5.2f ", v);
+    printf("\n");
+  }
+}
+

--- a/format.sh
+++ b/format.sh
@@ -2,7 +2,7 @@
 
 shopt -s extglob
 if [ -z "$CLANG_FORMAT" ]; then
-CLANG_FORMAT=$(dirname $(which clang-15))/clang-format
+CLANG_FORMAT=clang-format
 fi
 
 $CLANG_FORMAT -i extras/*.cpp

--- a/format.sh
+++ b/format.sh
@@ -2,7 +2,7 @@
 
 shopt -s extglob
 if [ -z "$CLANG_FORMAT" ]; then
-CLANG_FORMAT=$(dirname $(which clang-11))/clang-format
+CLANG_FORMAT=$(dirname $(which clang-15))/clang-format
 fi
 
 $CLANG_FORMAT -i extras/*.cpp

--- a/src/collider/src/collider.cpp
+++ b/src/collider/src/collider.cpp
@@ -372,8 +372,8 @@ bool Collider::Transform(glm::mat4x3 transform) {
     if (count != 2) axisAligned = false;
   }
   if (axisAligned) {
-    for_each(autoPolicy(nodeBBox_.size(), 100'000), nodeBBox_.begin(), nodeBBox_.end(),
-             TransformBox({transform}));
+    for_each(autoPolicy(nodeBBox_.size(), 100'000), nodeBBox_.begin(),
+             nodeBBox_.end(), TransformBox({transform}));
   }
   return axisAligned;
 }

--- a/src/collider/src/collider.cpp
+++ b/src/collider/src/collider.cpp
@@ -290,7 +290,7 @@ Collider::Collider(const VecView<const Box>& leafBB,
   nodeParent_.resize(num_nodes, -1);
   internalChildren_.resize(leafBB.size() - 1, std::make_pair(-1, -1));
   // organize tree
-  for_each_n(autoPolicy(NumInternal(), 10'000), countAt(0), NumInternal(),
+  for_each_n(autoPolicy(NumInternal(), 1e4), countAt(0), NumInternal(),
              CreateRadixTree({nodeParent_, internalChildren_, leafMorton}));
   UpdateBoxes(leafBB);
 }
@@ -353,7 +353,7 @@ void Collider::UpdateBoxes(const VecView<const Box>& leafBB) {
   Vec<int> counter(NumInternal(), 0);
   // kernel over leaves to save internal Boxes
   for_each_n(
-      autoPolicy(NumInternal(), 1'000), countAt(0), NumLeaves(),
+      autoPolicy(NumInternal(), 1e3), countAt(0), NumLeaves(),
       BuildInternalBoxes({nodeBBox_, counter, nodeParent_, internalChildren_}));
 }
 
@@ -372,7 +372,7 @@ bool Collider::Transform(glm::mat4x3 transform) {
     if (count != 2) axisAligned = false;
   }
   if (axisAligned) {
-    for_each(autoPolicy(nodeBBox_.size(), 100'000), nodeBBox_.begin(),
+    for_each(autoPolicy(nodeBBox_.size(), 1e5), nodeBBox_.begin(),
              nodeBBox_.end(), TransformBox({transform}));
   }
   return axisAligned;

--- a/src/collider/src/collider.cpp
+++ b/src/collider/src/collider.cpp
@@ -323,8 +323,8 @@ SparseIndices Collider::Collisions(const VecView<const T>& queriesIn) const {
                FindCollisions<T, selfCollision, CountCollisions>{
                    queriesIn, nodeBBox_, internalChildren_, {counts, empty}});
     // compute start index for each query and total count
-    exclusive_scan(ExecutionPolicy::Par, counts.begin(), counts.end(),
-                   counts.begin(), 0, std::plus<int>());
+    manifold::exclusive_scan(counts.begin(), counts.end(), counts.begin(), 0,
+                             std::plus<int>());
     if (counts.back() == 0) return SparseIndices(0);
     SparseIndices queryTri(counts.back());
     // actually recording collisions
@@ -348,13 +348,12 @@ void Collider::UpdateBoxes(const VecView<const Box>& leafBB) {
                "must have the same number of updated boxes as original");
   // copy in leaf node Boxes
   auto leaves = StridedRange(nodeBBox_.begin(), nodeBBox_.end(), 2);
-  auto policy = autoPolicy(NumInternal());
-  copy(policy, leafBB.cbegin(), leafBB.cend(), leaves.begin());
+  copy(leafBB.cbegin(), leafBB.cend(), leaves.begin());
   // create global counters
   Vec<int> counter(NumInternal(), 0);
   // kernel over leaves to save internal Boxes
   for_each_n(
-      policy, countAt(0), NumLeaves(),
+      autoPolicy(NumInternal()), countAt(0), NumLeaves(),
       BuildInternalBoxes({nodeBBox_, counter, nodeParent_, internalChildren_}));
 }
 

--- a/src/collider/src/collider.cpp
+++ b/src/collider/src/collider.cpp
@@ -290,7 +290,7 @@ Collider::Collider(const VecView<const Box>& leafBB,
   nodeParent_.resize(num_nodes, -1);
   internalChildren_.resize(leafBB.size() - 1, std::make_pair(-1, -1));
   // organize tree
-  for_each_n(autoPolicy(NumInternal()), countAt(0), NumInternal(),
+  for_each_n(autoPolicy(NumInternal(), 10'000), countAt(0), NumInternal(),
              CreateRadixTree({nodeParent_, internalChildren_, leafMorton}));
   UpdateBoxes(leafBB);
 }
@@ -353,7 +353,7 @@ void Collider::UpdateBoxes(const VecView<const Box>& leafBB) {
   Vec<int> counter(NumInternal(), 0);
   // kernel over leaves to save internal Boxes
   for_each_n(
-      autoPolicy(NumInternal()), countAt(0), NumLeaves(),
+      autoPolicy(NumInternal(), 1'000), countAt(0), NumLeaves(),
       BuildInternalBoxes({nodeBBox_, counter, nodeParent_, internalChildren_}));
 }
 
@@ -372,7 +372,7 @@ bool Collider::Transform(glm::mat4x3 transform) {
     if (count != 2) axisAligned = false;
   }
   if (axisAligned) {
-    for_each(autoPolicy(nodeBBox_.size()), nodeBBox_.begin(), nodeBBox_.end(),
+    for_each(autoPolicy(nodeBBox_.size(), 100'000), nodeBBox_.begin(), nodeBBox_.end(),
              TransformBox({transform}));
   }
   return axisAligned;

--- a/src/manifold/src/boolean3.cpp
+++ b/src/manifold/src/boolean3.cpp
@@ -93,9 +93,9 @@ SparseIndices Filter11(const Manifold::Impl &inP, const Manifold::Impl &inQ,
                        const SparseIndices &p1q2, const SparseIndices &p2q1) {
   ZoneScoped;
   SparseIndices p1q1(3 * p1q2.size() + 3 * p2q1.size());
-  for_each_n(autoPolicy(p1q2.size(), 100'000), countAt(0_z), p1q2.size(),
+  for_each_n(autoPolicy(p1q2.size(), 1e5), countAt(0_z), p1q2.size(),
              CopyFaceEdges<false>({p1q2, p1q1, inQ.halfedge_, 0_z}));
-  for_each_n(autoPolicy(p2q1.size(), 100'000), countAt(0_z), p2q1.size(),
+  for_each_n(autoPolicy(p2q1.size(), 1e5), countAt(0_z), p2q1.size(),
              CopyFaceEdges<true>({p2q1, p1q1, inP.halfedge_, p1q2.size()}));
   p1q1.Unique();
   return p1q1;
@@ -263,7 +263,7 @@ std::tuple<Vec<int>, Vec<glm::vec4>> Shadow11(SparseIndices &p1q1,
   Vec<int> s11(p1q1.size());
   Vec<glm::vec4> xyzz11(p1q1.size());
 
-  for_each_n(autoPolicy(p1q1.size(), 10'000), countAt(0_z), p1q1.size(),
+  for_each_n(autoPolicy(p1q1.size(), 1e4), countAt(0_z), p1q1.size(),
              Kernel11({xyzz11, s11, inP.vertPos_, inQ.vertPos_, inP.halfedge_,
                        inQ.halfedge_, expandP, inP.vertNormal_, p1q1}));
 
@@ -355,7 +355,7 @@ std::tuple<Vec<int>, Vec<float>> Shadow02(const Manifold::Impl &inP,
   Vec<float> z02(p0q2.size());
 
   auto vertNormalP = forward ? inP.vertNormal_ : inQ.vertNormal_;
-  for_each_n(autoPolicy(p0q2.size(), 10'000), countAt(0_z), p0q2.size(),
+  for_each_n(autoPolicy(p0q2.size(), 1e4), countAt(0_z), p0q2.size(),
              Kernel02({s02, z02, inP.vertPos_, inQ.halfedge_, inQ.vertPos_,
                        expandP, vertNormalP, p0q2, forward}));
 
@@ -463,7 +463,7 @@ std::tuple<Vec<int>, Vec<glm::vec3>> Intersect12(
   Vec<glm::vec3> v12(p1q2.size());
 
   for_each_n(
-      autoPolicy(p1q2.size(), 10'000), countAt(0_z), p1q2.size(),
+      autoPolicy(p1q2.size(), 1e4), countAt(0_z), p1q2.size(),
       Kernel12({x12, v12, p0q2.AsVec64(), s02, z02, p1q1.AsVec64(), s11, xyzz11,
                 inP.halfedge_, inQ.halfedge_, inP.vertPos_, forward, p1q2}));
 
@@ -477,7 +477,7 @@ Vec<int> Winding03(const Manifold::Impl &inP, Vec<int> &vertices, Vec<int> &s02,
   ZoneScoped;
   // verts that are not shadowed (not in p0q2) have winding number zero.
   Vec<int> w03(inP.NumVert(), 0);
-  if (vertices.size() <= 100'000) {
+  if (vertices.size() <= 1e5) {
     for_each_n(ExecutionPolicy::Seq, countAt(0), s02.size(),
                [&w03, &vertices, &s02, reverse](const int i) {
                  w03[vertices[i]] += s02[i] * (reverse ? -1 : 1);

--- a/src/manifold/src/boolean3.cpp
+++ b/src/manifold/src/boolean3.cpp
@@ -93,9 +93,9 @@ SparseIndices Filter11(const Manifold::Impl &inP, const Manifold::Impl &inQ,
                        const SparseIndices &p1q2, const SparseIndices &p2q1) {
   ZoneScoped;
   SparseIndices p1q1(3 * p1q2.size() + 3 * p2q1.size());
-  for_each_n(autoPolicy(p1q2.size()), countAt(0_z), p1q2.size(),
+  for_each_n(autoPolicy(p1q2.size(), 100'000), countAt(0_z), p1q2.size(),
              CopyFaceEdges<false>({p1q2, p1q1, inQ.halfedge_, 0_z}));
-  for_each_n(autoPolicy(p2q1.size()), countAt(0_z), p2q1.size(),
+  for_each_n(autoPolicy(p2q1.size(), 100'000), countAt(0_z), p2q1.size(),
              CopyFaceEdges<true>({p2q1, p1q1, inP.halfedge_, p1q2.size()}));
   p1q1.Unique();
   return p1q1;
@@ -263,7 +263,7 @@ std::tuple<Vec<int>, Vec<glm::vec4>> Shadow11(SparseIndices &p1q1,
   Vec<int> s11(p1q1.size());
   Vec<glm::vec4> xyzz11(p1q1.size());
 
-  for_each_n(autoPolicy(p1q1.size()), countAt(0_z), p1q1.size(),
+  for_each_n(autoPolicy(p1q1.size(), 10'000), countAt(0_z), p1q1.size(),
              Kernel11({xyzz11, s11, inP.vertPos_, inQ.vertPos_, inP.halfedge_,
                        inQ.halfedge_, expandP, inP.vertNormal_, p1q1}));
 
@@ -355,7 +355,7 @@ std::tuple<Vec<int>, Vec<float>> Shadow02(const Manifold::Impl &inP,
   Vec<float> z02(p0q2.size());
 
   auto vertNormalP = forward ? inP.vertNormal_ : inQ.vertNormal_;
-  for_each_n(autoPolicy(p0q2.size()), countAt(0_z), p0q2.size(),
+  for_each_n(autoPolicy(p0q2.size(), 10'000), countAt(0_z), p0q2.size(),
              Kernel02({s02, z02, inP.vertPos_, inQ.halfedge_, inQ.vertPos_,
                        expandP, vertNormalP, p0q2, forward}));
 
@@ -463,7 +463,7 @@ std::tuple<Vec<int>, Vec<glm::vec3>> Intersect12(
   Vec<glm::vec3> v12(p1q2.size());
 
   for_each_n(
-      autoPolicy(p1q2.size()), countAt(0_z), p1q2.size(),
+      autoPolicy(p1q2.size(), 10'000), countAt(0_z), p1q2.size(),
       Kernel12({x12, v12, p0q2.AsVec64(), s02, z02, p1q1.AsVec64(), s11, xyzz11,
                 inP.halfedge_, inQ.halfedge_, inP.vertPos_, forward, p1q2}));
 
@@ -477,11 +477,17 @@ Vec<int> Winding03(const Manifold::Impl &inP, Vec<int> &vertices, Vec<int> &s02,
   ZoneScoped;
   // verts that are not shadowed (not in p0q2) have winding number zero.
   Vec<int> w03(inP.NumVert(), 0);
-  auto policy = autoPolicy(vertices.size());
-  for_each_n(policy, countAt(0), s02.size(),
-             [&w03, &vertices, &s02, reverse](const int i) {
-               AtomicAdd(w03[vertices[i]], s02[i] * (reverse ? -1 : 1));
-             });
+  if (vertices.size() <= 100'000) {
+    for_each_n(ExecutionPolicy::Seq, countAt(0), s02.size(),
+               [&w03, &vertices, &s02, reverse](const int i) {
+                 w03[vertices[i]] += s02[i] * (reverse ? -1 : 1);
+               });
+  } else {
+    for_each_n(ExecutionPolicy::Par, countAt(0), s02.size(),
+               [&w03, &vertices, &s02, reverse](const int i) {
+                 AtomicAdd(w03[vertices[i]], s02[i] * (reverse ? -1 : 1));
+               });
+  }
   return w03;
 };
 }  // namespace

--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -46,7 +46,7 @@ namespace {
 constexpr int kParallelThreshold = 128;
 
 struct AbsSum {
-  int operator()(int a, int b) { return abs(a) + abs(b); }
+  int operator()(int a, int b) const { return abs(a) + abs(b); }
 };
 
 struct DuplicateVerts {
@@ -133,10 +133,10 @@ std::tuple<Vec<int>, Vec<int>> SizeOutput(
     return std::numeric_limits<size_t>::max();
   });
 
-  auto next = copy_if<decltype(tmpBuffer.begin())>(
-      autoPolicy(inP.faceNormal_.size()), faceIds,
-      faceIds + inP.faceNormal_.size(), tmpBuffer.begin(),
-      [](size_t v) { return v != std::numeric_limits<size_t>::max(); });
+  auto next =
+      copy_if(autoPolicy(inP.faceNormal_.size()), faceIds,
+              faceIds + inP.faceNormal_.size(), tmpBuffer.begin(),
+              [](size_t v) { return v != std::numeric_limits<size_t>::max(); });
 
   gather(autoPolicy(inP.faceNormal_.size()), tmpBuffer.begin(), next,
          inP.faceNormal_.begin(), outR.faceNormal_.begin());
@@ -146,10 +146,10 @@ std::tuple<Vec<int>, Vec<int>> SizeOutput(
         if (sidesPerFacePQ[i + inP.faceNormal_.size()] > 0) return i;
         return std::numeric_limits<size_t>::max();
       });
-  auto end = copy_if<decltype(tmpBuffer.begin())>(
-      autoPolicy(inQ.faceNormal_.size()), faceIdsQ,
-      faceIdsQ + inQ.faceNormal_.size(), next,
-      [](size_t v) { return v != std::numeric_limits<size_t>::max(); });
+  auto end = copy_if(autoPolicy(inQ.faceNormal_.size()), faceIdsQ,
+                     faceIdsQ + inQ.faceNormal_.size(), next, [](size_t v) {
+                       return v != std::numeric_limits<size_t>::max();
+                     });
 
   if (invertQ) {
     gather(autoPolicy(inQ.faceNormal_.size()), next, end,

--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -115,7 +115,7 @@ std::tuple<Vec<int>, Vec<int>> SizeOutput(
   auto sidesPerFaceP = sidesPerFacePQ.view(0, inP.NumTri());
   auto sidesPerFaceQ = sidesPerFacePQ.view(inP.NumTri(), inQ.NumTri());
 
-  if (inP.halfedge_.size() >= 100'000) {
+  if (inP.halfedge_.size() >= 1e5) {
     for_each(ExecutionPolicy::Par, inP.halfedge_.begin(), inP.halfedge_.end(),
              CountVerts<true>({sidesPerFaceP, i03}));
     for_each(ExecutionPolicy::Par, inQ.halfedge_.begin(), inQ.halfedge_.end(),
@@ -127,7 +127,7 @@ std::tuple<Vec<int>, Vec<int>> SizeOutput(
              CountVerts<false>({sidesPerFaceQ, i30}));
   }
 
-  if (i12.size() >= 100'000) {
+  if (i12.size() >= 1e5) {
     for_each_n(ExecutionPolicy::Par, countAt(0), i12.size(),
                CountNewVerts<false, true>(
                    {sidesPerFaceP, sidesPerFaceQ, i12, p1q2, inP.halfedge_}));
@@ -508,7 +508,7 @@ void UpdateReference(Manifold::Impl &outR, const Manifold::Impl &inP,
                      const Manifold::Impl &inQ, bool invertQ) {
   const int offsetQ = Manifold::Impl::meshIDCounter_;
   for_each_n(
-      autoPolicy(outR.NumTri(), 100'000), outR.meshRelation_.triRef.begin(),
+      autoPolicy(outR.NumTri(), 1e5), outR.meshRelation_.triRef.begin(),
       outR.NumTri(),
       MapTriRef({inP.meshRelation_.triRef, inQ.meshRelation_.triRef, offsetQ}));
 
@@ -566,7 +566,7 @@ void CreateProperties(Manifold::Impl &outR, const Manifold::Impl &inP,
   outR.meshRelation_.triProperties.resize(numTri);
 
   Vec<glm::vec3> bary(outR.halfedge_.size());
-  for_each_n(autoPolicy(numTri, 10'000), countAt(0), numTri,
+  for_each_n(autoPolicy(numTri, 1e4), countAt(0), numTri,
              Barycentric({bary, outR.meshRelation_.triRef, inP.vertPos_,
                           inQ.vertPos_, outR.vertPos_, inP.halfedge_,
                           inQ.halfedge_, outR.halfedge_, outR.precision_}));
@@ -737,14 +737,14 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   outR.vertPos_.resize(numVertR);
   // Add vertices, duplicating for inclusion numbers not in [-1, 1].
   // Retained vertices from P and Q:
-  for_each_n(autoPolicy(inP_.NumVert(), 10'000), countAt(0), inP_.NumVert(),
+  for_each_n(autoPolicy(inP_.NumVert(), 1e4), countAt(0), inP_.NumVert(),
              DuplicateVerts({outR.vertPos_, i03, vP2R, inP_.vertPos_}));
-  for_each_n(autoPolicy(inQ_.NumVert(), 10'000), countAt(0), inQ_.NumVert(),
+  for_each_n(autoPolicy(inQ_.NumVert(), 1e4), countAt(0), inQ_.NumVert(),
              DuplicateVerts({outR.vertPos_, i30, vQ2R, inQ_.vertPos_}));
   // New vertices created from intersections:
-  for_each_n(autoPolicy(i12.size(), 10'000), countAt(0), i12.size(),
+  for_each_n(autoPolicy(i12.size(), 1e4), countAt(0), i12.size(),
              DuplicateVerts({outR.vertPos_, i12, v12R, v12_}));
-  for_each_n(autoPolicy(i21.size(), 10'000), countAt(0), i21.size(),
+  for_each_n(autoPolicy(i21.size(), 1e4), countAt(0), i21.size(),
              DuplicateVerts({outR.vertPos_, i21, v21R, v21_}));
 
   PRINT(nPv << " verts from inP");

--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -562,7 +562,7 @@ void CreateProperties(Manifold::Impl &outR, const Manifold::Impl &inP,
   outR.meshRelation_.numProp = numProp;
   if (numProp == 0) return;
 
-  const size_t numTri = outR.NumTri();
+  const int numTri = outR.NumTri();
   outR.meshRelation_.triProperties.resize(numTri);
 
   Vec<glm::vec3> bary(outR.halfedge_.size());

--- a/src/manifold/src/boolean_result.cpp
+++ b/src/manifold/src/boolean_result.cpp
@@ -673,39 +673,35 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   Vec<int> i03(w03_.size());
   Vec<int> i30(w30_.size());
 
-  transform(autoPolicy(x12_.size()), x12_.begin(), x12_.end(), i12.begin(),
+  transform(x12_.begin(), x12_.end(), i12.begin(),
             [c3](int v) { return c3 * v; });
-  transform(autoPolicy(x21_.size()), x21_.begin(), x21_.end(), i21.begin(),
+  transform(x21_.begin(), x21_.end(), i21.begin(),
             [c3](int v) { return c3 * v; });
-  transform(autoPolicy(w03_.size()), w03_.begin(), w03_.end(), i03.begin(),
+  transform(w03_.begin(), w03_.end(), i03.begin(),
             [c1, c3](int v) { return c1 + c3 * v; });
-  transform(autoPolicy(w30_.size()), w30_.begin(), w30_.end(), i30.begin(),
+  transform(w30_.begin(), w30_.end(), i30.begin(),
             [c2, c3](int v) { return c2 + c3 * v; });
 
   Vec<int> vP2R(inP_.NumVert());
-  exclusive_scan(autoPolicy(i03.size()), i03.begin(), i03.end(), vP2R.begin(),
-                 0, AbsSum());
+  exclusive_scan(i03.begin(), i03.end(), vP2R.begin(), 0, AbsSum());
   int numVertR = AbsSum()(vP2R.back(), i03.back());
   const int nPv = numVertR;
 
   Vec<int> vQ2R(inQ_.NumVert());
-  exclusive_scan(autoPolicy(i30.size()), i30.begin(), i30.end(), vQ2R.begin(),
-                 numVertR, AbsSum());
+  exclusive_scan(i30.begin(), i30.end(), vQ2R.begin(), numVertR, AbsSum());
   numVertR = AbsSum()(vQ2R.back(), i30.back());
   const int nQv = numVertR - nPv;
 
   Vec<int> v12R(v12_.size());
   if (v12_.size() > 0) {
-    exclusive_scan(autoPolicy(i12.size()), i12.begin(), i12.end(), v12R.begin(),
-                   numVertR, AbsSum());
+    exclusive_scan(i12.begin(), i12.end(), v12R.begin(), numVertR, AbsSum());
     numVertR = AbsSum()(v12R.back(), i12.back());
   }
   const int n12 = numVertR - nPv - nQv;
 
   Vec<int> v21R(v21_.size());
   if (v21_.size() > 0) {
-    exclusive_scan(autoPolicy(i21.size()), i21.begin(), i21.end(), v21R.begin(),
-                   numVertR, AbsSum());
+    exclusive_scan(i21.begin(), i21.end(), v21R.begin(), numVertR, AbsSum());
     numVertR = AbsSum()(v21R.back(), i21.back());
   }
   const int n21 = numVertR - nPv - nQv - n12;

--- a/src/manifold/src/constructors.cpp
+++ b/src/manifold/src/constructors.cpp
@@ -181,7 +181,7 @@ Manifold Manifold::Sphere(float radius, int circularSegments) {
                                : Quality::GetCircularSegments(radius) / 4;
   auto pImpl_ = std::make_shared<Impl>(Impl::Shape::Octahedron);
   pImpl_->Subdivide([n](glm::vec3 edge) { return n - 1; });
-  for_each_n(autoPolicy(pImpl_->NumVert()), pImpl_->vertPos_.begin(),
+  for_each_n(autoPolicy(pImpl_->NumVert(), 100'000), pImpl_->vertPos_.begin(),
              pImpl_->NumVert(), [radius](glm::vec3& v) {
                v = glm::cos(glm::half_pi<float>() * (1.0f - v));
                v = radius * glm::normalize(v);

--- a/src/manifold/src/constructors.cpp
+++ b/src/manifold/src/constructors.cpp
@@ -471,7 +471,6 @@ std::vector<Manifold> Manifold::Decompose() const {
   Vec<int> vertLabel(componentIndices);
 
   const int numVert = NumVert();
-  auto policy = autoPolicy(numVert);
   std::vector<Manifold> meshes;
   for (int i = 0; i < numComponents; ++i) {
     auto impl = std::make_shared<Impl>();
@@ -480,18 +479,18 @@ std::vector<Manifold> Manifold::Decompose() const {
 
     Vec<int> vertNew2Old(numVert);
     const int nVert =
-        copy_if(policy, countAt(0), countAt(numVert), vertNew2Old.begin(),
+        copy_if(countAt(0), countAt(numVert), vertNew2Old.begin(),
                 [i, &vertLabel](int v) { return vertLabel[v] == i; }) -
         vertNew2Old.begin();
     impl->vertPos_.resize(nVert);
     vertNew2Old.resize(nVert);
-    gather(policy, vertNew2Old.begin(), vertNew2Old.end(),
-           pImpl_->vertPos_.begin(), impl->vertPos_.begin());
+    gather(vertNew2Old.begin(), vertNew2Old.end(), pImpl_->vertPos_.begin(),
+           impl->vertPos_.begin());
 
     Vec<int> faceNew2Old(NumTri());
     const auto& halfedge = pImpl_->halfedge_;
     const int nFace =
-        copy_if(policy, countAt(0), countAt(NumTri()), faceNew2Old.begin(),
+        copy_if(countAt(0), countAt(NumTri()), faceNew2Old.begin(),
                 [i, &vertLabel, &halfedge](int face) {
                   return vertLabel[halfedge[3 * face].startVert] == i;
                 }) -

--- a/src/manifold/src/constructors.cpp
+++ b/src/manifold/src/constructors.cpp
@@ -480,9 +480,8 @@ std::vector<Manifold> Manifold::Decompose() const {
 
     Vec<int> vertNew2Old(numVert);
     const int nVert =
-        copy_if<decltype(vertNew2Old.begin())>(
-            policy, countAt(0), countAt(numVert), vertNew2Old.begin(),
-            [i, &vertLabel](int v) { return vertLabel[v] == i; }) -
+        copy_if(policy, countAt(0), countAt(numVert), vertNew2Old.begin(),
+                [i, &vertLabel](int v) { return vertLabel[v] == i; }) -
         vertNew2Old.begin();
     impl->vertPos_.resize(nVert);
     vertNew2Old.resize(nVert);
@@ -492,11 +491,10 @@ std::vector<Manifold> Manifold::Decompose() const {
     Vec<int> faceNew2Old(NumTri());
     const auto& halfedge = pImpl_->halfedge_;
     const int nFace =
-        copy_if<decltype(faceNew2Old.begin())>(
-            policy, countAt(0), countAt(NumTri()), faceNew2Old.begin(),
-            [i, &vertLabel, &halfedge](int face) {
-              return vertLabel[halfedge[3 * face].startVert] == i;
-            }) -
+        copy_if(policy, countAt(0), countAt(NumTri()), faceNew2Old.begin(),
+                [i, &vertLabel, &halfedge](int face) {
+                  return vertLabel[halfedge[3 * face].startVert] == i;
+                }) -
         faceNew2Old.begin();
     faceNew2Old.resize(nFace);
 

--- a/src/manifold/src/constructors.cpp
+++ b/src/manifold/src/constructors.cpp
@@ -181,7 +181,7 @@ Manifold Manifold::Sphere(float radius, int circularSegments) {
                                : Quality::GetCircularSegments(radius) / 4;
   auto pImpl_ = std::make_shared<Impl>(Impl::Shape::Octahedron);
   pImpl_->Subdivide([n](glm::vec3 edge) { return n - 1; });
-  for_each_n(autoPolicy(pImpl_->NumVert(), 100'000), pImpl_->vertPos_.begin(),
+  for_each_n(autoPolicy(pImpl_->NumVert(), 1e5), pImpl_->vertPos_.begin(),
              pImpl_->NumVert(), [radius](glm::vec3& v) {
                v = glm::cos(glm::half_pi<float>() * (1.0f - v));
                v = radius * glm::normalize(v);

--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -232,12 +232,11 @@ Manifold::Impl CsgLeafNode::Compose(
       [&nodes, &vertIndices, &edgeIndices, &triIndices, &propVertIndices,
        numPropOut, &combined, policy](int i) {
         auto &node = nodes[i];
-        copy(policy, node->pImpl_->halfedgeTangent_.begin(),
+        copy(node->pImpl_->halfedgeTangent_.begin(),
              node->pImpl_->halfedgeTangent_.end(),
              combined.halfedgeTangent_.begin() + edgeIndices[i]);
         transform(
-            policy, node->pImpl_->halfedge_.begin(),
-            node->pImpl_->halfedge_.end(),
+            node->pImpl_->halfedge_.begin(), node->pImpl_->halfedge_.end(),
             combined.halfedge_.begin() + edgeIndices[i],
             UpdateHalfedge({vertIndices[i], edgeIndices[i], triIndices[i]}));
 
@@ -246,7 +245,7 @@ Manifold::Impl CsgLeafNode::Compose(
               combined.meshRelation_.triProperties.begin() + triIndices[i];
           if (node->pImpl_->NumProp() > 0) {
             auto &triProp = node->pImpl_->meshRelation_.triProperties;
-            transform(policy, triProp.begin(), triProp.end(), start,
+            transform(triProp.begin(), triProp.end(), start,
                       UpdateTriProp({propVertIndices[i]}));
 
             const int numProp = node->pImpl_->NumProp();
@@ -258,20 +257,19 @@ Manifold::Impl CsgLeafNode::Compose(
               auto newRange = StridedRange(
                   newProp.begin() + numPropOut * propVertIndices[i] + p,
                   newProp.end(), numPropOut);
-              copy(policy, oldRange.begin(), oldRange.end(), newRange.begin());
+              copy(oldRange.begin(), oldRange.end(), newRange.begin());
             }
           } else {
             // point all triangles at single new property of zeros.
-            fill(policy, start, start + node->pImpl_->NumTri(),
+            fill(start, start + node->pImpl_->NumTri(),
                  glm::ivec3(propVertIndices[i]));
           }
         }
 
         if (node->transform_ == glm::mat4x3(1.0f)) {
-          copy(policy, node->pImpl_->vertPos_.begin(),
-               node->pImpl_->vertPos_.end(),
+          copy(node->pImpl_->vertPos_.begin(), node->pImpl_->vertPos_.end(),
                combined.vertPos_.begin() + vertIndices[i]);
-          copy(policy, node->pImpl_->faceNormal_.begin(),
+          copy(node->pImpl_->faceNormal_.begin(),
                node->pImpl_->faceNormal_.end(),
                combined.faceNormal_.begin() + triIndices[i]);
         } else {
@@ -284,9 +282,9 @@ Manifold::Impl CsgLeafNode::Compose(
           auto faceNormalBegin =
               TransformIterator(node->pImpl_->faceNormal_.begin(),
                                 TransformNormals({normalTransform}));
-          copy_n(policy, vertPosBegin, node->pImpl_->vertPos_.size(),
+          copy_n(vertPosBegin, node->pImpl_->vertPos_.size(),
                  combined.vertPos_.begin() + vertIndices[i]);
-          copy_n(policy, faceNormalBegin, node->pImpl_->faceNormal_.size(),
+          copy_n(faceNormalBegin, node->pImpl_->faceNormal_.size(),
                  combined.faceNormal_.begin() + triIndices[i]);
 
           const bool invert = glm::determinant(glm::mat3(node->transform_)) < 0;
@@ -304,7 +302,7 @@ Manifold::Impl CsgLeafNode::Compose(
         // important to add an offset so that each node instance gets
         // unique meshIDs.
         const int offset = i * Manifold::Impl::meshIDCounter_;
-        transform(policy, node->pImpl_->meshRelation_.triRef.begin(),
+        transform(node->pImpl_->meshRelation_.triRef.begin(),
                   node->pImpl_->meshRelation_.triRef.end(),
                   combined.meshRelation_.triRef.begin() + triIndices[i],
                   UpdateMeshIDs({offset}));

--- a/src/manifold/src/edge_op.cpp
+++ b/src/manifold/src/edge_op.cpp
@@ -144,7 +144,7 @@ void Manifold::Impl::SimplifyTopology() {
   if (!halfedge_.size()) return;
 
   const size_t nbEdges = halfedge_.size();
-  auto policy = autoPolicy(nbEdges);
+  auto policy = autoPolicy(nbEdges, 100'000);
   size_t numFlagged = 0;
   Vec<uint8_t> bflags(nbEdges);
 

--- a/src/manifold/src/edge_op.cpp
+++ b/src/manifold/src/edge_op.cpp
@@ -144,7 +144,7 @@ void Manifold::Impl::SimplifyTopology() {
   if (!halfedge_.size()) return;
 
   const size_t nbEdges = halfedge_.size();
-  auto policy = autoPolicy(nbEdges, 100'000);
+  auto policy = autoPolicy(nbEdges, 1e5);
   size_t numFlagged = 0;
   Vec<uint8_t> bflags(nbEdges);
 

--- a/src/manifold/src/edge_op.cpp
+++ b/src/manifold/src/edge_op.cpp
@@ -162,7 +162,7 @@ void Manifold::Impl::SimplifyTopology() {
       }
     }
 
-    stable_sort(policy, entries.begin(), entries.end());
+    stable_sort(entries.begin(), entries.end());
     for (size_t i = 0; i < entries.size() - 1; ++i) {
       if (entries[i].start == entries[i + 1].start &&
           entries[i].end == entries[i + 1].end) {

--- a/src/manifold/src/face_op.cpp
+++ b/src/manifold/src/face_op.cpp
@@ -162,7 +162,7 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
 
   auto processFace2 = std::bind(
       processFace, [&](size_t face) { return std::move(results[face]); },
-      [&](int face, glm::ivec3 tri, glm::vec3 normal, TriRef r) {
+      [&](size_t face, glm::ivec3 tri, glm::vec3 normal, TriRef r) {
         triVerts[triCount[face]] = tri;
         triNormal[triCount[face]] = normal;
         triRef[triCount[face]] = r;
@@ -178,7 +178,7 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
   triRef.reserve(faceEdge.size());
   auto processFace2 = std::bind(
       processFace, generalTriangulation,
-      [&](int _face, glm::ivec3 tri, glm::vec3 normal, TriRef r) {
+      [&](size_t _face, glm::ivec3 tri, glm::vec3 normal, TriRef r) {
         triVerts.push_back(tri);
         triNormal.push_back(normal);
         triRef.push_back(r);
@@ -203,7 +203,8 @@ PolygonsIdx Manifold::Impl::Face2Polygons(VecView<Halfedge>::IterC start,
                                           glm::mat3x2 projection) const {
   std::multimap<int, int> vert_edge;
   for (auto edge = start; edge != end; ++edge) {
-    vert_edge.emplace(std::make_pair(edge->startVert, edge - start));
+    vert_edge.emplace(
+        std::make_pair(edge->startVert, static_cast<int>(edge - start)));
   }
 
   PolygonsIdx polys;

--- a/src/manifold/src/face_op.cpp
+++ b/src/manifold/src/face_op.cpp
@@ -140,7 +140,7 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
   triCount.back() = 0;
   // precompute number of triangles per face, and launch async tasks to
   // triangulate complex faces
-  for_each(autoPolicy(faceEdge.size(), 100'000), countAt(0_z),
+  for_each(autoPolicy(faceEdge.size(), 1e5), countAt(0_z),
            countAt(faceEdge.size() - 1), [&](size_t face) {
              triCount[face] = faceEdge[face + 1] - faceEdge[face] - 2;
              DEBUG_ASSERT(triCount[face] >= 1, topologyErr,
@@ -169,7 +169,7 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
       },
       std::placeholders::_1);
   // set triangles in parallel
-  for_each(autoPolicy(faceEdge.size(), 10'000), countAt(0_z),
+  for_each(autoPolicy(faceEdge.size(), 1e4), countAt(0_z),
            countAt(faceEdge.size() - 1), processFace2);
 #else
   triVerts.reserve(faceEdge.size());

--- a/src/manifold/src/face_op.cpp
+++ b/src/manifold/src/face_op.cpp
@@ -154,8 +154,7 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
            });
   group.wait();
   // prefix sum computation (assign unique index to each face) and preallocation
-  exclusive_scan(autoPolicy(triCount.size()), triCount.begin(), triCount.end(),
-                 triCount.begin(), 0_z);
+  exclusive_scan(triCount.begin(), triCount.end(), triCount.begin(), 0_z);
   triVerts.resize(triCount.back());
   triNormal.resize(triCount.back());
   triRef.resize(triCount.back());
@@ -291,11 +290,9 @@ Polygons Manifold::Impl::Slice(float height) const {
 
 Polygons Manifold::Impl::Project() const {
   const glm::mat3x2 projection = GetAxisAlignedProjection({0, 0, 1});
-  auto policy = autoPolicy(halfedge_.size());
-
   Vec<Halfedge> cusps(NumEdge());
   cusps.resize(
-      copy_if(policy, halfedge_.cbegin(), halfedge_.cend(), cusps.begin(),
+      copy_if(halfedge_.cbegin(), halfedge_.cend(), cusps.begin(),
               [&](Halfedge edge) {
                 return faceNormal_[edge.face].z >= 0 &&
                        faceNormal_[halfedge_[edge.pairedHalfedge].face].z < 0;

--- a/src/manifold/src/face_op.cpp
+++ b/src/manifold/src/face_op.cpp
@@ -293,14 +293,13 @@ Polygons Manifold::Impl::Project() const {
   auto policy = autoPolicy(halfedge_.size());
 
   Vec<Halfedge> cusps(NumEdge());
-  cusps.resize(copy_if<decltype(cusps.begin())>(
-                   policy, halfedge_.cbegin(), halfedge_.cend(), cusps.begin(),
-                   [&](Halfedge edge) {
-                     return faceNormal_[edge.face].z >= 0 &&
-                            faceNormal_[halfedge_[edge.pairedHalfedge].face].z <
-                                0;
-                   }) -
-               cusps.begin());
+  cusps.resize(
+      copy_if(policy, halfedge_.cbegin(), halfedge_.cend(), cusps.begin(),
+              [&](Halfedge edge) {
+                return faceNormal_[edge.face].z >= 0 &&
+                       faceNormal_[halfedge_[edge.pairedHalfedge].face].z < 0;
+              }) -
+      cusps.begin());
 
   PolygonsIdx polysIndexed =
       Face2Polygons(cusps.cbegin(), cusps.cend(), projection);

--- a/src/manifold/src/face_op.cpp
+++ b/src/manifold/src/face_op.cpp
@@ -140,7 +140,7 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
   triCount.back() = 0;
   // precompute number of triangles per face, and launch async tasks to
   // triangulate complex faces
-  for_each(autoPolicy(faceEdge.size()), countAt(0_z),
+  for_each(autoPolicy(faceEdge.size(), 100'000), countAt(0_z),
            countAt(faceEdge.size() - 1), [&](size_t face) {
              triCount[face] = faceEdge[face + 1] - faceEdge[face] - 2;
              DEBUG_ASSERT(triCount[face] >= 1, topologyErr,
@@ -169,7 +169,7 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
       },
       std::placeholders::_1);
   // set triangles in parallel
-  for_each(autoPolicy(faceEdge.size()), countAt(0_z),
+  for_each(autoPolicy(faceEdge.size(), 10'000), countAt(0_z),
            countAt(faceEdge.size() - 1), processFace2);
 #else
   triVerts.reserve(faceEdge.size());

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -534,7 +534,7 @@ Manifold::Impl::Impl(Shape shape, const glm::mat4x3 m) {
 void Manifold::Impl::RemoveUnreferencedVerts(Vec<glm::ivec3>& triVerts) {
   ZoneScoped;
   Vec<int> vertOld2New(NumVert() + 1, 0);
-  auto policy = autoPolicy(NumVert());
+  auto policy = autoPolicy(NumVert(), 100'000);
   for_each(policy, triVerts.cbegin(), triVerts.cend(),
            MarkVerts({vertOld2New.view(1)}));
 
@@ -566,7 +566,7 @@ void Manifold::Impl::InitializeOriginal() {
   if (meshID < 0) return;
   auto& triRef = meshRelation_.triRef;
   triRef.resize(NumTri());
-  for_each_n(autoPolicy(NumTri()), countAt(0), NumTri(),
+  for_each_n(autoPolicy(NumTri(), 100'000), countAt(0), NumTri(),
              [meshID, &triRef](const int tri) {
                triRef[tri] = {meshID, meshID, tri};
              });
@@ -583,7 +583,7 @@ void Manifold::Impl::CreateFaces(const std::vector<float>& propertyTolerance) {
   Vec<std::pair<int, int>> face2face(halfedge_.size(), {-1, -1});
   Vec<std::pair<int, int>> vert2vert(halfedge_.size(), {-1, -1});
   Vec<float> triArea(NumTri());
-  for_each_n(autoPolicy(halfedge_.size()), countAt(0), halfedge_.size(),
+  for_each_n(autoPolicy(halfedge_.size(), 10'000), countAt(0), halfedge_.size(),
              CoplanarEdge({face2face, vert2vert, triArea, halfedge_, vertPos_,
                            meshRelation_.triRef, meshRelation_.triProperties,
                            meshRelation_.properties, propertyToleranceD,
@@ -606,7 +606,7 @@ void Manifold::Impl::CreateFaces(const std::vector<float>& propertyTolerance) {
     }
   }
 
-  for_each_n(autoPolicy(halfedge_.size()), countAt(0), NumTri(),
+  for_each_n(autoPolicy(halfedge_.size(), 10'000), countAt(0), NumTri(),
              CheckCoplanarity(
                  {comp2tri, halfedge_, vertPos_, &components, precision_}));
 
@@ -624,14 +624,14 @@ void Manifold::Impl::CreateFaces(const std::vector<float>& propertyTolerance) {
  */
 void Manifold::Impl::CreateHalfedges(const Vec<glm::ivec3>& triVerts) {
   ZoneScoped;
-  const int numTri = triVerts.size();
+  const size_t numTri = triVerts.size();
   const int numHalfedge = 3 * numTri;
   // drop the old value first to avoid copy
   halfedge_.resize(0);
   halfedge_.resize(numHalfedge);
   Vec<uint64_t> edge(numHalfedge);
   Vec<int> ids(numHalfedge);
-  auto policy = autoPolicy(numTri);
+  auto policy = autoPolicy(numTri, 100'000);
   sequence(ids.begin(), ids.end());
   for_each_n(policy, countAt(0), numTri,
              [this, &edge, &triVerts](const int tri) {
@@ -786,7 +786,7 @@ void Manifold::Impl::SetPrecision(float minPrecision) {
 void Manifold::Impl::CalculateNormals() {
   ZoneScoped;
   vertNormal_.resize(NumVert());
-  auto policy = autoPolicy(NumTri());
+  auto policy = autoPolicy(NumTri(), 10'000);
   fill(vertNormal_.begin(), vertNormal_.end(), glm::vec3(0));
   bool calculateTriNormal = false;
   if (faceNormal_.size() != NumTri()) {
@@ -816,8 +816,8 @@ void Manifold::Impl::IncrementMeshIDs() {
     meshRelation_.meshIDtransform[nextMeshID++] = pair.second;
   }
 
-  const int numTri = NumTri();
-  for_each_n(autoPolicy(numTri), meshRelation_.triRef.begin(), numTri,
+  const size_t numTri = NumTri();
+  for_each_n(autoPolicy(numTri, 100'000), meshRelation_.triRef.begin(), numTri,
              UpdateMeshID({meshIDold2new.D()}));
 }
 
@@ -830,10 +830,10 @@ SparseIndices Manifold::Impl::EdgeCollisions(const Impl& Q,
                                              bool inverted) const {
   ZoneScoped;
   Vec<TmpEdge> edges = CreateTmpEdges(Q.halfedge_);
-  const int numEdge = edges.size();
+  const size_t numEdge = edges.size();
   Vec<Box> QedgeBB(numEdge);
   const auto& vertPos = Q.vertPos_;
-  auto policy = autoPolicy(numEdge);
+  auto policy = autoPolicy(numEdge, 100'000);
   for_each_n(
       policy, countAt(0), numEdge, [&QedgeBB, &edges, &vertPos](const int e) {
         QedgeBB[e] = Box(vertPos[edges[e].first], vertPos[edges[e].second]);

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -534,7 +534,7 @@ Manifold::Impl::Impl(Shape shape, const glm::mat4x3 m) {
 void Manifold::Impl::RemoveUnreferencedVerts(Vec<glm::ivec3>& triVerts) {
   ZoneScoped;
   Vec<int> vertOld2New(NumVert() + 1, 0);
-  auto policy = autoPolicy(NumVert(), 100'000);
+  auto policy = autoPolicy(NumVert(), 1e5);
   for_each(policy, triVerts.cbegin(), triVerts.cend(),
            MarkVerts({vertOld2New.view(1)}));
 
@@ -566,7 +566,7 @@ void Manifold::Impl::InitializeOriginal() {
   if (meshID < 0) return;
   auto& triRef = meshRelation_.triRef;
   triRef.resize(NumTri());
-  for_each_n(autoPolicy(NumTri(), 100'000), countAt(0), NumTri(),
+  for_each_n(autoPolicy(NumTri(), 1e5), countAt(0), NumTri(),
              [meshID, &triRef](const int tri) {
                triRef[tri] = {meshID, meshID, tri};
              });
@@ -583,7 +583,7 @@ void Manifold::Impl::CreateFaces(const std::vector<float>& propertyTolerance) {
   Vec<std::pair<int, int>> face2face(halfedge_.size(), {-1, -1});
   Vec<std::pair<int, int>> vert2vert(halfedge_.size(), {-1, -1});
   Vec<float> triArea(NumTri());
-  for_each_n(autoPolicy(halfedge_.size(), 10'000), countAt(0), halfedge_.size(),
+  for_each_n(autoPolicy(halfedge_.size(), 1e4), countAt(0), halfedge_.size(),
              CoplanarEdge({face2face, vert2vert, triArea, halfedge_, vertPos_,
                            meshRelation_.triRef, meshRelation_.triProperties,
                            meshRelation_.properties, propertyToleranceD,
@@ -606,7 +606,7 @@ void Manifold::Impl::CreateFaces(const std::vector<float>& propertyTolerance) {
     }
   }
 
-  for_each_n(autoPolicy(halfedge_.size(), 10'000), countAt(0), NumTri(),
+  for_each_n(autoPolicy(halfedge_.size(), 1e4), countAt(0), NumTri(),
              CheckCoplanarity(
                  {comp2tri, halfedge_, vertPos_, &components, precision_}));
 
@@ -631,7 +631,7 @@ void Manifold::Impl::CreateHalfedges(const Vec<glm::ivec3>& triVerts) {
   halfedge_.resize(numHalfedge);
   Vec<uint64_t> edge(numHalfedge);
   Vec<int> ids(numHalfedge);
-  auto policy = autoPolicy(numTri, 100'000);
+  auto policy = autoPolicy(numTri, 1e5);
   sequence(ids.begin(), ids.end());
   for_each_n(policy, countAt(0), numTri,
              [this, &edge, &triVerts](const int tri) {
@@ -786,7 +786,7 @@ void Manifold::Impl::SetPrecision(float minPrecision) {
 void Manifold::Impl::CalculateNormals() {
   ZoneScoped;
   vertNormal_.resize(NumVert());
-  auto policy = autoPolicy(NumTri(), 10'000);
+  auto policy = autoPolicy(NumTri(), 1e4);
   fill(vertNormal_.begin(), vertNormal_.end(), glm::vec3(0));
   bool calculateTriNormal = false;
   if (faceNormal_.size() != NumTri()) {
@@ -817,7 +817,7 @@ void Manifold::Impl::IncrementMeshIDs() {
   }
 
   const size_t numTri = NumTri();
-  for_each_n(autoPolicy(numTri, 100'000), meshRelation_.triRef.begin(), numTri,
+  for_each_n(autoPolicy(numTri, 1e5), meshRelation_.triRef.begin(), numTri,
              UpdateMeshID({meshIDold2new.D()}));
 }
 
@@ -833,7 +833,7 @@ SparseIndices Manifold::Impl::EdgeCollisions(const Impl& Q,
   const size_t numEdge = edges.size();
   Vec<Box> QedgeBB(numEdge);
   const auto& vertPos = Q.vertPos_;
-  auto policy = autoPolicy(numEdge, 100'000);
+  auto policy = autoPolicy(numEdge, 1e5);
   for_each_n(
       policy, countAt(0), numEdge, [&QedgeBB, &edges, &vertPos](const int e) {
         QedgeBB[e] = Box(vertPos[edges[e].first], vertPos[edges[e].second]);

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -546,10 +546,10 @@ void Manifold::Impl::RemoveUnreferencedVerts(Vec<glm::ivec3>& triVerts) {
     return std::numeric_limits<size_t>::max();
   });
 
-  auto next = copy_if(
-      autoPolicy(tmpBuffer.size()), vertIdIter, vertIdIter + tmpBuffer.size(),
-      tmpBuffer.begin(),
-      [](size_t v) { return v != std::numeric_limits<size_t>::max(); });
+  auto next =
+      copy_if(autoPolicy(tmpBuffer.size()), vertIdIter,
+              vertIdIter + tmpBuffer.size(), tmpBuffer.begin(),
+              [](size_t v) { return v != std::numeric_limits<size_t>::max(); });
   gather(autoPolicy(tmpBuffer.size()), tmpBuffer.begin(), next,
          oldVertPos.begin(), vertPos_.begin());
 

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -546,7 +546,7 @@ void Manifold::Impl::RemoveUnreferencedVerts(Vec<glm::ivec3>& triVerts) {
     return std::numeric_limits<size_t>::max();
   });
 
-  auto next = copy_if<decltype(tmpBuffer.begin())>(
+  auto next = copy_if(
       autoPolicy(tmpBuffer.size()), vertIdIter, vertIdIter + tmpBuffer.size(),
       tmpBuffer.begin(),
       [](size_t v) { return v != std::numeric_limits<size_t>::max(); });

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -157,7 +157,7 @@ Mesh Manifold::GetMesh() const {
   result.triVerts.resize(NumTri());
   auto& triVerts = result.triVerts;
   const auto& halfedges = impl.halfedge_;
-  for_each_n(autoPolicy(NumTri()), countAt(0), NumTri(),
+  for_each_n(autoPolicy(NumTri(), 100'000), countAt(0), NumTri(),
              [&triVerts, &halfedges](const int tri) {
                for (int i : {0, 1, 2}) {
                  triVerts[tri][i] = halfedges[3 * tri + i].startVert;

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -157,7 +157,7 @@ Mesh Manifold::GetMesh() const {
   result.triVerts.resize(NumTri());
   auto& triVerts = result.triVerts;
   const auto& halfedges = impl.halfedge_;
-  for_each_n(autoPolicy(NumTri(), 100'000), countAt(0), NumTri(),
+  for_each_n(autoPolicy(NumTri(), 1e5), countAt(0), NumTri(),
              [&triVerts, &halfedges](const int tri) {
                for (int i : {0, 1, 2}) {
                  triVerts[tri][i] = halfedges[3 * tri + i].startVert;

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -754,8 +754,9 @@ Manifold Manifold::Refine(int n) const {
 Manifold Manifold::RefineToLength(float length) const {
   length = glm::abs(length);
   auto pImpl = std::make_shared<Impl>(*GetCsgLeafNode().GetImpl());
-  pImpl->Refine(
-      [length](glm::vec3 edge) { return glm::length(edge) / length; });
+  pImpl->Refine([length](glm::vec3 edge) {
+    return static_cast<int>(glm::length(edge) / length);
+  });
   return Manifold(std::make_shared<CsgLeafNode>(pImpl));
 }
 

--- a/src/manifold/src/properties.cpp
+++ b/src/manifold/src/properties.cpp
@@ -281,7 +281,7 @@ void Manifold::Impl::CalculateCurvature(int gaussianIdx, int meanIdx) {
   Vec<float> vertGaussianCurvature(NumVert(), glm::two_pi<float>());
   Vec<float> vertArea(NumVert(), 0);
   Vec<float> degree(NumVert(), 0);
-  auto policy = autoPolicy(NumTri());
+  auto policy = autoPolicy(NumTri(), 10'000);
   for_each(policy, countAt(0_z), countAt(NumTri()),
            CurvatureAngles({vertMeanCurvature, vertGaussianCurvature, vertArea,
                             degree, halfedge_, vertPos_, faceNormal_}));

--- a/src/manifold/src/properties.cpp
+++ b/src/manifold/src/properties.cpp
@@ -281,7 +281,7 @@ void Manifold::Impl::CalculateCurvature(int gaussianIdx, int meanIdx) {
   Vec<float> vertGaussianCurvature(NumVert(), glm::two_pi<float>());
   Vec<float> vertArea(NumVert(), 0);
   Vec<float> degree(NumVert(), 0);
-  auto policy = autoPolicy(NumTri(), 10'000);
+  auto policy = autoPolicy(NumTri(), 1e4);
   for_each(policy, countAt(0_z), countAt(NumTri()),
            CurvatureAngles({vertMeanCurvature, vertGaussianCurvature, vertArea,
                             degree, halfedge_, vertPos_, faceNormal_}));

--- a/src/manifold/src/shared.h
+++ b/src/manifold/src/shared.h
@@ -183,7 +183,7 @@ Vec<TmpEdge> inline CreateTmpEdges(const Vec<Halfedge>& halfedge) {
              });
 
   size_t numEdge =
-      remove_if(autoPolicy(edges.size()), edges.begin(), edges.end(),
+      remove_if(edges.begin(), edges.end(),
                 [](const TmpEdge& edge) { return edge.halfedgeIdx < 0; }) -
       edges.begin();
   DEBUG_ASSERT(numEdge == halfedge.size() / 2, topologyErr, "Not oriented!");

--- a/src/manifold/src/shared.h
+++ b/src/manifold/src/shared.h
@@ -183,9 +183,8 @@ Vec<TmpEdge> inline CreateTmpEdges(const Vec<Halfedge>& halfedge) {
              });
 
   size_t numEdge =
-      remove_if<decltype(edges.begin())>(
-          autoPolicy(edges.size()), edges.begin(), edges.end(),
-          [](const TmpEdge& edge) { return edge.halfedgeIdx < 0; }) -
+      remove_if(autoPolicy(edges.size()), edges.begin(), edges.end(),
+                [](const TmpEdge& edge) { return edge.halfedgeIdx < 0; }) -
       edges.begin();
   DEBUG_ASSERT(numEdge == halfedge.size() / 2, topologyErr, "Not oriented!");
   edges.resize(numEdge);

--- a/src/manifold/src/smoothing.cpp
+++ b/src/manifold/src/smoothing.cpp
@@ -356,7 +356,7 @@ std::vector<Smoothness> Manifold::Impl::UpdateSharpenedEdges(
 Vec<bool> Manifold::Impl::FlatFaces() const {
   const int numTri = NumTri();
   Vec<bool> triIsFlatFace(numTri, false);
-  for_each_n(autoPolicy(numTri, 100'000), countAt(0), numTri,
+  for_each_n(autoPolicy(numTri, 1e5), countAt(0), numTri,
              [this, &triIsFlatFace](const int tri) {
                const TriRef& ref = meshRelation_.triRef[tri];
                int faceNeighbors = 0;
@@ -403,8 +403,8 @@ Vec<int> Manifold::Impl::VertFlatFace(const Vec<bool>& flatFaces) const {
 
 Vec<int> Manifold::Impl::VertHalfedge() const {
   Vec<int> vertHalfedge(NumVert());
-  for_each_n(autoPolicy(halfedge_.size(), 100'000), countAt(0),
-             halfedge_.size(), [&vertHalfedge, this](const int idx) {
+  for_each_n(autoPolicy(halfedge_.size(), 1e5), countAt(0), halfedge_.size(),
+             [&vertHalfedge, this](const int idx) {
                // arbitrary, last one wins.
                vertHalfedge[halfedge_[idx].startVert] = idx;
              });
@@ -484,12 +484,10 @@ void Manifold::Impl::SetNormals(int normalIdx, float minSharpAngle) {
   meshRelation_.numProp = numProp;
   if (meshRelation_.triProperties.size() == 0) {
     meshRelation_.triProperties.resize(numTri);
-    for_each_n(autoPolicy(numTri, 100'000), countAt(0), numTri,
-               [this](int tri) {
-                 for (const int j : {0, 1, 2})
-                   meshRelation_.triProperties[tri][j] =
-                       halfedge_[3 * tri + j].startVert;
-               });
+    for_each_n(autoPolicy(numTri, 1e5), countAt(0), numTri, [this](int tri) {
+      for (const int j : {0, 1, 2})
+        meshRelation_.triProperties[tri][j] = halfedge_[3 * tri + j].startVert;
+    });
   }
   Vec<glm::ivec3> oldTriProp(numTri, {-1, -1, -1});
   meshRelation_.triProperties.swap(oldTriProp);
@@ -657,7 +655,7 @@ void Manifold::Impl::SetNormals(int normalIdx, float minSharpAngle) {
  */
 void Manifold::Impl::LinearizeFlatTangents() {
   const int n = halfedgeTangent_.size();
-  for_each_n(autoPolicy(n, 10'000), countAt(0), n, [this](const int halfedge) {
+  for_each_n(autoPolicy(n, 1e4), countAt(0), n, [this](const int halfedge) {
     glm::vec4& tangent = halfedgeTangent_[halfedge];
     glm::vec4& otherTangent =
         halfedgeTangent_[halfedge_[halfedge].pairedHalfedge];
@@ -692,7 +690,7 @@ void Manifold::Impl::LinearizeFlatTangents() {
 void Manifold::Impl::DistributeTangents(const Vec<bool>& fixedHalfedges) {
   const int numHalfedge = fixedHalfedges.size();
   for_each_n(
-      autoPolicy(numHalfedge, 1'000), countAt(0), numHalfedge,
+      autoPolicy(numHalfedge, 1e4), countAt(0), numHalfedge,
       [this, &fixedHalfedges](int halfedge) {
         if (!fixedHalfedges[halfedge]) return;
 
@@ -791,7 +789,7 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
 
   Vec<int> vertHalfedge = VertHalfedge();
   for_each_n(
-      autoPolicy(numVert, 1'000), vertHalfedge.begin(), numVert,
+      autoPolicy(numVert, 1e4), vertHalfedge.begin(), numVert,
       [this, &tangent, &fixedHalfedge, normalIdx](int e) {
         struct FlatNormal {
           bool isFlatFace;
@@ -885,7 +883,7 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges) {
     }
   }
 
-  for_each_n(autoPolicy(numHalfedge, 10'000), countAt(0), numHalfedge,
+  for_each_n(autoPolicy(numHalfedge, 1e4), countAt(0), numHalfedge,
              [&tangent, &vertNormal, this](const int edgeIdx) {
                tangent[edgeIdx] =
                    IsInsideQuad(edgeIdx)
@@ -935,7 +933,7 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges) {
 
   const int numVert = NumVert();
   for_each_n(
-      autoPolicy(numVert, 1'000), countAt(0), numVert,
+      autoPolicy(numVert, 1e4), countAt(0), numVert,
       [this, &vertTangents, &fixedHalfedge, &vertHalfedge,
        &triIsFlatFace](int v) {
         auto it = vertTangents.find(v);
@@ -1008,7 +1006,7 @@ void Manifold::Impl::Refine(std::function<int(glm::vec3)> edgeDivisions) {
   if (vertBary.size() == 0) return;
 
   if (old.halfedgeTangent_.size() == old.halfedge_.size()) {
-    for_each_n(autoPolicy(NumTri(), 10'000), countAt(0), NumVert(),
+    for_each_n(autoPolicy(NumTri(), 1e4), countAt(0), NumVert(),
                InterpTri({vertPos_, vertBary, &old}));
     // Make original since the subdivided faces have been warped into
     // being non-coplanar, and hence not being related to the original faces.

--- a/src/manifold/src/sort.cpp
+++ b/src/manifold/src/sort.cpp
@@ -185,7 +185,7 @@ void Manifold::Impl::SortVerts() {
   ZoneScoped;
   const auto numVert = NumVert();
   Vec<uint32_t> vertMorton(numVert);
-  auto policy = autoPolicy(numVert, 100'000);
+  auto policy = autoPolicy(numVert, 1e5);
   for_each_n(policy, countAt(0), numVert, [this, &vertMorton](const int vert) {
     vertMorton[vert] = MortonCode(vertPos_[vert], bBox_);
   });
@@ -226,7 +226,7 @@ void Manifold::Impl::ReindexVerts(const Vec<int>& vertNew2Old, int oldNumVert) {
   Vec<int> vertOld2New(oldNumVert);
   scatter(countAt(0), countAt(static_cast<int>(NumVert())), vertNew2Old.begin(),
           vertOld2New.begin());
-  for_each(autoPolicy(oldNumVert, 100'000), halfedge_.begin(), halfedge_.end(),
+  for_each(autoPolicy(oldNumVert, 1e5), halfedge_.begin(), halfedge_.end(),
            Reindex({vertOld2New}));
 }
 
@@ -239,7 +239,7 @@ void Manifold::Impl::CompactProps() {
 
   const int numVerts = meshRelation_.properties.size() / meshRelation_.numProp;
   Vec<int> keep(numVerts, 0);
-  auto policy = autoPolicy(numVerts, 100'000);
+  auto policy = autoPolicy(numVerts, 1e5);
 
   for_each(policy, meshRelation_.triProperties.cbegin(),
            meshRelation_.triProperties.cend(), MarkProp({keep}));
@@ -274,7 +274,7 @@ void Manifold::Impl::GetFaceBoxMorton(Vec<Box>& faceBox,
   ZoneScoped;
   faceBox.resize(NumTri());
   faceMorton.resize(NumTri());
-  for_each_n(autoPolicy(NumTri(), 100'000), countAt(0), NumTri(),
+  for_each_n(autoPolicy(NumTri(), 1e5), countAt(0), NumTri(),
              [this, &faceBox, &faceMorton](const int face) {
                // Removed tris are marked by all halfedges having pairedHalfedge
                // = -1, and this will sort them to the end (the Morton code only
@@ -343,7 +343,7 @@ void Manifold::Impl::GatherFaces(const Vec<int>& faceNew2Old) {
   Vec<Halfedge> oldHalfedge(std::move(halfedge_));
   Vec<glm::vec4> oldHalfedgeTangent(std::move(halfedgeTangent_));
   Vec<int> faceOld2New(oldHalfedge.size() / 3);
-  auto policy = autoPolicy(numTri, 100'000);
+  auto policy = autoPolicy(numTri, 1e5);
   scatter(countAt(0), countAt(numTri), faceNew2Old.begin(),
           faceOld2New.begin());
 
@@ -387,7 +387,7 @@ void Manifold::Impl::GatherFaces(const Impl& old, const Vec<int>& faceNew2Old) {
 
   halfedge_.resize(3 * numTri);
   if (old.halfedgeTangent_.size() != 0) halfedgeTangent_.resize(3 * numTri);
-  for_each_n(autoPolicy(numTri, 100'000), countAt(0), numTri,
+  for_each_n(autoPolicy(numTri, 1e5), countAt(0), numTri,
              ReindexFace({halfedge_, halfedgeTangent_, old.halfedge_,
                           old.halfedgeTangent_, faceNew2Old, faceOld2New}));
 }
@@ -482,7 +482,7 @@ bool MeshGL::Merge() {
   precision = MaxPrecision(precision, bBox);
   if (precision < 0) return false;
 
-  auto policy = autoPolicy(numOpenVert, 100'000);
+  auto policy = autoPolicy(numOpenVert, 1e5);
   Vec<Box> vertBox(numOpenVert);
   Vec<uint32_t> vertMorton(numOpenVert);
 

--- a/src/manifold/src/subdivision.cpp
+++ b/src/manifold/src/subdivision.cpp
@@ -493,7 +493,7 @@ Vec<Barycentric> Manifold::Impl::Subdivide(
   const int numEdge = edges.size();
   const int numTri = NumTri();
   Vec<int> half2Edge(2 * numEdge);
-  auto policy = autoPolicy(numEdge, 1'000);
+  auto policy = autoPolicy(numEdge, 1e4);
   for_each_n(policy, countAt(0), numEdge,
              [&half2Edge, &edges, this](const int edge) {
                const int idx = edges[edge].halfedgeIdx;

--- a/src/manifold/src/subdivision.cpp
+++ b/src/manifold/src/subdivision.cpp
@@ -493,7 +493,7 @@ Vec<Barycentric> Manifold::Impl::Subdivide(
   const int numEdge = edges.size();
   const int numTri = NumTri();
   Vec<int> half2Edge(2 * numEdge);
-  auto policy = autoPolicy(numEdge);
+  auto policy = autoPolicy(numEdge, 1'000);
   for_each_n(policy, countAt(0), numEdge,
              [&half2Edge, &edges, this](const int edge) {
                const int idx = edges[edge].halfedgeIdx;

--- a/src/manifold/src/subdivision.cpp
+++ b/src/manifold/src/subdivision.cpp
@@ -567,11 +567,12 @@ Vec<Barycentric> Manifold::Impl::Subdivide(
   exclusive_scan(policy, numSubTris, numSubTris + numTri, triOffset.begin(), 0);
 
   Vec<int> interiorOffset(numTri);
-  auto numInterior = TransformIterator(
-      subTris.begin(),
-      [](const Partition& part) { return part.NumInterior(); });
+  auto numInterior =
+      TransformIterator(subTris.begin(), [](const Partition& part) {
+        return static_cast<int>(part.NumInterior());
+      });
   exclusive_scan(policy, numInterior, numInterior + numTri,
-                 interiorOffset.begin(), vertBary.size());
+                 interiorOffset.begin(), static_cast<int>(vertBary.size()));
 
   Vec<glm::ivec3> triVerts(triOffset.back() + subTris.back().triVert.size());
   vertBary.resize(interiorOffset.back() + subTris.back().NumInterior());

--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -190,7 +190,7 @@ bool IsConvex(const PolygonsIdx &polys, float precision) {
  * avoid creating high-degree vertices.
  */
 std::vector<glm::ivec3> TriangulateConvex(const PolygonsIdx &polys) {
-  const size_t numTri = transform_reduce<size_t>(
+  const size_t numTri = transform_reduce(
       autoPolicy(polys.size()), polys.begin(), polys.end(), 0,
       [](size_t a, size_t b) { return a + b; },
       [](const SimplePolygonIdx &poly) { return poly.size() - 2; });

--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -191,7 +191,7 @@ bool IsConvex(const PolygonsIdx &polys, float precision) {
  */
 std::vector<glm::ivec3> TriangulateConvex(const PolygonsIdx &polys) {
   const size_t numTri = transform_reduce(
-      autoPolicy(polys.size()), polys.begin(), polys.end(), 0,
+      autoPolicy(polys.size()), polys.begin(), polys.end(), 0_z,
       [](size_t a, size_t b) { return a + b; },
       [](const SimplePolygonIdx &poly) { return poly.size() - 2; });
   std::vector<glm::ivec3> triangles;

--- a/src/polygon/src/polygon.cpp
+++ b/src/polygon/src/polygon.cpp
@@ -190,9 +190,8 @@ bool IsConvex(const PolygonsIdx &polys, float precision) {
  * avoid creating high-degree vertices.
  */
 std::vector<glm::ivec3> TriangulateConvex(const PolygonsIdx &polys) {
-  const size_t numTri = transform_reduce(
-      autoPolicy(polys.size()), polys.begin(), polys.end(), 0_z,
-      [](size_t a, size_t b) { return a + b; },
+  const size_t numTri = manifold::transform_reduce(
+      polys.begin(), polys.end(), 0_z, [](size_t a, size_t b) { return a + b; },
       [](const SimplePolygonIdx &poly) { return poly.size() - 2; });
   std::vector<glm::ivec3> triangles;
   triangles.reserve(numTri);
@@ -845,11 +844,10 @@ class EarClip {
     }
 
     const int numVert = itr.size();
-    auto policy = autoPolicy(numVert);
     Vec<int> vertNew2Old(numVert);
-    sequence(policy, vertNew2Old.begin(), vertNew2Old.end());
+    sequence(vertNew2Old.begin(), vertNew2Old.end());
 
-    stable_sort(policy, vertNew2Old.begin(), vertNew2Old.end(),
+    stable_sort(vertNew2Old.begin(), vertNew2Old.end(),
                 [&vertMorton](const int a, const int b) {
                   return vertMorton[a] < vertMorton[b];
                 });

--- a/src/sdf/src/sdf.cpp
+++ b/src/sdf/src/sdf.cpp
@@ -350,7 +350,7 @@ Mesh LevelSet(std::function<float(glm::vec3)> sdf, Box bounds, float edgeLength,
   Vec<glm::ivec3> triVerts(gridVerts.Entries() * 12);  // worst case
 
   Vec<int> index(1, 0);
-  for_each_n(pol, countAt(0_z), gridVerts.Size(),
+  for_each_n(pol, countAt(0), gridVerts.Size(),
              BuildTris({triVerts, index, gridVerts.D()}));
   triVerts.resize(index[0]);
 

--- a/src/utilities/include/hashtable.h
+++ b/src/utilities/include/hashtable.h
@@ -17,7 +17,6 @@
 #include <atomic>
 
 #include "public.h"
-#include "utils.h"
 #include "vec.h"
 
 namespace {

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -428,7 +428,7 @@ T reduce(ExecutionPolicy policy, InputIter first, InputIter last, T init,
 template <typename InputIter, typename BinaryOp,
           typename T = typename std::iterator_traits<InputIter>::value_type>
 T reduce(InputIter first, InputIter last, T init, BinaryOp f) {
-  return reduce(autoPolicy(first, last, 100'000), first, last, init, f);
+  return reduce(autoPolicy(first, last, 1e5), first, last, init, f);
 }
 
 // Transform and reduce the range `[first, last)` by first applying a unary
@@ -512,7 +512,7 @@ void inclusive_scan(ExecutionPolicy policy, InputIter first, InputIter last,
 template <typename InputIter, typename OutputIter,
           typename T = typename std::iterator_traits<InputIter>::value_type>
 void inclusive_scan(InputIter first, InputIter last, OutputIter d_first) {
-  return inclusive_scan(autoPolicy(first, last, 100'000), first, last, d_first);
+  return inclusive_scan(autoPolicy(first, last, 1e5), first, last, d_first);
 }
 
 // Compute the inclusive prefix sum for the range `[first, last)` using the
@@ -663,7 +663,7 @@ void copy(ExecutionPolicy policy, InputIter first, InputIter last,
 // must be equal or non-overlapping.
 template <typename InputIter, typename OutputIter>
 void copy(InputIter first, InputIter last, OutputIter d_first) {
-  copy(autoPolicy(first, last, 1'000'000), first, last, d_first);
+  copy(autoPolicy(first, last, 1e6), first, last, d_first);
 }
 
 // Copy the input range `[first, first + n)` to the output range
@@ -733,7 +733,7 @@ size_t count_if(ExecutionPolicy policy, InputIter first, InputIter last,
 // predicate `pred`, i.e. `pred(x) == true`.
 template <typename InputIter, typename P>
 size_t count_if(InputIter first, InputIter last, P pred) {
-  return count_if(autoPolicy(first, last, 10'000), first, last, pred);
+  return count_if(autoPolicy(first, last, 1e4), first, last, pred);
 }
 
 // Check if all elements in the input range `[first, last)` satisfy
@@ -765,7 +765,7 @@ bool all_of(ExecutionPolicy policy, InputIter first, InputIter last, P pred) {
 // predicate `pred`, i.e. `pred(x) == true`.
 template <typename InputIter, typename P>
 bool all_of(InputIter first, InputIter last, P pred) {
-  return all_of(autoPolicy(first, last, 100'000), first, last, pred);
+  return all_of(autoPolicy(first, last, 1e5), first, last, pred);
 }
 
 // Copy values in the input range `[first, last)` to the output range

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -239,9 +239,10 @@ struct CopyIfScanBody {
   void operator()(const tbb::blocked_range<size_t> &r, Tag) {
     size_t temp = sum;
     for (size_t i = r.begin(); i < r.end(); ++i) {
-      bool good = pred(input[i]);
-      temp += good;
-      if (Tag::is_final_scan() && good) output[temp - 1] = input[i];
+      if (pred(input[i])) {
+        temp += 1;
+        if (Tag::is_final_scan()) output[temp - 1] = input[i];
+      }
     }
     sum = temp;
   }

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -308,7 +308,7 @@ struct SortFunctor<Iterator, T, std::enable_if_t<std::is_integral_v<T>>> {
   void operator()(ExecutionPolicy policy, Iterator first, Iterator last) {
 #if MANIFOLD_PAR == 'T'
     if (policy == ExecutionPolicy::Par &&
-        std::distance(first, last) >= kSeqThreshold) {
+        static_cast<size_t>(std::distance(first, last)) >= kSeqThreshold) {
       radix_sort(first, std::distance(first, last));
       return;
     }

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -44,7 +44,8 @@ inline constexpr ExecutionPolicy autoPolicy(size_t size,
   return ExecutionPolicy::Par;
 }
 
-template <typename Iter>
+template <typename Iter,
+          typename Dummy = std::enable_if_t<!std::is_integral_v<Iter>>>
 inline constexpr ExecutionPolicy autoPolicy(Iter first, Iter last,
                                             size_t threshold = kSeqThreshold) {
   if (static_cast<size_t>(std::distance(first, last)) <= threshold) {

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -160,7 +160,7 @@ struct Hist {
     for (int i = 0; i < k; ++i)
       for (int j = 0; j < 256; ++j) hist[i][j] += other.hist[i][j];
   }
-  void prefixSum(int total, bool *canSkip) {
+  void prefixSum(N total, bool *canSkip) {
     for (int i = 0; i < k; ++i) {
       size_t count = 0;
       for (int j = 0; j < 256; ++j) {
@@ -309,7 +309,7 @@ struct SortFunctor<Iterator, T, std::enable_if_t<std::is_integral_v<T>>> {
 #if MANIFOLD_PAR == 'T'
     if (policy == ExecutionPolicy::Par &&
         static_cast<size_t>(std::distance(first, last)) >= kSeqThreshold) {
-      radix_sort(first, static_cast<size_t>(std::distance(first, last)));
+      radix_sort(&*first, static_cast<size_t>(std::distance(first, last)));
       return;
     }
 #endif

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -164,7 +164,7 @@ struct Hist {
     for (int i = 0; i < k; ++i) {
       size_t count = 0;
       for (int j = 0; j < 256; ++j) {
-        size_t tmp = hist[i][j];
+        N tmp = hist[i][j];
         hist[i][j] = count;
         count += tmp;
         if (tmp == total) canSkip[i] = true;

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -163,7 +163,6 @@ struct Hist {
   void prefixSum(int total, bool *canSkip) {
     for (int i = 0; i < k; ++i) {
       size_t count = 0;
-#pragma unroll 4
       for (int j = 0; j < 256; ++j) {
         size_t tmp = hist[i][j];
         hist[i][j] = count;
@@ -588,7 +587,11 @@ Iter unique(ExecutionPolicy policy, Iter first, Iter last) {
 template <typename Iterator,
           typename T = typename std::iterator_traits<Iterator>::value_type>
 void stable_sort(ExecutionPolicy policy, Iterator first, Iterator last) {
+#if MANIFOLD_PAR == 'T'
   details::SortFunctor<Iterator, T>()(policy, first, last);
+#else
+  std::stable_sort(first, last);
+#endif
 }
 
 template <typename Iterator,
@@ -596,7 +599,11 @@ template <typename Iterator,
           typename Comp = decltype(std::less<T>())>
 void stable_sort(ExecutionPolicy policy, Iterator first, Iterator last,
                  Comp comp) {
+#if MANIFOLD_PAR == 'T'
   details::mergeSort(policy, first, last, comp);
+#else
+  std::stable_sort(first, last, comp);
+#endif
 }
 
 template <typename Iter,

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -627,7 +627,7 @@ void transform(InputIter first, InputIter last, OutputIter d_first, F f) {
 //
 // The input range `[first, last)` and
 // the output range `[d_first, d_first + last - first)`
-// must be equal or non-overlapping.
+// must not overlap.
 template <typename InputIter, typename OutputIter>
 void copy(ExecutionPolicy policy, InputIter first, InputIter last,
           OutputIter d_first) {
@@ -660,7 +660,7 @@ void copy(ExecutionPolicy policy, InputIter first, InputIter last,
 //
 // The input range `[first, last)` and
 // the output range `[d_first, d_first + last - first)`
-// must be equal or non-overlapping.
+// must not overlap.
 template <typename InputIter, typename OutputIter>
 void copy(InputIter first, InputIter last, OutputIter d_first) {
   copy(autoPolicy(first, last, 1e6), first, last, d_first);
@@ -669,9 +669,9 @@ void copy(InputIter first, InputIter last, OutputIter d_first) {
 // Copy the input range `[first, first + n)` to the output range
 // starting from `d_first`.
 //
-// The input range `[first, last)` and
-// the output range `[d_first, d_first + last - first)`
-// must be equal or non-overlapping.
+// The input range `[first, first + n)` and
+// the output range `[d_first, d_first + n)`
+// must not overlap.
 template <typename InputIter, typename OutputIter>
 void copy_n(ExecutionPolicy policy, InputIter first, size_t n,
             OutputIter d_first) {
@@ -681,9 +681,9 @@ void copy_n(ExecutionPolicy policy, InputIter first, size_t n,
 // Copy the input range `[first, first + n)` to the output range
 // starting from `d_first`.
 //
-// The input range `[first, last)` and
-// the output range `[d_first, d_first + last - first)`
-// must be equal or non-overlapping.
+// The input range `[first, first + n)` and
+// the output range `[d_first, d_first + n)`
+// must not overlap.
 template <typename InputIter, typename OutputIter>
 void copy_n(InputIter first, size_t n, OutputIter d_first) {
   copy(autoPolicy(n, 1e6), first, first + n, d_first);
@@ -778,7 +778,7 @@ bool all_of(InputIter first, InputIter last, P pred) {
 //
 // The input range `[first, last)` and
 // the output range `[d_first, d_first + last - first)`
-// must be equal or non-overlapping.
+// must not overlap.
 template <typename InputIter, typename OutputIter, typename P>
 OutputIter copy_if(ExecutionPolicy policy, InputIter first, InputIter last,
                    OutputIter d_first, P pred) {
@@ -813,7 +813,7 @@ OutputIter copy_if(ExecutionPolicy policy, InputIter first, InputIter last,
 //
 // The input range `[first, last)` and
 // the output range `[d_first, d_first + last - first)`
-// must be equal or non-overlapping.
+// must not overlap.
 template <typename InputIter, typename OutputIter, typename P>
 OutputIter copy_if(InputIter first, InputIter last, OutputIter d_first,
                    P pred) {

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -128,6 +128,7 @@ void inclusive_scan(ExecutionPolicy policy, InputIter first, InputIter last,
   std::inclusive_scan(first, last, d_first);
 }
 
+#if MANIFOLD_PAR == 'T'
 template <typename T, typename InputIter, typename OutputIter, typename BinOp>
 struct ScanBody {
   T sum;
@@ -158,6 +159,7 @@ struct ScanBody {
   void reverse_join(ScanBody &a) { sum = f(a.sum, sum); }
   void assign(ScanBody &b) { sum = b.sum; }
 };
+#endif
 
 template <typename InputIter, typename OutputIter,
           typename BinOp = decltype(std::plus<typename std::iterator_traits<
@@ -221,6 +223,7 @@ bool all_of(ExecutionPolicy policy, InputIter first, InputIter last, P pred) {
                 [](bool a, bool b) { return a && b; });
 }
 
+#if MANIFOLD_PAR == 'T'
 template <typename InputIter, typename OutputIter, typename P>
 struct CopyIfScanBody {
   size_t sum;
@@ -246,6 +249,7 @@ struct CopyIfScanBody {
   void reverse_join(CopyIfScanBody &a) { sum = a.sum + sum; }
   void assign(CopyIfScanBody &b) { sum = b.sum; }
 };
+#endif
 
 // note that you should not have alias between input and output...
 // in general it is impossible to check if there is any alias, as the input

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -149,7 +149,7 @@ struct CopyIfScanBody {
   void assign(CopyIfScanBody &b) { sum = b.sum; }
 };
 
-constexpr size_t kSeqThreshold = 1 << 18;
+constexpr size_t kSeqThreshold = 1 << 14;
 
 template <typename N, const int K>
 struct Hist {
@@ -309,7 +309,7 @@ struct SortFunctor<Iterator, T, std::enable_if_t<std::is_integral_v<T>>> {
 #if MANIFOLD_PAR == 'T'
     if (policy == ExecutionPolicy::Par &&
         static_cast<size_t>(std::distance(first, last)) >= kSeqThreshold) {
-      radix_sort(first, std::distance(first, last));
+      radix_sort(first, static_cast<size_t>(std::distance(first, last)));
       return;
     }
 #endif

--- a/src/utilities/include/par.h
+++ b/src/utilities/include/par.h
@@ -347,7 +347,8 @@ T reduce(ExecutionPolicy policy, InputIter first, InputIter last, T init,
   if (policy == ExecutionPolicy::Par) {
     // should we use deterministic reduce here?
     return tbb::parallel_reduce(
-        tbb::blocked_range<InputIter>(first, last, details::kSeqThreshold), init,
+        tbb::blocked_range<InputIter>(first, last, details::kSeqThreshold),
+        init,
         [&f](const tbb::blocked_range<InputIter> &range, T value) {
           return std::reduce(range.begin(), range.end(), value, f);
         },
@@ -435,7 +436,8 @@ void copy(ExecutionPolicy policy, InputIter first, InputIter last,
 #if MANIFOLD_PAR == 'T'
   if (policy == ExecutionPolicy::Par) {
     tbb::parallel_for(tbb::blocked_range<size_t>(
-                          0_z, static_cast<size_t>(std::distance(first, last)), details::kSeqThreshold),
+                          0_z, static_cast<size_t>(std::distance(first, last)),
+                          details::kSeqThreshold),
                       [&](const tbb::blocked_range<size_t> &range) {
                         std::copy(first + range.begin(), first + range.end(),
                                   d_first + range.begin());

--- a/src/utilities/include/sparse.h
+++ b/src/utilities/include/sparse.h
@@ -142,10 +142,10 @@ class SparseIndices {
     auto policy = autoPolicy(S.size());
     sequence(policy, new2Old.begin(), new2Old.end());
 
-    size_t size = copy_if<decltype(new2Old.begin())>(
-                      policy, countAt(0_z), countAt(S.size()), new2Old.begin(),
-                      [&S](const int i) { return S[i] != 0; }) -
-                  new2Old.begin();
+    size_t size =
+        copy_if(policy, countAt(0_z), countAt(S.size()), new2Old.begin(),
+                [&S](const int i) { return S[i] != 0; }) -
+        new2Old.begin();
     new2Old.resize(size);
 
     Permute(S, new2Old);
@@ -178,9 +178,8 @@ class SparseIndices {
     Vec<int> new2Old(v.size());
     auto policy = autoPolicy(v.size());
 
-    size_t size = copy_if<decltype(new2Old.begin())>(
-                      policy, countAt(0_z), countAt(v.size()), new2Old.begin(),
-                      firstFinite<T>({v})) -
+    size_t size = copy_if(policy, countAt(0_z), countAt(v.size()),
+                          new2Old.begin(), firstFinite<T>({v})) -
                   new2Old.begin();
     new2Old.resize(size);
 

--- a/src/utilities/include/sparse.h
+++ b/src/utilities/include/sparse.h
@@ -128,8 +128,7 @@ class SparseIndices {
   void Unique() {
     Sort();
     VecView<int64_t> view = AsVec64();
-    size_t newSize = unique<decltype(view.begin())>(autoPolicy(view.size()),
-                                                    view.begin(), view.end()) -
+    size_t newSize = unique(autoPolicy(view.size()), view.begin(), view.end()) -
                      view.begin();
     Resize(newSize);
   }

--- a/src/utilities/include/sparse.h
+++ b/src/utilities/include/sparse.h
@@ -137,7 +137,7 @@ class SparseIndices {
     DEBUG_ASSERT(S.size() == size(), userErr,
                  "Different number of values than indicies!");
 
-    Vec<int> new2Old(S.size());
+    Vec<size_t> new2Old(S.size());
     auto policy = autoPolicy(S.size());
     sequence(policy, new2Old.begin(), new2Old.end());
 

--- a/src/utilities/include/sparse.h
+++ b/src/utilities/include/sparse.h
@@ -143,7 +143,7 @@ class SparseIndices {
 
     size_t size =
         copy_if(policy, countAt(0_z), countAt(S.size()), new2Old.begin(),
-                [&S](const int i) { return S[i] != 0; }) -
+                [&S](const size_t i) { return S[i] != 0; }) -
         new2Old.begin();
     new2Old.resize(size);
 

--- a/src/utilities/include/sparse.h
+++ b/src/utilities/include/sparse.h
@@ -64,7 +64,7 @@ class SparseIndices {
 
   void Sort() {
     VecView<int64_t> view = AsVec64();
-    stable_sort(autoPolicy(size()), view.begin(), view.end());
+    stable_sort(view.begin(), view.end());
   }
 
   void Resize(size_t size) { data_.resize(size * sizeof(int64_t), -1); }
@@ -128,8 +128,7 @@ class SparseIndices {
   void Unique() {
     Sort();
     VecView<int64_t> view = AsVec64();
-    size_t newSize = unique(autoPolicy(view.size()), view.begin(), view.end()) -
-                     view.begin();
+    size_t newSize = unique(view.begin(), view.end()) - view.begin();
     Resize(newSize);
   }
 
@@ -138,19 +137,17 @@ class SparseIndices {
                  "Different number of values than indicies!");
 
     Vec<size_t> new2Old(S.size());
-    auto policy = autoPolicy(S.size());
-    sequence(policy, new2Old.begin(), new2Old.end());
+    sequence(new2Old.begin(), new2Old.end());
 
-    size_t size =
-        copy_if(policy, countAt(0_z), countAt(S.size()), new2Old.begin(),
-                [&S](const size_t i) { return S[i] != 0; }) -
-        new2Old.begin();
+    size_t size = copy_if(countAt(0_z), countAt(S.size()), new2Old.begin(),
+                          [&S](const size_t i) { return S[i] != 0; }) -
+                  new2Old.begin();
     new2Old.resize(size);
 
     Permute(S, new2Old);
     Vec<char> tmp(std::move(data_));
     Resize(size);
-    gather(policy, new2Old.begin(), new2Old.end(),
+    gather(new2Old.begin(), new2Old.end(),
            reinterpret_cast<int64_t*>(tmp.data()),
            reinterpret_cast<int64_t*>(data_.data()));
 
@@ -175,10 +172,8 @@ class SparseIndices {
                  "Different number of values than indicies!");
 
     Vec<int> new2Old(v.size());
-    auto policy = autoPolicy(v.size());
-
-    size_t size = copy_if(policy, countAt(0_z), countAt(v.size()),
-                          new2Old.begin(), firstFinite<T>({v})) -
+    size_t size = copy_if(countAt(0_z), countAt(v.size()), new2Old.begin(),
+                          firstFinite<T>({v})) -
                   new2Old.begin();
     new2Old.resize(size);
 
@@ -186,7 +181,7 @@ class SparseIndices {
     Permute(x, new2Old);
     Vec<char> tmp(std::move(data_));
     Resize(size);
-    gather(policy, new2Old.begin(), new2Old.end(),
+    gather(new2Old.begin(), new2Old.end(),
            reinterpret_cast<int64_t*>(tmp.data()),
            reinterpret_cast<int64_t*>(data_.data()));
 

--- a/src/utilities/include/utils.h
+++ b/src/utilities/include/utils.h
@@ -73,8 +73,8 @@ inline int Prev3(int i) {
   return prev3[i];
 }
 
-template <typename T>
-void Permute(Vec<T>& inOut, const Vec<int>& new2Old) {
+template <typename T, typename T1>
+void Permute(Vec<T>& inOut, const Vec<T1>& new2Old) {
   Vec<T> tmp(std::move(inOut));
   inOut.resize(new2Old.size());
   gather(autoPolicy(new2Old.size()), new2Old.begin(), new2Old.end(),

--- a/src/utilities/include/utils.h
+++ b/src/utilities/include/utils.h
@@ -77,8 +77,7 @@ template <typename T, typename T1>
 void Permute(Vec<T>& inOut, const Vec<T1>& new2Old) {
   Vec<T> tmp(std::move(inOut));
   inOut.resize(new2Old.size());
-  gather(autoPolicy(new2Old.size()), new2Old.begin(), new2Old.end(),
-         tmp.begin(), inOut.begin());
+  gather(new2Old.begin(), new2Old.end(), tmp.begin(), inOut.begin());
 }
 
 template <typename T>
@@ -137,7 +136,7 @@ struct UnionFind {
   Vec<R> ranks;
 
   UnionFind(I numNodes) : parents(numNodes), ranks(numNodes, 0) {
-    sequence(autoPolicy(numNodes), parents.begin(), parents.end());
+    sequence(parents.begin(), parents.end());
   }
 
   I find(I x) {

--- a/src/utilities/include/vec.h
+++ b/src/utilities/include/vec.h
@@ -21,7 +21,6 @@
 #endif
 
 #include "par.h"
-#include "public.h"
 #include "vec_view.h"
 
 namespace manifold {
@@ -63,7 +62,7 @@ class Vec : public VecView<T> {
       this->ptr_ = reinterpret_cast<T *>(malloc(this->size_ * sizeof(T)));
       ASSERT(this->ptr_ != nullptr, std::bad_alloc());
       TracyAllocS(this->ptr_, this->size_ * sizeof(T), 3);
-      uninitialized_copy(policy, vec.begin(), vec.end(), this->ptr_);
+      copy(policy, vec.begin(), vec.end(), this->ptr_);
     }
   }
 
@@ -75,7 +74,7 @@ class Vec : public VecView<T> {
       this->ptr_ = reinterpret_cast<T *>(malloc(this->size_ * sizeof(T)));
       ASSERT(this->ptr_ != nullptr, std::bad_alloc());
       TracyAllocS(this->ptr_, this->size_ * sizeof(T), 3);
-      uninitialized_copy(policy, vec.begin(), vec.end(), this->ptr_);
+      copy(policy, vec.begin(), vec.end(), this->ptr_);
     }
   }
 
@@ -114,7 +113,7 @@ class Vec : public VecView<T> {
       this->ptr_ = reinterpret_cast<T *>(malloc(this->size_ * sizeof(T)));
       ASSERT(this->ptr_ != nullptr, std::bad_alloc());
       TracyAllocS(this->ptr_, this->size_ * sizeof(T), 3);
-      uninitialized_copy(policy, other.begin(), other.end(), this->ptr_);
+      copy(policy, other.begin(), other.end(), this->ptr_);
     }
     return *this;
   }
@@ -159,8 +158,8 @@ class Vec : public VecView<T> {
       ASSERT(newBuffer != nullptr, std::bad_alloc());
       TracyAllocS(newBuffer, n * sizeof(T), 3);
       if (this->size_ > 0)
-        uninitialized_copy(autoPolicy(this->size_), this->ptr_,
-                           this->ptr_ + this->size_, newBuffer);
+        copy(autoPolicy(this->size_), this->ptr_, this->ptr_ + this->size_,
+             newBuffer);
       if (this->ptr_ != nullptr) {
         TracyFreeS(this->ptr_, 3);
         free(this->ptr_);
@@ -174,8 +173,8 @@ class Vec : public VecView<T> {
     bool shrink = this->size_ > 2 * newSize;
     reserve(newSize);
     if (this->size_ < newSize) {
-      uninitialized_fill(autoPolicy(newSize - this->size_),
-                         this->ptr_ + this->size_, this->ptr_ + newSize, val);
+      fill(autoPolicy(newSize - this->size_), this->ptr_ + this->size_,
+           this->ptr_ + newSize, val);
     }
     this->size_ = newSize;
     if (shrink) shrink_to_fit();
@@ -187,8 +186,8 @@ class Vec : public VecView<T> {
       newBuffer = reinterpret_cast<T *>(malloc(this->size_ * sizeof(T)));
       ASSERT(newBuffer != nullptr, std::bad_alloc());
       TracyAllocS(newBuffer, this->size_ * sizeof(T), 3);
-      uninitialized_copy(autoPolicy(this->size_), this->ptr_,
-                         this->ptr_ + this->size_, newBuffer);
+      copy(autoPolicy(this->size_), this->ptr_, this->ptr_ + this->size_,
+           newBuffer);
     }
     if (this->ptr_ != nullptr) {
       TracyFreeS(this->ptr_, 3);


### PR DESCRIPTION
Most of the algorithms done. My major reasoning for this is that:

1. oneDPL seems like another huge dependency for mac users, while the algorithms we use can mostly be implemented with tbb.
2. I want to find a way to fix #787 without asking users to disable tbb.
3. It seems unlikely that (in the foreseeable) future accelerators will allow seamless interop with PSTL. If you look at how oneDPL and thrust works, they all require some specific device container/queues, which I think is unavoidable. So we are probably not losing much by ditching PSTL for now.
4. The implementations are very simple, with good performance. So far I haven't yet implemented `unique`, `uninitialized_fill`, `uninitialized_copy`, `stable_sort`. I don't think these are hard, just I probably need some sleep now. And the performance with my simple implementation for all the other algorithm is on-par with PSTL.
5. I always wanted to get rid of those explicit template specialization.

I think in the end `remove_if`, `unique`, `stable_sort` will require temporary storage buffer because they do in-place update, and I think all other parallel algorithm libraries does that anyway. Everything else can be parallelized.

I also took the time to remove some of the unused or (apparently) not useful algorithms here. E.g. `find`. Actually I am not sure if they are in a sorted array and maybe we can use avoid this generic find function? Probably does not matter much anyway...