### PR TITLE
sdf interpreter

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -14,7 +14,7 @@ $CLANG_FORMAT -i bindings/wasm/*.{js,ts} &
 $CLANG_FORMAT -i bindings/wasm/examples/*.{js,ts,html} &
 $CLANG_FORMAT -i bindings/wasm/examples/public/*.{js,ts} &
 $CLANG_FORMAT -i src/*.{h,cpp} &
-$CLANG_FORMAT -i src/*/*.cpp &
+$CLANG_FORMAT -i src/*/*.{h,cpp} &
 $CLANG_FORMAT -i include/manifold/*.h &
 
 black --quiet bindings/python/examples/*.py &

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,9 @@ set(
   tri_dist.h
   utils.h
   vec.h
+  sdf/eval.h
+  sdf/interval.h
+  sdf/tape.h
 )
 
 # Include directories

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,8 @@ set(
   smoothing.cpp
   sort.cpp
   subdivision.cpp
+  sdf/value.cpp
+  sdf/context.cpp
   # optional source files
   $<$<BOOL:${MANIFOLD_CROSS_SECTION}>:cross_section/cross_section.cpp>
   $<$<BOOL:${MANIFOLD_EXPORT}>:meshIO/meshIO.cpp>
@@ -51,9 +53,10 @@ set(
   tri_dist.h
   utils.h
   vec.h
-  sdf/eval.h
   sdf/interval.h
   sdf/tape.h
+  sdf/value.h
+  sdf/context.h
 )
 
 # Include directories

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+
 #include "./hashtable.h"
 #include "./impl.h"
 #include "./parallel.h"
 #include "./utils.h"
 #include "./vec.h"
 #include "manifold/manifold.h"
-#include <chrono>
 
 namespace {
 using namespace manifold;
@@ -491,7 +492,10 @@ Manifold Manifold::LevelSet(std::function<double(vec3)> sdf, Box bounds,
                                  origin, spacing, gridSize, level, sdf);
       });
   auto end = std::chrono::high_resolution_clock::now();
-  printf("sdf evaluations: %d, %ld\n", sdf_counter.load(), std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
+  printf("sdf evaluations: %d, %dus\n", sdf_counter.load(),
+         static_cast<int>(
+             std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+                 .count()));
 
   size_t tableSize = std::min(
       2 * maxIndex, static_cast<Uint64>(10 * la::pow(maxIndex, 0.667)));

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -18,6 +18,7 @@
 #include "./utils.h"
 #include "./vec.h"
 #include "manifold/manifold.h"
+#include <chrono>
 
 namespace {
 using namespace manifold;
@@ -121,6 +122,8 @@ vec3 Bound(vec3 pos, vec3 origin, vec3 spacing, ivec3 gridSize) {
   return min(max(pos, origin), origin + spacing * (vec3(gridSize) - 1));
 }
 
+static std::atomic_int32_t sdf_counter;
+
 double BoundedSDF(ivec4 gridIndex, vec3 origin, vec3 spacing, ivec3 gridSize,
                   double level, std::function<double(vec3)> sdf) {
   const ivec3 xyz(gridIndex);
@@ -131,6 +134,7 @@ double BoundedSDF(ivec4 gridIndex, vec3 origin, vec3 spacing, ivec3 gridSize,
   if (boundDist < 0) {
     return 0.0;
   }
+  sdf_counter.fetch_add(1, std::memory_order_relaxed);
   const double d = sdf(Position(gridIndex, origin, spacing)) - level;
   return boundDist == 0 ? std::min(d, 0.0) : d;
 }
@@ -477,12 +481,17 @@ Manifold Manifold::LevelSet(std::function<double(vec3)> sdf, Box bounds,
 
   const vec3 origin = bounds.min;
   Vec<double> voxels(maxIndex);
+  sdf_counter.store(0);
+
+  auto start = std::chrono::high_resolution_clock::now();
   for_each_n(
       pol, countAt(0_uz), maxIndex,
       [&voxels, sdf, level, origin, spacing, gridSize, gridPow](Uint64 idx) {
         voxels[idx] = BoundedSDF(DecodeIndex(idx, gridPow) - kVoxelOffset,
                                  origin, spacing, gridSize, level, sdf);
       });
+  auto end = std::chrono::high_resolution_clock::now();
+  printf("sdf evaluations: %d, %ld\n", sdf_counter.load(), std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
 
   size_t tableSize = std::min(
       2 * maxIndex, static_cast<Uint64>(10 * la::pow(maxIndex, 0.667)));

--- a/src/sdf/affine_value.h
+++ b/src/sdf/affine_value.h
@@ -1,0 +1,42 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "context.h"
+
+namespace manifold::sdf {
+struct AffineValue {
+  // value = var * a + b
+  Operand var;
+  double a;
+  double b;
+
+  AffineValue(Operand var, double a, double b) : var(var), a(a), b(b) {}
+  AffineValue(double constant) : var(Operand::none()), a(0.0), b(constant) {}
+  bool operator==(const AffineValue &other) const {
+    return var == other.var && a == other.a && b == other.b;
+  }
+  AffineValue operator+(double d) { return AffineValue(var, a, b + d); }
+  AffineValue operator*(double d) { return AffineValue(var, a * d, b * d); }
+};
+}  // namespace manifold::sdf
+
+template <>
+struct std::hash<AffineValue> {
+  size_t operator()(const AffineValue &value) const {
+    size_t h = std::hash<int>()(value.var.id);
+    hash_combine(h, value.a, value.b);
+    return h;
+  }
+};

--- a/src/sdf/context.cpp
+++ b/src/sdf/context.cpp
@@ -200,7 +200,7 @@ Operand Context::addInstruction(OpCode op, Operand a, Operand b, Operand c) {
 }
 
 void Context::optimizeFMA() {
-  auto tryApply = [&](int i, Operand lhs, Operand rhs) {
+  auto tryApply = [&](size_t i, Operand lhs, Operand rhs) {
     if (!lhs.isResult()) return false;
     auto lhsInst = lhs.toInstIndex();
     if (operations[lhsInst] != OpCode::MUL || opUses[lhsInst].size() != 1)

--- a/src/sdf/context.cpp
+++ b/src/sdf/context.cpp
@@ -450,7 +450,6 @@ void Context::optimizeAffine() {
         for (auto operand : inst.operands) removeUse(operand, i);
         addUse(result.var, i);
         // modify instruction
-        // FIXME: handle constant uses...
         if (result.a == 1.0 && result.b == 0.0 && result.var.isResult()) {
           // this result is being optimized away, replace uses with the value
           pair.first->second = result.var.toInstIndex();

--- a/src/sdf/context.cpp
+++ b/src/sdf/context.cpp
@@ -312,7 +312,7 @@ void Context::reschedule() {
       // compute operand costs as distance in the dependency graph
       std::array<size_t, 3> costs = {0, 0, 0};
       std::array<size_t, 3> ids = {0, 1, 2};
-      for (int i = 0; i < curOperands.size(); i++) {
+      for (size_t i = 0; i < curOperands.size(); i++) {
         auto operand = curOperands[i];
         if (!requiresComputation(operand)) continue;
         tmpStack.push_back(operand.toInstIndex());
@@ -414,8 +414,6 @@ std::pair<std::vector<uint8_t>, std::vector<double>> Context::genTape() {
       auto operand = operands[i][0];
       tape.push_back(static_cast<uint8_t>(operations[i]));
       tape.push_back(getReg(operand));
-      dumpOpCode(operations[i]);
-      std::cout << " r" << static_cast<int>(tape.back()) << std::endl;
       break;
     }
     // free up operand registers if possible
@@ -448,17 +446,12 @@ std::pair<std::vector<uint8_t>, std::vector<double>> Context::genTape() {
     }
     opToReg.push_back(reg);
     tape.push_back(static_cast<uint8_t>(operations[i]));
-    dumpOpCode(operations[i]);
-    std::cout << " r" << static_cast<int>(reg);
     tape.push_back(reg);
     for (auto operand : operands[i]) {
       if (operand.isNone()) break;
       tape.push_back(getReg(operand));
-      std::cout << " r" << static_cast<int>(tape.back());
     }
-    std::cout << std::endl;
   }
-  std::cout << "-----------" << std::endl;
   return std::make_pair(std::move(tape), std::move(buffer));
 }
 

--- a/src/sdf/context.cpp
+++ b/src/sdf/context.cpp
@@ -367,7 +367,7 @@ std::pair<std::vector<uint8_t>, std::vector<double>> Context::genTape() {
       spills.insert({lru.front().operand, slot});
       tape.push_back(static_cast<uint8_t>(OpCode::STORE));
       std::array<uint8_t, sizeof(uint32_t)> tmpBuffer;
-      std::memcpy(tmpBuffer.begin(), &slot, sizeof(uint32_t));
+      std::memcpy(tmpBuffer.data(), &slot, sizeof(uint32_t));
       for (auto byte : tmpBuffer) tape.push_back(byte);
       auto reg = lru.front().reg;
       tape.push_back(reg);
@@ -401,14 +401,14 @@ std::pair<std::vector<uint8_t>, std::vector<double>> Context::genTape() {
         tape.push_back(static_cast<uint8_t>(OpCode::CONST));
         tape.push_back(reg);
         std::array<uint8_t, sizeof(double)> tmpBuffer;
-        std::memcpy(tmpBuffer.begin(), &constants[operand.toConstIndex()],
+        std::memcpy(tmpBuffer.data(), &constants[operand.toConstIndex()],
                     sizeof(double));
         for (auto byte : tmpBuffer) tape.push_back(byte);
       } else {
         tape.push_back(static_cast<uint8_t>(OpCode::LOAD));
         tape.push_back(reg);
         std::array<uint8_t, sizeof(uint32_t)> tmpBuffer;
-        std::memcpy(tmpBuffer.begin(), &iter->second, sizeof(uint32_t));
+        std::memcpy(tmpBuffer.data(), &iter->second, sizeof(uint32_t));
         for (auto byte : tmpBuffer) tape.push_back(byte);
         spillSlots.push_back(iter->second);
         spills.erase(iter);

--- a/src/sdf/context.cpp
+++ b/src/sdf/context.cpp
@@ -458,6 +458,8 @@ void Context::optimizeAffine() {
           auto constant = addConstant(result.b);
           addUse(constant, i);
           instructions[i] = {OpCode::ADD, {constant, result.var, none}};
+        } else if (result.a == -1.0 && result.b == 0.0) {
+          instructions[i] = {OpCode::NEG, {result.var, none, none}};
         } else if (result.a == -1.0) {
           auto constant = addConstant(result.b);
           addUse(constant, i);

--- a/src/sdf/context.cpp
+++ b/src/sdf/context.cpp
@@ -265,6 +265,14 @@ std::pair<std::vector<uint8_t>, std::vector<double>> Context::genTape() {
   std::vector<uint8_t> opToReg;
   std::vector<uint8_t> availableReg;
 
+  auto getReg = [&](Operand operand) {
+    if (operand.isResult())
+      return opToReg[operand.toInstIndex()];
+    else if (operand.isConst())
+      return constantToReg[operand.toConstIndex()];
+    return static_cast<uint8_t>(-(operand.id + 1));
+  };
+
   // FIXME: handle spills
   for (size_t i = 0; i < operations.size(); i++) {
     if (operations[i] == OpCode::NOP) {
@@ -274,10 +282,7 @@ std::pair<std::vector<uint8_t>, std::vector<double>> Context::genTape() {
     if (operations[i] == OpCode::RETURN) {
       auto operand = operands[i][0];
       tape.push_back(static_cast<uint8_t>(operations[i]));
-      if (operand.isResult())
-        tape.push_back(opToReg[operand.toInstIndex()]);
-      else
-        tape.push_back(constantToReg[operand.toConstIndex()]);
+      tape.push_back(getReg(operand));
       dumpOpCode(operations[i]);
       std::cout << " r" << static_cast<int>(tape.back()) << std::endl;
       break;
@@ -316,10 +321,7 @@ std::pair<std::vector<uint8_t>, std::vector<double>> Context::genTape() {
     tape.push_back(reg);
     for (auto operand : operands[i]) {
       if (operand.isNone()) break;
-      if (operand.isResult())
-        tape.push_back(opToReg[operand.toInstIndex()]);
-      else
-        tape.push_back(constantToReg[operand.toConstIndex()]);
+      tape.push_back(getReg(operand));
       std::cout << " r" << static_cast<int>(tape.back());
     }
     std::cout << std::endl;

--- a/src/sdf/context.cpp
+++ b/src/sdf/context.cpp
@@ -364,8 +364,8 @@ std::pair<std::vector<uint8_t>, size_t> Context::genTape() {
       // special xyz variables with fixed register
       if (!operand.isConst() && !operand.isResult())
         return static_cast<uint8_t>(-(operand.id + 1));
-      // the operand, if present, must be at the end of the cache, due to how the
-      // cache is ordered
+      // the operand, if present, must be at the end of the cache, due to how
+      // the cache is ordered
       for (auto it = regCache.rbegin();
            it != regCache.rend() && it->nextUse == inst; ++it)
         if (it->operand == operand) return it->reg;

--- a/src/sdf/context.cpp
+++ b/src/sdf/context.cpp
@@ -98,6 +98,11 @@ Operand Context::addInstruction(Instruction inst) {
   // common subexpression elimination
   auto entry = cache.find(inst);
   if (entry != cache.end()) return entry->second;
+  auto simplified = trySimplify(inst);
+  if (simplified.has_value()) {
+    cache.insert({inst, simplified.value()});
+    return simplified.value();
+  }
   auto result = addInstructionNoCache(inst);
   cache.insert({inst, result});
   return result;
@@ -210,9 +215,6 @@ std::optional<Operand> Context::trySimplify(Instruction inst) {
 // bypass the cache because we don't expect to have more common subexpressions
 // after optimizations
 Operand Context::addInstructionNoCache(Instruction inst) {
-  auto simplified = trySimplify(inst);
-  if (simplified.has_value()) return simplified.value();
-
   size_t i = instructions.size();
   instructions.push_back(inst);
   opUses.emplace_back();

--- a/src/sdf/context.cpp
+++ b/src/sdf/context.cpp
@@ -1,0 +1,331 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "context.h"
+
+#include <algorithm>
+#include <iostream>
+
+#include "manifold/optional_assert.h"
+
+namespace manifold::sdf {
+
+void dumpOpCode(OpCode op) {
+  switch (op) {
+    case OpCode::NOP:
+      std::cout << "NOP";
+      break;
+    case OpCode::RETURN:
+      std::cout << "RETURN";
+      break;
+    case OpCode::ABS:
+      std::cout << "ABS";
+      break;
+    case OpCode::NEG:
+      std::cout << "NEG";
+      break;
+    case OpCode::EXP:
+      std::cout << "EXP";
+      break;
+    case OpCode::LOG:
+      std::cout << "LOG";
+      break;
+    case OpCode::SQRT:
+      std::cout << "SQRT";
+      break;
+    case OpCode::FLOOR:
+      std::cout << "FLOOR";
+      break;
+    case OpCode::CEIL:
+      std::cout << "CEIL";
+      break;
+    case OpCode::ROUND:
+      std::cout << "ROUND";
+      break;
+    case OpCode::SIN:
+      std::cout << "SIN";
+      break;
+    case OpCode::COS:
+      std::cout << "COS";
+      break;
+    case OpCode::TAN:
+      std::cout << "TAN";
+      break;
+    case OpCode::ASIN:
+      std::cout << "ASIN";
+      break;
+    case OpCode::ACOS:
+      std::cout << "ACOS";
+      break;
+    case OpCode::ATAN:
+      std::cout << "ATAN";
+      break;
+    case OpCode::DIV:
+      std::cout << "DIV";
+      break;
+    case OpCode::MOD:
+      std::cout << "MOD";
+      break;
+    case OpCode::MIN:
+      std::cout << "MIN";
+      break;
+    case OpCode::MAX:
+      std::cout << "MAX";
+      break;
+    case OpCode::EQ:
+      std::cout << "EQ";
+      break;
+    case OpCode::GT:
+      std::cout << "GT";
+      break;
+    case OpCode::AND:
+      std::cout << "AND";
+      break;
+    case OpCode::OR:
+      std::cout << "OR";
+      break;
+    case OpCode::ADD:
+      std::cout << "ADD";
+      break;
+    case OpCode::SUB:
+      std::cout << "SUB";
+      break;
+    case OpCode::MUL:
+      std::cout << "MUL";
+      break;
+    case OpCode::FMA:
+      std::cout << "FMA";
+      break;
+    case OpCode::CHOICE:
+      std::cout << "CHOICE";
+      break;
+  }
+}
+
+void Context::dump() const {
+  for (size_t i = 0; i < operations.size(); i++) {
+    std::cout << i << " ";
+    dumpOpCode(operations[i]);
+    std::cout << " ";
+    for (Operand operand : operands[i]) {
+      if (operand.isNone()) break;
+      if (operand.isResult())
+        std::cout << "r" << operand.toInstIndex();
+      else if (operand.isConst())
+        std::cout << constants[operand.toConstIndex()];
+      else
+        std::cout << static_cast<char>('X' - operand.id - 1);
+      std::cout << " ";
+    }
+    std::cout << "{";
+    for (size_t use : opUses[i]) std::cout << use << " ";
+    std::cout << "}" << std::endl;
+  }
+  std::cout << "-----------" << std::endl;
+}
+
+Operand Context::addConstant(double d) {
+  auto result = constantsIds.insert(
+      {d, Operand{-4 - static_cast<int>(constants.size())}});
+  if (result.second) {
+    constants.push_back(d);
+    constantUses.emplace_back();
+  }
+  return result.first->second;
+}
+
+// TODO: hashconsing
+Operand Context::addInstruction(OpCode op, Operand a, Operand b, Operand c) {
+  // constant choice
+  if (op == OpCode::CHOICE && a.isConst()) {
+    if (constants[a.toConstIndex()] == 1.0) return b;
+    return c;
+  }
+  // constant propagation
+  bool all_constants = true;
+  for (auto operand : {a, b, c}) {
+    if (operand.isNone()) break;
+    if (!operand.isConst()) {
+      all_constants = false;
+      break;
+    }
+  }
+  if (all_constants) {
+    tmpTape.clear();
+    tmpBuffer.clear();
+    tmpTape.push_back(static_cast<uint8_t>(op));
+    tmpTape.push_back(0);
+    tmpBuffer.push_back(0.0);
+    for (Operand x : {a, b, c}) {
+      if (!x.isConst()) break;
+      tmpTape.push_back(tmpBuffer.size());
+      tmpBuffer.push_back(constants[x.toConstIndex()]);
+    }
+    tmpTape.push_back(static_cast<uint8_t>(OpCode::RETURN));
+    tmpTape.push_back(0);
+    return addConstant(EvalContext<double>{
+        tmpTape, VecView(tmpBuffer.data(), tmpBuffer.size())}
+                           .eval());
+  }
+
+  size_t i = operations.size();
+  operations.push_back(op);
+  operands.push_back({a, b, c});
+  opUses.emplace_back();
+  // update uses
+  for (auto operand : {a, b, c}) {
+    std::vector<size_t> *target;
+    if (operand.isResult()) {
+      target = &opUses[operand.toInstIndex()];
+    } else if (operand.isConst()) {
+      target = &constantUses[operand.toConstIndex()];
+    } else {
+      continue;
+    }
+    // avoid duplicates
+    if (target->empty() || target->back() != i) target->push_back(i);
+  }
+  return {static_cast<int>(i) + 1};
+}
+
+void Context::optimizeFMA() {
+  auto tryApply = [&](int i, Operand lhs, Operand rhs) {
+    if (!lhs.isResult()) return false;
+    auto lhsInst = lhs.toInstIndex();
+    if (operations[lhsInst] != OpCode::MUL || opUses[lhsInst].size() != 1)
+      return false;
+    operations[i] = OpCode::FMA;
+    Operand a = operands[lhsInst][0];
+    Operand b = operands[lhsInst][1];
+    operands[i][0] = a;
+    operands[i][1] = b;
+    operands[i][2] = rhs;
+    // remove instruction
+    operations[lhsInst] = OpCode::NOP;
+    operands[lhsInst][0] = Operand::none();
+    operands[lhsInst][1] = Operand::none();
+    // update uses, note that we need to maintain the order of the indices
+    opUses[lhsInst].clear();
+    auto updateUses = [&](Operand x) {
+      if (!x.isResult() && !x.isConst()) return;
+      auto &uses = x.isResult() ? opUses[x.toInstIndex()]
+                                : constantUses[x.toConstIndex()];
+      auto iter1 = std::lower_bound(uses.begin(), uses.end(), lhsInst);
+      DEBUG_ASSERT(*iter1 == lhsInst, logicErr, "expected use");
+      uses.erase(iter1);
+      auto iter2 = std::lower_bound(uses.begin(), uses.end(), i);
+      // make sure there is no duplicate
+      if (iter2 == uses.end() || *iter2 != i + 1) uses.insert(iter2, i);
+    };
+    updateUses(a);
+    if (a != b) updateUses(b);
+    return true;
+  };
+  for (size_t i = 0; i < operations.size(); i++) {
+    if (operations[i] == OpCode::ADD) {
+      // check if lhs/rhs comes from MUL with no other uses
+      auto lhs = operands[i][0];
+      auto rhs = operands[i][1];
+      if (!tryApply(i, lhs, rhs)) tryApply(i, rhs, lhs);
+    }
+  }
+}
+
+std::pair<std::vector<uint8_t>, std::vector<double>> Context::genTape() {
+  std::vector<uint8_t> tape;
+  std::vector<double> buffer;
+  std::vector<uint8_t> constantToReg;
+  for (int i : {0, 1, 2})  // x, y, z
+    buffer.push_back(0.0);
+  // handle constants by putting them inside the buffer/register
+  // they are different because they require static lifetime, and cannot be
+  // changed in an execution
+  // FIXME: this is just temporary, we should optimize by encoding some
+  // constants with a minimal number of uses into the read-only code when there
+  // is a register pressure (more than 255...)
+  for (size_t i = 0; i < constants.size(); i++) {
+    constantToReg.push_back(0);
+    if (constantUses[i].empty()) continue;
+    constantToReg.back() = static_cast<uint8_t>(buffer.size());
+    buffer.push_back(constants[i]);
+  }
+
+  std::vector<bool> regUsed(buffer.size(), true);
+  std::vector<uint8_t> opToReg;
+  std::vector<uint8_t> availableReg;
+
+  // FIXME: handle spills
+  for (size_t i = 0; i < operations.size(); i++) {
+    if (operations[i] == OpCode::NOP) {
+      opToReg.push_back(0);
+      continue;
+    }
+    if (operations[i] == OpCode::RETURN) {
+      auto operand = operands[i][0];
+      tape.push_back(static_cast<uint8_t>(operations[i]));
+      if (operand.isResult())
+        tape.push_back(opToReg[operand.toInstIndex()]);
+      else
+        tape.push_back(constantToReg[operand.toConstIndex()]);
+      dumpOpCode(operations[i]);
+      std::cout << " r" << static_cast<int>(tape.back()) << std::endl;
+      break;
+    }
+    // free up operand registers if possible
+    for (auto operand : operands[i]) {
+      if (!operand.isResult()) continue;
+      auto operandInst = operand.toInstIndex();
+      // not the last instruction, cannot free it up
+      if (opUses[operandInst].back() != i) continue;
+      uint8_t reg = opToReg[operandInst];
+      // already freed, probably due to identical arguments
+      if (!regUsed[reg]) continue;
+      regUsed[reg] = false;
+      availableReg.push_back(reg);
+    }
+    // allocate register
+    uint8_t reg;
+    if (availableReg.empty()) {
+      // GG if we used too many registers, need spilling
+      if (buffer.size() == 255) {
+        // just return some nonsense that will not crash
+        return {{static_cast<uint8_t>(OpCode::RETURN), 0}, {0.0}};
+      }
+      reg = buffer.size();
+      buffer.push_back(0.0);
+      regUsed.push_back(true);
+    } else {
+      reg = availableReg.back();
+      availableReg.pop_back();
+    }
+    opToReg.push_back(reg);
+    tape.push_back(static_cast<uint8_t>(operations[i]));
+    dumpOpCode(operations[i]);
+    std::cout << " r" << static_cast<int>(reg);
+    tape.push_back(reg);
+    for (auto operand : operands[i]) {
+      if (operand.isNone()) break;
+      if (operand.isResult())
+        tape.push_back(opToReg[operand.toInstIndex()]);
+      else
+        tape.push_back(constantToReg[operand.toConstIndex()]);
+      std::cout << " r" << static_cast<int>(tape.back());
+    }
+    std::cout << std::endl;
+  }
+  std::cout << "-----------" << std::endl;
+  return std::make_pair(std::move(tape), std::move(buffer));
+}
+
+}  // namespace manifold::sdf

--- a/src/sdf/context.cpp
+++ b/src/sdf/context.cpp
@@ -20,31 +20,8 @@
 #include <iostream>
 #endif
 
+#include "affine_value.h"
 #include "manifold/optional_assert.h"
-
-struct AffineValue {
-  // value = var * a + b
-  Operand var;
-  double a;
-  double b;
-
-  AffineValue(Operand var, double a, double b) : var(var), a(a), b(b) {}
-  AffineValue(double constant) : var(Operand::none()), a(0.0), b(constant) {}
-  bool operator==(const AffineValue &other) const {
-    return var == other.var && a == other.a && b == other.b;
-  }
-  AffineValue operator+(double d) { return AffineValue(var, a, b + d); }
-  AffineValue operator*(double d) { return AffineValue(var, a * d, b * d); }
-};
-
-template <>
-struct std::hash<AffineValue> {
-  size_t operator()(const AffineValue &value) const {
-    size_t h = std::hash<int>()(value.var.id);
-    hash_combine(h, value.a, value.b);
-    return h;
-  }
-};
 
 namespace manifold::sdf {
 void Context::dump() const {

--- a/src/sdf/context.cpp
+++ b/src/sdf/context.cpp
@@ -277,7 +277,7 @@ void Context::optimizeFMA() {
 void Context::reschedule() {
   DEBUG_ASSERT(!operations.empty() && operations.back() == OpCode::RETURN,
                logicErr, "return expected");
-
+  cache.clear();
   auto oldOperations = std::move(operations);
   auto oldOperands = std::move(operands);
   opUses.clear();

--- a/src/sdf/context.h
+++ b/src/sdf/context.h
@@ -13,8 +13,8 @@
 // limitations under the License.
 #pragma once
 
-#include <unordered_map>
 #include <map>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -68,7 +68,8 @@ class Context {
 
   std::vector<uint8_t> tmpTape;
   std::vector<double> tmpBuffer;
-  std::map<std::pair<OpCode, std::tuple<Operand, Operand, Operand>>, Operand> cache;
+  std::map<std::pair<OpCode, std::tuple<Operand, Operand, Operand>>, Operand>
+      cache;
 
   Operand addInstructionNoCache(OpCode op, Operand a = Operand::none(),
                                 Operand b = Operand::none(),

--- a/src/sdf/context.h
+++ b/src/sdf/context.h
@@ -57,7 +57,6 @@ using namespace manifold::sdf;
 
 inline void hash_combine(std::size_t& seed) {}
 
-// note: ankerl hash combine function is too costly
 template <typename T, typename... Rest>
 inline void hash_combine(std::size_t& seed, const T& v, Rest... rest) {
   std::hash<T> hasher;

--- a/src/sdf/context.h
+++ b/src/sdf/context.h
@@ -30,6 +30,8 @@ struct Operand {
   int id;
 
   static Operand none() { return {0}; }
+  static Operand fromInstIndex(size_t i) { return {static_cast<int>(i) + 1}; }
+  static Operand fromConstIndex(size_t i) { return {-static_cast<int>(i) - 4}; }
   bool isConst() const { return id <= -4; }
   bool isResult() const { return id > 0; }
   bool isNone() const { return id == 0; }

--- a/src/sdf/context.h
+++ b/src/sdf/context.h
@@ -107,6 +107,16 @@ class Context {
   Operand addInstructionNoCache(OpCode op, Operand a = Operand::none(),
                                 Operand b = Operand::none(),
                                 Operand c = Operand::none());
+
+  small_vector<size_t, 4>* getUses(Operand operand) {
+    if (operand.isResult()) {
+      return &opUses[operand.toInstIndex()];
+    } else if (operand.isConst()) {
+      return &constantUses[operand.toConstIndex()];
+    } else {
+      return static_cast<small_vector<size_t, 4>*>(nullptr);
+    }
+  };
 };
 
 }  // namespace manifold::sdf

--- a/src/sdf/context.h
+++ b/src/sdf/context.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <unordered_map>
+#include <map>
 #include <utility>
 #include <vector>
 
@@ -32,6 +33,7 @@ struct Operand {
   size_t toInstIndex() const { return static_cast<size_t>(id - 1); }
   bool operator==(const Operand& other) const { return id == other.id; }
   bool operator!=(const Operand& other) const { return id != other.id; }
+  bool operator<(const Operand& other) const { return id < other.id; }
 };
 
 class Context {
@@ -66,6 +68,11 @@ class Context {
 
   std::vector<uint8_t> tmpTape;
   std::vector<double> tmpBuffer;
+  std::map<std::pair<OpCode, std::tuple<Operand, Operand, Operand>>, Operand> cache;
+
+  Operand addInstructionNoCache(OpCode op, Operand a = Operand::none(),
+                                Operand b = Operand::none(),
+                                Operand c = Operand::none());
 };
 
 }  // namespace manifold::sdf

--- a/src/sdf/context.h
+++ b/src/sdf/context.h
@@ -107,7 +107,7 @@ class Context {
   std::vector<UsesVector> opUses;
   unordered_map<Instruction, Operand> cache;
 
-  std::optional<Operand> trySimplify(Instruction);
+  // std::optional<Operand> trySimplify(Instruction);
   Operand addInstructionNoCache(Instruction);
   void combineFMA();
   void optimizeAffine();

--- a/src/sdf/context.h
+++ b/src/sdf/context.h
@@ -41,7 +41,7 @@ class Context {
                          Operand b = Operand::none(),
                          Operand c = Operand::none());
   void optimizeFMA();
-  // TODO: DCE
+  void reschedule();
 
   std::pair<std::vector<uint8_t>, std::vector<double>> genTape();
 

--- a/src/sdf/context.h
+++ b/src/sdf/context.h
@@ -70,6 +70,8 @@ struct std::hash<std::pair<OpCode, std::tuple<Operand, Operand, Operand>>> {
 namespace manifold::sdf {
 class Context {
  public:
+  using UsesVector = small_vector<size_t, 4>;
+
   Operand addConstant(double d);
   Operand addInstruction(OpCode op, Operand a = Operand::none(),
                          Operand b = Operand::none(),
@@ -88,11 +90,11 @@ class Context {
   std::vector<double> constants;
   // constant use vector, elements are instruction indices
   // constant with ID -4 is mapped to 0, etc.
-  std::vector<small_vector<size_t, 4>> constantUses;
+  std::vector<UsesVector> constantUses;
   // instructions, index 0 is mapped to ID 1, etc.
   std::vector<OpCode> operations;
   // instruction value use vector, elements are instruction indices
-  std::vector<small_vector<size_t, 4>> opUses;
+  std::vector<UsesVector> opUses;
   // operands, 0 is invalid (uses fewer operands)
   // +ve are instruction results
   // -ve are constants

--- a/src/sdf/context.h
+++ b/src/sdf/context.h
@@ -1,0 +1,71 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "tape.h"
+
+namespace manifold::sdf {
+
+struct Operand {
+  int id;
+
+  static Operand none() { return {0}; }
+  bool isConst() const { return id <= -4; }
+  bool isResult() const { return id > 0; }
+  bool isNone() const { return id == 0; }
+  int toConstIndex() const { return -(id + 4); }
+  int toInstIndex() const { return id - 1; }
+  bool operator==(const Operand& other) const { return id == other.id; }
+  bool operator!=(const Operand& other) const { return id != other.id; }
+};
+
+class Context {
+ public:
+  Operand addConstant(double d);
+  Operand addInstruction(OpCode op, Operand a = Operand::none(),
+                         Operand b = Operand::none(),
+                         Operand c = Operand::none());
+  void optimizeFMA();
+  // TODO: DCE
+
+  std::pair<std::vector<uint8_t>, std::vector<double>> genTape();
+
+  void dump() const;
+
+ private:
+  // constants have negative IDs, starting from -4
+  // -1, -2 and -3 are reserved for x y z
+  std::unordered_map<double, Operand> constantsIds;
+  std::vector<double> constants;
+  // constant use vector, elements are instruction indices
+  // constant with ID -4 is mapped to 0, etc.
+  std::vector<std::vector<size_t>> constantUses;
+  // instructions, index 0 is mapped to ID 1, etc.
+  std::vector<OpCode> operations;
+  // instruction value use vector, elements are instruction indices
+  std::vector<std::vector<size_t>> opUses;
+  // operands, 0 is invalid (uses fewer operands)
+  // +ve are instruction results
+  // -ve are constants
+  std::vector<std::array<Operand, 3>> operands;
+
+  std::vector<uint8_t> tmpTape;
+  std::vector<double> tmpBuffer;
+};
+
+}  // namespace manifold::sdf

--- a/src/sdf/context.h
+++ b/src/sdf/context.h
@@ -28,8 +28,8 @@ struct Operand {
   bool isConst() const { return id <= -4; }
   bool isResult() const { return id > 0; }
   bool isNone() const { return id == 0; }
-  int toConstIndex() const { return -(id + 4); }
-  int toInstIndex() const { return id - 1; }
+  size_t toConstIndex() const { return static_cast<size_t>(-(id + 4)); }
+  size_t toInstIndex() const { return static_cast<size_t>(id - 1); }
   bool operator==(const Operand& other) const { return id == other.id; }
   bool operator!=(const Operand& other) const { return id != other.id; }
 };

--- a/src/sdf/context.h
+++ b/src/sdf/context.h
@@ -80,11 +80,11 @@ struct std::hash<Instruction> {
 namespace manifold::sdf {
 class Context {
  public:
-  using UsesVector = small_vector<size_t, 4>;
+  using UsesVector = std::vector<size_t>;
 
   Operand addConstant(double d);
   Operand addInstruction(Instruction);
-  void peephole();
+  void optimize();
   void reschedule();
 
   std::pair<std::vector<uint8_t>, size_t> genTape();
@@ -106,8 +106,12 @@ class Context {
   unordered_map<Instruction, Operand> cache;
 
   std::optional<Operand> trySimplify(Instruction);
-  Instruction strengthReduction(Instruction);
   Operand addInstructionNoCache(Instruction);
+  void combineFMA();
+  void optimizeAffine();
+  void addUse(Operand operand, size_t inst);
+  void removeUse(Operand operand, size_t inst);
+  void schedule();
 
   UsesVector* getUses(Operand operand) {
     if (operand.isResult()) {

--- a/src/sdf/context.h
+++ b/src/sdf/context.h
@@ -56,13 +56,11 @@ struct std::hash<Operand> {
 };
 
 template <>
-struct std::hash<std::pair<OpCode, std::tuple<Operand, Operand, Operand>>> {
+struct std::hash<std::pair<OpCode, std::array<Operand, 3>>> {
   size_t operator()(
-      const std::pair<OpCode, std::tuple<Operand, Operand, Operand>>& pair)
-      const {
+      const std::pair<OpCode, std::array<Operand, 3>>& pair) const {
     size_t h = std::hash<uint8_t>()(static_cast<uint8_t>(pair.first));
-    hash_combine(h, std::get<0>(pair.second), std::get<1>(pair.second),
-                 std::get<2>(pair.second));
+    hash_combine(h, pair.second[0], pair.second[1], pair.second[2]);
     return h;
   }
 };
@@ -73,9 +71,7 @@ class Context {
   using UsesVector = small_vector<size_t, 4>;
 
   Operand addConstant(double d);
-  Operand addInstruction(OpCode op, Operand a = Operand::none(),
-                         Operand b = Operand::none(),
-                         Operand c = Operand::none());
+  Operand addInstruction(OpCode op, std::array<Operand, 3> operands);
   void optimizeFMA();
   void reschedule();
 
@@ -102,13 +98,9 @@ class Context {
 
   std::vector<uint8_t> tmpTape;
   std::vector<double> tmpBuffer;
-  std::unordered_map<std::pair<OpCode, std::tuple<Operand, Operand, Operand>>,
-                     Operand>
-      cache;
+  std::unordered_map<std::pair<OpCode, std::array<Operand, 3>>, Operand> cache;
 
-  Operand addInstructionNoCache(OpCode op, Operand a = Operand::none(),
-                                Operand b = Operand::none(),
-                                Operand c = Operand::none());
+  Operand addInstructionNoCache(OpCode op, std::array<Operand, 3> operands);
 
   small_vector<size_t, 4>* getUses(Operand operand) {
     if (operand.isResult()) {

--- a/src/sdf/context.h
+++ b/src/sdf/context.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 #pragma once
 
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -104,6 +105,8 @@ class Context {
   std::vector<UsesVector> opUses;
   unordered_map<Instruction, Operand> cache;
 
+  std::optional<Operand> trySimplify(Instruction);
+  Instruction strengthReduction(Instruction);
   Operand addInstructionNoCache(Instruction);
 
   UsesVector* getUses(Operand operand) {

--- a/src/sdf/interval.h
+++ b/src/sdf/interval.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 
 #include "manifold/common.h"
@@ -33,15 +34,13 @@ struct Interval {
   Interval(Domain lower, Domain upper) : lower(lower), upper(upper) {}
   static Interval constant(Domain v) { return {v, v}; }
 
-  constexpr Interval operator+(const Interval &other) const {
+  Interval operator+(const Interval &other) const {
     return {lower + other.lower, upper + other.upper};
   }
 
-  constexpr Interval operator-() const { return {-upper, -lower}; }
+  Interval operator-() const { return {-upper, -lower}; }
 
-  constexpr Interval operator-(const Interval &other) const {
-    return *this + (-other);
-  }
+  Interval operator-(const Interval &other) const { return *this + (-other); }
 
   Interval operator*(const Interval &other) const {
     Domain a1b1 = lower * other.lower;
@@ -86,7 +85,7 @@ struct Interval {
 
   constexpr bool is_const() const { return lower == upper; }
 
-  constexpr Interval operator==(const Interval &other) const {
+  Interval operator==(const Interval &other) const {
     if (is_const() && other.is_const() && lower == other.lower)
       return constant(1);  // must be equal
     if (lower > other.upper || upper < other.lower)
@@ -96,49 +95,49 @@ struct Interval {
 
   constexpr bool operator==(double d) const { return is_const() && lower == d; }
 
-  constexpr Interval operator>(const Interval &other) const {
+  Interval operator>(const Interval &other) const {
     if (lower > other.upper) return constant(1);
     if (upper < other.lower) return constant(0);
     return {0, 1};
   }
 
-  constexpr Interval operator<(const Interval &other) const {
+  Interval operator<(const Interval &other) const {
     if (upper < other.lower) return constant(1);
     if (lower > other.upper) return constant(0);
     return {0, 1};
   }
 
-  constexpr Interval min(const Interval &other) const {
+  Interval min(const Interval &other) const {
     return {std::min(lower, other.lower), std::min(upper, other.upper)};
   }
 
-  constexpr Interval max(const Interval &other) const {
+  Interval max(const Interval &other) const {
     return {std::max(lower, other.lower), std::max(upper, other.upper)};
   }
 
-  constexpr Interval merge(const Interval &other) const {
+  Interval merge(const Interval &other) const {
     return {std::min(lower, other.lower), std::max(upper, other.upper)};
   }
 
   template <typename F>
-  constexpr Interval monotone_map(F f) const {
+  Interval monotone_map(F f) const {
     if (is_const()) return constant(f(lower));
     return {f(lower), f(upper)};
   }
 
   template <typename F>
-  constexpr Interval antimonotone_map(F f) const {
+  Interval antimonotone_map(F f) const {
     if (is_const()) return constant(f(lower));
     return {f(upper), f(lower)};
   }
 
-  constexpr Interval abs() const {
+  Interval abs() const {
     if (lower >= 0) return *this;
     if (upper <= 0) return {-upper, -lower};
     return {0.0, std::max(-lower, upper)};
   }
 
-  constexpr Interval mod(double m) const {
+  Interval mod(double m) const {
     // FIXME: cannot deal with negative m right now...
     Domain diff = std::fmod(lower, m);
     if (diff < 0) diff += m;
@@ -148,17 +147,17 @@ struct Interval {
     return {diff, upper - cycle_min};
   }
 
-  constexpr Interval logical_and(const Interval &other) const {
+  Interval logical_and(const Interval &other) const {
     return {lower == 0.0 || other.lower == 0.0 ? 0.0 : 1.0,
             upper == 1.0 && other.upper == 1.0 ? 1.0 : 0.0};
   }
 
-  constexpr Interval logical_or(const Interval &other) const {
+  Interval logical_or(const Interval &other) const {
     return {lower == 0.0 && other.lower == 0.0 ? 0.0 : 1.0,
             upper == 1.0 || other.upper == 1.0 ? 1.0 : 0.0};
   }
 
-  constexpr Interval sin() const {
+  Interval sin() const {
     if (is_const()) return constant(std::sin(lower));
     // largely similar to cos
     int64_t min_pis = static_cast<int64_t>(std::floor((lower - kHalfPi) / kPi));
@@ -176,7 +175,7 @@ struct Interval {
     return {new_min, new_max};
   }
 
-  constexpr Interval cos() const {
+  Interval cos() const {
     if (is_const()) return constant(std::cos(lower));
     int64_t min_pis = static_cast<int64_t>(std::floor(lower / kPi));
     int64_t max_pis = static_cast<int64_t>(std::floor(upper / kPi));
@@ -193,7 +192,7 @@ struct Interval {
     return {new_min, new_max};
   }
 
-  constexpr Interval tan() const {
+  Interval tan() const {
     if (is_const()) return constant(std::tan(lower));
     int64_t min_pis = static_cast<int64_t>(std::floor((lower + kHalfPi) / kPi));
     int64_t max_pis = static_cast<int64_t>(std::floor((upper + kHalfPi) / kPi));

--- a/src/sdf/interval.h
+++ b/src/sdf/interval.h
@@ -26,6 +26,11 @@ struct Interval {
   Domain lower;
   Domain upper;
 
+  Interval()
+      : lower(-std::numeric_limits<Domain>::infinity()),
+        upper(std::numeric_limits<Domain>::infinity()) {}
+  Interval(Domain v) : lower(v), upper(v) {}
+  Interval(Domain lower, Domain upper) : lower(lower), upper(upper) {}
   static Interval constant(Domain v) { return {v, v}; }
 
   constexpr Interval operator+(const Interval &other) const {

--- a/src/sdf/interval.h
+++ b/src/sdf/interval.h
@@ -1,0 +1,202 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <algorithm>
+#include <limits>
+
+#include "manifold/common.h"
+
+namespace manifold::sdf {
+
+// not really a precise implementation...
+template <typename Domain>
+struct Interval {
+  Domain lower;
+  Domain upper;
+
+  static Interval constant(Domain v) { return {v, v}; }
+
+  constexpr Interval operator+(const Interval &other) const {
+    return {lower + other.lower, upper + other.upper};
+  }
+
+  constexpr Interval operator-() const { return {-upper, -lower}; }
+
+  constexpr Interval operator-(const Interval &other) const {
+    return *this + (-other);
+  }
+
+  Interval operator*(const Interval &other) const {
+    Domain a1b1 = lower * other.lower;
+    Domain a2b2 = upper * other.upper;
+    // we can write more "fast paths", but at some point it will become slower
+    // than just going the general path...
+    if (lower >= 0.0 && other.lower >= 0.0)
+      return {a1b1, a2b2};
+    else if (upper <= 0.0 && other.upper <= 0.0)
+      return {a2b2, a1b1};
+
+    Domain a1b2 = lower * other.upper;
+    Domain a2b1 = upper * other.lower;
+    return {std::min(std::min(a1b1, a1b2), std::min(a2b1, a2b2)),
+            std::max(std::max(a1b1, a1b2), std::max(a2b1, a2b2))};
+  }
+
+  Interval operator*(double d) const {
+    if (d > 0) return {lower * d, upper * d};
+    return {upper * d, lower * d};
+  }
+
+  Interval operator/(const Interval &other) const {
+    if (other.is_const()) return *this / other.lower;
+    constexpr Domain zero = static_cast<Domain>(0);
+    constexpr Domain infty = std::numeric_limits<Domain>::infinity();
+    Interval reci;
+    if (other.lower >= zero || other.upper <= zero) {
+      reci.lower = other.upper == zero ? -infty : (1 / other.upper);
+      reci.upper = other.lower == zero ? infty : (1 / other.lower);
+    } else {
+      reci.lower = -infty;
+      reci.upper = infty;
+    }
+    return *this * reci;
+  }
+
+  Interval operator/(double d) const {
+    if (d > 0) return {lower / d, upper / d};
+    return {upper / d, lower / d};
+  }
+
+  constexpr bool is_const() const { return lower == upper; }
+
+  constexpr Interval operator==(const Interval &other) const {
+    if (is_const() && other.is_const() && lower == other.lower)
+      return constant(1);  // must be equal
+    if (lower > other.upper || upper < other.lower)
+      return constant(0);  // disjoint, cannot possibly be equal
+    return {0, 1};
+  }
+
+  constexpr bool operator==(double d) const { return is_const() && lower == d; }
+
+  constexpr Interval operator>(const Interval &other) const {
+    if (lower > other.upper) return constant(1);
+    if (upper < other.lower) return constant(0);
+    return {0, 1};
+  }
+
+  constexpr Interval operator<(const Interval &other) const {
+    if (upper < other.lower) return constant(1);
+    if (lower > other.upper) return constant(0);
+    return {0, 1};
+  }
+
+  constexpr Interval min(const Interval &other) const {
+    return {std::min(lower, other.lower), std::min(upper, other.upper)};
+  }
+
+  constexpr Interval max(const Interval &other) const {
+    return {std::max(lower, other.lower), std::max(upper, other.upper)};
+  }
+
+  constexpr Interval merge(const Interval &other) const {
+    return {std::min(lower, other.lower), std::max(upper, other.upper)};
+  }
+
+  template <typename F>
+  constexpr Interval monotone_map(F f) const {
+    if (is_const()) return constant(f(lower));
+    return {f(lower), f(upper)};
+  }
+
+  template <typename F>
+  constexpr Interval antimonotone_map(F f) const {
+    if (is_const()) return constant(f(lower));
+    return {f(upper), f(lower)};
+  }
+
+  constexpr Interval abs() const {
+    if (lower >= 0) return *this;
+    if (upper <= 0) return {-upper, -lower};
+    return {0.0, std::max(-lower, upper)};
+  }
+
+  constexpr Interval mod(double m) const {
+    // FIXME: cannot deal with negative m right now...
+    Domain diff = std::fmod(lower, m);
+    if (diff < 0) diff += m;
+    Domain cycle_min = lower - diff;
+    // may be disjoint intervals, but we don't deal with that...
+    if (upper - cycle_min >= m) return {0.0, m};
+    return {diff, upper - cycle_min};
+  }
+
+  constexpr Interval logical_and(const Interval &other) const {
+    return {lower == 0.0 || other.lower == 0.0 ? 0.0 : 1.0,
+            upper == 1.0 && other.upper == 1.0 ? 1.0 : 0.0};
+  }
+
+  constexpr Interval logical_or(const Interval &other) const {
+    return {lower == 0.0 && other.lower == 0.0 ? 0.0 : 1.0,
+            upper == 1.0 || other.upper == 1.0 ? 1.0 : 0.0};
+  }
+
+  constexpr Interval sin() const {
+    if (is_const()) return constant(std::sin(lower));
+    // largely similar to cos
+    int64_t min_pis = static_cast<int64_t>(std::floor((lower - kHalfPi) / kPi));
+    int64_t max_pis = static_cast<int64_t>(std::floor((upper - kHalfPi) / kPi));
+
+    bool not_cross_pos_1 =
+        (min_pis % 2 == 0) ? max_pis - min_pis <= 1 : max_pis == min_pis;
+    bool not_cross_neg_1 =
+        (min_pis % 2 == 0) ? max_pis == min_pis : max_pis - min_pis <= 1;
+
+    Domain new_min =
+        not_cross_neg_1 ? std::min(std::sin(lower), std::sin(upper)) : -1.0;
+    Domain new_max =
+        not_cross_pos_1 ? std::max(std::sin(lower), std::sin(upper)) : 1.0;
+    return {new_min, new_max};
+  }
+
+  constexpr Interval cos() const {
+    if (is_const()) return constant(std::cos(lower));
+    int64_t min_pis = static_cast<int64_t>(std::floor(lower / kPi));
+    int64_t max_pis = static_cast<int64_t>(std::floor(upper / kPi));
+
+    bool not_cross_pos_1 =
+        (min_pis % 2 == 0) ? max_pis - min_pis <= 1 : max_pis == min_pis;
+    bool not_cross_neg_1 =
+        (min_pis % 2 == 0) ? max_pis == min_pis : max_pis - min_pis <= 1;
+
+    Domain new_min =
+        not_cross_neg_1 ? std::min(std::cos(lower), std::cos(upper)) : -1.0;
+    Domain new_max =
+        not_cross_pos_1 ? std::max(std::cos(lower), std::cos(upper)) : 1.0;
+    return {new_min, new_max};
+  }
+
+  constexpr Interval tan() const {
+    if (is_const()) return constant(std::tan(lower));
+    int64_t min_pis = static_cast<int64_t>(std::floor((lower + kHalfPi) / kPi));
+    int64_t max_pis = static_cast<int64_t>(std::floor((upper + kHalfPi) / kPi));
+    if (min_pis != max_pis)
+      return {-std::numeric_limits<Domain>::infinity(),
+              std::numeric_limits<Domain>::infinity()};
+    return monotone_map([](Domain x) { return std::tan(x); });
+  }
+};
+
+}  // namespace manifold::sdf

--- a/src/sdf/optimizing_tape.h
+++ b/src/sdf/optimizing_tape.h
@@ -15,6 +15,7 @@
 
 #include <vector>
 
+#include "affine_value.h"
 #include "interval.h"
 #include "manifold/vec_view.h"
 
@@ -58,7 +59,7 @@ class OptimizerContext {
    * For dependencies, we use relative index to track them.
    *   ID = current ID - value
    * - If value is 0, this means the operand is not being used, i.e. the
-   *   instruction does not have 3 operands.
+   *   instruction does not have that operand.
    * - If value is 255, this means the dependency is too far away, and we
    *   should look it up in far dependencies.
    * Ideally, we should not have too many far dependencies.
@@ -80,10 +81,9 @@ class OptimizerContext {
    * memory operations, we reuse them.
    *
    * - `buffer` is the regular register buffer for tape evaluation.
-   * - `constantOffset` is a constant that adds to a corresponding register.
-   *   This can be constant folded.
-   * - `results` contains instruction id + register id, indicating the
-   *   predetermined branch result for choice/min/max function.
+   * - `affineValue` is the affine value associated with a register.
+   * - `results` contains instruction id + affine value, indicating the
+   *   optimized result for some instruction.
    *   Note that this must be sorted according to instruction id.
    * - `uses` is the temporary use count vector that is mutable in each
    *   evaluation. It is reset before each evaluation.
@@ -91,8 +91,8 @@ class OptimizerContext {
    *   elimination.
    */
   VecView<Interval<double>> buffer;
