### PR TITLE
feat: add C binding for Manifold::NumProp()

### DIFF
--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -195,6 +195,7 @@ ManifoldError manifold_status(ManifoldManifold *m);
 size_t manifold_num_vert(ManifoldManifold *m);
 size_t manifold_num_edge(ManifoldManifold *m);
 size_t manifold_num_tri(ManifoldManifold *m);
+size_t manifold_num_prop(ManifoldManifold *m);
 ManifoldBox *manifold_bounding_box(void *mem, ManifoldManifold *m);
 double manifold_epsilon(ManifoldManifold *m);
 int manifold_genus(ManifoldManifold *m);

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -633,6 +633,7 @@ ManifoldError manifold_status(ManifoldManifold *m) {
 size_t manifold_num_vert(ManifoldManifold *m) { return from_c(m)->NumVert(); }
 size_t manifold_num_edge(ManifoldManifold *m) { return from_c(m)->NumEdge(); }
 size_t manifold_num_tri(ManifoldManifold *m) { return from_c(m)->NumTri(); }
+size_t manifold_num_prop(ManifoldManifold *m) { return from_c(m)->NumProp(); };
 int manifold_genus(ManifoldManifold *m) { return from_c(m)->Genus(); }
 
 double manifold_surface_area(ManifoldManifold *m) {

--- a/test/manifoldc_test.cpp
+++ b/test/manifoldc_test.cpp
@@ -294,10 +294,15 @@ TEST(CBIND, properties) {
 
   ManifoldManifold *cube =
       manifold_cube(alloc_manifold_buffer(), 1.0, 1.0, 1.0, 1);
+  EXPECT_EQ(manifold_num_prop(cube), 0);
+
   ManifoldManifold *cube_props =
       manifold_set_properties(alloc_manifold_buffer(), cube, 1, props, NULL);
+  EXPECT_EQ(manifold_num_prop(cube_props), 1);
+
   ManifoldManifold *cube_props_context = manifold_set_properties(
       alloc_manifold_buffer(), cube, 1, propscontext, context);
+  EXPECT_EQ(manifold_num_prop(cube_props_context), 1);
 
   manifold_destruct_manifold(cube);
   manifold_destruct_manifold(cube_props);


### PR DESCRIPTION
Answers https://github.com/elalish/manifold/discussions/1075

Introduced a new function to the C bindings: `manifold_num_prop`. This function retrieves the number of properties associated with a Manifold object. Added corresponding tests to validate its integration.