### PR TITLE
avoid recursion in csg tree

### DIFF
--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -624,6 +624,8 @@ CsgNodeType CsgOpNode::GetNodeType() const {
     case OpType::Intersect:
       return CsgNodeType::Intersection;
   }
+  // unreachable...
+  return CsgNodeType::Leaf;
 }
 
 mat3x4 CsgOpNode::GetTransform() const { return transform_; }

--- a/src/csg_tree.h
+++ b/src/csg_tree.h
@@ -77,7 +77,7 @@ class CsgOpNode final : public CsgNode {
 
   std::shared_ptr<CsgLeafNode> ToLeafNode() const override;
 
-  CsgNodeType GetNodeType() const override { return op_; }
+  CsgNodeType GetNodeType() const override;
 
   mat3x4 GetTransform() const override;
 
@@ -87,22 +87,10 @@ class CsgOpNode final : public CsgNode {
     bool forcedToLeafNodes_ = false;
   };
   mutable ConcurrentSharedPtr<Impl> impl_ = ConcurrentSharedPtr<Impl>(Impl{});
-  CsgNodeType op_;
+  OpType op_;
   mat3x4 transform_ = la::identity;
   // the following fields are for lazy evaluation, so they are mutable
   mutable std::shared_ptr<CsgLeafNode> cache_ = nullptr;
-
-  void SetOp(OpType);
-  bool IsOp(OpType op);
-
-  static std::shared_ptr<Manifold::Impl> BatchBoolean(
-      OpType operation,
-      std::vector<std::shared_ptr<const Manifold::Impl>> &results);
-
-  void BatchUnion() const;
-
-  std::vector<std::shared_ptr<CsgNode>> &GetChildren(
-      bool forceToLeafNodes = true) const;
 };
 
 }  // namespace manifold


### PR DESCRIPTION
Fixes #989.

This refactors the code into a single loop that does dfs on the csg tree, and perform flattening on-the-fly. 

There are still some failures, I guess this is due to shared nodes being evaluated in a weird way... Will try to fix it soon. But for now I think the logic is mostly there and should be ready for review.

For comparison:
```
// before
n = 20
nTri = 91814, time = 2.28608 sec
n = 30
nTri = 279334, time = 20.6878 sec

// after
n = 20
nTri = 91814, time = 1.18475 sec
n = 30
nTri = 279334, time = 5.67487 sec
```