### PR TITLE
make format run in parallel

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -5,25 +5,27 @@ if [ -z "$CLANG_FORMAT" ]; then
 CLANG_FORMAT=clang-format
 fi
 
-$CLANG_FORMAT -i extras/*.cpp
-$CLANG_FORMAT -i samples/*/*.{h,cpp}
-$CLANG_FORMAT -i test/*.{h,cpp}
-$CLANG_FORMAT -i bindings/*/*.cpp
-$CLANG_FORMAT -i bindings/c/include/manifold/*.h
-$CLANG_FORMAT -i bindings/wasm/*.{js,ts}
-$CLANG_FORMAT -i bindings/wasm/examples/*.{js,ts,html}
-$CLANG_FORMAT -i bindings/wasm/examples/public/*.{js,ts}
-$CLANG_FORMAT -i src/*.{h,cpp}
-$CLANG_FORMAT -i src/*/*.cpp
-$CLANG_FORMAT -i include/manifold/*.h
+$CLANG_FORMAT -i extras/*.cpp &
+$CLANG_FORMAT -i samples/*/*.{h,cpp} &
+$CLANG_FORMAT -i test/*.{h,cpp} &
+$CLANG_FORMAT -i bindings/*/*.cpp &
+$CLANG_FORMAT -i bindings/c/include/manifold/*.h &
+$CLANG_FORMAT -i bindings/wasm/*.{js,ts} &
+$CLANG_FORMAT -i bindings/wasm/examples/*.{js,ts,html} &
+$CLANG_FORMAT -i bindings/wasm/examples/public/*.{js,ts} &
+$CLANG_FORMAT -i src/*.{h,cpp} &
+$CLANG_FORMAT -i src/*/*.cpp &
+$CLANG_FORMAT -i include/manifold/*.h &
 
-black bindings/python/examples/*.py
+black --quiet bindings/python/examples/*.py &
 
 for pattern in 'CMakeLists.txt' '*.cmake*'; do
   for f in $(find -name ${pattern}); do
     # skip build directories
     if [[ $f != *build* && $f != *node_modules* ]]; then
-      gersemi -i $f
+      gersemi --no-warn-about-unknown-commands -i $f &
     fi
   done
 done
+
+wait


### PR DESCRIPTION
Originally, the format script will block for about 2s because things are run in sequence, and this will cause git commit to lag when this is added to git commit hook. This is basically instant now (takes ~0.2s).