### PR TITLE
Use system nanobind if installed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "src/third_party/quickhull"]
 	path = src/third_party/quickhull
 	url = https://github.com/akuukka/quickhull
-[submodule "bindings/python/third_party/nanobind"]
-	path = bindings/python/third_party/nanobind
-	url = https://github.com/wjakob/nanobind

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -14,7 +14,18 @@
 
 project(python)
 
-add_subdirectory(third_party)
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --version
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE NB_VERSION)
+if(NB_VERSION VERSION_GREATER_EQUAL 1.8.0)
+  message("Found nanobind, version ${NB_VERSION}")
+  execute_process(
+    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+  find_package(nanobind CONFIG REQUIRED)
+else()
+  add_subdirectory(third_party)
+endif()
 nanobind_add_module(
   manifold3d
   NB_STATIC STABLE_ABI LTO

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -24,7 +24,14 @@ if(NB_VERSION VERSION_GREATER_EQUAL 1.8.0)
     OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
   find_package(nanobind CONFIG REQUIRED)
 else()
-  add_subdirectory(third_party)
+  message(STATUS "nanobind not found, downloading from source")
+  include(FetchContent)
+  FetchContent_Declare(nanobind
+    GIT_REPOSITORY https://github.com/wjakob/nanobind.git
+    GIT_TAG 8d7f1ee0621c17fa370b704b2100ffa0243d5bf  # v2.0.0
+    GIT_PROGRESS TRUE
+  )
+  FetchContent_MakeAvailable(nanobind)
 endif()
 nanobind_add_module(
   manifold3d

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
                 cmake
                 ninja
                 (python3.withPackages
-                  (ps: with ps; [ trimesh pytest ]))
+                  (ps: with ps; [ nanobind trimesh pytest ]))
                 gtest
                 pkg-config
               ]) ++ build-tools;
@@ -123,7 +123,6 @@
                 tbb
                 glm
                 clipper2
-                nanobind
               ];
               nativeBuildInputs = with pkgs; [
                 cmake
@@ -135,6 +134,7 @@
                 pkg-config
               ];
               checkInputs = [
+                nanobind
                 trimesh
                 pytest
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,7 @@
                 tbb
                 glm
                 clipper2
+                nanobind
               ];
               nativeBuildInputs = with pkgs; [
                 cmake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,10 @@ dependencies = [
 "Bug Tracker" = "https://github.com/elalish/manifold/issues"
 
 [build-system]
-requires = ["scikit-build-core"]
+requires = [
+    "nanobind>=1.8.0",
+    "scikit-build-core",
+]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,6 @@ sdist.exclude = [
     "samples",
     "test",
     "oneTBB", # we may have this when we build with cibuildwheel
-    "bindings/python/third_party/nanobind/tests/",
-    "bindings/python/third_party/nanobind/docs/",
 ]
 wheel.packages = ["manifold3d"]
 cmake.args = ["-DMANIFOLD_PYBIND=ON", "-DMANIFOLD_PAR=TBB", "-DMANIFOLD_TEST=OFF", "-DBUILD_SHARED_LIBS=OFF"]


### PR DESCRIPTION
I think I saw mention of supporting system nanobind in one of the discussions, it is becoming a thing now.

This uses the recommended approach - with additional version checking. 

This still falls back to the third_party directory for now, but obviously that is easily replaced. For pyproject.toml users  automatically fetching nanobind is supported.