-  VecView<double> constantOffset;
-  std::vector<std::pair<uint32_t, uint8_t>> results;
+  VecView<AffineValue> affineValues;
+  std::vector<std::pair<uint32_t, AffineValue>> results;
   std::vector<uint8_t> uses;
   std::vector<uint32_t> dead;
 };

--- a/src/sdf/optimizing_tape.h
+++ b/src/sdf/optimizing_tape.h
@@ -1,0 +1,99 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <vector>
+
+#include "interval.h"
+#include "manifold/vec_view.h"
+
+namespace manifold::sdf {
+class OptimizerContext {
+ public:
+ private:
+  struct TapeMetadata {
+    size_t tapeLength;
+    size_t instructionCount;
+    size_t farDependencyCount;
+  };
+  struct FarDependency {
+    uint32_t instructionIndex;
+    // dependency indices for the three operands
+    // value std::numeric_limits<uint32_t>::max() means there is no such an
+    // operand
+    std::array<uint32_t, 3> dependencyIndices;
+    bool operator<(const FarDependency &other) const {
+      return instructionIndex < other.instructionIndex;
+    }
+  };
+
+  /* --------------------------------------------------------------------------
+   * Multiple tape storage, but each tape is represented with 4 arrays,
+   * and we join the individual arrays.
+   * Ends are marked with tape metadata.
+   *
+   * Each tape consists of the underlying opcode, use counts for each
+   * instruction result, dependencies for each instruction operand. While
+   * dependencies can be reconstructed while executing the code, that adds a
+   * considerable overhead *regardless* of whether we can optimize later.
+   * Instead, we move the overhead to initialization and in the optimizer (it
+   * tracks the use count), with the cost of using more memory.
+   *
+   * Note that we only track direct dependencies: Instructions can depend on
+   * load instructions instead of the actual instruction computing the value of
+   * the spill, and the load instruction depends on the corresponding store
+   * instruction. This allows us to remove register spills if possible.
+   *
+   * For dependencies, we use relative index to track them.
+   *   ID = current ID - value
+   * - If value is 0, this means the operand is not being used, i.e. the
+   *   instruction does not have 3 operands.
+   * - If value is 255, this means the dependency is too far away, and we
+   *   should look it up in far dependencies.
+   * Ideally, we should not have too many far dependencies.
+   *
+   * Due to the variable length encoding used in the instruction tape, we
+   * cannot find the opcode in O(1) time given instruction ID, so things we do
+   * during optimization should not involve the opcode until we actually need
+   * to generate a new tape.
+   */
+  std::vector<uint8_t> tapes;
+  std::vector<uint8_t> useCounts;
+  std::vector<std::array<uint8_t, 3>> dependencies;
+  std::vector<FarDependency> farDependencies;
+  std::vector<TapeMetadata> tapeMetadata;
+
+  /* --------------------------------------------------------------------------
+   * Per evaluation data structures.
+   * In principle, these can be constructed per evaluation, but to minimize
+   * memory operations, we reuse them.
+   *
+   * - `buffer` is the regular register buffer for tape evaluation.
+   * - `constantOffset` is a constant that adds to a corresponding register.
+   *   This can be constant folded.
+   * - `results` contains instruction id + register id, indicating the
+   *   predetermined branch result for choice/min/max function.
+   *   Note that this must be sorted according to instruction id.
+   * - `uses` is the temporary use count vector that is mutable in each
+   *   evaluation. It is reset before each evaluation.
+   * - `dead` contains instruction IDs that are dead, for later dead code
+   *   elimination.
+   */
+  VecView<Interval<double>> buffer;
+  VecView<double> constantOffset;
+  std::vector<std::pair<uint32_t, uint8_t>> results;
+  std::vector<uint8_t> uses;
+  std::vector<uint32_t> dead;
+};
+}  // namespace manifold::sdf

