### PR TITLE
improved decimation

### DIFF
--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -311,6 +311,7 @@ class Manifold {
   Manifold Warp(std::function<void(vec3&)>) const;
   Manifold WarpBatch(std::function<void(VecView<vec3>)>) const;
   Manifold SetTolerance(double) const;
+  Manifold Simplify(double tolerance = 0) const;
   ///@}
 
   /** @name Boolean

--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -856,7 +856,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
 
   UpdateReference(outR, inP_, inQ_, invertQ);
 
-  outR.SimplifyTopology();
+  outR.SimplifyTopology(nPv + nQv);
   outR.RemoveUnreferencedVerts();
 
   if (ManifoldParams().intermediateChecks)

--- a/src/edge_op.cpp
+++ b/src/edge_op.cpp
@@ -48,11 +48,10 @@ struct ShortEdge {
   VecView<const Halfedge> halfedge;
   VecView<const vec3> vertPos;
   const double tolerance;
-  const size_t firstNewVert;
 
   bool operator()(int edge) const {
     const Halfedge& half = halfedge[edge];
-    if (half.pairedHalfedge < 0 || half.startVert < firstNewVert) return false;
+    if (half.pairedHalfedge < 0) return false;
     // Flag short edges
     const vec3 delta = vertPos[half.endVert] - vertPos[half.startVert];
     return la::dot(delta, delta) < tolerance * tolerance;
@@ -322,7 +321,7 @@ void Manifold::Impl::SimplifyTopology(size_t firstNewVert) {
   {
     ZoneScopedN("CollapseShortEdge");
     numFlagged = 0;
-    ShortEdge se{halfedge_, vertPos_, epsilon_, firstNewVert};
+    ShortEdge se{halfedge_, vertPos_, epsilon_};
     s.run(nbEdges, se, [&](size_t i) {
       const bool didCollapse = CollapseEdge(i, scratchBuffer);
       if (didCollapse) numFlagged++;

--- a/src/edge_op.cpp
+++ b/src/edge_op.cpp
@@ -61,7 +61,7 @@ struct ShortEdge {
 struct FlagEdge {
   VecView<const Halfedge> halfedge;
   VecView<const TriRef> triRef;
-  const size_t firstNewVert;
+  const int firstNewVert;
 
   bool operator()(int edge) const {
     const Halfedge& half = halfedge[edge];
@@ -301,7 +301,7 @@ void Manifold::Impl::CleanupTopology() {
  * Rather than actually removing the edges, this step merely marks them for
  * removal, by setting vertPos to NaN and halfedge to {-1, -1, -1, -1}.
  */
-void Manifold::Impl::SimplifyTopology(size_t firstNewVert) {
+void Manifold::Impl::SimplifyTopology(int firstNewVert) {
   if (!halfedge_.size()) return;
 
   CleanupTopology();

--- a/src/edge_op.cpp
+++ b/src/edge_op.cpp
@@ -94,13 +94,10 @@ struct SwappableEdge {
   VecView<const vec3> vertPos;
   VecView<const vec3> triNormal;
   const double tolerance;
-  const size_t firstNewVert;
 
   bool operator()(int edge) const {
     const Halfedge& half = halfedge[edge];
-    if (half.pairedHalfedge < 0 ||
-        (half.startVert < firstNewVert && half.endVert < firstNewVert))
-      return false;
+    if (half.pairedHalfedge < 0) return false;
 
     int tri = edge / 3;
     ivec3 triEdge = TriOf(edge);
@@ -356,7 +353,7 @@ void Manifold::Impl::SimplifyTopology(int firstNewVert) {
   {
     ZoneScopedN("RecursiveEdgeSwap");
     numFlagged = 0;
-    SwappableEdge se{halfedge_, vertPos_, faceNormal_, tolerance_, 0};
+    SwappableEdge se{halfedge_, vertPos_, faceNormal_, tolerance_};
     std::vector<int> edgeSwapStack;
     std::vector<int> visited(halfedge_.size(), -1);
     int tag = 0;

--- a/src/edge_op.cpp
+++ b/src/edge_op.cpp
@@ -52,9 +52,7 @@ struct ShortEdge {
 
   bool operator()(int edge) const {
     const Halfedge& half = halfedge[edge];
-    if (half.pairedHalfedge < 0 ||
-        (half.startVert < firstNewVert && half.endVert < firstNewVert))
-      return false;
+    if (half.pairedHalfedge < 0 || half.startVert < firstNewVert) return false;
     // Flag short edges
     const vec3 delta = vertPos[half.endVert] - vertPos[half.startVert];
     return la::dot(delta, delta) < tolerance * tolerance;
@@ -68,9 +66,7 @@ struct FlagEdge {
 
   bool operator()(int edge) const {
     const Halfedge& half = halfedge[edge];
-    if (half.pairedHalfedge < 0 ||
-        (half.startVert < firstNewVert && half.endVert < firstNewVert))
-      return false;
+    if (half.pairedHalfedge < 0 || half.startVert < firstNewVert) return false;
     // Flag redundant edges - those where the startVert is surrounded by only
     // two original triangles.
     const TriRef ref0 = triRef[edge / 3];

--- a/src/impl.h
+++ b/src/impl.h
@@ -329,7 +329,7 @@ struct Manifold::Impl {
 
   // edge_op.cpp
   void CleanupTopology();
-  void SimplifyTopology();
+  void SimplifyTopology(size_t firstNewVert = 0);
   void DedupeEdge(int edge);
   bool CollapseEdge(int edge, std::vector<int>& edges);
   void RecursiveEdgeSwap(int edge, int& tag, std::vector<int>& visited,

--- a/src/impl.h
+++ b/src/impl.h
@@ -331,7 +331,7 @@ struct Manifold::Impl {
   void CleanupTopology();
   void SimplifyTopology();
   void DedupeEdge(int edge);
-  void CollapseEdge(int edge, std::vector<int>& edges);
+  bool CollapseEdge(int edge, std::vector<int>& edges);
   void RecursiveEdgeSwap(int edge, int& tag, std::vector<int>& visited,
                          std::vector<int>& edgeSwapStack,
                          std::vector<int>& edges);

--- a/src/impl.h
+++ b/src/impl.h
@@ -329,7 +329,7 @@ struct Manifold::Impl {
 
   // edge_op.cpp
   void CleanupTopology();
-  void SimplifyTopology(size_t firstNewVert = 0);
+  void SimplifyTopology(int firstNewVert = 0);
   void DedupeEdge(int edge);
   bool CollapseEdge(int edge, std::vector<int>& edges);
   void RecursiveEdgeSwap(int edge, int& tag, std::vector<int>& visited,

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -424,7 +424,7 @@ Manifold Manifold::Simplify(double tolerance) const {
   auto impl = std::make_shared<Impl>(*GetCsgLeafNode().GetImpl());
   const double oldTolerance = impl->tolerance_;
   if (tolerance == 0) tolerance = oldTolerance;
-  if (tolerance > oldTolerance) {
+  if (tolerance >= oldTolerance) {
     impl->tolerance_ = tolerance;
     impl->CreateFaces();
     impl->SimplifyTopology();

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -432,10 +432,6 @@ Manifold Manifold::Simplify(double tolerance) const {
   }
   impl->tolerance_ = oldTolerance;
   return Manifold(impl);
-  // const double oldTolerance = GetCsgLeafNode().GetImpl()->tolerance_;
-  // Manifold result = SetTolerance(tolerance);
-  // result.GetCsgLeafNode().GetImpl()->tolerance_ = oldTolerance;
-  // return result;
 }
 
 /**

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -416,6 +416,29 @@ Manifold Manifold::SetTolerance(double tolerance) const {
 }
 
 /**
+ * Return a copy of the manifold simplified to the given tolerance, but with its
+ * actual tolerance value unchanged. If no tolerance is given, the current
+ * tolerance is used for simplification.
+ */
+Manifold Manifold::Simplify(double tolerance) const {
+  auto impl = std::make_shared<Impl>(*GetCsgLeafNode().GetImpl());
+  const double oldTolerance = impl->tolerance_;
+  if (tolerance == 0) tolerance = oldTolerance;
+  if (tolerance > oldTolerance) {
+    impl->tolerance_ = tolerance;
+    impl->CreateFaces();
+    impl->SimplifyTopology();
+    impl->Finish();
+  }
+  impl->tolerance_ = oldTolerance;
+  return Manifold(impl);
+  // const double oldTolerance = GetCsgLeafNode().GetImpl()->tolerance_;
+  // Manifold result = SetTolerance(tolerance);
+  // result.GetCsgLeafNode().GetImpl()->tolerance_ = oldTolerance;
+  // return result;
+}
+
+/**
  * The genus is a topological property of the manifold, representing the number
  * of "handles". A sphere is 0, torus 1, etc. It is only meaningful for a single
  * mesh, so it is best to call Decompose() first.

--- a/test/boolean_complex_test.cpp
+++ b/test/boolean_complex_test.cpp
@@ -912,6 +912,8 @@ TEST(BooleanComplex, CraycloudBool) {
   Manifold m2 = ReadMesh("Cray_right.glb");
   Manifold res = m1 - m2;
   EXPECT_EQ(res.Status(), Manifold::Error::NoError);
+  EXPECT_FALSE(res.IsEmpty());
+  res = res.SetTolerance(res.GetTolerance() * 1.01);
   EXPECT_TRUE(res.IsEmpty());
 }
 

--- a/test/boolean_complex_test.cpp
+++ b/test/boolean_complex_test.cpp
@@ -912,8 +912,6 @@ TEST(BooleanComplex, CraycloudBool) {
   Manifold m2 = ReadMesh("Cray_right.glb");
   Manifold res = m1 - m2;
   EXPECT_EQ(res.Status(), Manifold::Error::NoError);
-  EXPECT_FALSE(res.IsEmpty());
-  res = res.SetTolerance(res.GetTolerance() * 1.01);
   EXPECT_TRUE(res.IsEmpty());
 }
 

--- a/test/boolean_complex_test.cpp
+++ b/test/boolean_complex_test.cpp
@@ -912,6 +912,8 @@ TEST(BooleanComplex, CraycloudBool) {
   Manifold m2 = ReadMesh("Cray_right.glb");
   Manifold res = m1 - m2;
   EXPECT_EQ(res.Status(), Manifold::Error::NoError);
+  EXPECT_FALSE(res.IsEmpty());
+  res = res.Simplify();
   EXPECT_TRUE(res.IsEmpty());
 }
 

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -141,7 +141,7 @@ TEST(Boolean, Cubes) {
 TEST(Boolean, Simplify) {
   Manifold cube = Manifold::Cube().Refine(10);
   Manifold result = cube + cube.Translate({1, 0, 0});
-  EXPECT_EQ(result.NumTri(), 2000);
+  EXPECT_EQ(result.NumTri(), 1974);
   result = result.Simplify();
   EXPECT_EQ(result.NumTri(), 20);
 }

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -138,6 +138,14 @@ TEST(Boolean, Cubes) {
 #endif
 }
 
+TEST(Boolean, Simplify) {
+  Manifold cube = Manifold::Cube().Refine(10);
+  Manifold result = cube + cube.Translate({1, 0, 0});
+  EXPECT_EQ(result.NumTri(), 2000);
+  result = result.Simplify();
+  EXPECT_EQ(result.NumTri(), 20);
+}
+
 TEST(Boolean, NoRetainedVerts) {
   Manifold cube = Manifold::Cube(vec3(1), true);
   Manifold oct = Manifold::Sphere(1, 4);

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -141,7 +141,7 @@ TEST(Boolean, Cubes) {
 TEST(Boolean, Simplify) {
   Manifold cube = Manifold::Cube().Refine(10);
   Manifold result = cube + cube.Translate({1, 0, 0});
-  EXPECT_EQ(result.NumTri(), 1974);
+  EXPECT_EQ(result.NumTri(), 1928);
   result = result.Simplify();
   EXPECT_EQ(result.NumTri(), 20);
 }

--- a/test/properties_test.cpp
+++ b/test/properties_test.cpp
@@ -77,14 +77,14 @@ TEST(Properties, Tolerance) {
 }
 
 TEST(Properties, ToleranceSphere) {
-  const int n = 100;
+  const int n = 1000;
   Manifold sphere = Manifold::Sphere(1, 4 * n);
   EXPECT_EQ(sphere.NumTri(), 8 * n * n);
 
   Manifold sphere2 = sphere.SetTolerance(0.01);
-  EXPECT_LT(sphere2.NumTri(), 15000);
-  EXPECT_NEAR(sphere.Volume(), sphere2.Volume(), 0.02);
-  EXPECT_NEAR(sphere.SurfaceArea(), sphere2.SurfaceArea(), 0.01);
+  EXPECT_LT(sphere2.NumTri(), 2500);
+  EXPECT_NEAR(sphere.Volume(), sphere2.Volume(), 0.05);
+  EXPECT_NEAR(sphere.SurfaceArea(), sphere2.SurfaceArea(), 0.05);
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) ExportMesh("sphere.glb", sphere2.GetMeshGL(), {});
 #endif


### PR DESCRIPTION
Fixes #1017

Added `Simplify()` which is a lot like `SetTolerance()`, but with a clearer name that matches our `CrossSection` API. 

We now have the beginnings of a halfway-decent decimator; in 3 seconds we can take a sphere with 8 million triangles and reduce it to under 2,500, looking like this:
<img width="929" alt="image" src="https://github.com/user-attachments/assets/3e06e311-403b-489a-8335-91b7fd6a83dd" />

I've also updated our edge collapse to only operate on intersected edges when it runs as part of the Boolean cleanup, which has been requested by several people, and should increase performance a bit too. I tried to apply that logic to the edge swapping as well, but it broke a few tests, so I'll come back to that.