### PR TITLE
Provide a numeric version number to compare against.

### DIFF
--- a/cmake/version.h.in
+++ b/cmake/version.h.in
@@ -17,3 +17,13 @@
 #define MANIFOLD_VERSION_MAJOR @MANIFOLD_VERSION_MAJOR@
 #define MANIFOLD_VERSION_MINOR @MANIFOLD_VERSION_MINOR@
 #define MANIFOLD_VERSION_PATCH @MANIFOLD_VERSION_PATCH@
+
+// Comparable version numbers to check version in code or preprocessing.
+// Check if your minimum requirements are met with e.g.
+//  MANIFOLD_VERSION > MANIFOLD_VERSION_NUMBER(2, 5, 1)
+#define MANIFOLD_VERSION_NUMBER(v_major, v_minor, v_patch) \
+  (((v_major) * 1000000) + ((v_minor) * 1000) + (v_patch))
+
+#define MANIFOLD_VERSION MANIFOLD_VERSION_NUMBER(MANIFOLD_VERSION_MAJOR, \
+                                                 MANIFOLD_VERSION_MINOR, \
+                                                 MANIFOLD_VERSION_PATCH)

--- a/scripts/test-cmake.sh
+++ b/scripts/test-cmake.sh
@@ -13,6 +13,11 @@ EOT
 cat <<EOT > test.cpp
 #include <manifold/manifold.h>
 #include <manifold/version.h>
+
+#if MANIFOLD_VERSION < MANIFOLD_VERSION_NUMBER(2, 5, 1)
+# error "Unexpected: minimum version number not available"
+#endif
+
 int main() { manifold::Manifold foo; return 0; }
 EOT
 
@@ -21,4 +26,3 @@ cd build
 cmake ..
 make
 ./testing
-

--- a/scripts/test-pkgconfig.sh
+++ b/scripts/test-pkgconfig.sh
@@ -12,6 +12,11 @@ EOT
 cat <<EOT > testing.cpp
 #include <manifold/manifold.h>
 #include <manifold/version.h>
+
+#if MANIFOLD_VERSION < MANIFOLD_VERSION_NUMBER(2, 5, 1)
+# error "Unexpected: minimum version number not available"
+#endif
+
 int main() { manifold::Manifold foo; return 0; }
 EOT
 


### PR DESCRIPTION
Including simple example in version.h.in and checking in the test-{cmake,pkgconfig}.sh scripts.