### PR TITLE
CI: remove glm

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -12,16 +12,16 @@ on:
 
 jobs:
   build:
-    name: CrossSection:${{matrix.cross_section}} ${{matrix.parallel_backend == 'ON'}} GCC ${{matrix.gcc}}
+    name: CrossSection:${{matrix.cross_section}} ${{matrix.parallelization == 'ON'}} GCC ${{matrix.gcc}}
     timeout-minutes: 45
     strategy:
       matrix:
         cross_section: [ON]
-        parallel_backend: [OFF, ON]
+        parallelization: [OFF, ON]
         gcc: [13, 14]
         include:
           - cross_section: OFF
-            parallel_backend: ON
+            parallelization: ON
             gcc: 14
     runs-on: ubuntu-24.04
     env:
@@ -34,23 +34,23 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install libglm-dev libgtest-dev libassimp-dev git libtbb-dev pkg-config libpython3-dev lcov
+        sudo apt-get install libgtest-dev libassimp-dev git libtbb-dev pkg-config libpython3-dev lcov
         python -m pip install -U trimesh pytest
     - uses: actions/checkout@v4
     - uses: jwlawson/actions-setup-cmake@v2
-    - name: Build ${{matrix.parallel_backend}}
-      if: matrix.parallel_backend != 'OFF'
+    - name: Build ${{matrix.parallelization}}
+      if: matrix.parallelization != 'OFF'
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PYBIND=ON -DMANIFOLD_DEBUG=ON -DMANIFOLD_FLAGS=-UNDEBUG -DMANIFOLD_CROSS_SECTION=${{matrix.cross_section}} -DMANIFOLD_EXPORT=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} .. && make
-    - name: Test ${{matrix.parallel_backend}}
-      if: matrix.parallel_backend != 'OFF'
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PYBIND=ON -DMANIFOLD_DEBUG=ON -DMANIFOLD_FLAGS=-UNDEBUG -DMANIFOLD_CROSS_SECTION=${{matrix.cross_section}} -DMANIFOLD_EXPORT=ON -DMANIFOLD_PAR=${{matrix.parallelization}} .. && make
+    - name: Test ${{matrix.parallelization}}
+      if: matrix.parallelization != 'OFF'
       run: |
         cd build/test
         ./manifold_test
-    - name: Test Python bindings ${{matrix.parallel_backend}}
-      if: matrix.parallel_backend != 'OFF' && matrix.cross_section == 'ON'
+    - name: Test Python bindings ${{matrix.parallelization}}
+      if: matrix.parallelization != 'OFF' && matrix.cross_section == 'ON'
       run: |
         export PYTHONPATH=$PYTHONPATH:$(pwd)/build/bindings/python
         python3 bindings/python/examples/run_all.py -e
@@ -59,11 +59,11 @@ jobs:
       # only do code coverage for default sequential backend, it seems that TBB
       # backend will cause failure
       # perhaps issue related to invalid memory access?
-      if: matrix.parallel_backend == 'OFF'
+      if: matrix.parallelization == 'OFF'
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} -DCODE_COVERAGE=ON .. && make
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PAR=${{matrix.parallelization}} -DCODE_COVERAGE=ON .. && make
         lcov --capture --gcov-tool gcov-${{ matrix.gcc }} --ignore-errors mismatch --initial --directory . --output-file ./code_coverage_init.info
         cd test
         ./manifold_test
@@ -73,11 +73,11 @@ jobs:
         lcov --remove ./code_coverage_total.info '/usr/*' '*/test/*' '*/extras/*' '*/bindings/*' --output-file ./code_coverage.info
         cd ../
     - uses: codecov/codecov-action@v4
-      if: matrix.parallel_backend == 'OFF'
+      if: matrix.parallelization == 'OFF'
       with:
         files: build/code_coverage.info
         fail_ci_if_error: false
-        name: ${{matrix.parallel_backend}}
+        name: ${{matrix.parallelization}}
     - name: test cmake consumer
       run: |
         cd build
