### PR TITLE
always use 64-bit integer for MeshGL64

### DIFF
--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -55,11 +55,12 @@ ManifoldMeshGL *manifold_meshgl_merge(void *mem, ManifoldMeshGL *m);
 
 ManifoldMeshGL64 *manifold_meshgl64(void *mem, double *vert_props,
                                     size_t n_verts, size_t n_props,
-                                    size_t *tri_verts, size_t n_tris);
+                                    uint64_t *tri_verts, size_t n_tris);
 
 ManifoldMeshGL64 *manifold_meshgl64_w_tangents(void *mem, double *vert_props,
                                                size_t n_verts, size_t n_props,
-                                               size_t *tri_verts, size_t n_tris,
+                                               uint64_t *tri_verts,
+                                               size_t n_tris,
                                                double *halfedge_tangent);
 ManifoldMeshGL64 *manifold_get_meshgl64(void *mem, ManifoldManifold *m);
 ManifoldMeshGL64 *manifold_meshgl64_copy(void *mem, ManifoldMeshGL64 *m);
@@ -173,7 +174,7 @@ ManifoldManifold *manifold_smooth(void *mem, ManifoldMeshGL *mesh,
                                   size_t *half_edges, double *smoothness,
                                   size_t n_idxs);
 ManifoldManifold *manifold_smooth64(void *mem, ManifoldMeshGL64 *mesh,
-                                    size_t *half_edges, double *smoothness,
+                                    uint64_t *half_edges, double *smoothness,
                                     size_t n_idxs);
 ManifoldManifold *manifold_extrude(void *mem, ManifoldPolygons *cs,
                                    double height, int slices,

--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -174,7 +174,7 @@ ManifoldManifold *manifold_smooth(void *mem, ManifoldMeshGL *mesh,
                                   size_t *half_edges, double *smoothness,
                                   size_t n_idxs);
 ManifoldManifold *manifold_smooth64(void *mem, ManifoldMeshGL64 *mesh,
-                                    uint64_t *half_edges, double *smoothness,
+                                    size_t *half_edges, double *smoothness,
                                     size_t n_idxs);
 ManifoldManifold *manifold_extrude(void *mem, ManifoldPolygons *cs,
                                    double height, int slices,

--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -406,13 +406,13 @@ size_t manifold_meshgl64_run_transform_length(ManifoldMeshGL64 *m);
 size_t manifold_meshgl64_face_id_length(ManifoldMeshGL64 *m);
 size_t manifold_meshgl64_tangent_length(ManifoldMeshGL64 *m);
 double *manifold_meshgl64_vert_properties(void *mem, ManifoldMeshGL64 *m);
-size_t *manifold_meshgl64_tri_verts(void *mem, ManifoldMeshGL64 *m);
-size_t *manifold_meshgl64_merge_from_vert(void *mem, ManifoldMeshGL64 *m);
-size_t *manifold_meshgl64_merge_to_vert(void *mem, ManifoldMeshGL64 *m);
-size_t *manifold_meshgl64_run_index(void *mem, ManifoldMeshGL64 *m);
+uint64_t *manifold_meshgl64_tri_verts(void *mem, ManifoldMeshGL64 *m);
+uint64_t *manifold_meshgl64_merge_from_vert(void *mem, ManifoldMeshGL64 *m);
+uint64_t *manifold_meshgl64_merge_to_vert(void *mem, ManifoldMeshGL64 *m);
+uint64_t *manifold_meshgl64_run_index(void *mem, ManifoldMeshGL64 *m);
 uint32_t *manifold_meshgl64_run_original_id(void *mem, ManifoldMeshGL64 *m);
 double *manifold_meshgl64_run_transform(void *mem, ManifoldMeshGL64 *m);
-size_t *manifold_meshgl64_face_id(void *mem, ManifoldMeshGL64 *m);
+uint64_t *manifold_meshgl64_face_id(void *mem, ManifoldMeshGL64 *m);
 double *manifold_meshgl64_halfedge_tangent(void *mem, ManifoldMeshGL64 *m);
 
 // memory size

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -365,7 +365,7 @@ ManifoldMeshGL *manifold_meshgl_w_tangents(void *mem, float *vert_props,
 
 ManifoldMeshGL64 *manifold_meshgl64(void *mem, double *vert_props,
                                     size_t n_verts, size_t n_props,
-                                    size_t *tri_verts, size_t n_tris) {
+                                    uint64_t *tri_verts, size_t n_tris) {
   auto mesh = new (mem) MeshGL64();
   mesh->numProp = n_props;
   mesh->vertProperties = vector_of_array(vert_props, n_verts * n_props);
@@ -375,7 +375,8 @@ ManifoldMeshGL64 *manifold_meshgl64(void *mem, double *vert_props,
 
 ManifoldMeshGL64 *manifold_meshgl64_w_tangents(void *mem, double *vert_props,
                                                size_t n_verts, size_t n_props,
-                                               size_t *tri_verts, size_t n_tris,
+                                               uint64_t *tri_verts,
+                                               size_t n_tris,
                                                double *halfedge_tangent) {
   auto mesh = new (mem) MeshGL64();
   mesh->numProp = n_props;
@@ -397,7 +398,7 @@ ManifoldManifold *manifold_smooth(void *mem, ManifoldMeshGL *mesh,
 }
 
 ManifoldManifold *manifold_smooth64(void *mem, ManifoldMeshGL64 *mesh,
-                                    size_t *half_edges, double *smoothness,
+                                    uint64_t *half_edges, double *smoothness,
                                     size_t n_edges) {
   auto smooth = std::vector<Smoothness>();
   for (size_t i = 0; i < n_edges; ++i) {

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -587,16 +587,16 @@ size_t manifold_meshgl64_tangent_length(ManifoldMeshGL64 *m) {
 double *manifold_meshgl64_vert_properties(void *mem, ManifoldMeshGL64 *m) {
   return copy_data(mem, from_c(m)->vertProperties);
 }
-size_t *manifold_meshgl64_tri_verts(void *mem, ManifoldMeshGL64 *m) {
+uint64_t *manifold_meshgl64_tri_verts(void *mem, ManifoldMeshGL64 *m) {
   return copy_data(mem, from_c(m)->triVerts);
 }
-size_t *manifold_meshgl64_merge_from_vert(void *mem, ManifoldMeshGL64 *m) {
+uint64_t *manifold_meshgl64_merge_from_vert(void *mem, ManifoldMeshGL64 *m) {
   return copy_data(mem, from_c(m)->mergeFromVert);
 }
-size_t *manifold_meshgl64_merge_to_vert(void *mem, ManifoldMeshGL64 *m) {
+uint64_t *manifold_meshgl64_merge_to_vert(void *mem, ManifoldMeshGL64 *m) {
   return copy_data(mem, from_c(m)->mergeToVert);
 }
-size_t *manifold_meshgl64_run_index(void *mem, ManifoldMeshGL64 *m) {
+uint64_t *manifold_meshgl64_run_index(void *mem, ManifoldMeshGL64 *m) {
   return copy_data(mem, from_c(m)->runIndex);
 }
 uint32_t *manifold_meshgl64_run_original_id(void *mem, ManifoldMeshGL64 *m) {
@@ -605,7 +605,7 @@ uint32_t *manifold_meshgl64_run_original_id(void *mem, ManifoldMeshGL64 *m) {
 double *manifold_meshgl64_run_transform(void *mem, ManifoldMeshGL64 *m) {
   return copy_data(mem, from_c(m)->runTransform);
 }
-size_t *manifold_meshgl64_face_id(void *mem, ManifoldMeshGL64 *m) {
+uint64_t *manifold_meshgl64_face_id(void *mem, ManifoldMeshGL64 *m) {
   return copy_data(mem, from_c(m)->faceID);
 }
 double *manifold_meshgl64_halfedge_tangent(void *mem, ManifoldMeshGL64 *m) {

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -398,7 +398,7 @@ ManifoldManifold *manifold_smooth(void *mem, ManifoldMeshGL *mesh,
 }
 
 ManifoldManifold *manifold_smooth64(void *mem, ManifoldMeshGL64 *mesh,
-                                    uint64_t *half_edges, double *smoothness,
+                                    size_t *half_edges, double *smoothness,
                                     size_t n_edges) {
   auto smooth = std::vector<Smoothness>();
   for (size_t i = 0; i < n_edges; ++i) {

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -597,19 +597,19 @@ NB_MODULE(manifold3d, m) {
           "__init__",
           [](MeshGL64 *self,
              nb::ndarray<double, nb::shape<-1, -1>, nb::c_contig> &vertProp,
-             nb::ndarray<size_t, nb::shape<-1, 3>, nb::c_contig> &triVerts,
-             const std::optional<nb::ndarray<size_t, nb::shape<-1>,
+             nb::ndarray<uint64_t, nb::shape<-1, 3>, nb::c_contig> &triVerts,
+             const std::optional<nb::ndarray<uint64_t, nb::shape<-1>,
                                              nb::c_contig>> &mergeFromVert,
+             const std::optional<nb::ndarray<uint64_t, nb::shape<-1>,
+                                             nb::c_contig>> &mergeToVert,
              const std::optional<
-                 nb::ndarray<size_t, nb::shape<-1>, nb::c_contig>> &mergeToVert,
-             const std::optional<
-                 nb::ndarray<size_t, nb::shape<-1>, nb::c_contig>> &runIndex,
+                 nb::ndarray<uint64_t, nb::shape<-1>, nb::c_contig>> &runIndex,
              const std::optional<nb::ndarray<uint32_t, nb::shape<-1>,
                                              nb::c_contig>> &runOriginalID,
              std::optional<nb::ndarray<double, nb::shape<-1, 4, 3>,
                                        nb::c_contig>> &runTransform,
              const std::optional<
-                 nb::ndarray<size_t, nb::shape<-1>, nb::c_contig>> &faceID,
+                 nb::ndarray<uint64_t, nb::shape<-1>, nb::c_contig>> &faceID,
              const std::optional<nb::ndarray<double, nb::shape<-1, 3, 4>,
                                              nb::c_contig>> &halfedgeTangent,
              float tolerance) {

--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -166,7 +166,7 @@ using MeshGL = MeshGLP<float>;
 /**
  * @brief Double-precision, 64-bit indices - best for huge meshes.
  */
-using MeshGL64 = MeshGLP<double, size_t>;
+using MeshGL64 = MeshGLP<double, uint64_t>;
 
 /**
  * @brief This library's internal representation of an oriented, 2-manifold,

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -323,7 +323,7 @@ MeshGL Manifold::GetMeshGL(int normalIdx) const {
  */
 MeshGL64 Manifold::GetMeshGL64(int normalIdx) const {
   const Impl& impl = *GetCsgLeafNode().GetImpl();
-  return GetMeshGLImpl<double, size_t>(impl, normalIdx);
+  return GetMeshGLImpl<double, uint64_t>(impl, normalIdx);
 }
 
 /**


### PR DESCRIPTION
Addresses comment in #1036.