### PR TITLE
Fix hull_test isMeshConvex() vertices check

### DIFF
--- a/test/hull_test.cpp
+++ b/test/hull_test.cpp
@@ -40,7 +40,7 @@ bool isMeshConvex(manifold::Manifold hullManifold, double epsilon = 0.0000001) {
 
     // Check all other vertices
     for (int i = 0; i < (int)vertPos.size(); ++i) {
-      if (i == tri[0] || i == tri[2] || i == tri[3])
+      if (i == tri[0] || i == tri[1] || i == tri[2])
         continue;  // Skip vertices of the current triangle
 
       // Get the vertex


### PR DESCRIPTION
Don't know why this isn't failing on GitHub but for me Hull.FailingTest1 and Hull.FailingTest2 cause coredumps:

```
[ RUN      ] Hull.FailingTest1
manifold_test: /usr/include/glm/detail/type_vec3.inl:188: constexpr const T& glm::vec<3, T, Q>::operator[](length_type) const [with T = int; glm::qualifier Q = glm::packed_highp; length_type = int]: Assertion `(i) >= 0 && (i) < (this->length())' failed.
```

gdb:

```
#4  0x00007f3c1f970f26 in __assert_fail () from /usr/lib64/libc.so.6
#5  0x000056477e252666 in glm::vec<3, int, (glm::qualifier)0>::operator[] (this=<optimized out>, i=3)
    at /usr/include/glm/detail/type_vec3.inl:186
#6  glm::vec<3, int, (glm::qualifier)0>::operator[] (this=<optimized out>, i=3) at /usr/include/glm/detail/type_vec3.inl:186
#7  isMeshConvex (hullManifold=..., epsilon=epsilon@entry=8.9962799999999992e-06)
    at manifold-e26e01a2310db36c23240fb7ad2e9692f6411a92/test/hull_test.cpp:43
#8  0x000056477e252ba5 in Hull_FailingTest1_Test::TestBody (this=<optimized out>)
    at manifold-e26e01a2310db36c23240fb7ad2e9692f6411a92/test/hull_test.cpp:165
```