--- a/src/sdf/small_vector.h
+++ b/src/sdf/small_vector.h
@@ -272,8 +272,8 @@ class small_vector {
       ptr_--;
       return i;
     }
-    self_type operator+(size_t i) { return self_type(ptr_ + i); }
-    self_type operator-(size_t i) { return self_type(ptr_ - i); }
+    self_type operator+(size_type i) { return self_type(ptr_ + i); }
+    self_type operator-(size_type i) { return self_type(ptr_ - i); }
     reference operator*() { return *ptr_; }
     pointer operator->() { return ptr_; }
     bool operator==(const self_type &rhs) { return ptr_ == rhs.ptr_; }
@@ -310,8 +310,8 @@ class small_vector {
       ptr_--;
       return i;
     }
-    self_type operator+(size_t i) { return self_type(ptr_ + i); }
-    self_type operator-(size_t i) { return self_type(ptr_ - i); }
+    self_type operator+(size_type i) { return self_type(ptr_ + i); }
+    self_type operator-(size_type i) { return self_type(ptr_ - i); }
     const value_type &operator*() { return *ptr_; }
     const pointer operator->() { return ptr_; }
     bool operator==(const self_type &rhs) { return ptr_ == rhs.ptr_; }
@@ -358,7 +358,7 @@ class small_vector {
   const_iterator end() const { return cend(); }
 
   void erase(iterator iter) {
-    size_t i = std::distance(begin(), iter);
+    size_type i = std::distance(begin(), iter);
     if (size_ <= N) {
       std::move_backward(stack_.begin() + i + 1, stack_.begin() + size_,
                          stack_.begin() + i);
@@ -373,7 +373,7 @@ class small_vector {
   }
 
   void insert(iterator iter, const T &value) {
-    size_t i = std::distance(begin(), iter);
+    size_type i = std::distance(begin(), iter);
     if (size_ < N) {
       if (i + 1 < size_)
         std::move_backward(stack_.begin() + i, stack_.begin() + size_,
@@ -388,7 +388,7 @@ class small_vector {
   }
 
   void insert(const_iterator iter, const T &value) {
-    insert(cbegin() + std::distance(cbegin(), iter), value);
+    insert(begin() + std::distance(cbegin(), iter), value);
   }
 };
 

--- a/src/sdf/small_vector.h
+++ b/src/sdf/small_vector.h
@@ -258,7 +258,7 @@ class small_vector {
       ptr_++;
       return *this;
     }
-    self_type operator++(int) const {
+    self_type operator++(int) {
       self_type i = *this;
       ptr_++;
       return i;
@@ -267,7 +267,7 @@ class small_vector {
       ptr_--;
       return *this;
     }
-    self_type operator--(int) const {
+    self_type operator--(int) {
       self_type i = *this;
       ptr_--;
       return i;
@@ -298,7 +298,7 @@ class small_vector {
       ptr_++;
       return *this;
     }
-    self_type operator++(int) const {
+    self_type operator++(int) {
       self_type i = *this;
       ptr_++;
       return i;
@@ -307,7 +307,7 @@ class small_vector {
       ptr_--;
       return *this;
     }
-    self_type operator--(int) const {
+    self_type operator--(int) {
       self_type i = *this;
       ptr_--;
       return i;

--- a/src/sdf/small_vector.h
+++ b/src/sdf/small_vector.h
@@ -1,0 +1,395 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// rewrite of https://github.com/p-ranav/small_vector
+#pragma once
+#include <array>
+#include <vector>
+
+namespace manifold {
+
+// note that this will not work with non-trivial data (custom
+// constructor/destructor)
+template <class T, std::size_t N>
+class small_vector {
+  std::array<T, N> stack_;
+  std::vector<T> heap_;
+  std::size_t size_{0};
+
+ public:
+  using value_type = T;
+  using size_type = std::size_t;
+  using reference = value_type &;
+  using const_reference = const value_type &;
+  using pointer = T *;
+  using const_pointer = const T *;
+
+  small_vector() = default;
+
+  explicit small_vector(size_type count, const T &value = T()) {
+    if (count <= N) {
+      std::fill(stack_.begin(), stack_.begin() + count, value);
+    } else {
+      // use heap
+      heap_.resize(count, value);
+    }
+    size_ = count;
+  }
+
+  small_vector(const small_vector &other)
+      : stack_(other.stack_), heap_(other.heap_), size_(other.size_) {}
+
+  small_vector(small_vector &&other)
+      : stack_(std::move(other.stack_)),
+        heap_(std::move(other.heap_)),
+        size_(other.size_) {}
+
+  small_vector(std::initializer_list<T> initlist) {
+    const auto input_size = initlist.size();
+    if (input_size <= N) {
+      std::copy(initlist.begin(), initlist.end(), stack_.begin());
+    } else {
+      std::copy(initlist.begin(), initlist.end(), std::back_inserter(heap_));
+    }
+    size_ = input_size;
+  }
+
+  small_vector &operator=(const small_vector &rhs) {
+    stack_ = rhs.stack_;
+    heap_ = rhs.heap_;
+    size_ = rhs.size_;
+    return *this;
+  }
+
+  small_vector &operator=(small_vector &&rhs) {
+    stack_ = std::move(rhs.stack_);
+    heap_ = std::move(rhs.heap_);
+    size_ = rhs.size_;
+    rhs.size_ = 0;
+    return *this;
+  }
+
+  small_vector &operator=(std::initializer_list<value_type> rhs) {
+    if (rhs.size() <= N) {
+      stack_ = rhs;
+    } else {
+      heap_ = rhs;
+    }
+    size_ = rhs.size();
+  }
+
+  reference at(size_type pos) {
+    if (size_ <= N) {
+      return stack_.at(pos);
+    } else {
+      return heap_.at(pos);
+    }
+  }
+
+  const_reference at(size_type pos) const {
+    if (size_ <= N) {
+      return stack_.at(pos);
+    } else {
+      return heap_.at(pos);
+    }
+  }
+
+  reference operator[](size_type pos) {
+    if (size_ <= N) {
+      return stack_[pos];
+    } else {
+      return heap_[pos];
+    }
+  }
+
+  const_reference operator[](size_type pos) const {
+    if (size_ <= N) {
+      return stack_[pos];
+    } else {
+      return heap_[pos];
+    }
+  }
+
+  reference front() {
+    if (size_ <= N) {
+      return stack_.front();
+    } else {
+      return heap_.front();
+    }
+  }
+
+  const_reference front() const {
+    if (size_ <= N) {
+      return stack_.front();
+    } else {
+      return heap_.front();
+    }
+  }
+
+  reference back() {
+    if (size_ <= N) {
+      return stack_[size_ - 1];
+    } else {
+      return heap_[size_ - 1];
+    }
+  }
+
+  const_reference back() const {
+    if (size_ <= N) {
+      return stack_[size_ - 1];
+    } else {
+      return heap_[size_ - 1];
+    }
+  }
+
+  pointer data() noexcept {
+    if (size_ <= N) {
+      return stack_.data();
+    } else {
+      return heap_.data();
+    }
+  }
+
+  const_pointer data() const noexcept {
+    if (size_ <= N) {
+      return stack_.data();
+    } else {
+      return heap_.data();
+    }
+  }
+
+  bool empty() const { return size_ == 0; }
+
+  size_type size() const { return size_; }
+
+  void shrink_to_fit() {
+    if (size_ > N) {
+      heap_.shrink_to_fit();
+    }
+  }
+
+  void push_back(const T &value) {
+    if (size_ < N) {
+      stack_[size_] = value;
+    } else {
+      if (size_ == N) {
+        std::move(stack_.begin(), stack_.end(), std::back_inserter(heap_));
+      }
+      heap_.emplace_back(value);
+    }
+    size_ += 1;
+  }
+
+  void pop_back() {
+    if (size_ == 0) return;
+    if (size_ <= N) {
+      size_ -= 1;
+    } else {
+      // currently using heap
+      heap_.pop_back();
+      size_ -= 1;
+      // now check if all data can fit on stack
+      // if so, move back to stack
+      if (size_ <= N) {
+        std::move(heap_.begin(), heap_.end(), stack_.begin());
+        heap_.clear();
+      }
+    }
+  }
+
+  // Resizes the container to contain count elements.
+  void resize(size_type count, T value = T()) {
+    if (count <= N) {
+      // new `count` of elements completely fit on stack
+      if (size_ >= N) {
+        // currently, all data on heap
+        // move back to stack
+        std::move(heap_.begin(), heap_.end(), stack_.begin());
+      } else {
+        // all data already on stack
+        // just update size
+      }
+    } else {
+      // new `count` of data is going to be on the heap
+      // check if data is currently on the stack
+      if (size_ <= N) {
+        // move to heap
+        std::move(stack_.begin(), stack_.end(), std::back_inserter(heap_));
+      }
+      heap_.resize(count, value);
+    }
+    size_ = count;
+  }
+
+  void clear() {
+    if (size_ > N) {
+      heap_.clear();
+    }
+    size_ = 0;
+  }
+
+  void swap(small_vector &other) noexcept {
+    std::swap(stack_, other.stack_);
+    std::swap(heap_, other.heap_);
+    std::swap(size_, other.size_);
+  };
+
+  class iterator {
+   public:
+    using self_type = iterator;
+    using value_type = T;
+    using reference = T &;
+    using pointer = T *;
+    using difference_type = int;
+    using iterator_category = std::bidirectional_iterator_tag;
+    iterator(pointer ptr) : ptr_(ptr) {}
+    self_type operator++() {
+      ptr_++;
+      return *this;
+    }
+    self_type operator++(int) {
+      self_type i = *this;
+      ptr_++;
+      return i;
+    }
+    self_type operator--() {
+      ptr_--;
+      return *this;
+    }
+    self_type operator--(int) {
+      self_type i = *this;
+      ptr_--;
+      return i;
+    }
+    self_type operator+(size_t i) { return self_type(ptr_ + i); }
+    self_type operator-(size_t i) { return self_type(ptr_ - i); }
+    reference operator*() { return *ptr_; }
+    pointer operator->() { return ptr_; }
+    bool operator==(const self_type &rhs) { return ptr_ == rhs.ptr_; }
+    bool operator!=(const self_type &rhs) { return ptr_ != rhs.ptr_; }
+
+   private:
+    pointer ptr_;
+  };
+
+  class const_iterator {
+   public:
+    using self_type = const_iterator;
+    using value_type = T;
+    using reference = const T &;
+    using pointer = const T *;
+    using difference_type = int;
+    using iterator_category = std::bidirectional_iterator_tag;
+    const_iterator(pointer ptr) : ptr_(ptr) {}
+    self_type operator++() {
+      ptr_++;
+      return *this;
+    }
+    self_type operator++(int) {
+      self_type i = *this;
+      ptr_++;
+      return i;
+    }
+    self_type operator--() {
+      ptr_--;
+      return *this;
+    }
+    self_type operator--(int) {
+      self_type i = *this;
+      ptr_--;
+      return i;
+    }
+    self_type operator+(size_t i) { return self_type(ptr_ + i); }
+    self_type operator-(size_t i) { return self_type(ptr_ - i); }
+    const value_type &operator*() { return *ptr_; }
+    const pointer operator->() { return ptr_; }
+    bool operator==(const self_type &rhs) { return ptr_ == rhs.ptr_; }
+    bool operator!=(const self_type &rhs) { return ptr_ != rhs.ptr_; }
+
+   private:
+    pointer ptr_;
+  };
+
+  iterator begin() {
+    if (size_ <= N) {
+      return iterator(stack_.data());
+    } else {
+      return iterator(heap_.data());
+    }
+  }
+
+  iterator end() {
+    if (size_ <= N) {
+      return iterator(stack_.data() + size_);
+    } else {
+      return iterator(heap_.data() + size_);
+    }
+  }
+
+  const_iterator cbegin() const {
+    if (size_ <= N) {
+      return const_iterator(stack_.data());
+    } else {
+      return const_iterator(heap_.data());
+    }
+  }
+
+  const_iterator cend() const {
+    if (size_ <= N) {
+      return const_iterator(stack_.data() + size_);
+    } else {
+      return const_iterator(heap_.data() + size_);
+    }
+  }
+
+  const_iterator begin() const { return cbegin(); }
+
+  const_iterator end() const { return cend(); }
+
+  void erase(iterator iter) {
+    size_t i = std::distance(begin(), iter);
+    if (size_ <= N) {
+      std::move_backward(stack_.begin() + i + 1, stack_.begin() + size_,
+                         stack_.begin() + i);
+    } else {
+      heap_.erase(heap_.begin() + i);
+    }
+    size_ -= 1;
+  }
+
+  void erase(const_iterator iter) {
+    erase(begin() + std::distance(cbegin(), iter));
+  }
+
+  void insert(iterator iter, const T &value) {
+    size_t i = std::distance(begin(), iter);
+    if (size_ < N) {
+      if (i + 1 < size_)
+        std::move_backward(stack_.begin() + i, stack_.begin() + size_,
+                           stack_.begin() + i + 1);
+      stack_[i] = value;
+    } else {
+      if (size_ == N)
+        std::move(stack_.begin(), stack_.end(), std::back_inserter(heap_));
+      heap_.insert(heap_.begin() + i, value);
+    }
+    size_ += 1;
+  }
+
+  void insert(const_iterator iter, const T &value) {
+    insert(cbegin() + std::distance(cbegin(), iter), value);
+  }
+};
+
+}  // namespace manifold

--- a/src/sdf/small_vector.h
+++ b/src/sdf/small_vector.h
@@ -258,7 +258,7 @@ class small_vector {
       ptr_++;
       return *this;
     }
-    self_type operator++(int) {
+    self_type operator++(int) const {
       self_type i = *this;
       ptr_++;
       return i;
@@ -267,17 +267,19 @@ class small_vector {
       ptr_--;
       return *this;
     }
-    self_type operator--(int) {
+    self_type operator--(int) const {
       self_type i = *this;
       ptr_--;
       return i;
     }
-    self_type operator+(size_type i) { return self_type(ptr_ + i); }
-    self_type operator-(size_type i) { return self_type(ptr_ - i); }
+    self_type operator+(size_type i) const { return self_type(ptr_ + i); }
+    self_type operator-(size_type i) const { return self_type(ptr_ - i); }
     reference operator*() { return *ptr_; }
+    const value_type &operator*() const { return *ptr_; }
     pointer operator->() { return ptr_; }
-    bool operator==(const self_type &rhs) { return ptr_ == rhs.ptr_; }
-    bool operator!=(const self_type &rhs) { return ptr_ != rhs.ptr_; }
+    const pointer operator->() const { return ptr_; }
+    bool operator==(const self_type &rhs) const { return ptr_ == rhs.ptr_; }
+    bool operator!=(const self_type &rhs) const { return ptr_ != rhs.ptr_; }
 
    private:
     pointer ptr_;
@@ -296,7 +298,7 @@ class small_vector {
       ptr_++;
       return *this;
     }
-    self_type operator++(int) {
+    self_type operator++(int) const {
       self_type i = *this;
       ptr_++;
       return i;
@@ -305,17 +307,17 @@ class small_vector {
       ptr_--;
       return *this;
     }
-    self_type operator--(int) {
+    self_type operator--(int) const {
       self_type i = *this;
       ptr_--;
       return i;
     }
-    self_type operator+(size_type i) { return self_type(ptr_ + i); }
-    self_type operator-(size_type i) { return self_type(ptr_ - i); }
-    const value_type &operator*() { return *ptr_; }
-    const pointer operator->() { return ptr_; }
-    bool operator==(const self_type &rhs) { return ptr_ == rhs.ptr_; }
-    bool operator!=(const self_type &rhs) { return ptr_ != rhs.ptr_; }
+    self_type operator+(size_type i) const { return self_type(ptr_ + i); }
+    self_type operator-(size_type i) const { return self_type(ptr_ - i); }
+    reference operator*() const { return *ptr_; }
+    pointer operator->() const { return ptr_; }
+    bool operator==(const self_type &rhs) const { return ptr_ == rhs.ptr_; }
+    bool operator!=(const self_type &rhs) const { return ptr_ != rhs.ptr_; }
 
    private:
     pointer ptr_;

--- a/src/sdf/tape.h
+++ b/src/sdf/tape.h
@@ -358,6 +358,7 @@ inline std::string dumpOpCode(OpCode op) {
     case OpCode::CHOICE:
       return "CHOICE";
   }
+  return "";
 }
 
 }  // namespace manifold::sdf

--- a/src/sdf/tape.h
+++ b/src/sdf/tape.h
@@ -1,0 +1,277 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+
+#include "interval.h"
+#include "manifold/vec_view.h"
+
+namespace manifold::sdf {
+
+enum class OpCode : uint8_t {
+  NOP,
+  RETURN,
+
+  // unary operations
+  ABS,
+  NEG,
+  EXP,
+  LOG,
+  SQRT,
+  FLOOR,
+  CEIL,
+  ROUND,
+  SIN,
+  COS,
+  TAN,
+  ASIN,
+  ACOS,
+  ATAN,
+
+  // binary operations,
+  DIV,
+  MOD,
+  MIN,
+  MAX,
+  EQ,
+  GT,
+  AND,
+  OR,
+
+  // fast binary operations
+  ADD,
+  SUB,
+  MUL,
+  // ternary operations
+  FMA,
+  CHOICE,
+};
+
+template <typename Domain>
+struct EvalContext {
+  VecView<const uint8_t> tape;
+  VecView<Domain> buffer;
+
+  Domain& operand(uint32_t x) { return buffer[x]; }
+
+  static Domain handle_unary(OpCode op, Domain operand);
+
+  static Domain handle_binary(OpCode op, Domain lhs, Domain rhs);
+
+  static Domain handle_choice(Domain cond, Domain lhs, Domain rhs);
+
+  Domain eval() {
+    size_t i = 0;
+    while (1) {
+      OpCode current = static_cast<OpCode>(tape[i]);
+      // fast binary/ternary operations
+      if (current >= OpCode::ADD) {
+        // loop is needed to force the compiler to use a tight code layout
+        do {
+          size_t result = tape[i + 1];
+          Domain lhs = operand(tape[i + 2]);
+          Domain rhs = operand(tape[i + 3]);
+          i += 4;
+          if (current <= OpCode::MUL) {
+            if (current == OpCode::ADD)
+              operand(result) = lhs + rhs;
+            else if (current == OpCode::SUB)
+              operand(result) = lhs - rhs;
+            else
+              operand(result) = lhs * rhs;
+          } else {
+            Domain z = operand(tape[i++]);
+            if (current == OpCode::FMA)
+              operand(result) = lhs * rhs + z;
+            else
+              operand(result) = handle_choice(lhs, rhs, z);
+          }
+          current = static_cast<OpCode>(tape[i]);
+        } while (current >= OpCode::ADD);
+      }
+      if (current >= OpCode::DIV) {
+        Domain lhs = operand(tape[i + 2]);
+        Domain rhs = operand(tape[i + 3]);
+        operand(tape[i + 1]) = handle_binary(current, lhs, rhs);
+        i += 4;
+      } else if (current >= OpCode::ABS) {
+        Domain x = operand(tape[i + 2]);
+        operand(tape[i + 1]) = handle_unary(current, x);
+        i += 3;
+      } else if (current == OpCode::RETURN) {
+        return operand(tape[i + 1]);
+      } else {
+        i += 1;
+      }
+    }
+  }
+};
+
+template <>
+inline double EvalContext<double>::handle_unary(OpCode op, double x) {
+  switch (op) {
+    case OpCode::ABS:
+      return std::abs(x);
+    case OpCode::NEG:
+      return -x;
+    case OpCode::EXP:
+      return std::exp(x);
+    case OpCode::LOG:
+      return std::log(x);
+    case OpCode::SQRT:
+      return std::sqrt(x);
+    case OpCode::FLOOR:
+      return std::floor(x);
+    case OpCode::CEIL:
+      return std::ceil(x);
+    case OpCode::ROUND:
+      return std::round(x);
+    case OpCode::SIN:
+      return std::sin(x);
+    case OpCode::COS:
+      return std::cos(x);
+    case OpCode::TAN:
+      return std::tan(x);
+    case OpCode::ASIN:
+      return std::asin(x);
+    case OpCode::ACOS:
+      return std::acos(x);
+    case OpCode::ATAN:
+      return std::atan(x);
+    default:
+      return 0.0;
+  }
+}
+
+template <>
+inline double EvalContext<double>::handle_binary(OpCode op, double lhs,
+                                                 double rhs) {
+  switch (op) {
+    case OpCode::DIV:
+      return lhs / rhs;
+    case OpCode::MOD:
+      // FIXME: negative rhs???
+      return std::fmod(std::fmod(lhs, rhs) + rhs, rhs);
+    case OpCode::MIN:
+      return std::min(lhs, rhs);
+    case OpCode::MAX:
+      return std::max(lhs, rhs);
+    case OpCode::EQ:
+      return lhs == rhs ? 1.0 : 0.0;
+    case OpCode::GT:
+      return lhs > rhs ? 1.0 : 0.0;
+    case OpCode::AND:
+      return (lhs == 1.0 && rhs == 1.0) ? 1.0 : 0.0;
+    case OpCode::OR:
+      return (lhs == 1.0 || rhs == 1.0) ? 1.0 : 0.0;
+    default:
+      return 0;
+  }
+}
+
+template <>
+inline double EvalContext<double>::handle_choice(double cond, double lhs,
+                                                 double rhs) {
+  if (cond == 1.0) return lhs;
+  return rhs;
+}
+
+template <>
+inline Interval<double> EvalContext<Interval<double>>::handle_unary(
+    OpCode op, Interval<double> x) {
+  constexpr double infty = std::numeric_limits<double>::infinity();
+  switch (op) {
+    case OpCode::ABS:
+      return x.abs();
+    case OpCode::NEG:
+      return -x;
+    case OpCode::EXP:
+      return x.monotone_map([](double v) { return std::exp(v); });
+    case OpCode::LOG:
+      return x.monotone_map(
+          [infty](double v) { return v > 0.0 ? std::log(v) : -infty; });
+    case OpCode::SQRT:
+      return x.monotone_map(
+          [infty](double v) { return v >= 0.0 ? std::sqrt(v) : 0.0; });
+    case OpCode::FLOOR:
+      return x.monotone_map([](double v) { return std::floor(v); });
+    case OpCode::CEIL:
+      return x.monotone_map([](double v) { return std::ceil(v); });
+    case OpCode::ROUND:
+      return x.monotone_map([](double v) { return std::round(v); });
+    case OpCode::SIN:
+      return x.sin();
+    case OpCode::COS:
+      return x.cos();
+    case OpCode::TAN:
+      return x.tan();
+    case OpCode::ASIN:
+      return x.monotone_map([infty](double v) {
+        return v < -1.0 ? -infty : v > 1.0 ? infty : std::asin(v);
+      });
+    case OpCode::ACOS:
+      return x.antimonotone_map([infty](double v) {
+        return v < -1.0 ? infty : v > 1.0 ? -infty : std::acos(v);
+      });
+    case OpCode::ATAN:
+      return x.monotone_map([](double v) { return std::atan(v); });
+    default:
+      return {0.0, 0.0};
+  }
+}
+
+template <>
+inline Interval<double> EvalContext<Interval<double>>::handle_binary(
+    OpCode op, Interval<double> lhs, Interval<double> rhs) {
+  switch (op) {
+    case OpCode::DIV:
+      return lhs / rhs;
+    case OpCode::MOD:
+      return lhs.is_const()
+                 ? lhs.mod(rhs.lower)
+                 : (rhs.lower < 0
+                        ? Interval<double>{rhs.lower, std::max(0.0, rhs.upper)}
+                        : Interval<double>{0, rhs.upper});
+    case OpCode::MIN:
+      return lhs.min(rhs);
+    case OpCode::MAX:
+      return lhs.max(rhs);
+    case OpCode::EQ:
+      return lhs == rhs;
+    case OpCode::GT:
+      return lhs > rhs;
+    case OpCode::AND:
+      return lhs.logical_and(rhs);
+    case OpCode::OR:
+      return lhs.logical_or(rhs);
+    default:
+      return {0.0, 0.0};
+  }
+}
+
+template <>
+inline Interval<double> EvalContext<Interval<double>>::handle_choice(
+    Interval<double> cond, Interval<double> lhs, Interval<double> rhs) {
+  if (cond.is_const()) {
+    if (cond.lower == 1.0) return lhs;
+    return rhs;
+  }
+  return lhs.merge(rhs);
+}
+
+}  // namespace manifold::sdf

--- a/src/sdf/tape.h
+++ b/src/sdf/tape.h
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <limits>
 
 #include "interval.h"
@@ -26,6 +27,7 @@ namespace manifold::sdf {
 enum class OpCode : uint8_t {
   NOP,
   RETURN,
+  // CONST,
 
   // unary operations
   ABS,
@@ -113,6 +115,11 @@ struct EvalContext {
         Domain x = operand(tape[i + 2]);
         operand(tape[i + 1]) = handle_unary(current, x);
         i += 3;
+      // } else if (current == OpCode::CONST) {
+      //   double x;
+      //   std::memcpy(&x, tape.data() + i + 2, sizeof(x));
+      //   operand(tape[i + 1]) = x;
+      //   i += 2 + sizeof(x);
       } else if (current == OpCode::RETURN) {
         return operand(tape[i + 1]);
       } else {

--- a/src/sdf/tape.h
+++ b/src/sdf/tape.h
@@ -115,11 +115,11 @@ struct EvalContext {
         Domain x = operand(tape[i + 2]);
         operand(tape[i + 1]) = handle_unary(current, x);
         i += 3;
-      // } else if (current == OpCode::CONST) {
-      //   double x;
-      //   std::memcpy(&x, tape.data() + i + 2, sizeof(x));
-      //   operand(tape[i + 1]) = x;
-      //   i += 2 + sizeof(x);
+        // } else if (current == OpCode::CONST) {
+        //   double x;
+        //   std::memcpy(&x, tape.data() + i + 2, sizeof(x));
+        //   operand(tape[i + 1]) = x;
+        //   i += 2 + sizeof(x);
       } else if (current == OpCode::RETURN) {
         return operand(tape[i + 1]);
       } else {

--- a/src/sdf/value.cpp
+++ b/src/sdf/value.cpp
@@ -209,7 +209,7 @@ std::pair<std::vector<uint8_t>, std::vector<double>> Value::genTape() const {
         return Operand{-2};
       case ValueKind::Z:
         return Operand{-3};
-      case ValueKind::INVALID:
+      default:
         return Operand::none();
     }
   };

--- a/src/sdf/value.cpp
+++ b/src/sdf/value.cpp
@@ -1,0 +1,243 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "value.h"
+
+#include <unordered_map>
+
+#include "context.h"
+#include "tape.h"
+
+namespace manifold::sdf {
+
+struct ValueOperation {
+  OpCode op;
+  std::array<Value, 3> operands;
+
+  ValueOperation(OpCode op, Value a, Value b, Value c)
+      : op(op), operands({a, b, c}) {}
+};
+
+Value Value::Invalid() { return Value(ValueKind::INVALID, 0.0); }
+
+Value Value::Constant(double d) { return Value(ValueKind::CONSTANT, d); }
+
+Value Value::X() { return Value(ValueKind::X, 0.0); }
+
+Value Value::Y() { return Value(ValueKind::Y, 0.0); }
+
+Value Value::Z() { return Value(ValueKind::Z, 0.0); }
+
+Value Value::operator+(const Value& other) const {
+  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
+                                         OpCode::ADD, *this, other, Invalid()));
+}
+
+Value Value::operator-(const Value& other) const {
+  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
+                                         OpCode::SUB, *this, other, Invalid()));
+}
+
+Value Value::operator*(const Value& other) const {
+  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
+                                         OpCode::MUL, *this, other, Invalid()));
+}
+
+Value Value::operator/(const Value& other) const {
+  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
+                                         OpCode::DIV, *this, other, Invalid()));
+}
+
+Value Value::cond(const Value& then, const Value& otherwise) const {
+  return Value(
+      ValueKind::OPERATION,
+      std::make_shared<ValueOperation>(OpCode::CHOICE, *this, then, otherwise));
+}
+
+Value Value::mod(const Value& other) const {
+  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
+                                         OpCode::MOD, *this, other, Invalid()));
+}
+
+Value Value::min(const Value& other) const {
+  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
+                                         OpCode::MIN, *this, other, Invalid()));
+}
+
+Value Value::max(const Value& other) const {
+  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
+                                         OpCode::MAX, *this, other, Invalid()));
+}
+
+Value Value::operator==(const Value& other) const {
+  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
+                                         OpCode::EQ, *this, other, Invalid()));
+}
+
+Value Value::operator>(const Value& other) const {
+  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
+                                         OpCode::GT, *this, other, Invalid()));
+}
+
+Value Value::operator&&(const Value& other) const {
+  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
+                                         OpCode::AND, *this, other, Invalid()));
+}
+
+Value Value::operator||(const Value& other) const {
+  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
+                                         OpCode::OR, *this, other, Invalid()));
+}
+
+Value Value::abs() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::ABS, *this, Invalid(),
+                                                Invalid()));
+}
+
+Value Value::operator-() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::NEG, *this, Invalid(),
+                                                Invalid()));
+}
+
+Value Value::exp() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::EXP, *this, Invalid(),
+                                                Invalid()));
+}
+
+Value Value::log() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::LOG, *this, Invalid(),
+                                                Invalid()));
+}
+
+Value Value::sqrt() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::SQRT, *this, Invalid(),
+                                                Invalid()));
+}
+
+Value Value::floor() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::FLOOR, *this, Invalid(),
+                                                Invalid()));
+}
+
+Value Value::ceil() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::CEIL, *this, Invalid(),
+                                                Invalid()));
+}
+
+Value Value::round() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::ROUND, *this, Invalid(),
+                                                Invalid()));
+}
+
+Value Value::sin() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::SIN, *this, Invalid(),
+                                                Invalid()));
+}
+
+Value Value::cos() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::COS, *this, Invalid(),
+                                                Invalid()));
+}
+
+Value Value::tan() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::TAN, *this, Invalid(),
+                                                Invalid()));
+}
+
+Value Value::asin() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::ASIN, *this, Invalid(),
+                                                Invalid()));
+}
+
+Value Value::acos() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::ACOS, *this, Invalid(),
+                                                Invalid()));
+}
+
+Value Value::atan() const {
+  return Value(ValueKind::OPERATION,
+               std::make_shared<ValueOperation>(OpCode::ATAN, *this, Invalid(),
+                                                Invalid()));
+}
+
+std::pair<std::vector<uint8_t>, std::vector<double>> Value::genTape() const {
+  using VO = std::shared_ptr<ValueOperation>;
+  Context ctx;
+  std::unordered_map<VO, Operand> cache;
+  std::vector<VO> stack;
+  if (kind == ValueKind::OPERATION) stack.push_back(std::get<VO>(v));
+
+  auto getOperand = [&](Value x, std::function<void(Value)> f) {
+    switch (x.kind) {
+      case ValueKind::OPERATION: {
+        auto iter = cache.find(std::get<VO>(x.v));
+        if (iter != cache.end()) return iter->second;
+        // stack.push_back(std::get<VO>(x.v));
+        // ready = false;
+        f(x);
+        return Operand::none();
+      }
+      case ValueKind::CONSTANT:
+        return ctx.addConstant(std::get<double>(x.v));
+      case ValueKind::X:
+        return Operand{-1};
+      case ValueKind::Y:
+        return Operand{-2};
+      case ValueKind::Z:
+        return Operand{-3};
+      case ValueKind::INVALID:
+        return Operand::none();
+    }
+  };
+  while (!stack.empty()) {
+    bool ready = true;
+    VO current = stack.back();
+    auto f = [&](Value x) {
+      stack.push_back(std::get<VO>(x.v));
+      ready = false;
+    };
+    Operand a = getOperand(current->operands[0], f);
+    Operand b = getOperand(current->operands[1], f);
+    Operand c = getOperand(current->operands[2], f);
+    if (ready) {
+      stack.pop_back();
+      // check if inserted... can happen when evaluating with a DAG
+      if (cache.find(current) != cache.end()) continue;
+      cache.insert({current, ctx.addInstruction(current->op, a, b, c)});
+    }
+  }
+
+  Operand result = getOperand(*this, [](Value _) {});
+  ctx.addInstruction(OpCode::RETURN, result, Operand::none(), Operand::none());
+
+  ctx.dump();
+  ctx.optimizeFMA();
+  ctx.dump();
+  return ctx.genTape();
+}
+
+}  // namespace manifold::sdf

