### PR TITLE
remove deterministic flag

### DIFF
--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -596,8 +596,6 @@ struct ExecutionParams {
   /// Suppresses printed errors regarding CW triangles. Has no effect if
   /// processOverlaps is true.
   bool suppressErrors = false;
-  /// Deterministic outputs. Will disable some parallel optimizations.
-  bool deterministic = false;
   /// Perform optional but recommended triangle cleanups in SimplifyTopology()
   bool cleanupTriangles = true;
 };

--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -253,7 +253,7 @@ void AddNewEdgeVerts(
 #if (MANIFOLD_PAR == 1) && __has_include(<tbb/tbb.h>)
   // parallelize operations, requires concurrent_map so we can only enable this
   // with tbb
-  if (!ManifoldParams().deterministic && p1q2.size() > kParallelThreshold) {
+  if (p1q2.size() > kParallelThreshold) {
     // ideally we should have 1 mutex per key, but kParallelThreshold is enough
     // to avoid contention for most of the cases
     std::array<std::mutex, kParallelThreshold> mutexes;
@@ -486,9 +486,7 @@ void AppendWholeEdges(Manifold::Impl &outR, Vec<int> &facePtrR,
                       bool forward) {
   ZoneScoped;
   for_each_n(
-      ManifoldParams().deterministic ? ExecutionPolicy::Seq
-                                     : autoPolicy(inP.halfedge_.size()),
-      countAt(0), inP.halfedge_.size(),
+      autoPolicy(inP.halfedge_.size()), countAt(0), inP.halfedge_.size(),
       DuplicateHalfedges({outR.halfedge_, halfedgeRef, facePtrR, wholeHalfedgeP,
                           inP.halfedge_, i03, vP2R, faceP2R, forward}));
 }

--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -468,35 +468,32 @@ std::shared_ptr<Manifold::Impl> CsgOpNode::BatchBoolean(
     return std::make_shared<Manifold::Impl>(boolean.Result(operation));
   }
 #if (MANIFOLD_PAR == 1) && __has_include(<tbb/tbb.h>)
-  if (!ManifoldParams().deterministic) {
-    tbb::task_group group;
-    tbb::concurrent_priority_queue<SharedImpl, MeshCompare> queue(
-        results.size());
-    for (auto result : results) {
-      queue.emplace(result);
-    }
-    results.clear();
-    std::function<void()> process = [&]() {
-      while (queue.size() > 1) {
-        SharedImpl a, b;
-        if (!queue.try_pop(a)) continue;
-        if (!queue.try_pop(b)) {
-          queue.push(a);
-          continue;
-        }
-        group.run([&, a, b]() {
-          Boolean3 boolean(*getImplPtr(a), *getImplPtr(b), operation);
-          queue.emplace(
-              std::make_shared<Manifold::Impl>(boolean.Result(operation)));
-          return group.run(process);
-        });
-      }
-    };
-    group.run_and_wait(process);
-    SharedImpl r;
-    queue.try_pop(r);
-    return *std::get_if<std::shared_ptr<Manifold::Impl>>(&r);
+  tbb::task_group group;
+  tbb::concurrent_priority_queue<SharedImpl, MeshCompare> queue(results.size());
+  for (auto result : results) {
+    queue.emplace(result);
   }
+  results.clear();
+  std::function<void()> process = [&]() {
+    while (queue.size() > 1) {
+      SharedImpl a, b;
+      if (!queue.try_pop(a)) continue;
+      if (!queue.try_pop(b)) {
+        queue.push(a);
+        continue;
+      }
+      group.run([&, a, b]() {
+        Boolean3 boolean(*getImplPtr(a), *getImplPtr(b), operation);
+        queue.emplace(
+            std::make_shared<Manifold::Impl>(boolean.Result(operation)));
+        return group.run(process);
+      });
+    }
+  };
+  group.run_and_wait(process);
+  SharedImpl r;
+  queue.try_pop(r);
+  return *std::get_if<std::shared_ptr<Manifold::Impl>>(&r);
 #endif
   // apply boolean operations starting from smaller meshes
   // the assumption is that boolean operations on smaller meshes is faster,
@@ -604,10 +601,8 @@ std::vector<std::shared_ptr<CsgNode>> &CsgOpNode::GetChildren(
 
   if (forceToLeafNodes && !impl->forcedToLeafNodes_) {
     impl->forcedToLeafNodes_ = true;
-    for_each(impl->children_.size() > 1 && !ManifoldParams().deterministic
-                 ? ExecutionPolicy::Par
-                 : ExecutionPolicy::Seq,
-             impl->children_.begin(), impl->children_.end(), [](auto &child) {
+    for_each(ExecutionPolicy::Par, impl->children_.begin(),
+             impl->children_.end(), [](auto &child) {
                if (child->GetNodeType() != CsgNodeType::Leaf) {
                  child = child->ToLeafNode();
                }


### PR DESCRIPTION
I want to remove the `deterministic` flag from our execution parameters - it leaves untested code paths that concern me. The question is what is more important: determinism or speed? I'm not quite ready to merge this as is because forcing everything to be deterministic all the time is making our tests run about 20% slower (at least on my M1 macbook pro). WDYT @pca006132?