### PR TITLE
optimizations

### DIFF
--- a/test/boolean_complex_test.cpp
+++ b/test/boolean_complex_test.cpp
@@ -996,4 +996,11 @@ TEST(BooleanComplex, CraycloudBool) {
   EXPECT_TRUE(res.IsEmpty());
 }
 
+TEST(BooleanComplex, HullMask) {
+  Manifold body = ReadMesh("hull-body.glb");
+  Manifold mask = ReadMesh("hull-mask.glb");
+  Manifold ret = body - mask;
+  MeshGL mesh = ret.GetMeshGL();
+}
+
 #endif

--- a/test/hull_test.cpp
+++ b/test/hull_test.cpp
@@ -81,15 +81,6 @@ TEST(Hull, Tictac) {
   EXPECT_NEAR(sphere.NumVert() + tictacSeg, tictac.NumVert(), 1);
 }
 
-#ifdef MANIFOLD_EXPORT
-TEST(Hull, Fail) {
-  Manifold body = ReadMesh("hull-body.glb");
-  Manifold mask = ReadMesh("hull-mask.glb");
-  Manifold ret = body - mask;
-  MeshGL mesh = ret.GetMeshGL();
-}
-#endif
-
 TEST(Hull, Hollow) {
   auto sphere = Manifold::Sphere(100, 360);
   auto hollow = sphere - sphere.Scale({0.8, 0.8, 0.8});


### PR DESCRIPTION
1. Make `AssignNormals` a template, so we can optimize away one branch.
2. Add "refinement" for collider to check for collision more precisely, so we get less collision pairs, and less work has to be done in `Boolean3`.
