### PR TITLE
CI: Cancel definition of NDEBUG in TBB build jobs

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PYBIND=ON -DMANIFOLD_DEBUG=ON -DMANIFOLD_CROSS_SECTION=${{matrix.cross_section}} -DMANIFOLD_EXPORT=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} .. && make
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PYBIND=ON -DMANIFOLD_DEBUG=ON -DMANIFOLD_FLAGS=-UNDEBUG -DMANIFOLD_CROSS_SECTION=${{matrix.cross_section}} -DMANIFOLD_EXPORT=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} .. && make
     - name: Test ${{matrix.parallel_backend}}
       if: matrix.parallel_backend != 'NONE'
       run: |


### PR DESCRIPTION
NDEBUG disables assert from cassert, as used by GLM.

---

CMAKE_BUILD_TYPE's other than Debug add -DNDEBUG. But Debug sets `-g -O0`. 

This change would have picked up the issue in  #898:

```
 [ RUN      ] Hull.FailingTest1
manifold_test: /usr/include/glm/detail/type_vec3.inl:186: constexpr const T& glm::vec<3, T, Q>::operator[](length_type) const [with T = int; glm::qualifier Q = glm::packed_highp; length_type = int]: Assertion `i >= 0 && i < this->length()' failed.
/home/runner/work/_temp/01e00426-500f-495e-8b2e-814cac478a41.sh: line 2:  4930 Aborted                 (core dumped) ./manifold_test
Error: Process completed with exit code 134.
```
