### PR TITLE
Fix missing 'this' for property access in wasm bindings

### DIFF
--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -368,12 +368,12 @@ Module.setup = function() {
     }
 
     position(vert) {
-      return this.vertProperties.subarray(numProp * vert, numProp * vert + 3);
+      return this.vertProperties.subarray(this.numProp * vert, this.numProp * vert + 3);
     }
 
     extras(vert) {
       return this.vertProperties.subarray(
-          numProp * vert + 3, numProp * (vert + 1));
+          this.numProp * vert + 3, this.numProp * (vert + 1));
     }
 
     tangent(halfedge) {

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -368,7 +368,8 @@ Module.setup = function() {
     }
 
     position(vert) {
-      return this.vertProperties.subarray(this.numProp * vert, this.numProp * vert + 3);
+      return this.vertProperties.subarray(
+          this.numProp * vert, this.numProp * vert + 3);
     }
 
     extras(vert) {

--- a/src/collider/include/collider.h
+++ b/src/collider/include/collider.h
@@ -277,7 +277,7 @@ constexpr inline uint32_t SpreadBits3(uint32_t v) {
 /** @ingroup Private */
 class Collider {
  public:
-  Collider(){};
+  Collider() {};
 
   Collider(const VecView<const Box>& leafBB,
            const VecView<const uint32_t>& leafMorton) {


### PR DESCRIPTION
The js bindings throw `numProp is not defined` when  trying to use `Mesh.position()` or `Mesh.extras()`. They were just missing a `this`