### PR TITLE
parallelize mesh fixup

### DIFF
--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -223,14 +223,17 @@ void Manifold::Impl::CreateFaces() {
   stable_sort(triPriority.begin(), triPriority.end(),
               [](auto a, auto b) { return a.area2 > b.area2; });
 
+  Vec<int> interiorHalfedges;
   for (const auto tp : triPriority) {
     if (meshRelation_.triRef[tp.tri].faceID >= 0) continue;
 
     meshRelation_.triRef[tp.tri].faceID = tp.tri;
     const vec3 base = vertPos_[halfedge_[3 * tp.tri].startVert];
     const vec3 normal = faceNormal_[tp.tri];
-    std::vector<int> interiorHalfedges = {3 * tp.tri, 3 * tp.tri + 1,
-                                          3 * tp.tri + 2};
+    interiorHalfedges.resize(3);
+    interiorHalfedges[0] = 3 * tp.tri;
+    interiorHalfedges[1] = 3 * tp.tri + 1;
+    interiorHalfedges[2] = 3 * tp.tri + 2;
     while (!interiorHalfedges.empty()) {
       const int h =
           NextHalfedge(halfedge_[interiorHalfedges.back()].pairedHalfedge);

--- a/src/impl.h
+++ b/src/impl.h
@@ -344,6 +344,7 @@ struct Manifold::Impl {
   void FormLoop(int current, int end);
   void CollapseTri(const ivec3& triEdge);
   void SplitPinchedVerts();
+  void DedupeEdges();
 
   // subdivision.cpp
   int GetNeighbor(int tri) const;

--- a/src/impl.h
+++ b/src/impl.h
@@ -246,7 +246,7 @@ struct Manifold::Impl {
     meshRelation_.originalID = -1;
   }
 
-  template<typename F>
+  template <typename F>
   inline void ForVert(int halfedge, F func) {
     int current = halfedge;
     do {

--- a/src/impl.h
+++ b/src/impl.h
@@ -188,10 +188,8 @@ struct Manifold::Impl {
 
     Vec<ivec3> triVerts;
     triVerts.reserve(numTri);
-    if (triRef.size() > 0)
-      meshRelation_.triRef.reserve(numTri);
-    if (numProp > 0)
-      meshRelation_.triProperties.reserve(numTri);
+    if (triRef.size() > 0) meshRelation_.triRef.reserve(numTri);
+    if (numProp > 0) meshRelation_.triProperties.reserve(numTri);
     for (size_t i = 0; i < numTri; ++i) {
       ivec3 tri;
       for (const size_t j : {0, 1, 2}) {

--- a/src/impl.h
+++ b/src/impl.h
@@ -246,7 +246,8 @@ struct Manifold::Impl {
     meshRelation_.originalID = -1;
   }
 
-  inline void ForVert(int halfedge, std::function<void(int halfedge)> func) {
+  template<typename F>
+  inline void ForVert(int halfedge, F func) {
     int current = halfedge;
     do {
       current = NextHalfedge(halfedge_[current].pairedHalfedge);

--- a/src/impl.h
+++ b/src/impl.h
@@ -188,6 +188,10 @@ struct Manifold::Impl {
 
     Vec<ivec3> triVerts;
     triVerts.reserve(numTri);
+    if (triRef.size() > 0)
+      meshRelation_.triRef.reserve(numTri);
+    if (numProp > 0)
+      meshRelation_.triProperties.reserve(numTri);
     for (size_t i = 0; i < numTri; ++i) {
       ivec3 tri;
       for (const size_t j : {0, 1, 2}) {

--- a/src/vec.h
+++ b/src/vec.h
@@ -176,7 +176,7 @@ class Vec : public VecView<T> {
   }
 
   void resize(size_t newSize, T val = T()) {
-    bool shrink = this->size_ > 2 * newSize;
+    bool shrink = this->size_ > 2 * newSize && this->size_ > 16;
     reserve(newSize);
     if (this->size_ < newSize) {
       fill(autoPolicy(newSize - this->size_), this->ptr_ + this->size_,
@@ -187,7 +187,7 @@ class Vec : public VecView<T> {
   }
 
   void resize_nofill(size_t newSize) {
-    bool shrink = this->size_ > 2 * newSize;
+    bool shrink = this->size_ > 2 * newSize && this->size_ > 16;
     reserve(newSize);
     this->size_ = newSize;
     if (shrink) shrink_to_fit();

--- a/src/vec.h
+++ b/src/vec.h
@@ -193,7 +193,7 @@ class Vec : public VecView<T> {
     if (shrink) shrink_to_fit();
   }
 
-  void pop_back() { resize(this->size_ - 1); }
+  void pop_back() { resize_nofill(this->size_ - 1); }
 
   void clear(bool shrink = true) {
     this->size_ = 0;


### PR DESCRIPTION
- `SplitPinchedVerts` now runs in parallel.
- Edge deduplication now avoids sorting, so it is much faster now.

Previously:
```
nTri = 512, time = 0.00387912 sec
nTri = 2048, time = 0.00780949 sec
nTri = 8192, time = 0.00926127 sec
nTri = 32768, time = 0.0170758 sec
nTri = 131072, time = 0.0393845 sec
nTri = 524288, time = 0.135483 sec
nTri = 2097152, time = 0.499138 sec
nTri = 8388608, time = 2.12073 sec
```

Now:
```
nTri = 512, time = 0.00200502 sec
nTri = 2048, time = 0.0026148 sec
nTri = 8192, time = 0.020302 sec
nTri = 32768, time = 0.0357589 sec
nTri = 131072, time = 0.0326722 sec
nTri = 524288, time = 0.116826 sec
nTri = 2097152, time = 0.445966 sec
nTri = 8388608, time = 1.86558 sec
```

About 10% improvement for larger meshes.