--- a/src/sdf/value.cpp
+++ b/src/sdf/value.cpp
@@ -40,150 +40,51 @@ Value Value::Y() { return Value(ValueKind::Y, 0.0); }
 
 Value Value::Z() { return Value(ValueKind::Z, 0.0); }
 
-Value Value::operator+(const Value& other) const {
-  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
-                                         OpCode::ADD, *this, other, Invalid()));
-}
-
-Value Value::operator-(const Value& other) const {
-  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
-                                         OpCode::SUB, *this, other, Invalid()));
-}
-
-Value Value::operator*(const Value& other) const {
-  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
-                                         OpCode::MUL, *this, other, Invalid()));
-}
-
-Value Value::operator/(const Value& other) const {
-  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
-                                         OpCode::DIV, *this, other, Invalid()));
-}
-
 Value Value::cond(const Value& then, const Value& otherwise) const {
   return Value(
       ValueKind::OPERATION,
       std::make_shared<ValueOperation>(OpCode::CHOICE, *this, then, otherwise));
 }
 
-Value Value::mod(const Value& other) const {
-  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
-                                         OpCode::MOD, *this, other, Invalid()));
-}
+#define MAKE_UNARY(NAME, OPCODE)                                          \
+  Value Value::NAME() const {                                             \
+    return Value(ValueKind::OPERATION,                                    \
+                 std::make_shared<ValueOperation>(OpCode::OPCODE, *this,  \
+                                                  Invalid(), Invalid())); \
+  }
+#define MAKE_BINARY(NAME, OPCODE)                                        \
+  Value Value::NAME(const Value& other) const {                          \
+    return Value(ValueKind::OPERATION,                                   \
+                 std::make_shared<ValueOperation>(OpCode::OPCODE, *this, \
+                                                  other, Invalid()));    \
+  }
 
