### PR TITLE
Make cross_section an installable library.

### DIFF
--- a/src/cross_section/CMakeLists.txt
+++ b/src/cross_section/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 project (cross_section)
 file(GLOB_RECURSE SOURCE_FILES CONFIGURE_DEPENDS *.cpp)
-add_library(${PROJECT_NAME} OBJECT ${SOURCE_FILES})
+add_library(${PROJECT_NAME} ${SOURCE_FILES})
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<INSTALL_INTERFACE:include/${CMAKE_PROJECT_NAME}>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)


### PR DESCRIPTION
While playing to use manifold as external library (not only as submodule) for after [this OpenSCAD PR](https://github.com/openscad/openscad/pull/5282) is merged, I noticed that a `make install` of cross_section is not actually installing a  `libcross_section.so`.

This PR fixes that, but I am not sure if there were maybe other reasons for this _not_ being installed ?

If this is merged, it would be possible to use manifold from a system library when building openscad.