### PR TITLE
Fix target include directory when building as a submodule

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,7 +101,7 @@ target_include_directories(
   manifold
   PUBLIC
     $<INSTALL_INTERFACE:include>
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   PRIVATE ${MANIFOLD_INCLUDE_DIRS}
 )
 


### PR DESCRIPTION
Do check, but by trial and error it seems that for the project using the git submodule Manifold's src/ is the `CMAKE_SOURCE_DIR`, in any event it can't find Manifold's include directory which is the level above src.

Manifold still builds for me on its own and the installed cmake files are the same.