-Value Value::min(const Value& other) const {
-  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
-                                         OpCode::MIN, *this, other, Invalid()));
-}
+MAKE_UNARY(abs, ABS)
+MAKE_UNARY(operator-, NEG)
+MAKE_UNARY(exp, EXP)
+MAKE_UNARY(log, LOG)
+MAKE_UNARY(sqrt, SQRT)
+MAKE_UNARY(floor, FLOOR)
+MAKE_UNARY(ceil, CEIL)
+MAKE_UNARY(round, ROUND)
+MAKE_UNARY(sin, SIN)
+MAKE_UNARY(cos, COS)
+MAKE_UNARY(tan, TAN)
+MAKE_UNARY(asin, ASIN)
+MAKE_UNARY(acos, ACOS)
+MAKE_UNARY(atan, ATAN)
 
-Value Value::max(const Value& other) const {
-  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
-                                         OpCode::MAX, *this, other, Invalid()));
-}
-
-Value Value::operator==(const Value& other) const {
-  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
-                                         OpCode::EQ, *this, other, Invalid()));
-}
-
-Value Value::operator>(const Value& other) const {
-  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
-                                         OpCode::GT, *this, other, Invalid()));
-}
-
-Value Value::operator&&(const Value& other) const {
-  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
-                                         OpCode::MUL, *this, other, Invalid()));
-}
-
-Value Value::operator||(const Value& other) const {
-  return Value(ValueKind::OPERATION, std::make_shared<ValueOperation>(
-                                         OpCode::ADD, *this, other, Invalid()));
-}
-
-Value Value::abs() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::ABS, *this, Invalid(),
-                                                Invalid()));
-}
-
-Value Value::operator-() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::NEG, *this, Invalid(),
-                                                Invalid()));
-}
-
-Value Value::exp() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::EXP, *this, Invalid(),
-                                                Invalid()));
-}
-
-Value Value::log() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::LOG, *this, Invalid(),
-                                                Invalid()));
-}
-
-Value Value::sqrt() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::SQRT, *this, Invalid(),
-                                                Invalid()));
-}
-
-Value Value::floor() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::FLOOR, *this, Invalid(),
-                                                Invalid()));
-}
-
-Value Value::ceil() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::CEIL, *this, Invalid(),
-                                                Invalid()));
-}
-
-Value Value::round() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::ROUND, *this, Invalid(),
-                                                Invalid()));
-}
-
-Value Value::sin() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::SIN, *this, Invalid(),
-                                                Invalid()));
-}
-
-Value Value::cos() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::COS, *this, Invalid(),
-                                                Invalid()));
-}
-
-Value Value::tan() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::TAN, *this, Invalid(),
-                                                Invalid()));
-}
-
-Value Value::asin() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::ASIN, *this, Invalid(),
-                                                Invalid()));
-}
-
-Value Value::acos() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::ACOS, *this, Invalid(),
-                                                Invalid()));
-}
-
-Value Value::atan() const {
-  return Value(ValueKind::OPERATION,
-               std::make_shared<ValueOperation>(OpCode::ATAN, *this, Invalid(),
-                                                Invalid()));
-}
+MAKE_BINARY(operator+, ADD)
+MAKE_BINARY(operator-, SUB)
+MAKE_BINARY(operator*, MUL)
+MAKE_BINARY(operator/, DIV)
+MAKE_BINARY(mod, MOD)
+MAKE_BINARY(min, MIN)
+MAKE_BINARY(max, MAX)
+MAKE_BINARY(operator==, EQ)
+MAKE_BINARY(operator>, GT)
+MAKE_BINARY(operator&&, MUL)
+MAKE_BINARY(operator||, ADD)
 
 Value::~Value() {
   using VO = std::shared_ptr<ValueOperation>;

--- a/src/sdf/value.cpp
+++ b/src/sdf/value.cpp
@@ -225,12 +225,13 @@ std::pair<std::vector<uint8_t>, size_t> Value::genTape() const {
       stack.pop_back();
       // check if inserted... can happen when evaluating with a DAG
       if (cache.find(current) != cache.end()) continue;
-      cache.insert({current, ctx.addInstruction(current->op, a, b, c)});
+      cache.insert({current, ctx.addInstruction(current->op, {a, b, c})});
     }
   }
 
   Operand result = getOperand(*this, [](Value _) {});
