### PR TITLE
Faster import

### DIFF
--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -154,7 +154,7 @@ std::tuple<Vec<int>, Vec<int>> SizeOutput(
   int numFaceR = facePQ2R.back();
   facePQ2R.resize(inP.NumTri() + inQ.NumTri());
 
-  outR.faceNormal_.resize(numFaceR);
+  outR.faceNormal_.resize_nofill(numFaceR);
 
   Vec<size_t> tmpBuffer(outR.faceNormal_.size());
   auto faceIds = TransformIterator(countAt(0_uz), [&sidesPerFacePQ](size_t i) {
@@ -563,7 +563,7 @@ void CreateProperties(Manifold::Impl &outR, const Manifold::Impl &inP,
   if (numProp == 0) return;
 
   const int numTri = outR.NumTri();
-  outR.meshRelation_.triProperties.resize(numTri);
+  outR.meshRelation_.triProperties.resize_nofill(numTri);
 
   Vec<vec3> bary(outR.halfedge_.size());
   for_each_n(autoPolicy(numTri, 1e4), countAt(0), numTri,
@@ -746,7 +746,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   outR.epsilon_ = std::max(inP_.epsilon_, inQ_.epsilon_);
   outR.tolerance_ = std::max(inP_.tolerance_, inQ_.tolerance_);
 
-  outR.vertPos_.resize(numVertR);
+  outR.vertPos_.resize_nofill(numVertR);
   // Add vertices, duplicating for inclusion numbers not in [-1, 1].
   // Retained vertices from P and Q:
   for_each_n(autoPolicy(inP_.NumVert(), 1e4), countAt(0), inP_.NumVert(),

--- a/src/collider.h
+++ b/src/collider.h
@@ -278,7 +278,7 @@ class Collider {
                  "vectors must be the same length");
     int num_nodes = 2 * leafBB.size() - 1;
     // assign and allocate members
-    nodeBBox_.resize(num_nodes);
+    nodeBBox_.resize_nofill(num_nodes);
     nodeParent_.resize(num_nodes, -1);
     internalChildren_.resize(leafBB.size() - 1, std::make_pair(-1, -1));
     // organize tree

--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -209,12 +209,12 @@ std::shared_ptr<CsgLeafNode> CsgLeafNode::Compose(
   combined.vertPos_.resize_nofill(numVert);
   combined.halfedge_.resize_nofill(2 * numEdge);
   combined.faceNormal_.resize_nofill(numTri);
-  combined.halfedgeTangent_.resize_nofill(2 * numEdge);
+  combined.halfedgeTangent_.resize(2 * numEdge);
   combined.meshRelation_.triRef.resize_nofill(numTri);
   if (numPropOut > 0) {
     combined.meshRelation_.numProp = numPropOut;
     combined.meshRelation_.properties.resize(numPropOut * numPropVert, 0);
-    combined.meshRelation_.triProperties.resize(numTri, ivec3(0));
+    combined.meshRelation_.triProperties.resize_nofill(numTri);
   }
   auto policy = autoPolicy(numTri);
 

--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -214,7 +214,7 @@ std::shared_ptr<CsgLeafNode> CsgLeafNode::Compose(
   if (numPropOut > 0) {
     combined.meshRelation_.numProp = numPropOut;
     combined.meshRelation_.properties.resize(numPropOut * numPropVert, 0);
-    combined.meshRelation_.triProperties.resize_nofill(numTri);
+    combined.meshRelation_.triProperties.resize(numTri, ivec3(0));
   }
   auto policy = autoPolicy(numTri);
 

--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -206,15 +206,15 @@ std::shared_ptr<CsgLeafNode> CsgLeafNode::Compose(
   Manifold::Impl combined;
   combined.epsilon_ = epsilon;
   combined.tolerance_ = tolerance;
-  combined.vertPos_.resize(numVert);
-  combined.halfedge_.resize(2 * numEdge);
-  combined.faceNormal_.resize(numTri);
-  combined.halfedgeTangent_.resize(2 * numEdge);
-  combined.meshRelation_.triRef.resize(numTri);
+  combined.vertPos_.resize_nofill(numVert);
+  combined.halfedge_.resize_nofill(2 * numEdge);
+  combined.faceNormal_.resize_nofill(numTri);
+  combined.halfedgeTangent_.resize_nofill(2 * numEdge);
+  combined.meshRelation_.triRef.resize_nofill(numTri);
   if (numPropOut > 0) {
     combined.meshRelation_.numProp = numPropOut;
     combined.meshRelation_.properties.resize(numPropOut * numPropVert, 0);
-    combined.meshRelation_.triProperties.resize(numTri);
+    combined.meshRelation_.triProperties.resize_nofill(numTri);
   }
   auto policy = autoPolicy(numTri);
 

--- a/src/edge_op.cpp
+++ b/src/edge_op.cpp
@@ -68,12 +68,20 @@ struct FlagEdge {
     // two original triangles.
     const TriRef ref0 = triRef[edge / 3];
     int current = NextHalfedge(halfedge[edge].pairedHalfedge);
-    const TriRef ref1 = triRef[current / 3];
+    TriRef ref1 = triRef[current / 3];
+    bool ref1Updated = !ref0.SameFace(ref1);
     while (current != edge) {
       current = NextHalfedge(halfedge[current].pairedHalfedge);
       int tri = current / 3;
       const TriRef ref = triRef[tri];
-      if (!ref.SameFace(ref0) && !ref.SameFace(ref1)) return false;
+      if (!ref.SameFace(ref0) && !ref.SameFace(ref1)) {
+        if (!ref1Updated) {
+          ref1 = ref;
+          ref1Updated = true;
+        } else {
+          return false;
+        }
+      }
     }
     return true;
   }

--- a/src/face_op.cpp
+++ b/src/face_op.cpp
@@ -44,7 +44,7 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
   Vec<ivec3> triVerts;
   Vec<vec3> triNormal;
   Vec<TriRef>& triRef = meshRelation_.triRef;
-  triRef.resize(0);
+  triRef.clear();
   auto processFace = [&](GeneralTriangulation general, AddTriangle addTri,
                          int face) {
     const int firstEdge = faceEdge[face];

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -297,7 +297,7 @@ void Manifold::Impl::InitializeOriginal(bool keepFaceID) {
   const int meshID = ReserveIDs(1);
   meshRelation_.originalID = meshID;
   auto& triRef = meshRelation_.triRef;
-  triRef.resize(NumTri());
+  triRef.resize_nofill(NumTri());
   for_each_n(autoPolicy(NumTri(), 1e5), countAt(0), NumTri(),
              [meshID, keepFaceID, &triRef](const int tri) {
                triRef[tri] = {meshID, meshID, tri,
@@ -390,8 +390,8 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
   const size_t numTri = triVerts.size();
   const int numHalfedge = 3 * numTri;
   // drop the old value first to avoid copy
-  halfedge_.resize(0);
-  halfedge_.resize(numHalfedge);
+  halfedge_.clear(true);
+  halfedge_.resize_nofill(numHalfedge);
   Vec<uint64_t> edge(numHalfedge);
   Vec<int> ids(numHalfedge);
   auto policy = autoPolicy(numTri, 1e5);
@@ -470,11 +470,11 @@ void Manifold::Impl::Update() {
 
 void Manifold::Impl::MarkFailure(Error status) {
   bBox_ = Box();
-  vertPos_.resize(0);
-  halfedge_.resize(0);
-  vertNormal_.resize(0);
-  faceNormal_.resize(0);
-  halfedgeTangent_.resize(0);
+  vertPos_.clear();
+  halfedge_.clear();
+  vertNormal_.clear();
+  faceNormal_.clear();
+  halfedgeTangent_.clear();
   meshRelation_ = MeshRelationD();
   status_ = status;
 }
@@ -493,7 +493,7 @@ void Manifold::Impl::WarpBatch(std::function<void(VecView<vec3>)> warpFunc) {
     return;
   }
   Update();
-  faceNormal_.resize(0);  // force recalculation of triNormal
+  faceNormal_.clear();  // force recalculation of triNormal
   CalculateNormals();
   SetEpsilon();
   Finish();

--- a/src/impl.h
+++ b/src/impl.h
@@ -110,11 +110,11 @@ struct Manifold::Impl {
 
     const auto numProp = meshGL.numProp - 3;
     meshRelation_.numProp = numProp;
-    meshRelation_.properties.resize(meshGL.NumVert() * numProp);
+    meshRelation_.properties.resize_nofill(meshGL.NumVert() * numProp);
     tolerance_ = meshGL.tolerance;
     // This will have unreferenced duplicate positions that will be removed by
     // Impl::RemoveUnreferencedVerts().
-    vertPos_.resize(meshGL.NumVert());
+    vertPos_.resize_nofill(meshGL.NumVert());
 
     for (size_t i = 0; i < meshGL.NumVert(); ++i) {
       for (const int j : {0, 1, 2})
@@ -124,7 +124,7 @@ struct Manifold::Impl {
             meshGL.vertProperties[meshGL.numProp * i + 3 + j];
     }
 
-    halfedgeTangent_.resize(meshGL.halfedgeTangent.size() / 4);
+    halfedgeTangent_.resize_nofill(meshGL.halfedgeTangent.size() / 4);
     for (size_t i = 0; i < halfedgeTangent_.size(); ++i) {
       for (const int j : {0, 1, 2, 3})
         halfedgeTangent_[i][j] = meshGL.halfedgeTangent[4 * i + j];
@@ -139,7 +139,7 @@ struct Manifold::Impl {
       } else if (runIndex.size() == meshGL.runOriginalID.size()) {
         runIndex.push_back(runEnd);
       }
-      triRef.resize(meshGL.NumTri());
+      triRef.resize_nofill(meshGL.NumTri());
       const auto startID = Impl::ReserveIDs(meshGL.runOriginalID.size());
       for (size_t i = 0; i < meshGL.runOriginalID.size(); ++i) {
         const int meshID = startID + i;

--- a/src/impl.h
+++ b/src/impl.h
@@ -96,6 +96,27 @@ struct Manifold::Impl {
       return;
     }
 
+    if (!manifold::all_of(meshGL.vertProperties.begin(),
+                          meshGL.vertProperties.end(),
+                          [](Precision x) { return std::isfinite(x); })) {
+      MarkFailure(Error::NonFiniteVertex);
+      return;
+    }
+
+    if (!manifold::all_of(meshGL.runTransform.begin(),
+                          meshGL.runTransform.end(),
+                          [](Precision x) { return std::isfinite(x); })) {
+      MarkFailure(Error::InvalidConstruction);
+      return;
+    }
+
+    if (!manifold::all_of(meshGL.halfedgeTangent.begin(),
+                          meshGL.halfedgeTangent.end(),
+                          [](Precision x) { return std::isfinite(x); })) {
+      MarkFailure(Error::InvalidConstruction);
+      return;
+    }
+
     std::vector<int> prop2vert(numVert);
     std::iota(prop2vert.begin(), prop2vert.end(), 0);
     for (size_t i = 0; i < meshGL.mergeFromVert.size(); ++i) {

--- a/src/impl.h
+++ b/src/impl.h
@@ -200,8 +200,6 @@ struct Manifold::Impl {
     CalculateBBox();
     SetEpsilon(-1, std::is_same<Precision, float>::value);
 
-    SplitPinchedVerts();
-
     CalculateNormals();
 
     if (meshGL.runOriginalID.empty()) {

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -639,12 +639,12 @@ Manifold Manifold::SetProperties(
 
   auto& triProperties = pImpl->meshRelation_.triProperties;
   if (numProp == 0) {
-    triProperties.resize(0);
-    pImpl->meshRelation_.properties.resize(0);
+    triProperties.clear();
+    pImpl->meshRelation_.properties.clear();
   } else {
     if (triProperties.size() == 0) {
       const int numTri = NumTri();
-      triProperties.resize(numTri);
+      triProperties.resize_nofill(numTri);
       for (int i = 0; i < numTri; ++i) {
         for (const int j : {0, 1, 2}) {
           triProperties[i][j] = pImpl->halfedge_[3 * i + j].startVert;

--- a/src/quickhull.cpp
+++ b/src/quickhull.cpp
@@ -289,7 +289,7 @@ std::pair<Vec<Halfedge>, Vec<vec3>> QuickHull::buildMesh(double epsilon) {
   for_each(
       autoPolicy(halfedges.size()), halfedges.begin(), halfedges.end(),
       [&](Halfedge& he) { he.pairedHalfedge = mapping[he.pairedHalfedge]; });
-  counts.resize(originalVertexData.size() + 1);
+  counts.resize_nofill(originalVertexData.size() + 1);
   fill(counts.begin(), counts.end(), 0);
 
   // remove unused vertices
@@ -804,7 +804,7 @@ void QuickHull::setupInitialTetrahedron() {
 
 std::unique_ptr<Vec<size_t>> QuickHull::getIndexVectorFromPool() {
   auto r = indexVectorPool.get();
-  r->resize(0);
+  r->clear();
   return r;
 }
 

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -487,7 +487,7 @@ Manifold Manifold::LevelSet(std::function<double(vec3)> sdf, Box bounds,
   size_t tableSize = std::min(
       2 * maxIndex, static_cast<Uint64>(10 * la::pow(maxIndex, 0.667)));
   HashTable<GridVert> gridVerts(tableSize);
-  vertPos.resize(gridVerts.Size() * 7);
+  vertPos.resize_nofill(gridVerts.Size() * 7);
 
   while (1) {
     Vec<int> index(1, 0);

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -770,7 +770,7 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
   ZoneScoped;
   const int numVert = NumVert();
   const int numHalfedge = halfedge_.size();
-  halfedgeTangent_.resize(0);
+  halfedgeTangent_.clear();
   Vec<vec4> tangent(numHalfedge);
   Vec<bool> fixedHalfedge(numHalfedge, false);
 
@@ -854,7 +854,7 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
 void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges) {
   ZoneScoped;
   const int numHalfedge = halfedge_.size();
-  halfedgeTangent_.resize(0);
+  halfedgeTangent_.clear();
   Vec<vec4> tangent(numHalfedge);
   Vec<bool> fixedHalfedge(numHalfedge, false);
 
@@ -994,7 +994,7 @@ void Manifold::Impl::Refine(std::function<int(vec3, vec4, vec4)> edgeDivisions,
                InterpTri({vertPos_, vertBary, &old}));
   }
 
-  halfedgeTangent_.resize(0);
+  halfedgeTangent_.clear();
   Finish();
   CreateFaces();
   meshRelation_.originalID = -1;

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -350,7 +350,7 @@ void Manifold::Impl::CompactProps() {
   const int numVertsNew = propOld2New[numVerts];
   const int numProp = meshRelation_.numProp;
   auto& properties = meshRelation_.properties;
-  properties.resize(numProp * numVertsNew);
+  properties.resize_nofill(numProp * numVertsNew);
   for_each_n(
       policy, countAt(0), numVerts,
       [&properties, &oldProp, &propOld2New, &keep, &numProp](const int oldIdx) {
@@ -372,8 +372,9 @@ void Manifold::Impl::CompactProps() {
 void Manifold::Impl::GetFaceBoxMorton(Vec<Box>& faceBox,
                                       Vec<uint32_t>& faceMorton) const {
   ZoneScoped;
-  faceBox.resize(NumTri());
-  faceMorton.resize(NumTri());
+  // faceBox should be initialized
+  faceBox.resize(NumTri(), Box());
+  faceMorton.resize_nofill(NumTri());
   for_each_n(autoPolicy(NumTri(), 1e5), countAt(0), NumTri(),
              [this, &faceBox, &faceMorton](const int face) {
                // Removed tris are marked by all halfedges having pairedHalfedge
@@ -446,8 +447,9 @@ void Manifold::Impl::GatherFaces(const Vec<int>& faceNew2Old) {
   scatter(countAt(0_uz), countAt(numTri), faceNew2Old.begin(),
           faceOld2New.begin());
 
-  halfedge_.resize(3 * numTri);
-  if (oldHalfedgeTangent.size() != 0) halfedgeTangent_.resize(3 * numTri);
+  halfedge_.resize_nofill(3 * numTri);
+  if (oldHalfedgeTangent.size() != 0)
+    halfedgeTangent_.resize_nofill(3 * numTri);
   for_each_n(policy, countAt(0), numTri,
              ReindexFace({halfedge_, halfedgeTangent_, oldHalfedge,
                           oldHalfedgeTangent, faceNew2Old, faceOld2New}));
@@ -457,7 +459,7 @@ void Manifold::Impl::GatherFaces(const Impl& old, const Vec<int>& faceNew2Old) {
   ZoneScoped;
   const auto numTri = faceNew2Old.size();
 
-  meshRelation_.triRef.resize(numTri);
+  meshRelation_.triRef.resize_nofill(numTri);
   gather(faceNew2Old.begin(), faceNew2Old.end(),
          old.meshRelation_.triRef.begin(), meshRelation_.triRef.begin());
 
@@ -466,7 +468,7 @@ void Manifold::Impl::GatherFaces(const Impl& old, const Vec<int>& faceNew2Old) {
   }
 
   if (old.meshRelation_.triProperties.size() > 0) {
-    meshRelation_.triProperties.resize(numTri);
+    meshRelation_.triProperties.resize_nofill(numTri);
     gather(faceNew2Old.begin(), faceNew2Old.end(),
            old.meshRelation_.triProperties.begin(),
            meshRelation_.triProperties.begin());
@@ -475,7 +477,7 @@ void Manifold::Impl::GatherFaces(const Impl& old, const Vec<int>& faceNew2Old) {
   }
 
   if (old.faceNormal_.size() == old.NumTri()) {
-    faceNormal_.resize(numTri);
+    faceNormal_.resize_nofill(numTri);
     gather(faceNew2Old.begin(), faceNew2Old.end(), old.faceNormal_.begin(),
            faceNormal_.begin());
   }
@@ -484,8 +486,9 @@ void Manifold::Impl::GatherFaces(const Impl& old, const Vec<int>& faceNew2Old) {
   scatter(countAt(0_uz), countAt(numTri), faceNew2Old.begin(),
           faceOld2New.begin());
 
-  halfedge_.resize(3 * numTri);
-  if (old.halfedgeTangent_.size() != 0) halfedgeTangent_.resize(3 * numTri);
+  halfedge_.resize_nofill(3 * numTri);
+  if (old.halfedgeTangent_.size() != 0)
+    halfedgeTangent_.resize_nofill(3 * numTri);
   for_each_n(autoPolicy(numTri, 1e5), countAt(0), numTri,
              ReindexFace({halfedge_, halfedgeTangent_, old.halfedge_,
                           old.halfedgeTangent_, faceNew2Old, faceOld2New}));

--- a/src/subdivision.cpp
+++ b/src/subdivision.cpp
@@ -113,7 +113,7 @@ class Partition {
     }
     const int offset = interiorOffset - newVerts.size();
     size_t old = newVerts.size();
-    newVerts.resize(vertBary.size());
+    newVerts.resize_nofill(vertBary.size());
     std::iota(newVerts.begin() + old, newVerts.end(), old + offset);
 
     const int numTri = triVert.size();
@@ -684,7 +684,7 @@ Vec<Barycentric> Manifold::Impl::Subdivide(
              });
   vertPos_ = newVertPos;
 
-  faceNormal_.resize(0);
+  faceNormal_.clear();
 
   if (meshRelation_.numProp > 0) {
     const int numPropVert = NumPropVert();

--- a/src/utils.h
+++ b/src/utils.h
@@ -72,7 +72,7 @@ inline int Prev3(int i) {
 template <typename T, typename T1>
 void Permute(Vec<T>& inOut, const Vec<T1>& new2Old) {
   Vec<T> tmp(std::move(inOut));
-  inOut.resize(new2Old.size());
+  inOut.resize_nofill(new2Old.size());
   gather(new2Old.begin(), new2Old.end(), tmp.begin(), inOut.begin());
 }
 

--- a/src/vec.h
+++ b/src/vec.h
@@ -186,6 +186,13 @@ class Vec : public VecView<T> {
     if (shrink) shrink_to_fit();
   }
 
+  void resize_nofill(size_t newSize) {
+    bool shrink = this->size_ > 2 * newSize;
+    reserve(newSize);
+    this->size_ = newSize;
+    if (shrink) shrink_to_fit();
+  }
+
   void pop_back() { resize(this->size_ - 1); }
 
   void clear(bool shrink = true) {


### PR DESCRIPTION
Optimize #1138 a bit.

1. Avoids calling fill after resize when possible. We often use resize and then fill in the vectors with various values, so we don't have to ensure that the vector content is not uninitialized values after calling resize. This adds a `resize_nofill` to explicitly avoid initializing the buffer.
2. Speed up simplification by trying to do things in parallel.
3. Fixing `FlagEdge` as mentioned in #970


This seems to be faster for cases where there are not too many edges to simplify. However, for Samples.Sponge4, this is slower, probably because there are too many edges to simplify. Will try to fix that.

Should also fix #1140.