### PR TITLE
free temporary vectors earlier

### DIFF
--- a/src/boolean3.cpp
+++ b/src/boolean3.cpp
@@ -573,6 +573,11 @@ Boolean3::Boolean3(const Manifold::Impl &inP, const Manifold::Impl &inQ,
       Intersect12(inQ, inP, s20, p2q0, s11, p1q1, z20, xyzz11, p2q1_, false);
   PRINT("x21 size = " << x21_.size());
 
+  s11.clear();
+  xyzz11.clear();
+  z02.clear();
+  z20.clear();
+
   Vec<int> p0 = p0q2.Copy(false);
   p0q2.Resize(0);
   Vec<int> q0 = p2q0.Copy(true);

--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -778,11 +778,17 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   AddNewEdgeVerts(edgesP, edgesNew, p1q2_, i12, v12R, inP_.halfedge_, true);
   AddNewEdgeVerts(edgesQ, edgesNew, p2q1_, i21, v21R, inQ_.halfedge_, false);
 
+  v12R.clear();
+  v21R.clear();
+
   // Level 4
   Vec<int> faceEdge;
   Vec<int> facePQ2R;
   std::tie(faceEdge, facePQ2R) =
       SizeOutput(outR, inP_, inQ_, i03, i30, i12, i21, p1q2_, p2q1_, invertQ);
+
+  i12.clear();
+  i21.clear();
 
   // This gets incremented for each halfedge that's added to a face so that the
   // next one knows where to slot in.
@@ -799,13 +805,27 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   AppendPartialEdges(outR, wholeHalfedgeQ, facePtrR, edgesQ, halfedgeRef, inQ_,
                      i30, vQ2R, facePQ2R.begin() + inP_.NumTri(), false);
 
+  edgesP.clear();
+  edgesQ.clear();
+
   AppendNewEdges(outR, facePtrR, edgesNew, halfedgeRef, facePQ2R,
                  inP_.NumTri());
+
+  edgesNew.clear();
 
   AppendWholeEdges(outR, facePtrR, halfedgeRef, inP_, wholeHalfedgeP, i03, vP2R,
                    facePQ2R.cview(0, inP_.NumTri()), true);
   AppendWholeEdges(outR, facePtrR, halfedgeRef, inQ_, wholeHalfedgeQ, i30, vQ2R,
                    facePQ2R.cview(inP_.NumTri(), inQ_.NumTri()), false);
+
+  wholeHalfedgeP.clear();
+  wholeHalfedgeQ.clear();
+  facePtrR.clear();
+  facePQ2R.clear();
+  i03.clear();
+  i30.clear();
+  vP2R.clear();
+  vQ2R.clear();
 
 #ifdef MANIFOLD_DEBUG
   assemble.Stop();
@@ -819,6 +839,8 @@ Manifold::Impl Boolean3::Result(OpType op) const {
     DEBUG_ASSERT(outR.IsManifold(), logicErr, "polygon mesh is not manifold!");
 
   outR.Face2Tri(faceEdge, halfedgeRef);
+  halfedgeRef.clear();
+  faceEdge.clear();
 
 #ifdef MANIFOLD_DEBUG
   triangulate.Stop();


### PR DESCRIPTION
Reduces peak memory usage when running `extras/perfTest` from 6237MB to 5613MB. (for memory tracked by tracy, i.e. our vectors)