### PR TITLE
update lcov excludes

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -74,7 +74,7 @@ jobs:
         cd ../
         lcov --capture --gcov-tool gcov-${{ matrix.gcc }} --ignore-errors mismatch --directory . --output-file ./code_coverage_test.info
         lcov --add-tracefile ./code_coverage_init.info --add-tracefile ./code_coverage_test.info --output-file ./code_coverage_total.info
-        lcov --remove ./code_coverage_total.info '/usr/*' '*/test/*' '*/extras/*' '*/bindings/*' --output-file ./code_coverage.info
+        lcov --remove ./code_coverage_total.info '/usr/*' '/*/test/*' '/*/extras/*' '/*/bindings/*' --output-file ./code_coverage.info
         cd ../
     - uses: codecov/codecov-action@v5
       if: matrix.parallelization == 'OFF'

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -67,14 +67,14 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PAR=${{matrix.parallelization}} -DCODE_COVERAGE=ON .. && make
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_CROSS_SECTION=${{matrix.cross_section}} -DMANIFOLD_PAR=${{matrix.parallelization}} -DCODE_COVERAGE=ON .. && make
         lcov --capture --gcov-tool gcov-${{ matrix.gcc }} --ignore-errors mismatch --initial --directory . --output-file ./code_coverage_init.info
         cd test
         ./manifold_test
         cd ../
         lcov --capture --gcov-tool gcov-${{ matrix.gcc }} --ignore-errors mismatch --directory . --output-file ./code_coverage_test.info
         lcov --add-tracefile ./code_coverage_init.info --add-tracefile ./code_coverage_test.info --output-file ./code_coverage_total.info
-        lcov --remove ./code_coverage_total.info "/usr/*"" "/*/test/*" "/*/extras/*" "/*/bindings/*" --output-file ./code_coverage.info
+        lcov --remove ./code_coverage_total.info "/usr/*" "/*/test/*" "/*/extras/*" "/*/bindings/*" "/*/include/*" --output-file ./code_coverage.info
         cd ../
     - uses: codecov/codecov-action@v5
       if: matrix.parallelization == 'OFF'

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -213,7 +213,7 @@ jobs:
     steps:
     - name: Install common dependencies
       run: |
-        brew install pkg-config googletest assimp
+        brew install pkgconf googletest assimp
         pip install trimesh pytest
     - name: Install TBB
       if: matrix.parallelization == 'ON'
@@ -244,7 +244,7 @@ jobs:
     steps:
     - name: Install common dependencies
       run: |
-        brew install pkg-config googletest
+        brew install pkgconf googletest
         pip install trimesh pytest
     - uses: actions/checkout@v4
     - uses: jwlawson/actions-setup-cmake@v2
@@ -272,7 +272,7 @@ jobs:
     steps:
     - name: Install common dependencies
       run: |
-        brew install pkg-config googletest
+        brew install pkgconf googletest
         pip install trimesh pytest
     - uses: actions/checkout@v4
     - uses: jwlawson/actions-setup-cmake@v2

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -213,7 +213,7 @@ jobs:
     steps:
     - name: Install common dependencies
       run: |
-        brew install pkgconf googletest assimp
+        brew install googletest assimp
         pip install trimesh pytest
     - name: Install TBB
       if: matrix.parallelization == 'ON'
@@ -244,7 +244,7 @@ jobs:
     steps:
     - name: Install common dependencies
       run: |
-        brew install pkgconf googletest
+        brew install googletest
         pip install trimesh pytest
     - uses: actions/checkout@v4
     - uses: jwlawson/actions-setup-cmake@v2
@@ -272,7 +272,7 @@ jobs:
     steps:
     - name: Install common dependencies
       run: |
-        brew install pkgconf googletest
+        brew install googletest
         pip install trimesh pytest
     - uses: actions/checkout@v4
     - uses: jwlawson/actions-setup-cmake@v2

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -74,7 +74,7 @@ jobs:
         cd ../
         lcov --capture --gcov-tool gcov-${{ matrix.gcc }} --ignore-errors mismatch --directory . --output-file ./code_coverage_test.info
         lcov --add-tracefile ./code_coverage_init.info --add-tracefile ./code_coverage_test.info --output-file ./code_coverage_total.info
-        lcov --remove ./code_coverage_total.info '/usr/*' '/*/test/*' '/*/extras/*' '/*/bindings/*' --output-file ./code_coverage.info
+        lcov --remove ./code_coverage_total.info "/usr/*"" "/*/test/*" "/*/extras/*" "/*/bindings/*" --output-file ./code_coverage.info
         cd ../
     - uses: codecov/codecov-action@v5
       if: matrix.parallelization == 'OFF'

--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -444,7 +444,7 @@ TEST(Smooth, SDF) {
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) {
     ExportOptions options2;
-    ExportMesh("smoothGyroid.glb", gyroid.GetMeshGL(), options2);
+    ExportMesh("smoothGyroid.glb", smoothed.GetMeshGL(), options2);
   }
 #endif
 }


### PR DESCRIPTION
Fixes #1066 - looks like `pkg-config` is now part of the mac image by default. 

Seems we're not excluding the lcov directories we were intending to anymore - supposedly this syntax may fix it.