### PR TITLE
removed face from halfedge

### DIFF
--- a/src/manifold/src/csg_tree.cpp
+++ b/src/manifold/src/csg_tree.cpp
@@ -48,7 +48,6 @@ struct UpdateHalfedge {
     edge.startVert += nextVert;
     edge.endVert += nextVert;
     edge.pairedHalfedge += nextEdge;
-    edge.face += nextFace;
     return edge;
   }
 };

--- a/src/manifold/src/edge_op.cpp
+++ b/src/manifold/src/edge_op.cpp
@@ -88,7 +88,7 @@ struct SwappableEdge {
   bool operator()(int edge) const {
     if (halfedge[edge].pairedHalfedge < 0) return false;
 
-    int tri = halfedge[edge].face;
+    int tri = edge / 3;
     ivec3 triEdge = TriOf(edge);
     mat3x2 projection = GetAxisAlignedProjection(triNormal[tri]);
     vec2 v[3];
@@ -99,7 +99,7 @@ struct SwappableEdge {
 
     // Switch to neighbor's projection.
     edge = halfedge[edge].pairedHalfedge;
-    tri = halfedge[edge].face;
+    tri = edge / 3;
     triEdge = TriOf(edge);
     projection = GetAxisAlignedProjection(triNormal[tri]);
     for (int i : {0, 1, 2})
@@ -299,7 +299,7 @@ void Manifold::Impl::DedupeEdge(const int edge) {
 
       int newHalfedge = halfedge_.size();
       int newFace = newHalfedge / 3;
-      int oldFace = halfedge_[current].face;
+      int oldFace = current / 3;
       int outsideVert = halfedge_[current].startVert;
       halfedge_.push_back({endVert, newVert, -1, newFace});
       halfedge_.push_back({newVert, outsideVert, -1, newFace});
@@ -315,7 +315,7 @@ void Manifold::Impl::DedupeEdge(const int edge) {
 
       newHalfedge += 3;
       ++newFace;
-      oldFace = halfedge_[opposite].face;
+      oldFace = opposite / 3;
       outsideVert = halfedge_[opposite].startVert;
       halfedge_.push_back({newVert, endVert, -1, newFace});
       halfedge_.push_back({endVert, outsideVert, -1, newFace});
@@ -587,7 +587,7 @@ void Manifold::Impl::RecursiveEdgeSwap(const int edge, int& tag,
     return;
 
   // Switch to neighbor's projection.
-  projection = GetAxisAlignedProjection(faceNormal_[halfedge_[pair].face]);
+  projection = GetAxisAlignedProjection(faceNormal_[pair / 3]);
   for (int i : {0, 1, 2})
     v[i] = projection * vertPos_[halfedge_[tri0edge[i]].startVert];
   v[3] = projection * vertPos_[halfedge_[tri1edge[2]].startVert];
@@ -604,8 +604,8 @@ void Manifold::Impl::RecursiveEdgeSwap(const int edge, int& tag,
     PairUp(tri1edge[0], halfedge_[tri0edge[2]].pairedHalfedge);
     PairUp(tri0edge[2], tri1edge[2]);
     // Both triangles are now subsets of the neighboring triangle.
-    const int tri0 = halfedge_[tri0edge[0]].face;
-    const int tri1 = halfedge_[tri1edge[0]].face;
+    const int tri0 = tri0edge[0] / 3;
+    const int tri1 = tri1edge[0] / 3;
     faceNormal_[tri0] = faceNormal_[tri1];
     triRef[tri0] = triRef[tri1];
     const double l01 = glm::length(v[1] - v[0]);

--- a/src/manifold/src/face_op.cpp
+++ b/src/manifold/src/face_op.cpp
@@ -291,11 +291,14 @@ Polygons Manifold::Impl::Project() const {
   const mat3x2 projection = GetAxisAlignedProjection({0, 0, 1});
   Vec<Halfedge> cusps(NumEdge());
   cusps.resize(
-      copy_if(halfedge_.cbegin(), halfedge_.cend(), cusps.begin(),
-              [&](Halfedge edge) {
-                return faceNormal_[edge.face].z >= 0 &&
-                       faceNormal_[halfedge_[edge.pairedHalfedge].face].z < 0;
-              }) -
+      copy_if(
+          halfedge_.cbegin(), halfedge_.cend(), cusps.begin(),
+          [&](Halfedge edge) {
+            return faceNormal_[halfedge_[edge.pairedHalfedge].pairedHalfedge /
+                               3]
+                           .z >= 0 &&
+                   faceNormal_[edge.pairedHalfedge / 3].z < 0;
+          }) -
       cusps.begin());
 
   PolygonsIdx polysIndexed =

--- a/src/manifold/src/impl.cpp
+++ b/src/manifold/src/impl.cpp
@@ -498,9 +498,6 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
       if (h0.startVert != h1.endVert || h0.endVert != h1.startVert) break;
       if (halfedge_[NextHalfedge(pair0)].endVert ==
           halfedge_[NextHalfedge(pair1)].endVert) {
-        // FIXME: this actually does nothing
-        // h0.face = -1;
-        // h1.face = -1;
         // Reorder so that remaining edges pair up
         if (k != i + numEdge) std::swap(ids[i + numEdge], ids[k]);
         break;
@@ -516,13 +513,8 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
   for_each_n(policy, countAt(0), numEdge, [this, &ids, numEdge](int i) {
     const int pair0 = ids[i];
     const int pair1 = ids[i + numEdge];
-    // if (halfedge_[pair0].face < 0) {
-    //   halfedge_[pair0] = {-1, -1, -1, -1};
-    //   halfedge_[pair1] = {-1, -1, -1, -1};
-    // } else {
     halfedge_[pair0].pairedHalfedge = pair1;
     halfedge_[pair1].pairedHalfedge = pair0;
-    // }
   });
 
   // When opposed triangles are removed, they may strand unreferenced verts.

--- a/src/manifold/src/quickhull.cpp
+++ b/src/manifold/src/quickhull.cpp
@@ -314,10 +314,6 @@ std::pair<Vec<Halfedge>, Vec<vec3>> QuickHull::buildMesh(double epsilon) {
              he.startVert = counts[he.startVert];
              he.endVert = counts[he.endVert];
            });
-  // setting face id
-  // for (size_t index = 0; index < halfedges.size(); index++) {
-  //   halfedges[index].face = index / 3;
-  // }
   return {std::move(halfedges), std::move(vertices)};
 }
 

--- a/src/manifold/src/quickhull.cpp
+++ b/src/manifold/src/quickhull.cpp
@@ -78,6 +78,7 @@ size_t MeshBuilder::addHalfedge() {
     return index;
   }
   halfedges.push_back({});
+  halfedgeToFace.push_back(0);
   halfedgeNext.push_back(0);
   return halfedges.size() - 1;
 }
@@ -85,6 +86,7 @@ size_t MeshBuilder::addHalfedge() {
 void MeshBuilder::setup(int a, int b, int c, int d) {
   faces.clear();
   halfedges.clear();
+  halfedgeToFace.clear();
   halfedgeNext.clear();
   disabledFaces.clear();
   disabledHalfedges.clear();
@@ -94,40 +96,52 @@ void MeshBuilder::setup(int a, int b, int c, int d) {
 
   // Create halfedges
   // AB
-  halfedges.push_back({0, b, 6, 0});
+  halfedges.push_back({0, b, 6});
+  halfedgeToFace.push_back(0);
   halfedgeNext.push_back(1);
   // BC
-  halfedges.push_back({0, c, 9, 0});
+  halfedges.push_back({0, c, 9});
+  halfedgeToFace.push_back(0);
   halfedgeNext.push_back(2);
   // CA
-  halfedges.push_back({0, a, 3, 0});
+  halfedges.push_back({0, a, 3});
+  halfedgeToFace.push_back(0);
   halfedgeNext.push_back(0);
   // AC
-  halfedges.push_back({0, c, 2, 1});
+  halfedges.push_back({0, c, 2});
+  halfedgeToFace.push_back(1);
   halfedgeNext.push_back(4);
   // CD
-  halfedges.push_back({0, d, 11, 1});
+  halfedges.push_back({0, d, 11});
+  halfedgeToFace.push_back(1);
   halfedgeNext.push_back(5);
   // DA
-  halfedges.push_back({0, a, 7, 1});
+  halfedges.push_back({0, a, 7});
+  halfedgeToFace.push_back(1);
   halfedgeNext.push_back(3);
   // BA
-  halfedges.push_back({0, a, 0, 2});
+  halfedges.push_back({0, a, 0});
+  halfedgeToFace.push_back(2);
   halfedgeNext.push_back(7);
   // AD
-  halfedges.push_back({0, d, 5, 2});
+  halfedges.push_back({0, d, 5});
+  halfedgeToFace.push_back(2);
   halfedgeNext.push_back(8);
   // DB
-  halfedges.push_back({0, b, 10, 2});
+  halfedges.push_back({0, b, 10});
+  halfedgeToFace.push_back(2);
   halfedgeNext.push_back(6);
   // CB
-  halfedges.push_back({0, b, 1, 3});
+  halfedges.push_back({0, b, 1});
+  halfedgeToFace.push_back(3);
   halfedgeNext.push_back(10);
   // BD
-  halfedges.push_back({0, d, 8, 3});
+  halfedges.push_back({0, d, 8});
+  halfedgeToFace.push_back(3);
   halfedgeNext.push_back(11);
   // DC
-  halfedges.push_back({0, c, 4, 3});
+  halfedges.push_back({0, c, 4});
+  halfedgeToFace.push_back(3);
   halfedgeNext.push_back(9);
 
   // Create faces
@@ -180,8 +194,9 @@ HalfEdgeMesh::HalfEdgeMesh(const MeshBuilder& builderObject,
   i = 0;
   for (const auto& halfEdge : builderObject.halfedges) {
     if (halfEdge.pairedHalfedge != -1) {
-      halfedges.push_back(
-          {halfEdge.endVert, halfEdge.pairedHalfedge, halfEdge.face});
+      halfedges.push_back({halfEdge.endVert, halfEdge.pairedHalfedge,
+                           builderObject.halfedgeToFace[i]});
+      halfedgeToFace.push_back(builderObject.halfedgeToFace[i]);
       halfedgeNext.push_back(builderObject.halfedgeNext[i]);
       halfEdgeMapping[i] = halfedges.size() - 1;
     }
@@ -196,7 +211,7 @@ HalfEdgeMesh::HalfEdgeMesh(const MeshBuilder& builderObject,
 
   for (size_t i = 0; i < halfedges.size(); i++) {
     auto& he = halfedges[i];
-    he.face = faceMapping[he.face];
+    halfedgeToFace[i] = faceMapping[halfedgeToFace[i]];
     he.pairedHalfedge = halfEdgeMapping[he.pairedHalfedge];
     halfedgeNext[i] = halfEdgeMapping[halfedgeNext[i]];
     he.endVert = vertexMapping[he.endVert];
@@ -236,6 +251,7 @@ std::pair<Vec<Halfedge>, Vec<vec3>> QuickHull::buildMesh(double epsilon) {
 
   // reorder halfedges
   Vec<Halfedge> halfedges(mesh.halfedges.size());
+  Vec<int> halfedgeToFace(mesh.halfedges.size());
   Vec<int> counts(mesh.halfedges.size(), 0);
   Vec<int> mapping(mesh.halfedges.size());
   Vec<int> faceMap(mesh.faces.size());
@@ -247,24 +263,28 @@ std::pair<Vec<Halfedge>, Vec<vec3>> QuickHull::buildMesh(double epsilon) {
       autoPolicy(mesh.halfedges.size()), countAt(0_uz),
       countAt(mesh.halfedges.size()), [&](size_t i) {
         if (mesh.halfedges[i].pairedHalfedge < 0) return;
-        if (mesh.faces[mesh.halfedges[i].face].isDisabled()) return;
-        if (AtomicAdd(counts[mesh.halfedges[i].face], 1) > 0) return;
+        if (mesh.faces[mesh.halfedgeToFace[i]].isDisabled()) return;
+        if (AtomicAdd(counts[mesh.halfedgeToFace[i]], 1) > 0) return;
         int currIndex = AtomicAdd(j, 3);
         mapping[i] = currIndex;
         halfedges[currIndex + 0] = mesh.halfedges[i];
+        halfedgeToFace[currIndex + 0] = mesh.halfedgeToFace[i];
 
         size_t k = mesh.halfedgeNext[i];
         mapping[k] = currIndex + 1;
         halfedges[currIndex + 1] = mesh.halfedges[k];
+        halfedgeToFace[currIndex + 1] = mesh.halfedgeToFace[k];
 
         k = mesh.halfedgeNext[k];
         mapping[k] = currIndex + 2;
         halfedges[currIndex + 2] = mesh.halfedges[k];
+        halfedgeToFace[currIndex + 2] = mesh.halfedgeToFace[k];
         halfedges[currIndex + 0].startVert = halfedges[currIndex + 2].endVert;
         halfedges[currIndex + 1].startVert = halfedges[currIndex + 0].endVert;
         halfedges[currIndex + 2].startVert = halfedges[currIndex + 1].endVert;
       });
   halfedges.resize(j);
+  halfedgeToFace.resize(j);
   // fix pairedHalfedge id
   for_each(
       autoPolicy(halfedges.size()), halfedges.begin(), halfedges.end(),
@@ -295,9 +315,9 @@ std::pair<Vec<Halfedge>, Vec<vec3>> QuickHull::buildMesh(double epsilon) {
              he.endVert = counts[he.endVert];
            });
   // setting face id
-  for (size_t index = 0; index < halfedges.size(); index++) {
-    halfedges[index].face = index / 3;
-  }
+  // for (size_t index = 0; index < halfedges.size(); index++) {
+  //   halfedges[index].face = index / 3;
+  // }
   return {std::move(halfedges), std::move(vertices)};
 }
 
@@ -378,7 +398,7 @@ void QuickHull::createConvexHalfedgeMesh() {
             if (mesh.halfedges[heIndex].pairedHalfedge !=
                 faceData.enteredFromHalfedge) {
               possiblyVisibleFaces.push_back(
-                  {mesh.halfedges[mesh.halfedges[heIndex].pairedHalfedge].face,
+                  {mesh.halfedgeToFace[mesh.halfedges[heIndex].pairedHalfedge],
                    heIndex});
             }
           }
@@ -396,12 +416,12 @@ void QuickHull::createConvexHalfedgeMesh() {
       // face will not be part of the final mesh so their data slots can by
       // recycled.
       const auto halfEdgesMesh = mesh.getHalfEdgeIndicesOfFace(
-          mesh.faces[mesh.halfedges[faceData.enteredFromHalfedge].face]);
+          mesh.faces[mesh.halfedgeToFace[faceData.enteredFromHalfedge]]);
       const std::int8_t ind =
           (halfEdgesMesh[0] == faceData.enteredFromHalfedge)
               ? 0
               : (halfEdgesMesh[1] == faceData.enteredFromHalfedge ? 1 : 2);
-      mesh.faces[mesh.halfedges[faceData.enteredFromHalfedge].face]
+      mesh.faces[mesh.halfedgeToFace[faceData.enteredFromHalfedge]]
           .horizonEdgesOnCurrentIteration |= (1 << ind);
     }
     const size_t horizonEdgeCount = horizonEdgesData.size();
@@ -491,9 +511,9 @@ void QuickHull::createConvexHalfedgeMesh() {
       mesh.halfedgeNext[BC] = CA;
       mesh.halfedgeNext[CA] = AB;
 
-      mesh.halfedges[BC].face = newFaceIndex;
-      mesh.halfedges[CA].face = newFaceIndex;
-      mesh.halfedges[AB].face = newFaceIndex;
+      mesh.halfedgeToFace[BC] = newFaceIndex;
+      mesh.halfedgeToFace[CA] = newFaceIndex;
+      mesh.halfedgeToFace[AB] = newFaceIndex;
 
       mesh.halfedges[CA].endVert = A;
       mesh.halfedges[BC].endVert = C;

--- a/src/manifold/src/quickhull.h
+++ b/src/manifold/src/quickhull.h
@@ -151,6 +151,7 @@ class MeshBuilder {
   // Mesh data
   std::vector<Face> faces;
   Vec<Halfedge> halfedges;
+  Vec<int> halfedgeToFace;
   Vec<int> halfedgeNext;
 
   // When the mesh is modified and faces and half edges are removed from it, we
@@ -202,6 +203,7 @@ class HalfEdgeMesh {
   // Index of one of the half edges of the faces
   std::vector<size_t> halfEdgeIndexFaces;
   Vec<Halfedge> halfedges;
+  Vec<int> halfedgeToFace;
   Vec<int> halfedgeNext;
 
   HalfEdgeMesh(const MeshBuilder& builderObject,

--- a/src/manifold/src/shared.h
+++ b/src/manifold/src/shared.h
@@ -206,8 +206,7 @@ struct ReindexEdge {
 inline std::ostream& operator<<(std::ostream& stream, const Halfedge& edge) {
   return stream << "startVert = " << edge.startVert
                 << ", endVert = " << edge.endVert
-                << ", pairedHalfedge = " << edge.pairedHalfedge
-                << ", face = " << edge.face;
+                << ", pairedHalfedge = " << edge.pairedHalfedge;
 }
 
 inline std::ostream& operator<<(std::ostream& stream, const Barycentric& bary) {

--- a/src/manifold/src/smoothing.cpp
+++ b/src/manifold/src/smoothing.cpp
@@ -562,8 +562,7 @@ void Manifold::Impl::SetNormals(int normalIdx, double minSharpAngle) {
                 pos += vec3(TangentFromNormal(
                     normal, halfedge_[current].pairedHalfedge));
               }
-              return FaceEdge(
-                  {current / 3, SafeNormalize(pos - centerPos)});
+              return FaceEdge({current / 3, SafeNormalize(pos - centerPos)});
             },
             [this, &triIsFlatFace, &normals, &group, minSharpAngle](
                 int current, const FaceEdge& here, FaceEdge& next) {


### PR DESCRIPTION
Just some cleanup, I think we talked about `face` being redundant because we can just compute it from the index, so I took the time to remove it.