### PR TITLE
Added DisabledFaceTest

### DIFF
--- a/test/hull_test.cpp
+++ b/test/hull_test.cpp
@@ -198,3 +198,28 @@ TEST(Hull, FailingTest2) {
 #endif
   EXPECT_TRUE(isMeshConvex(hull, 2.13966e-05));
 }
+
+TEST(Hull, DisabledFaceTest) {
+  // 101213.stl
+  // Replace glm::vec3 with vec3 later once Double PR merges
+  const std::vector<glm::vec3> hullPts = {
+      {65.398902893, 58.303115845, 58.765388489},
+      {42.147319794, 44.512584686, 75.703102112},
+      {89.208251953, 97.092460632, 41.632453918},
+      {69.860748291, 69.860748291, 56.492958069},
+      {45.375354767, 39.067985535, 64.844772339},
+      {26.555616379, 18.671405792, 81.067504883},
+      {88.179382324, 81.083595276, 43.981628418},
+      {51.823883057, 50.247039795, 70.359062195},
+      {58.489616394, 72.681190491, 51.274829865},
+      {110, 10, 65},
+      {29.590316772, 20.917686462, 73.143547058},
+      {101.61526489, 98.461585999, 30.909877777}};
+  auto hull = Manifold::Hull(hullPts);
+#ifdef MANIFOLD_EXPORT
+  if (options.exportModels) {
+    ExportMesh("disabledFaceTest.glb", hull.GetMesh(), {});
+  }
+#endif
+  EXPECT_TRUE(isMeshConvex(hull));
+}

--- a/test/hull_test.cpp
+++ b/test/hull_test.cpp
@@ -221,5 +221,6 @@ TEST(Hull, DisabledFaceTest) {
     ExportMesh("disabledFaceTest.glb", hull.GetMesh(), {});
   }
 #endif
+  EXPECT_TRUE(!hull.IsEmpty());
   EXPECT_TRUE(isMeshConvex(hull));
 }


### PR DESCRIPTION
I added the narrowed down version (12 points) of the test case `101213.stl`. It is a case where one of the `halfEdge` in the list of halfEdges has a disabled face. This case caused a segfault before, and it's a good check to identify if disabled faces are handled correctly. Thanks, @elalish for suggesting this. Let me know if I should change anything.