### PR TITLE
finer timing in ManifoldCAD.org

### DIFF
--- a/bindings/wasm/examples/editor.js
+++ b/bindings/wasm/examples/editor.js
@@ -434,16 +434,11 @@ function disableCancel() {
   runButton.classList.remove('red', 'cancel');
 }
 
-let t0 = performance.now();
-
 function finishRun() {
   disableCancel();
-  const t1 = performance.now();
   const log = consoleElement.textContent;
   // Remove "Running..."
   consoleElement.textContent = log.substring(log.indexOf('\n') + 1);
-  console.log(
-      `Took ${(Math.round((t1 - t0) / 10) / 100).toLocaleString()} seconds`);
 }
 
 const output = {
@@ -501,7 +496,6 @@ async function run() {
   console.log('Running...');
   const output = await tsWorker.getEmitOutput(editor.getModel().uri.toString());
   manifoldWorker.postMessage(output.outputFiles[0].text);
-  t0 = performance.now();
 }
 
 function cancel() {

--- a/bindings/wasm/examples/worker.ts
+++ b/bindings/wasm/examples/worker.ts
@@ -186,6 +186,7 @@ let timesAccessor: Accessor;
 let weightsAccessor: Accessor;
 let weightsSampler: AnimationSampler;
 let hasAnimation: boolean;
+let t0 = 0;
 
 export function cleanup() {
   for (const obj of memoryRegistry) {
@@ -736,6 +737,10 @@ async function exportModels(defaults: GlobalDefaults, manifold?: Manifold) {
     to3mf.items.push({objectID: `${object2globalID.get(manifold)}`});
   }
 
+  const t1 = performance.now();
+  console.log(`Manifold took ${
+      (Math.round((t1 - t0) / 10) / 100).toLocaleString()} seconds`);
+
   if (!hasAnimation) {
     timesAccessor.dispose();
     weightsAccessor.dispose();
@@ -758,6 +763,10 @@ async function exportModels(defaults: GlobalDefaults, manifold?: Manifold) {
   const blob3MF = new Blob(
       [zipFile],
       {type: 'application/vnd.ms-package.3dmanufacturing-3dmodel+xml'});
+
+  const t2 = performance.now();
+  console.log(`Exporting GLB & 3MF took ${
+      (Math.round((t2 - t1) / 10) / 100).toLocaleString()} seconds`);
 
   return ({
     glbURL: URL.createObjectURL(blobGLB),
@@ -786,6 +795,7 @@ function evaluateCADToManifold(code: string) {
 }
 
 export async function evaluateCADToModel(code: string) {
+  t0 = performance.now();
   const {globalDefaults, manifold} = evaluateCADToManifold(code);
   return await exportModels(globalDefaults, manifold);
 }


### PR DESCRIPTION
I've been playing around with timing our mesh smoothing SDF vs increasing SDF resolution, but the timings were giving me odd results: see this ManifoldCAD [example](https://tinyurl.com/2226r5e4). Turns out most of the time was being spent in file export, not the actual Manifold library. So here I've split the timing into two parts: Manifold time and export time. 

However, during the process I found that GLB export is next to instant - the real time killer is 3MF export, particularly the zip. I'm thinking now it would be better to do the 3MF export on save rather than on run. I wonder if we can just pass the whole `to3mf` JSON object out of the worker? Makes the API a bit less clean, but...