### PR TITLE
feat: exposes Quality::ResetToDefaults() via C bindings

### DIFF
--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -354,6 +354,7 @@ int manifold_box_is_finite(ManifoldBox *b);
 void manifold_set_min_circular_angle(double degrees);
 void manifold_set_min_circular_edge_length(double length);
 void manifold_set_circular_segments(int number);
+void manifold_reset_to_circular_defaults();
 
 // Manifold Mesh Extraction
 

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -583,6 +583,8 @@ int manifold_get_circular_segments(double radius) {
   return Quality::GetCircularSegments(radius);
 }
 
+void manifold_reset_to_circular_defaults() { Quality::ResetToDefaults(); }
+
 // memory size
 size_t manifold_cross_section_size() { return sizeof(CrossSection); }
 size_t manifold_cross_section_vec_size() {


### PR DESCRIPTION
Yesterday I started implementing rust bindings for this project and I wanted to run tests if my bindings for changing quality settings work as expected. I stumbled across the problem that tests fail when I run them all together instead of one by one.
I then pinned it down to the changed defaults, but I also figured out that there is no C binding for the reset function.

TL;DR: this PR exposes the Quality::ResetToDefaults() function via C bindings with roughly the same function name as for WASM (`resetToCircularDefaults`).