### PR TITLE
Add *.pc file for easier use in non-cmake environments.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,4 +163,12 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/manifoldConfig.cmake
   DESTINATION ${CMAKE_INSTALL_DATADIR}/manifold
 )
+
+if(MANIFOLD_CROSS_SECTION)
+  set(TEMPLATE_OPTIONAL_CLIPPER "Clipper2")
+endif()
+configure_file(manifold.pc.in ${CMAKE_CURRENT_BINARY_DIR}/manifold.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/manifold.pc
+  DESTINATION lib/pkgconfig)
+
 endif()

--- a/manifold.pc.in
+++ b/manifold.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: manifold@PCFILE_LIB_SUFFIX@
+Description: Geometry library for topological robustness
+Version: @MANIFOLD_VERSION@
+URL: https://github.com/elalish/manifold
+Requires-private: glm tbb @TEMPLATE_OPTIONAL_CLIPPER@
+Libs: -L${libdir} -lmanifold@PCFILE_LIB_SUFFIX@
+Cflags: -I${includedir}

--- a/test-pkgconfig.sh
+++ b/test-pkgconfig.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+mkdir make-consumer
+cd make-consumer
+
+cat <<'EOT' >> Makefile
+CXXFLAGS=$(shell pkg-config --cflags manifold)
+LDFLAGS=$(shell pkg-config --libs manifold)
+
+testing : testing.cpp
+EOT
+
+cat <<EOT >> testing.cpp
+#include <manifold/manifold.h>
+int main() { manifold::Manifold foo; return 0; }
+EOT
+
+make
+./testing


### PR DESCRIPTION
pkg-config is the common way how to find cflags and library flags for projects not using cmake.