### PR TITLE
SDF boundary cleanup

### DIFF
--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -119,11 +119,9 @@ vec3 Position(ivec4 gridIndex, vec3 origin, vec3 spacing) {
 
 double BoundedSDF(ivec4 gridIndex, vec3 origin, vec3 spacing, ivec3 gridSize,
                   double level, std::function<double(vec3)> sdf) {
-  auto Min = [](ivec3 p) { return std::min(p.x, std::min(p.y, p.z)); };
-
   const ivec3 xyz(gridIndex);
-  const int lowerBoundDist = Min(xyz);
-  const int upperBoundDist = Min(gridSize - xyz);
+  const int lowerBoundDist = minelem(xyz);
+  const int upperBoundDist = minelem(gridSize - xyz);
   const int boundDist = std::min(lowerBoundDist, upperBoundDist - gridIndex.w);
 
   if (boundDist < 0) {
@@ -258,12 +256,14 @@ struct NearSurface {
     if (closestNeighbor >= 0 && opposedVerts <= kMaxOpposed) {
       const vec3 gridPos = Position(gridIndex, origin, spacing);
       const ivec4 neighborIndex = Neighbor(gridIndex, closestNeighbor);
-      const vec3 pos = FindSurface(gridPos, gridVert.distance,
-                                   Position(neighborIndex, origin, spacing),
-                                   vMax, tol, level, sdf);
+      vec3 pos = FindSurface(gridPos, gridVert.distance,
+                             Position(neighborIndex, origin, spacing), vMax,
+                             tol, level, sdf);
       // Bound the delta of each vert to ensure the tetrahedron cannot invert.
       if (la::all(la::less(la::abs(pos - gridPos), kS * spacing))) {
         const int idx = AtomicAdd(vertIndex[0], 1);
+        pos = max(pos, origin);
+        pos = min(pos, origin + spacing * (vec3(gridSize) - 1));
         vertPos[idx] = pos;
         gridVert.movedVert = idx;
         for (int j = 0; j < 7; ++j) {
@@ -323,9 +323,12 @@ struct ComputeVerts {
       }
 
       const int idx = AtomicAdd(vertIndex[0], 1);
-      vertPos[idx] = FindSurface(position, gridVert.distance,
-                                 Position(neighborIndex, origin, spacing), val,
-                                 tol, level, sdf);
+      vec3 pos = FindSurface(position, gridVert.distance,
+                             Position(neighborIndex, origin, spacing), val, tol,
+                             level, sdf);
+      pos = max(pos, origin);
+      pos = min(pos, origin + spacing * (vec3(gridSize) - 1));
+      vertPos[idx] = pos;
       gridVert.edgeVerts[i] = idx;
     }
   }
@@ -423,23 +426,23 @@ namespace manifold {
 
 /**
  * Constructs a level-set manifold from the input Signed-Distance Function
- * (SDF). This uses a form of Marching Tetrahedra (akin to Marching Cubes, but
- * better for manifoldness). Instead of using a cubic grid, it uses a
- * body-centered cubic grid (two shifted cubic grids). This means if your
- * function's interior exceeds the given bounds, you will see a kind of
- * egg-crate shape closing off the manifold, which is due to the underlying
- * grid.
+ * (SDF). This uses a form of Marching Tetrahedra (akin to Marching
+ * Cubes, but better for manifoldness). Instead of using a cubic grid, it uses a
+ * body-centered cubic grid (two shifted cubic grids). These grid points are
+ * snapped to the surface where possible to keep short edges from forming.
  *
  * @param sdf The signed-distance functor, containing this function signature:
  * `double operator()(vec3 point)`, which returns the
  * signed distance of a given point in R^3. Positive values are inside,
- * negative outside.
+ * negative outside. There is no requirement that the function be a true
+ * distance, or even continuous.
  * @param bounds An axis-aligned box that defines the extent of the grid.
  * @param edgeLength Approximate maximum edge length of the triangles in the
  * final result. This affects grid spacing, and hence has a strong effect on
  * performance.
- * @param level You can inset your Mesh by using a positive value, or outset
- * it with a negative value.
+ * @param level Extract the surface at this value of your sdf; defaults to
+ * zero. You can inset your mesh by using a positive value, or outset it with a
+ * negative value.
  * @param tolerance Ensure each vertex is within this distance of the true
  * surface. Defaults to -1, which will return the interpolated
  * crossing-point based on the two nearest grid points. Small positive values

--- a/test/sdf_test.cpp
+++ b/test/sdf_test.cpp
@@ -78,7 +78,7 @@ TEST(SDF, Bounds) {
 
   EXPECT_EQ(cubeVoid.Status(), Manifold::Error::NoError);
   EXPECT_EQ(cubeVoid.Genus(), -1);
-  const double outerBound = size / 2 + edgeLength / 2;
+  const double outerBound = size / 2;
   EXPECT_NEAR(bounds.min.x, -outerBound, epsilon);
   EXPECT_NEAR(bounds.min.y, -outerBound, epsilon);
   EXPECT_NEAR(bounds.min.z, -outerBound, epsilon);
@@ -102,7 +102,7 @@ TEST(SDF, Bounds2) {
 
   EXPECT_EQ(cubeVoid.Status(), Manifold::Error::NoError);
   EXPECT_EQ(cubeVoid.Genus(), -1);
-  const double outerBound = size / 2 + edgeLength / 2;
+  const double outerBound = size / 2;
   EXPECT_NEAR(bounds.min.x, -outerBound, epsilon);
   EXPECT_NEAR(bounds.min.y, -outerBound, epsilon);
   EXPECT_NEAR(bounds.min.z, -outerBound, epsilon);
@@ -142,7 +142,7 @@ TEST(SDF, Resize) {
   const double size = 20;
   Manifold layers = Manifold::LevelSet(Layers(), {vec3(0.0), vec3(size)}, 1);
 #ifdef MANIFOLD_EXPORT
-  if (options.exportModels) ExportMesh("layers.gltf", layers.GetMeshGL(), {});
+  if (options.exportModels) ExportMesh("layers.glb", layers.GetMeshGL(), {});
 #endif
 
   EXPECT_EQ(layers.Status(), Manifold::Error::NoError);


### PR DESCRIPTION
A final minor breaking change: I've updated our SDF so that it does not exceed its given bounds. Before we would get a funny egg-crate shape due to the body-centered cubic grid, but that seems like an internal detail that users should not need to be aware of. It doesn't seem to affect performance noticeably, so I think it's worthwhile for clarity. 