### PR TITLE
Need to fix compilation flag lost in CMake refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ option(
 option(MANIFOLD_EXCEPTIONS "Build manifold with exception enabled" ON)
 option(MANIFOLD_EXPORT "Build mesh export (via assimp) utility library" OFF)
 option(MANIFOLD_PAR "Enable Parallel backend" OFF)
+option(
+  MANIFOLD_OPTIMIZED
+  "Force Optimized build, even with debugging enabled"
+  OFF
+)
 option(MANIFOLD_TEST "Enable testing suite" ON)
 option(BUILD_SHARED_LIBS "Build shared library" ON)
 include(CMakeDependentOption)
@@ -171,6 +176,13 @@ else()
     list(APPEND WARNING_FLAGS -Werror)
   endif()
   list(APPEND MANIFOLD_FLAGS ${WARNING_FLAGS})
+  if(
+    MANIFOLD_OPTIMIZED
+    OR "${CMAKE_BUILD_TYPE}" STREQUAL "Release"
+    OR "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo"
+  )
+    list(APPEND MANIFOLD_FLAGS -O3)
+  endif()
 endif()
 
 if(CODE_COVERAGE AND NOT MSVC)


### PR DESCRIPTION
Looks like we lost the O3 flag always being on.  This was good for some fun trying to figure out why performance had dropped off so dramatically - turned out it was simply because prior builds had NEVER been without O3, so all builds - Debug or Release - were optimized.

On the other hand, there are arguments for and against O3 with debug builds.  The optimizations complicate/obscure debugging, but it's also an order of magnitude slower running.  Rather than be completely either or, this PR defines a MANIFOLD_OPTIMIZED variable that a user can specify to ON explicitly.  Build types Release and RelWithDebInfo will always have O3, and for other cases it'll be up to whether the user has explicitly requested optimized building with MANIFOLD_OPTIMIZED.