### PR TITLE
SDF interpolation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -114,7 +114,11 @@
     "numbers": "cpp",
     "ranges": "cpp",
     "stop_token": "cpp",
-    "execution": "cpp"
+    "execution": "cpp",
+    "csetjmp": "cpp",
+    "cuchar": "cpp",
+    "propagate_const": "cpp",
+    "scoped_allocator": "cpp"
   },
   "C_Cpp.clang_format_fallbackStyle": "google",
   "editor.formatOnSave": true,

--- a/src/manifold/src/properties.cpp
+++ b/src/manifold/src/properties.cpp
@@ -146,19 +146,6 @@ struct CheckHalfedges {
   }
 };
 
-struct NoDuplicates {
-  VecView<const Halfedge> halfedges;
-
-  bool operator()(size_t edge) const {
-    const Halfedge halfedge = halfedges[edge];
-    if (halfedge.startVert == -1 && halfedge.endVert == -1 &&
-        halfedge.pairedHalfedge == -1)
-      return true;
-    return halfedge.startVert != halfedges[edge + 1].startVert ||
-           halfedge.endVert != halfedges[edge + 1].endVert;
-  }
-};
-
 struct CheckCCW {
   VecView<const Halfedge> halfedges;
   VecView<const glm::vec3> vertPos;
@@ -226,8 +213,14 @@ bool Manifold::Impl::Is2Manifold() const {
   Vec<Halfedge> halfedge(halfedge_);
   stable_sort(halfedge.begin(), halfedge.end());
 
-  return all_of(countAt(0_z), countAt(2 * NumEdge() - 1),
-                NoDuplicates({halfedge}));
+  return all_of(
+      countAt(0_z), countAt(2 * NumEdge() - 1), [halfedge](size_t edge) {
+        const Halfedge h = halfedge[edge];
+        if (h.startVert == -1 && h.endVert == -1 && h.pairedHalfedge == -1)
+          return true;
+        return h.startVert != halfedge[edge + 1].startVert ||
+               h.endVert != halfedge[edge + 1].endVert;
+      });
 }
 
 /**

--- a/src/manifold/src/smoothing.cpp
+++ b/src/manifold/src/smoothing.cpp
@@ -736,7 +736,7 @@ void Manifold::Impl::DistributeTangents(const Vec<bool>& fixedHalfedges) {
           lastTangent = thisTangent;
         } while (!fixedHalfedges[current]);
 
-        if (currentAngle.size() == 1) return;
+        if (currentAngle.size() == 1 || glm::dot(normal, normal) == 0) return;
 
         const float scale = currentAngle.back() / desiredAngle.back();
         float offset = 0;

--- a/src/manifold/src/subdivision.cpp
+++ b/src/manifold/src/subdivision.cpp
@@ -443,10 +443,9 @@ Manifold::Impl::BaryIndices Manifold::Impl::GetIndices(int halfedge) const {
     const int pair = halfedge_[3 * tri + neighbor].pairedHalfedge;
     if (pair / 3 < tri) {
       tri = pair / 3;
-      const int j = pair % 3;
-      idx = Next3(neighbor) == idx ? j : (j + 1) % 4;
-    } else if (idx > neighbor) {
-      ++idx;
+      idx = Next3(neighbor) == idx ? 0 : 1;
+    } else {
+      idx = Next3(neighbor) == idx ? 2 : 3;
     }
     return {tri, idx, (idx + 1) % 4};
   }

--- a/src/manifold/src/subdivision.cpp
+++ b/src/manifold/src/subdivision.cpp
@@ -89,19 +89,19 @@ class Partition {
     return partition;
   }
 
-  Vec<glm::ivec3> Reindex(glm::ivec4 tri, glm::ivec4 edgeOffsets,
+  Vec<glm::ivec3> Reindex(glm::ivec4 triVerts, glm::ivec4 edgeOffsets,
                           glm::bvec4 edgeFwd, int interiorOffset) const {
     Vec<int> newVerts;
     newVerts.reserve(vertBary.size());
     glm::ivec4 triIdx = idx;
     glm::ivec4 outTri = {0, 1, 2, 3};
-    if (tri[3] < 0 && idx[1] != Next3(idx[0])) {
+    if (triVerts[3] < 0 && idx[1] != Next3(idx[0])) {
       triIdx = {idx[2], idx[0], idx[1], idx[3]};
       edgeFwd = glm::not_(edgeFwd);
       std::swap(outTri[0], outTri[1]);
     }
     for (const int i : {0, 1, 2, 3}) {
-      if (tri[triIdx[i]] >= 0) newVerts.push_back(tri[triIdx[i]]);
+      if (triVerts[triIdx[i]] >= 0) newVerts.push_back(triVerts[triIdx[i]]);
     }
     for (const int i : {0, 1, 2, 3}) {
       const int n = sortedDivisions[i] - 1;
@@ -413,20 +413,12 @@ glm::ivec4 Manifold::Impl::GetHalfedges(int tri) const {
     if (pair / 3 < tri) {
       return glm::ivec4(-1);  // only process lower tri index
     }
-    glm::ivec2 otherHalf;
-    otherHalf[0] = NextHalfedge(pair);
-    otherHalf[1] = NextHalfedge(otherHalf[0]);
-    halfedges[neighbor] = otherHalf[0];
-    if (neighbor == 2) {
-      halfedges[3] = otherHalf[1];
-    } else if (neighbor == 1) {
-      halfedges[3] = halfedges[2];
-      halfedges[2] = otherHalf[1];
-    } else {
-      halfedges[3] = halfedges[2];
-      halfedges[2] = halfedges[1];
-      halfedges[1] = otherHalf[1];
-    }
+    // The order here matters to keep small quads split the way they started, or
+    // else it can create a 4-manifold edge.
+    halfedges[2] = NextHalfedge(halfedges[neighbor]);
+    halfedges[3] = NextHalfedge(halfedges[2]);
+    halfedges[0] = NextHalfedge(pair);
+    halfedges[1] = NextHalfedge(halfedges[0]);
   }
   return halfedges;
 }

--- a/src/sdf/include/sdf.h
+++ b/src/sdf/include/sdf.h
@@ -20,5 +20,6 @@
 
 namespace manifold {
 Mesh LevelSet(std::function<float(glm::vec3)> sdf, Box bounds, float edgeLength,
-              float level = 0, bool canParallel = true);
+              float level = 0, bool canParallel = true,
+              float precision = std::numeric_limits<float>::infinity());
 }

--- a/src/sdf/src/sdf.cpp
+++ b/src/sdf/src/sdf.cpp
@@ -164,16 +164,18 @@ struct ComputeVerts {
     // Sole tuning parameter, k: (0, 1) - smaller value gets better median
     // performance, but also hits the worst case more often.
     const float k = 0.1;
-    float maxStep = glm::length(pos0 - pos1);
+    const float tol2 = 4 * tol * tol;
+    const float dist2 = glm::dot(pos0 - pos1, pos0 - pos1);
+    float frac = 1;
+    float biFrac = 1;
     do {
-      const float l = glm::length(pos0 - pos1);
       const float a = d0 / (d0 - d1);
-      if (l < 2 * tol) {
+      if (dist2 * frac * frac < tol2) {
         return glm::mix(pos0, pos1, a);
       }
 
       const float t = glm::mix(a, 0.5f, k);
-      const float r = maxStep / l - 0.5;
+      const float r = biFrac / frac - 0.5;
       const float x = glm::abs(t - 0.5) < r ? t : 0.5 - r * (t < 0.5 ? 1 : -1);
 
       const glm::vec3 mid = glm::mix(pos0, pos1, x);
@@ -182,11 +184,13 @@ struct ComputeVerts {
       if ((d > 0) == (d0 > 0)) {
         d0 = d;
         pos0 = mid;
+        frac *= 1 - x;
       } else {
         d1 = d;
         pos1 = mid;
+        frac *= x;
       }
-      maxStep /= 2;
+      biFrac /= 2;
     } while (1);
   }
 

--- a/src/sdf/src/sdf.cpp
+++ b/src/sdf/src/sdf.cpp
@@ -157,10 +157,14 @@ struct ComputeVerts {
     } else if (d1 == 0) {
       return pos1;
     }
-    const float tol2 = tol * tol;
+    const float tol2 = 4 * tol * tol;
     do {
+      const glm::vec3 mid =
+          (pos0 + pos1) * 0.5f;  //(d0 * pos0 - d1 * pos1) / (d0 - d1);
       const glm::vec3 diff = pos0 - pos1;
-      const glm::vec3 mid = (d0 * pos0 - d1 * pos1) / (d0 - d1);
+      if (glm::dot(diff, diff) < tol2) {
+        return mid;
+      }
       const float d = sdf(mid) - level;
       if ((d > 0) == (d0 > 0)) {
         d0 = d;
@@ -168,9 +172,6 @@ struct ComputeVerts {
       } else {
         d1 = d;
         pos1 = mid;
-      }
-      if (glm::dot(diff, diff) < tol2) {
-        return mid;
       }
     } while (1);
   }
@@ -202,9 +203,8 @@ struct ComputeVerts {
       keep = true;
 
       const int idx = AtomicAdd(vertIndex[0], 1);
-      vertPos[idx] =
-          (val * position - gridVert.distance * Position(neighborIndex)) /
-          (val - gridVert.distance);
+      vertPos[idx] = FindSurface(position, gridVert.distance,
+                                 Position(neighborIndex), val, 0.00001);
       gridVert.edgeVerts[i] = idx;
     }
 

--- a/src/sdf/src/sdf.cpp
+++ b/src/sdf/src/sdf.cpp
@@ -150,6 +150,31 @@ struct ComputeVerts {
     return d;
   }
 
+  inline glm::vec3 FindSurface(glm::vec3 pos0, float d0, glm::vec3 pos1,
+                               float d1, float tol) const {
+    if (d0 == 0) {
+      return pos0;
+    } else if (d1 == 0) {
+      return pos1;
+    }
+    const float tol2 = tol * tol;
+    do {
+      const glm::vec3 diff = pos0 - pos1;
+      const glm::vec3 mid = (d0 * pos0 - d1 * pos1) / (d0 - d1);
+      const float d = sdf(mid) - level;
+      if ((d > 0) == (d0 > 0)) {
+        d0 = d;
+        pos0 = mid;
+      } else {
+        d1 = d;
+        pos1 = mid;
+      }
+      if (glm::dot(diff, diff) < tol2) {
+        return mid;
+      }
+    } while (1);
+  }
+
   inline void operator()(Uint64 mortonCode) {
     ZoneScoped;
     if (gridVerts.Full()) return;

--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -391,8 +391,8 @@ TEST(Smooth, SDF) {
               3,
               [r](float* newProp, glm::vec3 pos, const float* oldProp) {
                 const float rad = glm::length(pos);
-                const float d = glm::min(0.0f, r - glm::length(pos));
-                const glm::vec3 sphere = d * glm::normalize(pos + 0.0001f);
+                const float d = glm::min(0.0f, r - rad) / (rad > 0 ? rad : 1);
+                const glm::vec3 sphere = 2 * d * pos;
                 const glm::vec3 gyroidGrad(
                     cos(pos.z) * cos(pos.x) - sin(pos.x) * sin(pos.y),
                     cos(pos.x) * cos(pos.y) - sin(pos.y) * sin(pos.z),
@@ -400,7 +400,7 @@ TEST(Smooth, SDF) {
                 const glm::vec3 normal = -glm::normalize(gyroidGrad + sphere);
                 for (const int i : {0, 1, 2}) newProp[i] = normal[i];
               })
-          .SmoothOut(180)
+          .SmoothByNormals(0)
           .RefineToLength(0.1);
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) {

--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -403,7 +403,7 @@ TEST(Smooth, SDF) {
 
   Manifold gyroid = Manifold(
       LevelSet(sphericalGyroid, {glm::vec3(-r - extra), glm::vec3(r + extra)},
-               1, 0, true, 0.00001));
+               0.5, 0, true, 0.00001));
 
   Manifold interpolated = gyroid.Refine(3).SetProperties(1, error);
 
@@ -420,8 +420,8 @@ TEST(Smooth, SDF) {
           .SetProperties(1, error);
 
   MeshGL out = smoothed.GetMeshGL();
-  EXPECT_NEAR(GetMaxProperty(out, 3), 0, 0.11);
-  EXPECT_NEAR(GetMaxProperty(interpolated.GetMeshGL(), 3), 0, 0.22);
+  EXPECT_NEAR(GetMaxProperty(out, 3), 0, 0.016);
+  EXPECT_NEAR(GetMaxProperty(interpolated.GetMeshGL(), 3), 0, 0.068);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) {


### PR DESCRIPTION
This tests out a new use-case for our smooth mesh interpolation: evaluating SDFs on a coarse grid, then smoothly interpolating them to get a cleaner shape with less computation. The SDF grid size becomes about feature extraction (what is the thinnest feature desired, etc), but the smoothness of the surface can be refined arbitrarily after the fact. 

In order to not introduce wiggles to the interpolated mesh, the vertices must be very precise, so I've added a precision parameter to `LevelSet` and an improved version of bisection root-finding. This API is not final, as I'm making a follow-on PR to pull `LevelSet` into `Manifold` as a static constructor. It is also important to use precise normals, so I evaluated them analytically, rather than using our pseudonormal calculation. 

This isn't quite ready to merge, as I think I found a bug when I was playing around with the new test.

Original SDF result:
<img width="957" alt="image" src="https://github.com/user-attachments/assets/9ebd8dad-e7c9-4e05-a317-4c2f52c5dcfc">

With smoothing:
<img width="957" alt="image" src="https://github.com/user-attachments/assets/fe4a95d7-421c-4497-bde7-9dc26283a3a3">
