### PR TITLE
Cleaning Hull Algorithm Code

### DIFF
--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -488,13 +488,8 @@ void Manifold::Impl::Hull(const std::vector<glm::vec3>& vertPos) {
   Vec<glm::dvec3> pointCloudVec(numVert);
   manifold::transform(vertPos.begin(), vertPos.end(), pointCloudVec.begin(),
                       [](const glm::vec3& v) { return glm::dvec3(v); });
-  ConvexHull hull = getConvexHullAsMesh(pointCloudVec, false);
-  // TODO : Once double PR lands, replace this with move
-  vertPos_.resize(hull.vertices.size());
-  manifold::transform(hull.vertices.begin(), hull.vertices.end(),
-                      vertPos_.begin(),
-                      [](const glm::dvec3& v) { return glm::vec3(v); });
-  halfedge_ = std::move(hull.halfedges);
+  QuickHull qh(pointCloudVec);
+  std::tie(halfedge_, vertPos_) = qh.buildMesh();
   meshRelation_.originalID = ReserveIDs(1);
   CalculateBBox();
   SetPrecision(bBox_.Scale() * kTolerance);

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -478,29 +478,6 @@ Manifold::Impl::Impl(const Mesh& mesh, const MeshRelationD& relation,
   Finish();
 }
 
-void Manifold::Impl::Hull(const std::vector<glm::vec3>& vertPos) {
-  size_t numVert = vertPos.size();
-  if (numVert < 4) {
-    status_ = Error::InvalidConstruction;
-    return;
-  }
-
-  Vec<glm::dvec3> pointCloudVec(numVert);
-  manifold::transform(vertPos.begin(), vertPos.end(), pointCloudVec.begin(),
-                      [](const glm::vec3& v) { return glm::dvec3(v); });
-  QuickHull qh(pointCloudVec);
-  std::tie(halfedge_, vertPos_) = qh.buildMesh();
-  meshRelation_.originalID = ReserveIDs(1);
-  CalculateBBox();
-  SetPrecision(bBox_.Scale() * kTolerance);
-  SplitPinchedVerts();
-  CalculateNormals();
-  InitializeOriginal();
-  CreateFaces({});
-  SimplifyTopology();
-  Finish();
-}
-
 /**
  * Create either a unit tetrahedron, cube or octahedron. The cube is in the
  * first octant, while the others are symmetric about the origin.

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -488,8 +488,7 @@ void Manifold::Impl::Hull(const std::vector<glm::vec3>& vertPos) {
   Vec<glm::dvec3> pointCloudVec(numVert);
   manifold::transform(vertPos.begin(), vertPos.end(), pointCloudVec.begin(),
                       [](const glm::vec3& v) { return glm::dvec3(v); });
-  QuickHull qh(pointCloudVec);
-  ConvexHull hull = qh.getConvexHullAsMesh(pointCloudVec, false);
+  ConvexHull hull = getConvexHullAsMesh(pointCloudVec, false);
   // TODO : Once double PR lands, replace this with move
   vertPos_.resize(hull.vertices.size());
   manifold::transform(hull.vertices.begin(), hull.vertices.end(),

--- a/src/manifold/src/quickhull.cpp
+++ b/src/manifold/src/quickhull.cpp
@@ -24,7 +24,6 @@ namespace manifold {
 
 double defaultEps() { return 0.0000001; }
 
-// MathUtils.hpp
 inline double getSquaredDistanceBetweenPointAndRay(const glm::dvec3& p,
                                                    const Ray& r) {
   const glm::dvec3 s = p - r.S;
@@ -241,9 +240,8 @@ ConvexHull QuickHull::buildMesh(bool CCW, double epsilon) {
   Vec<int> mapping(mesh.halfedges.size());
   Vec<int> faceMap(mesh.faces.size());
 
-  // reorder halfedges
-  // Since all faces are not used now (so we should start from 0 and just
-  // increment, we can later set the face id as index/3 for each halfedge
+  // Some faces are disabled and should not go into the halfedge vector, we can
+  // update the face indices of the halfedges at the end using index/3
   int j = 0;
   for_each(
       autoPolicy(mesh.halfedges.size()), countAt(0_uz),

--- a/src/manifold/src/quickhull.cpp
+++ b/src/manifold/src/quickhull.cpp
@@ -205,10 +205,10 @@ HalfEdgeMesh::HalfEdgeMesh(const MeshBuilder& builderObject,
 /*
  * Implementation of the algorithm
  */
-
-ConvexHull QuickHull::buildMesh(bool CCW, double epsilon) {
+// TODO : Once double PR lands replace glm::vec3 with glm::dvec3
+std::pair<Vec<Halfedge>, Vec<glm::vec3>> QuickHull::buildMesh(double epsilon) {
   if (originalVertexData.size() == 0) {
-    return ConvexHull();
+    return {Vec<Halfedge>(), Vec<glm::vec3>()};
   }
 
   // Very first: find extreme values and use them to compute the scale of the
@@ -298,7 +298,11 @@ ConvexHull QuickHull::buildMesh(bool CCW, double epsilon) {
   for (size_t index = 0; index < halfedges.size(); index++) {
     halfedges[index].face = index / 3;
   }
-  return ConvexHull{std::move(halfedges), std::move(vertices)};
+  // TODO : Once double PR lands remove this code
+  Vec<glm::vec3> verticesFloat(vertices.size());
+  manifold::transform(vertices.begin(), vertices.end(), verticesFloat.begin(),
+                      [](const glm::dvec3& v) { return glm::vec3(v); });
+  return {std::move(halfedges), std::move(verticesFloat)};
 }
 
 void QuickHull::createConvexHalfedgeMesh() {
@@ -819,10 +823,4 @@ bool QuickHull::addPointToFace(typename MeshBuilder::Face& f,
   return false;
 }
 
-ConvexHull getConvexHullAsMesh(const Vec<glm::dvec3>& pointCloud, bool CCW,
-                               double epsilon) {
-  Vec<glm::dvec3> pointCloudVec(pointCloud);
-  QuickHull qh(pointCloudVec);
-  return qh.buildMesh(CCW, epsilon);
-}
 }  // namespace manifold

--- a/src/manifold/src/quickhull.cpp
+++ b/src/manifold/src/quickhull.cpp
@@ -825,6 +825,8 @@ bool QuickHull::addPointToFace(typename MeshBuilder::Face& f,
   return false;
 }
 
+// Wrapper to call the QuickHull algorithm with the given vertex data to build
+// the Impl
 void Manifold::Impl::Hull(const std::vector<glm::vec3>& vertPos) {
   size_t numVert = vertPos.size();
   if (numVert < 4) {

--- a/src/manifold/src/quickhull.h
+++ b/src/manifold/src/quickhull.h
@@ -63,12 +63,6 @@
 
 namespace manifold {
 
-class ConvexHull {
- public:
-  Vec<Halfedge> halfedges;
-  Vec<glm::dvec3> vertices;
-};
-
 class Pool {
   std::vector<std::unique_ptr<Vec<size_t>>> data;
 
@@ -281,21 +275,16 @@ class QuickHull {
   QuickHull(const Vec<glm::dvec3>& pointCloudVec)
       : originalVertexData(VecView(pointCloudVec)) {}
 
-  // Constructs the convex hull into halfEdges and NewVerts
-  ConvexHull buildMesh(bool CCW, double eps);
+  // Computes convex hull for a given point cloud. This function assumes that
+  // the vertex data resides in memory in the following format:
+  // x_0,y_0,z_0,x_1,y_1,z_1,... Params:
+  //   vertexData: pointer to the X component of the first point of the point
+  //   cloud. vertexCount: number of vertices in the point cloud eps: minimum
+  //   distance to a plane to consider a point being on positive side of it (for
+  //   a point cloud with scale 1)
+  // Returns:
+  //   Convex hull of the point cloud as halfEdge vector and vertex vector
+  std::pair<Vec<Halfedge>, Vec<glm::vec3>> buildMesh(double eps = defaultEps());
 };
-
-// Computes convex hull for a given point cloud. This function assumes that
-// the vertex data resides in memory in the following format:
-// x_0,y_0,z_0,x_1,y_1,z_1,... Params:
-//   vertexData: pointer to the X component of the first point of the point
-//   cloud. vertexCount: number of vertices in the point cloud CCW: whether
-//   the output mesh triangles should have CCW orientation eps: minimum
-//   distance to a plane to consider a point being on positive side of it (for
-//   a point cloud with scale 1)
-// Returns:
-//   Convex hull of the point cloud as halfEdge vector and vertex vector
-ConvexHull getConvexHullAsMesh(const Vec<glm::dvec3>& pointCloud, bool CCW,
-                               double epsilon = defaultEps());
 
 }  // namespace manifold

--- a/src/manifold/src/quickhull.h
+++ b/src/manifold/src/quickhull.h
@@ -69,7 +69,6 @@ class ConvexHull {
   Vec<glm::dvec3> vertices;
 };
 
-// Pool.hpp
 class Pool {
   std::vector<std::unique_ptr<Vec<size_t>>> data;
 
@@ -90,8 +89,6 @@ class Pool {
     return r;
   }
 };
-
-// Plane.hpp
 
 class Plane {
  public:
@@ -116,8 +113,6 @@ class Plane {
       : N(N), D(glm::dot(-N, P)), sqrNLength(glm::dot(N, N)) {}
 };
 
-// Ray.hpp
-
 struct Ray {
   const glm::dvec3 S;
   const glm::dvec3 V;
@@ -126,8 +121,6 @@ struct Ray {
   Ray(const glm::dvec3& S, const glm::dvec3& V)
       : S(S), V(V), VInvLengthSquared(1 / (glm::dot(V, V))) {}
 };
-
-// Mesh.hpp
 
 class MeshBuilder {
  public:
@@ -209,8 +202,6 @@ class MeshBuilder {
   }
 };
 
-// HalfEdgeMesh.hpp
-
 class HalfEdgeMesh {
  public:
   Vec<glm::dvec3> vertices;
@@ -222,8 +213,6 @@ class HalfEdgeMesh {
   HalfEdgeMesh(const MeshBuilder& builderObject,
                const VecView<glm::dvec3>& vertexData);
 };
-
-// QuickHull.hpp
 
 double defaultEps();
 

--- a/src/manifold/src/quickhull.h
+++ b/src/manifold/src/quickhull.h
@@ -267,23 +267,20 @@ class QuickHull {
   // the plane. Returns true if the points was on the positive side.
   inline bool addPointToFace(typename MeshBuilder::Face& f, size_t pointIndex);
 
-  // This will update mesh from which we create the ConvexHull object that
-  // getConvexHull function returns
+  // This will create HalfedgeMesh from which we create the ConvexHull object
+  // that buildMesh function returns
   void createConvexHalfedgeMesh();
 
  public:
+  // This function assumes that the pointCloudVec data resides in memory in the
+  // following format: x_0,y_0,z_0,x_1,y_1,z_1,...
   QuickHull(const Vec<glm::dvec3>& pointCloudVec)
       : originalVertexData(VecView(pointCloudVec)) {}
 
-  // Computes convex hull for a given point cloud. This function assumes that
-  // the vertex data resides in memory in the following format:
-  // x_0,y_0,z_0,x_1,y_1,z_1,... Params:
-  //   vertexData: pointer to the X component of the first point of the point
-  //   cloud. vertexCount: number of vertices in the point cloud eps: minimum
-  //   distance to a plane to consider a point being on positive side of it (for
-  //   a point cloud with scale 1)
-  // Returns:
-  //   Convex hull of the point cloud as halfEdge vector and vertex vector
+  // Computes convex hull for a given point cloud. Params: eps: minimum distance
+  // to a plane to consider a point being on positive side of it (for a point
+  // cloud with scale 1) Returns: Convex hull of the point cloud as halfEdge
+  // vector and vertex vector
   std::pair<Vec<Halfedge>, Vec<glm::vec3>> buildMesh(double eps = defaultEps());
 };
 


### PR DESCRIPTION
I've removed some redundant functions and structs, I also removed some comments. I had made some changes in the previous PR, which also removed some redundancy in the code. Should I make the same changes here? (like modifying the `for_each` loop to merge two for loops)

I was thinking I can pass the `vertPos_` and `halfedge_` to the function as arguments and then modify them inside the quickhull implementation to reduce the size of the `impl` Hull function and also reduce the `ConvexHull` class. What do you think?