### PR TITLE
Avoid Wundef trigger

### DIFF
--- a/src/utilities/include/optional_assert.h
+++ b/src/utilities/include/optional_assert.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include "public.h"
-#if MANIFOLD_EXCEPTIONS
+#ifdef MANIFOLD_EXCEPTIONS
 #include <stdexcept>
 #endif
 
@@ -40,7 +40,7 @@ void Assert(bool condition, const char* file, int line, const std::string& cond,
 #define DEBUG_ASSERT(condition, EX, msg)
 #endif
 
-#if MANIFOLD_EXCEPTIONS
+#ifdef MANIFOLD_EXCEPTIONS
 #define ASSERT(condition, EX) \
   if (!(condition)) throw(EX);
 #else


### PR DESCRIPTION
When the Manifold headers are included in BRL-CAD, one of our compile flags doesn't like MANIFOLD_EXCEPTIONS being undefined - if I'm not mistaken, we can just check for the definition here, without worrying about its specific value. 