### PR TITLE
Fix action

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -18,8 +18,6 @@ jobs:
       - run: |
           git config --global submodule.fetchJobs 8
           git config --global core.longpaths true
-      - if: matrix.os == 'macos-13'
-        run: echo "CIBW_ARCHS=x86_64" >> "$GITHUB_ENV"
       - if: matrix.os == 'macos-14'
         run: echo "CIBW_ARCHS=arm64 universal2" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,11 @@
 name: Deploy documentation 
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: [CI]
+    types:
+      - completed
+    branches: [master]
 
 jobs:
   deploy_github_pages:
@@ -26,10 +28,14 @@ jobs:
       with:
         workflow: manifold.yml
         workflow_conclusion: completed
-        event: push
+        branch: maser
+        # specific to the triggering workflow
+        run_id: ${{github.event.workflow_run.id}}
+        # do not download from old run
+        check_artifacts: true 
         name: wasm
         path: ./public
-        
+
     - name: Deploy Javascript Docs to Github Pages
       run: |
         cd bindings/wasm

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -1,6 +1,6 @@
 name: publish_npm
 
-on: 
+on:
   release:
     types: [published]
   workflow_dispatch:
@@ -23,6 +23,8 @@ jobs:
       with:
         workflow: manifold.yml
         workflow_conclusion: completed
+        branch: master
+        check_artifact: true
         name: wasm
         path: ./bindings/wasm/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ before-all = "git clone --depth 1 --branch v2021.10.0 https://github.com/oneapi-
 "cmake.define.FETCHCONTENT_UPDATES_DISCONNECTED" = "ON"
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64", "universal2"]
 environment = "MACOSX_DEPLOYMENT_TARGET=10.14"
 
 [tool.cibuildwheel.windows]


### PR DESCRIPTION
Closes #1058.

1. Simplified python `build_wheels.yaml` action a bit. The architecture is default to native only, so we don't have to explicitly tell x86_64 to only run x86_64 builds.
2. Use workflow complete to trigger deployment workflow, so the deployment workflow will wait for the CI workflow to complete. Note that this also means if anything in the CI workflow failed, the deployment workflow will not be triggered. And this is only triggered when the CI workflow is triggered by pushing to the master branch.
3. Limit artifact search for deployment and publish_npm to artifacts uploaded from actions from the master branch.

Previously, the deployment event runs when we push to master, i.e. when a PR is merged. When there is only one active PR, things are fine because the latest wasm artifact is the expected one. However, when there are multiple events, the CI will search for the last artifact, which may not be the result from the merged PR. We now try to wait until the master branch CI workflow is complete, and limit the artifact search to artifact produced by workflow run from the master branch. This should avoid downloading an incorrect artifact.

For publish_npm, I can't make it wait for the latest master branch without using external actions like https://github.com/marketplace/actions/wait-on-check. And I feel like we probably won't be pushing to master with large changes to wasm binaries and immediately do a publish, so it should be fine...?