@@ -92,7 +92,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get -y update
-        DEBIAN_FRONTEND=noninteractive sudo apt install -y libgtest-dev libglm-dev libassimp-dev git libtbb-dev pkg-config libpython3-dev python3 python3-distutils python3-pip
+        DEBIAN_FRONTEND=noninteractive sudo apt install -y libgtest-dev libassimp-dev git libtbb-dev pkg-config libpython3-dev python3 python3-distutils python3-pip
     - uses: actions/checkout@v4
     - uses: jwlawson/actions-setup-cmake@v2
     - name: Build C bindings with TBB
@@ -115,7 +115,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get -y update
-        DEBIAN_FRONTEND=noninteractive sudo apt install -y nodejs libglm-dev 
+        DEBIAN_FRONTEND=noninteractive sudo apt install -y nodejs
     - uses: actions/checkout@v4
     - name: Setup WASM
       run: |
@@ -155,20 +155,20 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        parallel_backend: [OFF, ON]
+        parallelization: [OFF, ON]
       max-parallel: 1
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v4
     - uses: jwlawson/actions-setup-cmake@v2
     - uses: ilammy/msvc-dev-cmd@v1
-    - name: Build ${{matrix.parallel_backend}}
+    - name: Build ${{matrix.parallelization}}
       shell: powershell
       run: |
-        cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DMANIFOLD_DEBUG=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} -A x64 -B build
+        cmake . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DMANIFOLD_DEBUG=ON -DMANIFOLD_PAR=${{matrix.parallelization}} -A x64 -B build
         cd build
         cmake --build . --target ALL_BUILD --config Release
-    - name: Test ${{matrix.parallel_backend}}
+    - name: Test ${{matrix.parallelization}}
       shell: bash
       run: |
         cd build/bin/Release
@@ -185,7 +185,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        parallel_backend: [OFF, ON]
+        parallelization: [OFF, ON]
       max-parallel: 1
     runs-on: ubuntu-latest
     container: openscad/mxe-x86_64-gui:latest
@@ -201,13 +201,13 @@ jobs:
         export MXETARGETDIR=$MXEDIR/usr/$MXE_TARGETS
         export PATH=/mxe/usr/bin:$PATH
         export CMAKE=$MXE_TARGETS-cmake
-        $CMAKE -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DMANIFOLD_PYBIND=OFF -DMANIFOLD_CBIND=OFF -DMANIFOLD_DEBUG=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} .. && make
+        $CMAKE -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DMANIFOLD_PYBIND=OFF -DMANIFOLD_CBIND=OFF -DMANIFOLD_DEBUG=ON -DMANIFOLD_PAR=${{matrix.parallelization}} .. && make
 
   build_mac:
     timeout-minutes: 30
     strategy:
       matrix:
-        parallel_backend: [OFF, ON]
+        parallelization: [OFF, ON]
     runs-on: macos-latest
     steps:
     - name: Install common dependencies
@@ -215,7 +215,7 @@ jobs:
         brew install pkg-config googletest assimp
         pip install trimesh pytest
     - name: Install TBB
-      if: matrix.parallel_backend == 'ON'
+      if: matrix.parallelization == 'ON'
       run: brew install tbb onedpl
     - uses: actions/checkout@v4
     - uses: jwlawson/actions-setup-cmake@v2
@@ -223,7 +223,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_DEBUG=ON -DMANIFOLD_PYBIND=ON -DMANIFOLD_EXPORT=ON -DMANIFOLD_PAR=${{matrix.parallel_backend}} .. && make
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_DEBUG=ON -DMANIFOLD_PYBIND=ON -DMANIFOLD_EXPORT=ON -DMANIFOLD_PAR=${{matrix.parallelization}} .. && make
     - name: Test
       run: |
         cd build/test


### PR DESCRIPTION
1. Removed glm.
2. Changed naming from `parallel_backend` to `parallel`. (because it no longer describes backend name).

