### PR TITLE
Support googletest with the CMake package name GTest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,8 +18,8 @@ endif()
 
 enable_testing()
 
-find_package(gtest QUIET)
-if(NOT gtest_FOUND)
+find_package(GTest QUIET)
+if(NOT GTest_FOUND)
   if(NOT MANIFOLD_DOWNLOADS)
     message(
       WARNING


### PR DESCRIPTION
This check fails for me, (and I guess for the alternative Ubuntu `libgtest-dev` package:
https://packages.ubuntu.com/noble/amd64/libgtest-dev/filelist
)

According to the CMake docs the lower-case name will get checked too. Let's see...
