### PR TITLE
wasm: fix CrossSection slice and project bindings

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -153,7 +153,7 @@ jobs:
         cp ../manifold.* ./dist/
     - name: Upload WASM files
       uses: actions/upload-artifact@v4
-      if: matrix.exception == 'ON'
+      if: matrix.exception == 'ON' && github.event_name == 'push'
       with:
         name: wasm
         path: bindings/wasm/examples/dist/

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -284,11 +284,17 @@ Module.setup = function() {
   };
 
   Module.Manifold.prototype.slice = function(height = 0.) {
-    return Module.CrossSection(this._Slice(height));
+    const polygonsVec = this._Slice(height);
+    const result = new CrossSectionCtor(polygonsVec, fillRuleToInt('Positive'));
+    disposePolygons(polygonsVec);
+    return result;
   };
 
   Module.Manifold.prototype.project = function() {
-    return Module.CrossSection(this._Project()).simplify(this.precision());
+    const polygonsVec = this._Project();
+    const result = new CrossSectionCtor(polygonsVec, fillRuleToInt('Positive'));
+    disposePolygons(polygonsVec);
+    return result.simplify(this.precision);
   };
 
   Module.Manifold.prototype.split = function(manifold) {

--- a/bindings/wasm/examples/public/examples.js
+++ b/bindings/wasm/examples/public/examples.js
@@ -550,7 +550,55 @@ export const examples = {
         0, 0, size / Math.sqrt(2)
       ]);
       return result;
-    }
+    },
+
+    SwissCheese: function() {
+      // A "swiss cheese" block that demonstrates `slice`-ing out a layer
+      const { cube, sphere } = Manifold;
+
+      const size = [ 100, 100, 100 ];
+      const radius = 5;
+      const numHoles = 50;
+
+      // Simple random number generator that allows us to control the seed 
+      // https://stackoverflow.com/a/47593316
+      function splitmix32(a) {
+      return function() {
+        a |= 0;
+        a = a + 0x9e3779b9 | 0;
+        let t = a ^ a >>> 16;
+        t = Math.imul(t, 0x21f0aaad);
+        t = t ^ t >>> 15;
+        t = Math.imul(t, 0x735a2d97);
+        return ((t = t ^ t >>> 15) >>> 0) / 4294967296;
+        }
+      }
+
+      const prng = splitmix32(987654321)
+      // Switch to this to get a random seed
+      //const prng = splitmix32((Math.random()*2**32)>>>0)
+
+      function rand(min, max) {
+        return prng() * (max-min) + min;
+      }
+
+      const holes = new Array(numHoles).fill(0).map((_, i) => {
+        const center = size.map(s => rand(0, s));
+        return sphere(radius).translate(center);
+      });
+
+      const block = cube(size);
+      const swiss = block.subtract(Manifold.union(holes));
+
+      const slice = swiss.slice(size[2]/2)
+        .extrude(2) // extrude the slice a bit so that it renders
+        .translate(0, 0, size[2]/2); // and positioned where it strated
+
+      // And render the target slice inside the block
+      const result = Manifold.union(only(slice), swiss);
+
+      return result;
+    },
   },
 
   functionBodies: new Map()

