### PR TITLE
refactor: change return type to size_t for cross section vertex/contour count

### DIFF
--- a/bindings/c/cross.cpp
+++ b/bindings/c/cross.cpp
@@ -213,11 +213,11 @@ double manifold_cross_section_area(ManifoldCrossSection *cs) {
   return from_c(cs)->Area();
 }
 
-int manifold_cross_section_num_vert(ManifoldCrossSection *cs) {
+size_t manifold_cross_section_num_vert(ManifoldCrossSection *cs) {
   return from_c(cs)->NumVert();
 }
 
-int manifold_cross_section_num_contour(ManifoldCrossSection *cs) {
+size_t manifold_cross_section_num_contour(ManifoldCrossSection *cs) {
   return from_c(cs)->NumContour();
 }
 

--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -310,8 +310,8 @@ ManifoldCrossSection *manifold_cross_section_offset(
 // CrossSection Info
 
 double manifold_cross_section_area(ManifoldCrossSection *cs);
-int manifold_cross_section_num_vert(ManifoldCrossSection *cs);
-int manifold_cross_section_num_contour(ManifoldCrossSection *cs);
+size_t manifold_cross_section_num_vert(ManifoldCrossSection *cs);
+size_t manifold_cross_section_num_contour(ManifoldCrossSection *cs);
 int manifold_cross_section_is_empty(ManifoldCrossSection *cs);
 ManifoldRect *manifold_cross_section_bounds(void *mem,
                                             ManifoldCrossSection *cs);

--- a/include/manifold/cross_section.h
+++ b/include/manifold/cross_section.h
@@ -119,8 +119,8 @@ class CrossSection {
    */
   ///@{
   bool IsEmpty() const;
-  int NumVert() const;
-  int NumContour() const;
+  size_t NumVert() const;
+  size_t NumContour() const;
   Rect Bounds() const;
   double Area() const;
   ///@}

--- a/src/cross_section/cross_section.cpp
+++ b/src/cross_section/cross_section.cpp
@@ -740,8 +740,8 @@ double CrossSection::Area() const { return C2::Area(GetPaths()->paths_); }
 /**
  * Return the number of vertices in the CrossSection.
  */
-int CrossSection::NumVert() const {
-  int n = 0;
+size_t CrossSection::NumVert() const {
+  size_t n = 0;
   auto paths = GetPaths()->paths_;
   for (auto p : paths) {
     n += p.size();
@@ -753,7 +753,7 @@ int CrossSection::NumVert() const {
  * Return the number of contours (both outer and inner paths) in the
  * CrossSection.
  */
-int CrossSection::NumContour() const { return GetPaths()->paths_.size(); }
+size_t CrossSection::NumContour() const { return GetPaths()->paths_.size(); }
 
 /**
  * Does the CrossSection contain any contours?


### PR DESCRIPTION
Fixes the return type of `CrossSection::NumVert()`, `CrossSection::NumContour()`, `manifold_cross_section_num_vert` and `manifold_cross_section_num_contour`