### PR TITLE
fix data races

### DIFF
--- a/include/manifold/parallel.h
+++ b/include/manifold/parallel.h
@@ -244,7 +244,14 @@ struct SortedRange {
       : input(input), tmp(tmp), offset(offset), length(length) {}
   SortedRange(SortedRange<T, SizeType> &r, tbb::split)
       : input(r.input), tmp(r.tmp) {}
-  void operator()(const tbb::blocked_range<SizeType> &range) {
+  // FIXME: no idea why thread sanitizer reports data race here
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+  __attribute__((no_sanitize("thread")))
+#endif
+#endif
+  void
+  operator()(const tbb::blocked_range<SizeType> &range) {
     SortedRange<T, SizeType> rhs(input, tmp, range.begin(),
                                  range.end() - range.begin());
     rhs.inTmp =

--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -201,6 +201,13 @@ struct EdgePos {
   bool isStart;
 };
 
+// thread sanitizer doesn't really know how to check when there are too many
+// mutex
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+__attribute__((no_sanitize("thread")))
+#endif
+#endif
 void AddNewEdgeVerts(
     // we need concurrent_map because we will be adding things concurrently
     concurrent_map<int, std::vector<EdgePos>> &edgesP,

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -387,8 +387,14 @@ Vec<int> Manifold::Impl::VertFlatFace(const Vec<bool>& flatFaces) const {
 
 Vec<int> Manifold::Impl::VertHalfedge() const {
   Vec<int> vertHalfedge(NumVert());
+  Vec<uint8_t> counters(NumVert(), 0);
   for_each_n(autoPolicy(halfedge_.size(), 1e5), countAt(0), halfedge_.size(),
-             [&vertHalfedge, this](const int idx) {
+             [&vertHalfedge, &counters, this](const int idx) {
+               auto old = std::atomic_exchange(
+                   reinterpret_cast<std::atomic<uint8_t>*>(
+                       &counters[halfedge_[idx].startVert]),
+                   1);
+               if (old == 1) return;
                // arbitrary, last one wins.
                vertHalfedge[halfedge_[idx].startVert] = idx;
              });


### PR DESCRIPTION
Fixed some known data races in our code. The issue with data race is that it is undefined behavior. Also, data race can introduce non-determinism into our code, although that is not yet addressed now.

I think thread sanitizer is happy with our code now, for some reason it reports the custom radix sort as racy, but I have no idea why it is racy (I think I followed the tbb API), so it is exempted for now. For `AddNewEdgeVerts`, we are probably using many mutexes, which thread sanitizer is not too happy about, so I exempted it for now either.