--- a/bindings/wasm/examples/public/examples.js
+++ b/bindings/wasm/examples/public/examples.js
@@ -554,32 +554,32 @@ export const examples = {
 
     SwissCheese: function() {
       // A "swiss cheese" block that demonstrates `slice`-ing out a layer
-      const { cube, sphere } = Manifold;
+      const {cube, sphere} = Manifold;
 
-      const size = [ 100, 100, 100 ];
+      const size = [100, 100, 100];
       const radius = 5;
       const numHoles = 50;
 
-      // Simple random number generator that allows us to control the seed 
+      // Simple random number generator that allows us to control the seed
       // https://stackoverflow.com/a/47593316
       function splitmix32(a) {
-      return function() {
-        a |= 0;
-        a = a + 0x9e3779b9 | 0;
-        let t = a ^ a >>> 16;
-        t = Math.imul(t, 0x21f0aaad);
-        t = t ^ t >>> 15;
-        t = Math.imul(t, 0x735a2d97);
-        return ((t = t ^ t >>> 15) >>> 0) / 4294967296;
+        return function() {
+          a |= 0;
+          a = a + 0x9e3779b9 | 0;
+          let t = a ^ a >>> 16;
+          t = Math.imul(t, 0x21f0aaad);
+          t = t ^ t >>> 15;
+          t = Math.imul(t, 0x735a2d97);
+          return ((t = t ^ t >>> 15) >>> 0) / 4294967296;
         }
       }
 
       const prng = splitmix32(987654321)
       // Switch to this to get a random seed
-      //const prng = splitmix32((Math.random()*2**32)>>>0)
+      // const prng = splitmix32((Math.random()*2**32)>>>0)
 
       function rand(min, max) {
-        return prng() * (max-min) + min;
+        return prng() * (max - min) + min;
       }
 
       const holes = new Array(numHoles).fill(0).map((_, i) => {
@@ -590,9 +590,10 @@ export const examples = {
       const block = cube(size);
       const swiss = block.subtract(Manifold.union(holes));
 
-      const slice = swiss.slice(size[2]/2)
-        .extrude(2) // extrude the slice a bit so that it renders
-        .translate(0, 0, size[2]/2); // and positioned where it strated
+      const slice =
+          swiss.slice(size[2] / 2)
+              .extrude(2)  // extrude the slice a bit so that it renders
+              .translate(0, 0, size[2] / 2);  // and positioned where it strated
 
       // And render the target slice inside the block
       const result = Manifold.union(only(slice), swiss);

--- a/bindings/wasm/examples/public/examples.js
+++ b/bindings/wasm/examples/public/examples.js
@@ -51,6 +51,34 @@ export const examples = {
       return result;
     },
 
+    Auger: function() {
+      const outerRadius = 20;
+      const beadRadius = 2;
+      const height = 40;
+      const twist = 90;
+
+      const {revolve, sphere, union, extrude} = Manifold;
+      const {circle} = CrossSection;
+      setMinCircularEdgeLength(0.1);
+
+      const bead1 =
+          revolve(circle(beadRadius).translate([outerRadius, 0]), 50, 90)
+              .add(sphere(beadRadius).translate([outerRadius, 0, 0]))
+              .translate([0, -outerRadius, 0]);
+
+      const beads = [];
+      for (let i = 0; i < 3; i++) {
+        beads.push(bead1.rotate(0, 0, 120 * i));
+      }
+      const bead = union(beads);
+
+      const auger = extrude(bead.slice(0), height, 50, twist);
+
+      const result =
+          auger.add(bead).add(bead.translate(0, 0, height).rotate(0, 0, twist));
+      return result;
+    },
+
     TetrahedronPuzzle: function() {
       // A tetrahedron cut into two identical halves that can screw together as
       // a puzzle. This demonstrates how redundant points along a polygon can be
@@ -549,55 +577,6 @@ export const examples = {
       const result = gyroidModule.rotate([-45, 0, 90]).translate([
         0, 0, size / Math.sqrt(2)
       ]);
-      return result;
-    },
-
-    SwissCheese: function() {
-      // A "swiss cheese" block that demonstrates `slice`-ing out a layer
-      const {cube, sphere} = Manifold;
-
-      const size = [100, 100, 100];
-      const radius = 5;
-      const numHoles = 50;
-
-      // Simple random number generator that allows us to control the seed
-      // https://stackoverflow.com/a/47593316
-      function splitmix32(a) {
-        return function() {
-          a |= 0;
-          a = a + 0x9e3779b9 | 0;
-          let t = a ^ a >>> 16;
-          t = Math.imul(t, 0x21f0aaad);
-          t = t ^ t >>> 15;
-          t = Math.imul(t, 0x735a2d97);
-          return ((t = t ^ t >>> 15) >>> 0) / 4294967296;
-        }
-      }
-
-      const prng = splitmix32(987654321)
-      // Switch to this to get a random seed
-      // const prng = splitmix32((Math.random()*2**32)>>>0)
-
-      function rand(min, max) {
-        return prng() * (max - min) + min;
-      }
-
-      const holes = new Array(numHoles).fill(0).map((_, i) => {
-        const center = size.map(s => rand(0, s));
-        return sphere(radius).translate(center);
-      });
-
-      const block = cube(size);
-      const swiss = block.subtract(Manifold.union(holes));
-
-      const slice =
-          swiss.slice(size[2] / 2)
-              .extrude(2)  // extrude the slice a bit so that it renders
-              .translate(0, 0, size[2] / 2);  // and positioned where it strated
-
-      // And render the target slice inside the block
-      const result = Manifold.union(only(slice), swiss);
-
       return result;
     },
   },

--- a/bindings/wasm/examples/worker.test.ts
+++ b/bindings/wasm/examples/worker.test.ts
@@ -114,4 +114,11 @@ suite('Examples', () => {
     expect(result.volume).to.be.closeTo(4175, 1, 'Volume');
     expect(result.surfaceArea).to.be.closeTo(5645, 1, 'Surface Area');
   });
+
+  test('Swiss Cheese', async () => {
+    const result = await runExample('Swiss Cheese');
+    expect(result.genus).to.equal(-33, 'Genus');
+    expect(result.volume).to.be.closeTo(976320, 1, 'Volume');
+    expect(result.surfaceArea).to.be.closeTo(73253, 1, 'Surface Area');
+  });
 });

--- a/bindings/wasm/examples/worker.test.ts
+++ b/bindings/wasm/examples/worker.test.ts
@@ -59,6 +59,13 @@ suite('Examples', () => {
     expect(result.surfaceArea).to.be.closeTo(62046, 1, 'Surface Area');
   });
 
+  test('Auger', async () => {
+    const result = await runExample('Auger');
+    expect(result.genus).to.equal(0, 'Genus');
+    expect(result.volume).to.be.closeTo(16842, 1, 'Volume');
+    expect(result.surfaceArea).to.be.closeTo(10519, 1, 'Surface Area');
+  });
+
   test('Tetrahedron Puzzle', async () => {
     const result = await runExample('Tetrahedron Puzzle');
     expect(result.genus).to.equal(0, 'Genus');
@@ -113,12 +120,5 @@ suite('Examples', () => {
     expect(result.genus).to.equal(15, 'Genus');
     expect(result.volume).to.be.closeTo(4175, 1, 'Volume');
     expect(result.surfaceArea).to.be.closeTo(5645, 1, 'Surface Area');
-  });
-
-  test('Swiss Cheese', async () => {
-    const result = await runExample('Swiss Cheese');
-    expect(result.genus).to.equal(-33, 'Genus');
-    expect(result.volume).to.be.closeTo(976320, 1, 'Volume');
-    expect(result.surfaceArea).to.be.closeTo(73253, 1, 'Surface Area');
   });
 });

--- a/format.sh
+++ b/format.sh
@@ -11,7 +11,9 @@ $CLANG_FORMAT -i samples/**/*.{h,cpp}
 $CLANG_FORMAT -i test/*.{h,cpp}
 $CLANG_FORMAT -i bindings/*/*.cpp
 $CLANG_FORMAT -i bindings/c/include/manifold/*.h
-$CLANG_FORMAT -i bindings/wasm/**/*.{js,ts,html}
+$CLANG_FORMAT -i bindings/wasm/*.{js,ts}
+$CLANG_FORMAT -i bindings/wasm/examples/*.{js,ts,html}
+$CLANG_FORMAT -i bindings/wasm/examples/public/*.{js,ts}
 $CLANG_FORMAT -i src/*/src/*.{h,cpp}
 $CLANG_FORMAT -i src/*/include/manifold/*.h
 black bindings/python/examples/*.py


### PR DESCRIPTION
Resolves #929 by calling the `CrossSectionCtor` directly. These functions already have the vector returned by the `_Slice`/`_Project` so the `polygons2vec` isn't needed. I just copied what the `CrossSection` wrapper did w/out it.

I'm not sure if the memory management with `disposePolygons` is correct, but my tests in with a local ManifoldCAD work after this change.

I also couldn't figure out how to add new tests. AFAICT, it's just running the examples? It might be worth adding a `slice` example anyway. Happy to add as part of this PR if you point me in the right direction.