### PR TITLE
fix download-artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,6 @@ jobs:
       with:
         workflow: manifold.yml
         workflow_conclusion: completed
-        branch: maser
         # specific to the triggering workflow
         run_id: ${{github.event.workflow_run.id}}
         # do not download from old run

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -24,7 +24,7 @@ jobs:
         workflow: manifold.yml
         workflow_conclusion: completed
         branch: master
-        check_artifact: true
+        check_artifacts: true
         name: wasm
         path: ./bindings/wasm/
 


### PR DESCRIPTION
I think this'll fix our WASM deployment. The error was `The following inputs cannot be used together: pr, commit, branch, run_id`