### PR TITLE
Added Valence 3D to Users in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Here is an incomplete list of our users, whose integrations may be anywhere from
 | [Godot Engine](https://godotengine.org/) | [OCADml](https://github.com/OCADml/OManifold) | [Flitter](https://flitter.readthedocs.io/en/latest/) |
 | [BRL-CAD](https://brlcad.org/) | [PolygonJS](https://polygonjs.com/) | [Spherene](https://spherene.ch/) |
 | [Babylon.js](https://doc.babylonjs.com/features/featuresDeepDive/mesh/mergeMeshes#merging-meshes-with-constructive-solid-geometry) | [trimesh](https://trimesh.org/) | [Gypsum](https://github.com/playkostudios/gypsum) |
+| [Valence 3D](https://apps.apple.com/us/app/valence-3d/id6450967410?mt=8&platform=ipad) |
 
 ### Bindings & Packages
 


### PR DESCRIPTION
Added Valence 3D to Users in README.md 

I'm using manifold perform robust boolean operations in Valence 3D. A trim by plane will land next week and its powered by Manifold's TrimByPlane method. 