### PR TITLE
Add const keyword to CrossSection::Compose parameter

### DIFF
--- a/include/manifold/cross_section.h
+++ b/include/manifold/cross_section.h
@@ -109,7 +109,7 @@ class CrossSection {
    */
   ///@{
   std::vector<CrossSection> Decompose() const;
-  static CrossSection Compose(std::vector<CrossSection>&);
+  static CrossSection Compose(const std::vector<CrossSection>&);
   static CrossSection Square(const vec2 dims, bool center = false);
   static CrossSection Circle(double radius, int circularSegments = 0);
   ///@}

--- a/src/cross_section/cross_section.cpp
+++ b/src/cross_section/cross_section.cpp
@@ -446,7 +446,7 @@ CrossSection& CrossSection::operator^=(const CrossSection& Q) {
  * Construct a CrossSection from a vector of other CrossSections (batch
  * boolean union).
  */
-CrossSection CrossSection::Compose(std::vector<CrossSection>& crossSections) {
+CrossSection CrossSection::Compose(const std::vector<CrossSection>& crossSections) {
   return BatchBoolean(crossSections, OpType::Add);
 }
 

--- a/src/cross_section/cross_section.cpp
+++ b/src/cross_section/cross_section.cpp
@@ -446,7 +446,8 @@ CrossSection& CrossSection::operator^=(const CrossSection& Q) {
  * Construct a CrossSection from a vector of other CrossSections (batch
  * boolean union).
  */
-CrossSection CrossSection::Compose(const std::vector<CrossSection>& crossSections) {
+CrossSection CrossSection::Compose(
+    const std::vector<CrossSection>& crossSections) {
   return BatchBoolean(crossSections, OpType::Add);
 }
 


### PR DESCRIPTION
Add a missing `const` to the `crossSections` parameter of`CrossSection::Compose`.