### PR TITLE
fix accidentally disabled tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,7 @@ endif()
 
 if(MANIFOLD_CROSS_SECTION)
   target_link_libraries(${PROJECT_NAME} cross_section)
+  target_compile_options(${PROJECT_NAME} PUBLIC -DMANIFOLD_CROSS_SECTION)
 endif()
 
 if(MANIFOLD_EXPORT)


### PR DESCRIPTION
A few tests were missing after #888 - just a one-liner in cmake. 