### PR TITLE
Fix test-{cmake,pkgconfig}.sh to create, not append, to test files.

### DIFF
--- a/test-cmake.sh
+++ b/test-cmake.sh
@@ -2,7 +2,7 @@
 mkdir cmake-consumer
 cd cmake-consumer
 
-cat <<EOT >> CMakeLists.txt
+cat <<EOT > CMakeLists.txt
 cmake_minimum_required(VERSION 3.18)
 project(testing LANGUAGES CXX)
 find_package(manifold "2.5.1" REQUIRED)
@@ -10,9 +10,9 @@ add_executable(testing test.cpp)
 target_link_libraries(testing PRIVATE manifold)
 EOT
 
-cat <<EOT >> test.cpp
-#include "manifold/manifold.h"
-#include "manifold/parallel.h"
+cat <<EOT > test.cpp
+#include <manifold/manifold.h>
+#include <manifold/parallel.h>
 int main() { manifold::Manifold foo; return 0; }
 EOT
 

--- a/test-pkgconfig.sh
+++ b/test-pkgconfig.sh
@@ -2,15 +2,16 @@
 mkdir make-consumer
 cd make-consumer
 
-cat <<'EOT' >> Makefile
+cat <<'EOT' > Makefile
 CXXFLAGS=$(shell pkg-config --cflags manifold)
 LDFLAGS=$(shell pkg-config --libs manifold)
 
 testing : testing.cpp
 EOT
 
-cat <<EOT >> testing.cpp
+cat <<EOT > testing.cpp
 #include <manifold/manifold.h>
+#include <manifold/parallel.h>
 int main() { manifold::Manifold foo; return 0; }
 EOT
 


### PR DESCRIPTION
The test.cc file and the CMakeLists/Makefile were created with the '>>' append in shell instead of '>'. Which means these files were growing on multiple invocations if *-consumer was not deleted between calls (which means they would fail the second time around)

While at it, add the manifold/parallel.h include also to the pkg-config test.

Make all includes 'system-header' style with angle brackets, as this is what users of the library would use.