### PR TITLE
Add C bindings for Triangulate()

### DIFF
--- a/bindings/c/conv.cpp
+++ b/bindings/c/conv.cpp
@@ -124,6 +124,10 @@ ManifoldVec3 to_c(vec3 v) { return {v.x, v.y, v.z}; }
 
 ManifoldIVec3 to_c(ivec3 v) { return {v.x, v.y, v.z}; }
 
+ManifoldTriangulation *to_c(std::vector<ivec3> *m) {
+  return reinterpret_cast<ManifoldTriangulation *>(m);
+}
+
 const manifold::Manifold *from_c(ManifoldManifold *m) {
   return reinterpret_cast<manifold::Manifold const *>(m);
 }
@@ -219,6 +223,10 @@ vec3 from_c(ManifoldVec3 v) { return vec3(v.x, v.y, v.z); }
 ivec3 from_c(ManifoldIVec3 v) { return ivec3(v.x, v.y, v.z); }
 
 vec4 from_c(ManifoldVec4 v) { return vec4(v.x, v.y, v.z, v.w); }
+
+const std::vector<ivec3> *from_c(ManifoldTriangulation *m) {
+  return reinterpret_cast<std::vector<ivec3> const *>(m);
+}
 
 std::vector<vec3> vector_of_vec_array(ManifoldVec3 *vs, size_t length) {
   auto vec = std::vector<vec3>();

--- a/bindings/c/conv.h
+++ b/bindings/c/conv.h
@@ -39,6 +39,7 @@ ManifoldError to_c(manifold::Manifold::Error error);
 ManifoldVec2 to_c(vec2 v);
 ManifoldVec3 to_c(vec3 v);
 ManifoldIVec3 to_c(ivec3 v);
+ManifoldTriangulation *to_c(std::vector<ivec3> *m);
 
 const manifold::Manifold *from_c(ManifoldManifold *m);
 ManifoldVec *from_c(ManifoldManifoldVec *ms);
@@ -57,6 +58,7 @@ vec2 from_c(ManifoldVec2 v);
 vec3 from_c(ManifoldVec3 v);
 ivec3 from_c(ManifoldIVec3 v);
 vec4 from_c(ManifoldVec4 v);
+const std::vector<ivec3> *from_c(ManifoldTriangulation *m);
 
 std::vector<vec3> vector_of_vec_array(ManifoldVec3 *vs, size_t length);
 std::vector<ivec3> vector_of_vec_array(ManifoldIVec3 *vs, size_t length);

--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -417,7 +417,8 @@ double *manifold_meshgl64_halfedge_tangent(void *mem, ManifoldMeshGL64 *m);
 
 // Triangulation
 
-ManifoldTriangulation *manifold_triangulate(void *mem, ManifoldPolygons *ps, double epsilon);
+ManifoldTriangulation *manifold_triangulate(void *mem, ManifoldPolygons *ps,
+                                            double epsilon);
 size_t manifold_triangulation_num_tri(ManifoldTriangulation *m);
 int *manifold_triangulation_tri_verts(void *mem, ManifoldTriangulation *m);
 

--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -415,6 +415,12 @@ double *manifold_meshgl64_run_transform(void *mem, ManifoldMeshGL64 *m);
 size_t *manifold_meshgl64_face_id(void *mem, ManifoldMeshGL64 *m);
 double *manifold_meshgl64_halfedge_tangent(void *mem, ManifoldMeshGL64 *m);
 
+// Triangulation
+
+ManifoldTriangulation *manifold_triangulate(void *mem, ManifoldPolygons *ps, double epsilon);
+size_t manifold_triangulation_num_tri(ManifoldTriangulation *m);
+int *manifold_triangulation_tri_verts(void *mem, ManifoldTriangulation *m);
+
 // memory size
 
 size_t manifold_manifold_size();
@@ -429,6 +435,7 @@ size_t manifold_meshgl64_size();
 size_t manifold_box_size();
 size_t manifold_rect_size();
 size_t manifold_curvature_size();
+size_t manifold_triangulation_size();
 
 // allocation
 
@@ -442,6 +449,7 @@ ManifoldMeshGL *manifold_alloc_meshgl();
 ManifoldMeshGL64 *manifold_alloc_meshgl64();
 ManifoldBox *manifold_alloc_box();
 ManifoldRect *manifold_alloc_rect();
+ManifoldTriangulation *manifold_alloc_triangulation();
 
 // destruction
 
@@ -455,6 +463,7 @@ void manifold_destruct_meshgl(ManifoldMeshGL *m);
 void manifold_destruct_meshgl64(ManifoldMeshGL64 *m);
 void manifold_destruct_box(ManifoldBox *b);
 void manifold_destruct_rect(ManifoldRect *b);
+void manifold_destruct_triangulation(ManifoldTriangulation *M);
 
 // pointer free + destruction
 
@@ -468,6 +477,7 @@ void manifold_delete_meshgl(ManifoldMeshGL *m);
 void manifold_delete_meshgl64(ManifoldMeshGL64 *m);
 void manifold_delete_box(ManifoldBox *b);
 void manifold_delete_rect(ManifoldRect *b);
+void manifold_delete_triangulation(ManifoldTriangulation *m);
 
 // MeshIO / Export
 

--- a/bindings/c/include/manifold/types.h
+++ b/bindings/c/include/manifold/types.h
@@ -27,6 +27,7 @@ typedef struct ManifoldMeshGL ManifoldMeshGL;
 typedef struct ManifoldMeshGL64 ManifoldMeshGL64;
 typedef struct ManifoldBox ManifoldBox;
 typedef struct ManifoldRect ManifoldRect;
+typedef struct ManifoldTriangulation ManifoldTriangulation;
 
 #ifdef MANIFOLD_EXPORT
 typedef struct ManifoldMaterial ManifoldMaterial;

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -21,6 +21,7 @@
 #include "manifold/cross_section.h"
 #include "manifold/manifold.h"
 #include "manifold/types.h"
+#include "manifold/polygon.h"
 
 using namespace manifold;
 
@@ -702,6 +703,19 @@ int manifold_get_circular_segments(double radius) {
 
 void manifold_reset_to_circular_defaults() { Quality::ResetToDefaults(); }
 
+ManifoldTriangulation *manifold_triangulate(void *mem, ManifoldPolygons *ps, double epsilon) {
+  auto triangulation = manifold::Triangulate(*from_c(ps), epsilon);
+  return to_c(new (mem) std::vector<ivec3>(triangulation));
+}
+
+size_t manifold_triangulation_num_tri(ManifoldTriangulation *m) {
+  return from_c(m)->size();
+}
+
+int *manifold_triangulation_tri_verts(void *mem, ManifoldTriangulation *m) {
+  return reinterpret_cast<int *>(copy_data<ivec3>(mem, *from_c(m)));
+}
+
 // memory size
 size_t manifold_cross_section_size() { return sizeof(CrossSection); }
 size_t manifold_cross_section_vec_size() {
@@ -716,6 +730,7 @@ size_t manifold_meshgl_size() { return sizeof(MeshGL); }
 size_t manifold_meshgl64_size() { return sizeof(MeshGL64); }
 size_t manifold_box_size() { return sizeof(Box); }
 size_t manifold_rect_size() { return sizeof(Rect); }
+size_t manifold_triangulation_size() { return sizeof(std::vector<ivec3>); }
 
 // allocation
 ManifoldManifold *manifold_alloc_manifold() {
@@ -740,6 +755,9 @@ ManifoldMeshGL *manifold_alloc_meshgl() { return to_c(new MeshGL); }
 ManifoldMeshGL64 *manifold_alloc_meshgl64() { return to_c(new MeshGL64); }
 ManifoldBox *manifold_alloc_box() { return to_c(new Box); }
 ManifoldRect *manifold_alloc_rect() { return to_c(new Rect); }
+ManifoldTriangulation *manifold_alloc_triangulation() {
+    return to_c(new std::vector<ivec3>);
+}
 
 // pointer free + destruction
 void manifold_delete_cross_section(ManifoldCrossSection *c) {
@@ -760,6 +778,9 @@ void manifold_delete_meshgl(ManifoldMeshGL *m) { delete from_c(m); }
 void manifold_delete_meshgl64(ManifoldMeshGL64 *m) { delete from_c(m); }
 void manifold_delete_box(ManifoldBox *b) { delete from_c(b); }
 void manifold_delete_rect(ManifoldRect *r) { delete from_c(r); }
+void manifold_delete_triangulation(ManifoldTriangulation *m) {
+    delete from_c(m);
+}
 
 // destruction
 void manifold_destruct_cross_section(ManifoldCrossSection *cs) {
@@ -780,6 +801,10 @@ void manifold_destruct_meshgl(ManifoldMeshGL *m) { from_c(m)->~MeshGL(); }
 void manifold_destruct_meshgl64(ManifoldMeshGL64 *m) { from_c(m)->~MeshGL64(); }
 void manifold_destruct_box(ManifoldBox *b) { from_c(b)->~Box(); }
 void manifold_destruct_rect(ManifoldRect *r) { from_c(r)->~Rect(); }
+// error: '~' in destructor name should be after nested name specifier
+// void manifold_destruct_triangulation(ManifoldTriangulation *m) {
+//     from_c(m)->~std::vector<ivec3>();
+// }
 
 #ifdef __cplusplus
 }

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -802,10 +802,9 @@ void manifold_destruct_meshgl(ManifoldMeshGL *m) { from_c(m)->~MeshGL(); }
 void manifold_destruct_meshgl64(ManifoldMeshGL64 *m) { from_c(m)->~MeshGL64(); }
 void manifold_destruct_box(ManifoldBox *b) { from_c(b)->~Box(); }
 void manifold_destruct_rect(ManifoldRect *r) { from_c(r)->~Rect(); }
-// error: '~' in destructor name should be after nested name specifier
-// void manifold_destruct_triangulation(ManifoldTriangulation *m) {
-//     from_c(m)->~std::vector<ivec3>();
-// }
+void manifold_destruct_triangulation(ManifoldTriangulation *m) {
+  from_c(m)->~vector<ivec3>();
+}
 
 #ifdef __cplusplus
 }

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -20,8 +20,8 @@
 #include "manifold/common.h"
 #include "manifold/cross_section.h"
 #include "manifold/manifold.h"
-#include "manifold/types.h"
 #include "manifold/polygon.h"
+#include "manifold/types.h"
 
 using namespace manifold;
 
@@ -703,7 +703,8 @@ int manifold_get_circular_segments(double radius) {
 
 void manifold_reset_to_circular_defaults() { Quality::ResetToDefaults(); }
 
-ManifoldTriangulation *manifold_triangulate(void *mem, ManifoldPolygons *ps, double epsilon) {
+ManifoldTriangulation *manifold_triangulate(void *mem, ManifoldPolygons *ps,
+                                            double epsilon) {
   auto triangulation = manifold::Triangulate(*from_c(ps), epsilon);
   return to_c(new (mem) std::vector<ivec3>(triangulation));
 }
@@ -756,7 +757,7 @@ ManifoldMeshGL64 *manifold_alloc_meshgl64() { return to_c(new MeshGL64); }
 ManifoldBox *manifold_alloc_box() { return to_c(new Box); }
 ManifoldRect *manifold_alloc_rect() { return to_c(new Rect); }
 ManifoldTriangulation *manifold_alloc_triangulation() {
-    return to_c(new std::vector<ivec3>);
+  return to_c(new std::vector<ivec3>);
 }
 
 // pointer free + destruction
@@ -779,7 +780,7 @@ void manifold_delete_meshgl64(ManifoldMeshGL64 *m) { delete from_c(m); }
 void manifold_delete_box(ManifoldBox *b) { delete from_c(b); }
 void manifold_delete_rect(ManifoldRect *r) { delete from_c(r); }
 void manifold_delete_triangulation(ManifoldTriangulation *m) {
-    delete from_c(m);
+  delete from_c(m);
 }
 
 // destruction

--- a/test/manifoldc_test.cpp
+++ b/test/manifoldc_test.cpp
@@ -383,3 +383,27 @@ TEST(CBIND, polygons) {
   free(sp);
   free(ps);
 }
+
+TEST(CBIND, triangulation) {
+  ManifoldVec2 vs[] = {{0, 0}, {1, 1}, {1, 2}};
+  ManifoldSimplePolygon *sp =
+      manifold_simple_polygon(manifold_alloc_simple_polygon(), vs, 3);
+  ManifoldSimplePolygon *sps[] = {sp};
+  ManifoldPolygons *ps = manifold_polygons(manifold_alloc_polygons(), sps, 1);
+  ManifoldTriangulation *triangulation =
+      manifold_triangulate(manifold_alloc_triangulation(), ps, 1e-6);
+
+  manifold_delete_simple_polygon(sp);
+  manifold_delete_polygons(ps);
+
+  size_t num_tri = manifold_triangulation_num_tri(triangulation);
+  int *tri_verts = (int *)manifold_triangulation_tri_verts(
+      malloc(num_tri * 3 * sizeof(int)), triangulation);
+
+  EXPECT_EQ(num_tri, 1);
+  EXPECT_EQ(tri_verts[0], 0);
+  EXPECT_EQ(tri_verts[1], 1);
+  EXPECT_EQ(tri_verts[2], 2);
+  manifold_delete_triangulation(triangulation);
+  free(tri_verts);
+}


### PR DESCRIPTION
Here's my attempt at adding C bindings for `Triangulate()`. The code seems to work; but there are still a couple things I need help with.

* `Triangulate()` returns a `std::vector<ivec3>`, which I tried to respect. Since `ivec3` is 3 `int`'s, I have `manifold_triangulation_tri_verts(void *mem, ...)` `copy_data` assume `mem` has size `(num_tri * 3 * sizeof(int))`.

* **NOTE:** manifoldc.cpp now includes `"manifold/polygon.h"`

* **NOTE:** I couldn't figure out `manifold_destruct_triangulation(...)`; **need some help on this.**
  * Also, I don't understand the use case(s) of the destruct functions (literally don't understand; I am sure they exist). **Help on this too would be great.**

* **NOTE:** I have not attempted to add bindings for `TriangulateIdx()`

* Usage Code

  ```c
  ManifoldTriangulation *triangulation = manifold_triangulate(manifold_alloc_triangulation(), polygons, epsilon);
  size_t num_tri = manifold_triangulation_num_tri(triangulation);
  int *tri_verts = (int *) manifold_triangulation_tri_verts(malloc(num_tri * 3 * sizeof(int)), triangulation);
  manifold_delete_triangulation(triangulation);
  ```

* Test
  * **NOTE:** I hacked this into my current codebase. I took the polygons I was already getting from `ManifoldPolygons *polygons = manifold_cross_section_to_polygons(manifold_alloc_polygons(), cross_section);`, triangulated them as in the usage code above, and drew them as outlined triangles.

  <img width="512" alt="Screenshot 2024-11-10 at 8 13 30 AM" src="https://github.com/user-attachments/assets/189d191f-6125-4ebf-9223-674b1356a0ef">



