### PR TITLE
manifold alias

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,7 @@ if(TBB_INCLUDE_DIRS)
 endif()
 
 add_library(manifold ${MANIFOLD_SRCS} ${MANIFOLD_PRIVATE_HDRS})
+add_library(manifold::manifold ALIAS manifold)
 set_property(TARGET manifold PROPERTY VERSION "${MANIFOLD_VERSION}")
 set_property(TARGET manifold PROPERTY SOVERSION ${MANIFOLD_VERSION_MAJOR})
 if(MSVC)


### PR DESCRIPTION
For openscad/openscad#5308, basically let them link against `manifold::manifold` regardless if our library is installed or put in a subdirectory.