### PR TITLE
Fix publishing

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -19,9 +19,9 @@ jobs:
           git config --global submodule.fetchJobs 8
           git config --global core.longpaths true
       - if: matrix.os == 'macos-13'
-        run: echo "CIBW_ARCHS=\"x86_64\"" >> "$GITHUB_ENV"
+        run: echo "CIBW_ARCHS=x86_64" >> "$GITHUB_ENV"
       - if: matrix.os == 'macos-14'
-        run: echo "CIBW_ARCHS=\"arm64 universal2\"" >> "$GITHUB_ENV"
+        run: echo "CIBW_ARCHS=arm64 universal2" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -18,6 +18,10 @@ jobs:
       - run: |
           git config --global submodule.fetchJobs 8
           git config --global core.longpaths true
+      - if: matrix.os == 'macos-13'
+        run: echo "CIBW_SKIP=\"*_arm64 *_universal2\"" >> "$GITHUB_ENV"
+      - if: matrix.os == 'macos-14'
+        run: echo "CIBW_SKIP=\"*_x86-64\"" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -19,9 +19,9 @@ jobs:
           git config --global submodule.fetchJobs 8
           git config --global core.longpaths true
       - if: matrix.os == 'macos-13'
-        run: echo "CIBW_ARCH=\"x86-64\"" >> "$GITHUB_ENV"
+        run: echo "CIBW_ARCHS=\"x86-64\"" >> "$GITHUB_ENV"
       - if: matrix.os == 'macos-14'
-        run: echo "CIBW_ARCH=\"arm64 universal2\"" >> "$GITHUB_ENV"
+        run: echo "CIBW_ARCHS=\"arm64 universal2\"" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2019, macos-latest]
+        # macos-13: x86-64
+        # macos-14: arm64
+        os: [ubuntu-22.04, windows-2019, macos-14, macos-13]
     steps:
       - run: |
           git config --global submodule.fetchJobs 8

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -19,7 +19,7 @@ jobs:
           git config --global submodule.fetchJobs 8
           git config --global core.longpaths true
       - if: matrix.os == 'macos-13'
-        run: echo "CIBW_ARCHS=\"x86-64\"" >> "$GITHUB_ENV"
+        run: echo "CIBW_ARCHS=\"x86_64\"" >> "$GITHUB_ENV"
       - if: matrix.os == 'macos-14'
         run: echo "CIBW_ARCHS=\"arm64 universal2\"" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -19,9 +19,9 @@ jobs:
           git config --global submodule.fetchJobs 8
           git config --global core.longpaths true
       - if: matrix.os == 'macos-13'
-        run: echo "CIBW_SKIP=\"*_arm64 *_universal2\"" >> "$GITHUB_ENV"
+        run: echo "CIBW_ARCH=\"x86-64\"" >> "$GITHUB_ENV"
       - if: matrix.os == 'macos-14'
-        run: echo "CIBW_SKIP=\"*_x86-64\"" >> "$GITHUB_ENV"
+        run: echo "CIBW_ARCH=\"arm64 universal2\"" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         mv ./docs ./public
 
     - name: Download built examples
-      uses: dawidd6/action-download-artifact@v3
+      uses: dawidd6/action-download-artifact@v6
       with:
         workflow: manifold.yml
         workflow_conclusion: completed

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -15,11 +15,11 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: 20
         registry-url: 'https://registry.npmjs.org'
 
     - name: Download built examples
-      uses: dawidd6/action-download-artifact@v3
+      uses: dawidd6/action-download-artifact@v6
       with:
         workflow: manifold.yml
         workflow_conclusion: completed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,9 +211,11 @@ include(${PROJECT_SOURCE_DIR}/cmake/configHelper.cmake)
 
 add_subdirectory(src)
 add_subdirectory(bindings)
-add_subdirectory(samples)
-add_subdirectory(test)
-add_subdirectory(extras)
+if(MANIFOLD_TEST)
+  add_subdirectory(samples)
+  add_subdirectory(test)
+  add_subdirectory(extras)
+endif()
 
 include(${PROJECT_SOURCE_DIR}/cmake/info.cmake)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,8 @@ before-all = "git clone --depth 1 --branch v2021.10.0 https://github.com/oneapi-
 "cmake.define.FETCHCONTENT_UPDATES_DISCONNECTED" = "ON"
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]
+archs = ["universal2"]
 environment = "MACOSX_DEPLOYMENT_TARGET=10.14"
-test-skip = "*-macosx_arm64 *-macosx_universal2:arm64"
 
 [tool.cibuildwheel.windows]
 before-build = "pip install delvewheel"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ before-all = "git clone --depth 1 --branch v2021.10.0 https://github.com/oneapi-
 "cmake.define.FETCHCONTENT_UPDATES_DISCONNECTED" = "ON"
 
 [tool.cibuildwheel.macos]
-archs = ["universal2"]
+archs = ["x86_64", "arm64", "universal2"]
 environment = "MACOSX_DEPLOYMENT_TARGET=10.14"
 
 [tool.cibuildwheel.windows]


### PR DESCRIPTION
Looks like our [npm](https://github.com/elalish/manifold/actions/runs/11886415327/job/33117548674) and [PyPI](https://github.com/elalish/manifold/actions/runs/11886415289/job/33117549096) publishing workflows failed again. The npm one failed because it didn't pick up our artifacts - I'm taking a shot in the dark that bumping our actions versions might help. 

There seem to be two different problems for Python, which are more baffling. Ubuntu works, and MacOS works for almost everything, but its x86_64 wheel is failing saying it needs 'arm64e' or 'arm64', which seems odd. And the the SDist failed because apparently CMake can't manage to add the `test`, `samples`, or `extras` directories (??). Seems to work fine everywhere else...

@pca006132 any thoughts?