### PR TITLE
cancel in-progress runs upon new push

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   build:
     name: CrossSection:${{matrix.cross_section}} ${{matrix.parallelization == 'ON'}} GCC ${{matrix.gcc}}
@@ -155,7 +159,6 @@ jobs:
     strategy:
       matrix:
         parallelization: [OFF, ON]
-      max-parallel: 1
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v4
@@ -185,7 +188,6 @@ jobs:
     strategy:
       matrix:
         parallelization: [OFF, ON]
-      max-parallel: 1
     runs-on: ubuntu-latest
     container: openscad/mxe-x86_64-gui:latest
     steps:


### PR DESCRIPTION
Thought it is a bit wasteful to keep running the old job when we push some new commits. This will now cancel the old job.

And this removes the parallel limit for some builds, I forgot why they were there in the first place, probably copied from openscad?