-  ctx.addInstruction(OpCode::RETURN, result, Operand::none(), Operand::none());
+  ctx.addInstruction(OpCode::RETURN,
+                     {result, Operand::none(), Operand::none()});
 
   ctx.optimizeFMA();
   ctx.reschedule();

--- a/src/sdf/value.cpp
+++ b/src/sdf/value.cpp
@@ -196,8 +196,6 @@ std::pair<std::vector<uint8_t>, std::vector<double>> Value::genTape() const {
       case ValueKind::OPERATION: {
         auto iter = cache.find(std::get<VO>(x.v));
         if (iter != cache.end()) return iter->second;
-        // stack.push_back(std::get<VO>(x.v));
-        // ready = false;
         f(x);
         return Operand::none();
       }

--- a/src/sdf/value.cpp
+++ b/src/sdf/value.cpp
@@ -234,11 +234,8 @@ std::pair<std::vector<uint8_t>, std::vector<double>> Value::genTape() const {
   Operand result = getOperand(*this, [](Value _) {});
   ctx.addInstruction(OpCode::RETURN, result, Operand::none(), Operand::none());
 
-  ctx.dump();
   ctx.optimizeFMA();
-  ctx.dump();
   ctx.reschedule();
-  ctx.dump();
   return ctx.genTape();
 }
 

--- a/src/sdf/value.cpp
+++ b/src/sdf/value.cpp
@@ -237,6 +237,8 @@ std::pair<std::vector<uint8_t>, std::vector<double>> Value::genTape() const {
   ctx.dump();
   ctx.optimizeFMA();
   ctx.dump();
+  ctx.reschedule();
+  ctx.dump();
   return ctx.genTape();
 }
 

--- a/src/sdf/value.h
+++ b/src/sdf/value.h
@@ -14,7 +14,6 @@
 #pragma once
 
 #include <memory>
-#include <utility>
 #include <variant>
 #include <vector>
 

--- a/src/sdf/value.h
+++ b/src/sdf/value.h
@@ -1,0 +1,75 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace manifold::sdf {
+
+enum class ValueKind { CONSTANT, X, Y, Z, OPERATION, INVALID };
+
+struct ValueOperation;
+
+class Value {
+ public:
+  static Value Invalid();
+  static Value Constant(double d);
+  static Value X();
+  static Value Y();
+  static Value Z();
+
+  Value operator+(const Value& other) const;
+  Value operator-(const Value& other) const;
+  Value operator*(const Value& other) const;
+  Value operator/(const Value& other) const;
+  Value cond(const Value& then, const Value& otherwise) const;
+  Value mod(const Value& m) const;
+  Value min(const Value& other) const;
+  Value max(const Value& other) const;
+
+  // TODO: should we have a boolean value type?
+  Value operator==(const Value& other) const;
+  Value operator>(const Value& other) const;
+  Value operator&&(const Value& other) const;
+  Value operator||(const Value& other) const;
+
+  Value abs() const;
+  Value operator-() const;
+  Value exp() const;
+  Value log() const;
+  Value sqrt() const;
+  Value floor() const;
+  Value ceil() const;
+  Value round() const;
+  Value sin() const;
+  Value cos() const;
+  Value tan() const;
+  Value asin() const;
+  Value acos() const;
+  Value atan() const;
+
+  // internal use only
+  std::pair<std::vector<uint8_t>, std::vector<double>> genTape() const;
+
+ private:
+  ValueKind kind = ValueKind::INVALID;
+  std::variant<double, std::shared_ptr<ValueOperation>> v;
+
+  Value(ValueKind kind, std::variant<double, std::shared_ptr<ValueOperation>> v)
+      : kind(kind), v(v) {}
+};
+}  // namespace manifold::sdf

--- a/src/sdf/value.h
+++ b/src/sdf/value.h
@@ -63,6 +63,7 @@ class Value {
 
   // internal use only
   std::pair<std::vector<uint8_t>, size_t> genTape() const;
+  ~Value();
 
  private:
   ValueKind kind = ValueKind::INVALID;

--- a/src/sdf/value.h
+++ b/src/sdf/value.h
@@ -62,7 +62,7 @@ class Value {
   Value atan() const;
 
   // internal use only
-  std::pair<std::vector<uint8_t>, std::vector<double>> genTape() const;
+  std::pair<std::vector<uint8_t>, size_t> genTape() const;
 
  private:
   ValueKind kind = ValueKind::INVALID;

--- a/src/utils.h
+++ b/src/utils.h
@@ -35,6 +35,15 @@
 
 #include "./parallel.h"
 
+#if __has_include(<parallel_hashmap/phmap.h>)
+#include <parallel_hashmap/phmap.h>
+template <typename K, typename V>
+using unordered_map = phmap::flat_hash_map<K, V>;
+#else
+template <typename K, typename V>
+using unordered_map = std::unordered_map<K, V>;
+#endif
+
 #if __has_include(<tracy/Tracy.hpp>)
 #include <tracy/Tracy.hpp>
 #else

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ set(
   hull_test.cpp
   samples_test.cpp
   boolean_complex_test.cpp
+  sdf_tape_test.cpp
   $<$<BOOL:${MANIFOLD_CROSS_SECTION}>:cross_section_test.cpp>
   $<$<BOOL:${MANIFOLD_CBIND}>:manifoldc_test.cpp>
 )

--- a/test/sdf_tape_test.cpp
+++ b/test/sdf_tape_test.cpp
@@ -1,0 +1,118 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include "../src/sdf/tape.h"
+#include "../src/sdf/value.h"
+#include "test.h"
+
+using namespace manifold;
+using namespace manifold::sdf;
+
+int recursive_interval(EvalContext<Interval<double>>& ctx, vec3 start,
+                       vec3 delta, const double edgeLength,
+                       const double level) {
+  if (delta.x < edgeLength && delta.y < edgeLength && delta.z < edgeLength)
+    return 1;  // we should do one evaluation...
+  ctx.buffer[0] = {start.x, start.x + delta.x};
+  ctx.buffer[1] = {start.y, start.y + delta.y};
+  ctx.buffer[2] = {start.z, start.z + delta.z};
+  auto result = ctx.eval() - level;
+
+  int count = 1;  // we did one evaluation
+  if (result.lower >= 0.0 || result.upper <= 0.0) return 1;
+  // in case it is not a cube, we may want to avoid dividing too much in some
+  // axis
+  vec3 new_delta = {delta.x < edgeLength ? delta.x : (delta.x / 2),
+                    delta.y < edgeLength ? delta.y : (delta.y / 2),
+                    delta.z < edgeLength ? delta.z : (delta.z / 2)};
+  // can easily be converted into a worklist
+  for (int a = 0; a <= (delta.x < edgeLength ? 0 : 1); a++)
+    for (int b = 0; b <= (delta.y < edgeLength ? 0 : 1); b++)
+      for (int c = 0; c <= (delta.z < edgeLength ? 0 : 1); c++) {
+        auto new_start = start;
+        if (a == 1) new_start.x += new_delta.x;
+        if (b == 1) new_start.y += new_delta.y;
+        if (c == 1) new_start.z += new_delta.z;
+        count +=
+            recursive_interval(ctx, new_start, new_delta, edgeLength, level);
+      }
+
+  return count;
+}
+
+TEST(TAPE, Gyroid) {
+  const double n = 20;
+  const double period = kTwoPi;
+  Value constantKPi4 = Value::Constant(kPi / 4);
+  auto x = Value::X() - constantKPi4;
+  auto y = Value::Y() - constantKPi4;
+  auto z = Value::Y() - constantKPi4;
+
+  auto result = x.cos() * y.sin() + y.cos() * z.sin() + z.cos() * x.sin();
+  auto tape = result.genTape();
+  std::vector<Interval<double>> intervalBuffer;
+  for (auto d : tape.second) intervalBuffer.push_back(Interval(d));
+  EvalContext<Interval<double>> ctx{
+      tape.first, VecView(intervalBuffer.data(), intervalBuffer.size())};
+  std::cout << recursive_interval(ctx, vec3(-period), vec3(period * 2),
+                                  period / n, -0.4)
+            << std::endl;
+  std::cout << recursive_interval(ctx, vec3(-period), vec3(period * 2),
+                                  period / n, 0.4)
+            << std::endl;
+}
+
+TEST(TAPE, Blobs) {
+  std::vector<vec4> balls = {{0, 0, 0, 2},     //
+                             {1, 2, 3, 2},     //
+                             {-2, 2, -2, 1},   //
+                             {-2, -3, -2, 2},  //
+                             {-3, -1, -3, 1},  //
+                             {2, -3, -2, 2},   //
+                             {-2, 3, 2, 2},    //
+                             {-2, -3, 2, 2},   //
+                             {1, -1, 1, -2},   //
+                             {-4, -3, -2, 1}};
+  auto lengthFn = [](Value x, Value y, Value z) {
+    return (x * x + y * y + z * z).sqrt();
+  };
+  auto smoothstepFn = [](Value edge0, Value edge1, Value a) {
+    auto x = ((a - edge0) / (edge1 - edge0))
+                 .min(Value::Constant(1))
+                 .max(Value::Constant(0));
+    return x * x * (Value::Constant(3) - Value::Constant(2) * x);
+  };
+  Value d = Value::Constant(0);
+  for (const auto& ball : balls) {
+    auto tmp = smoothstepFn(Value::Constant(-1), Value::Constant(1),
+                            Value::Constant(ball.w).abs() -
+                                lengthFn(Value::Constant(ball.x) - Value::X(),
+                                         Value::Constant(ball.y) - Value::Y(),
+                                         Value::Constant(ball.z) - Value::Z()));
+    if (ball.w > 0)
+      d = d + tmp;
+    else
+      d = d - tmp;
+  }
+  auto tape = d.genTape();
+
+  std::vector<Interval<double>> intervalBuffer;
+  for (auto d : tape.second) intervalBuffer.push_back(Interval(d));
+  EvalContext<Interval<double>> ctx{
+      tape.first, VecView(intervalBuffer.data(), intervalBuffer.size())};
+  std::cout << recursive_interval(ctx, vec3(-5), vec3(10), 0.05, 0.5)
+            << std::endl;
+}

--- a/test/sdf_tape_test.cpp
+++ b/test/sdf_tape_test.cpp
@@ -72,8 +72,9 @@ TEST(TAPE, Gyroid) {
            std::cos(p.z) * std::sin(p.x);
   };
 
-  EvalContext<double> ctxSimple{
-      tape.first, VecView(tape.second.data(), tape.second.size())};
+  std::vector<double> buffer(tape.second, 0.0);
+  EvalContext<double> ctxSimple{tape.first,
+                                VecView(buffer.data(), buffer.size())};
   for (double x = -period; x < period; x += period / n) {
     for (double y = -period; y < period; y += period / n) {
       for (double z = -period; z < period; z += period / n) {
@@ -85,8 +86,8 @@ TEST(TAPE, Gyroid) {
     }
   }
 
-  std::vector<Interval<double>> intervalBuffer;
-  for (auto d : tape.second) intervalBuffer.push_back(Interval(d));
+  std::vector<Interval<double>> intervalBuffer(tape.second,
+                                               Interval<double>::constant(0.0));
   EvalContext<Interval<double>> ctx{
       tape.first, VecView(intervalBuffer.data(), intervalBuffer.size())};
   auto start = std::chrono::high_resolution_clock::now();
@@ -132,7 +133,13 @@ TEST(TAPE, Blobs) {
     else
       d = d - tmp;
   }
+  auto start = std::chrono::high_resolution_clock::now();
   auto tape = d.genTape();
+  auto end = std::chrono::high_resolution_clock::now();
+  auto time = static_cast<int>(
+      std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+          .count());
+  printf("codegen time: %dus, %ld\n", time, tape.first.size());
 
   auto blobs = [&balls](vec3 p) {
     double d = 0;
@@ -142,8 +149,9 @@ TEST(TAPE, Blobs) {
     }
     return d;
   };
-  EvalContext<double> ctxSimple{
-      tape.first, VecView(tape.second.data(), tape.second.size())};
+  std::vector<double> buffer(tape.second, 0.0);
+  EvalContext<double> ctxSimple{tape.first,
+                                VecView(buffer.data(), buffer.size())};
   for (double x = -5; x < 5; x += 0.05) {
     for (double y = -5; y < 5; y += 0.05) {
       for (double z = -5; z < 5; z += 0.05) {
@@ -155,15 +163,15 @@ TEST(TAPE, Blobs) {
     }
   }
 
-  std::vector<Interval<double>> intervalBuffer;
-  for (auto d : tape.second) intervalBuffer.push_back(Interval(d));
+  std::vector<Interval<double>> intervalBuffer(tape.second,
+                                               Interval<double>::constant(0.0));
   EvalContext<Interval<double>> ctx{
       tape.first, VecView(intervalBuffer.data(), intervalBuffer.size())};
-  auto start = std::chrono::high_resolution_clock::now();
+  start = std::chrono::high_resolution_clock::now();
   std::cout << recursive_interval(ctx, vec3(-5), vec3(10), 0.05, 0.5)
             << std::endl;
-  auto end = std::chrono::high_resolution_clock::now();
-  auto time = static_cast<int>(
+  end = std::chrono::high_resolution_clock::now();
+  time = static_cast<int>(
       std::chrono::duration_cast<std::chrono::microseconds>(end - start)
           .count());
   printf("interval evaluation: %dus\n", time);


### PR DESCRIPTION
Some initial implementation for sdf interpreter. Names are quite random, I have no idea how I should name these.

Basically, there are four things here:

1. A general interval arithmetic class (`sdf/interval.h`). Note that it is not robust against things like NaN and rounding errors (yet).
2. A simple API for expressing symbolic expressions (`sdf/value.h`), and this file is intended to go to the public API later, probably with another name. It is currently using methods, but I am happy to make it use regular functions.
3. A code gen module (`sdf/context.h`) that transforms the value into low level opcode, and does some simple optimization. Currently, it only performs constant folding and convert (a * b + c) into FMA, but I plan to do a bit more than these. It is also very limited because I haven't yet added spilling support, and it can only support 256 variables for now.
4. An evaluator (`tape.h`) that is pretty fast, and does both pointwise evaluation and interval evaluation. Optimizations related to interval evaluation are not implemented yet, but I have idea about how to do them.  I will probably add more opcode later as well, e.g. load store for spilling.

And in the test file (`sdf_tape_test.cpp`), I implemented a simple version of manifold dual contouring (the algorithm that uses an octree and interval arithmetic) but without actually constructing the mesh. I do this just to test the number of evaluations needed. Note that I haven't yet fully debugged my implementation, so there may be bugs that can throw off the result...

Some initial statistics:

| Model | Grid Eval Count | Interval Eval Count | Grid Time | Interval Time |
| - | - | - | - | - |
| Gyroid | 143009 | 111177 | 7ms | 5ms |
| Blobs | 16 363 009 | 1 474 337 | 700ms | 96ms |

Do note that this is run without parallelization. I haven't yet tried to implement the interval evaluation with parallelization yet.