### PR TITLE
Install manifold.pc under CMAKE_INSTALL_LIBDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,7 @@ if(MANIFOLD_CROSS_SECTION)
 endif()
 configure_file(manifold.pc.in ${CMAKE_CURRENT_BINARY_DIR}/manifold.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/manifold.pc
-  DESTINATION lib/pkgconfig)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 endif()
 


### PR DESCRIPTION
On platforms that install libmanifold under lib64, manifold.pc should be installed in the pkgconfig directory under lib64.