### PR TITLE
Less alloc

### DIFF
--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -223,14 +223,17 @@ void Manifold::Impl::CreateFaces() {
   stable_sort(triPriority.begin(), triPriority.end(),
               [](auto a, auto b) { return a.area2 > b.area2; });
 
+  Vec<int> interiorHalfedges;
   for (const auto tp : triPriority) {
     if (meshRelation_.triRef[tp.tri].faceID >= 0) continue;
 
     meshRelation_.triRef[tp.tri].faceID = tp.tri;
     const vec3 base = vertPos_[halfedge_[3 * tp.tri].startVert];
     const vec3 normal = faceNormal_[tp.tri];
-    std::vector<int> interiorHalfedges = {3 * tp.tri, 3 * tp.tri + 1,
-                                          3 * tp.tri + 2};
+    interiorHalfedges.resize(3);
+    interiorHalfedges[0] = 3 * tp.tri;
+    interiorHalfedges[1] = 3 * tp.tri + 1;
+    interiorHalfedges[2] = 3 * tp.tri + 2;
     while (!interiorHalfedges.empty()) {
       const int h =
           NextHalfedge(halfedge_[interiorHalfedges.back()].pairedHalfedge);

--- a/src/impl.h
+++ b/src/impl.h
@@ -344,6 +344,7 @@ struct Manifold::Impl {
   void FormLoop(int current, int end);
   void CollapseTri(const ivec3& triEdge);
   void SplitPinchedVerts();
+  void DedupeEdges();
 
   // subdivision.cpp
   int GetNeighbor(int tri) const;

--- a/src/impl.h
+++ b/src/impl.h
@@ -246,7 +246,7 @@ struct Manifold::Impl {
     meshRelation_.originalID = -1;
   }
 
-  template<typename F>
+  template <typename F>
   inline void ForVert(int halfedge, F func) {
     int current = halfedge;
     do {

--- a/src/impl.h
+++ b/src/impl.h
@@ -188,10 +188,8 @@ struct Manifold::Impl {
 
     Vec<ivec3> triVerts;
     triVerts.reserve(numTri);
-    if (triRef.size() > 0)
-      meshRelation_.triRef.reserve(numTri);
-    if (numProp > 0)
-      meshRelation_.triProperties.reserve(numTri);
+    if (triRef.size() > 0) meshRelation_.triRef.reserve(numTri);
+    if (numProp > 0) meshRelation_.triProperties.reserve(numTri);
     for (size_t i = 0; i < numTri; ++i) {
       ivec3 tri;
       for (const size_t j : {0, 1, 2}) {

--- a/src/impl.h
+++ b/src/impl.h
@@ -246,7 +246,8 @@ struct Manifold::Impl {
     meshRelation_.originalID = -1;
   }
 
-  inline void ForVert(int halfedge, std::function<void(int halfedge)> func) {
+  template<typename F>
+  inline void ForVert(int halfedge, F func) {
     int current = halfedge;
     do {
       current = NextHalfedge(halfedge_[current].pairedHalfedge);

--- a/src/impl.h
+++ b/src/impl.h
@@ -188,6 +188,10 @@ struct Manifold::Impl {
 
     Vec<ivec3> triVerts;
     triVerts.reserve(numTri);
+    if (triRef.size() > 0)
+      meshRelation_.triRef.reserve(numTri);
+    if (numProp > 0)
+      meshRelation_.triProperties.reserve(numTri);
     for (size_t i = 0; i < numTri; ++i) {
       ivec3 tri;
       for (const size_t j : {0, 1, 2}) {

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -560,7 +560,8 @@ class EarClip {
 
   // Apply func to each un-clipped vert in a polygon and return an un-clipped
   // vert.
-  VertItrC Loop(VertItr first, std::function<void(VertItr)> func) const {
+  template <typename F>
+  VertItrC Loop(VertItr first, F func) const {
     VertItr v = first;
     do {
       if (Clipped(v)) {

--- a/src/small_vector.h
+++ b/src/small_vector.h
@@ -1,0 +1,277 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// rewrite of https://github.com/p-ranav/small_vector
+#pragma once
+#include <array>
+#include <vector>
+
+namespace manifold {
+
+template <class T, std::size_t N>
+class small_vector {
+  std::array<T, N> stack_;
+  std::vector<T> heap_;
+  std::size_t size_{0};
+
+ public:
+  using value_type = T;
+  using size_type = std::size_t;
+  using reference = value_type &;
+  using const_reference = const value_type &;
+  using pointer = T *;
+  using const_pointer = const T *;
+  using iterator = T *;
+  using const_iterator = const T *;
+
+  small_vector() = default;
+
+  explicit small_vector(size_type count, const T &value = T()) {
+    if (count <= N) {
+      std::uninitialized_fill_n(stack_.begin(), count, value);
+    } else {
+      heap_ = std::vector<T>(count, value);
+    }
+    size_ = count;
+  }
+
+  small_vector(const small_vector &other)
+      : stack_(other.stack_), heap_(other.heap_), size_(other.size_) {}
+
+  small_vector(small_vector &&other)
+      : stack_(std::move(other.stack_)),
+        heap_(std::move(other.heap_)),
+        size_(other.size_) {}
+
+  small_vector(std::initializer_list<T> initlist) {
+    const auto input_size = initlist.size();
+    if (input_size <= N) {
+      std::uninitialized_copy(initlist.begin(), initlist.end(), stack_.begin());
+    } else {
+      std::copy(initlist.begin(), initlist.end(), std::back_inserter(heap_));
+    }
+    size_ = input_size;
+  }
+
+  small_vector &operator=(const small_vector &rhs) {
+    if (this == &rhs) return *this;
+    if (size_ <= N) clear();  // clear initialized data
+    if (rhs.size_ <= N) {
+      std::uninitialized_copy(rhs.begin(), rhs.end(), stack_.begin());
+    } else {
+      heap_ = rhs.heap_;
+    }
+    size_ = rhs.size_;
+    return *this;
+  }
+
+  small_vector &operator=(small_vector &&rhs) {
+    if (this == &rhs) return *this;
+    if (size_ <= N) clear();  // clear initialized data
+    if (rhs.size_ <= N) {
+      std::uninitialized_move(rhs.begin(), rhs.end(), stack_.begin());
+    } else {
+      heap_ = std::move(rhs.heap_);
+    }
+    size_ = rhs.size_;
+    rhs.size_ = 0;
+    return *this;
+  }
+
+  small_vector &operator=(std::initializer_list<value_type> rhs) {
+    if (size_ <= N) clear();  // clear initialized data
+    if (rhs.size() <= N) {
+      std::uninitialized_copy(rhs.begin(), rhs.end(), stack_.begin());
+    } else {
+      heap_ = rhs;
+    }
+    size_ = rhs.size();
+  }
+
+  reference at(size_type pos) {
+    return size_ <= N ? stack_.at(pos) : heap_.at(pos);
+  }
+
+  const_reference at(size_type pos) const {
+    return size_ <= N ? stack_.at(pos) : heap_.at(pos);
+  }
+
+  reference operator[](size_type pos) {
+    return size_ <= N ? stack_[pos] : heap_[pos];
+  }
+
+  const_reference operator[](size_type pos) const {
+    return size_ <= N ? stack_[pos] : heap_[pos];
+  }
+
+  reference front() { return size_ <= N ? stack_.front() : heap_.front(); }
+
+  const_reference front() const {
+    return size_ <= N ? stack_.front() : heap_.front();
+  }
+
+  reference back() { return size_ <= N ? stack_[size_ - 1] : heap_.back(); }
+
+  const_reference back() const {
+    return size_ <= N ? stack_[size_ - 1] : heap_.back();
+  }
+
+  pointer data() noexcept { return size_ <= N ? stack_.data() : heap_.data(); }
+
+  const_pointer data() const noexcept {
+    return size_ <= N ? stack_.data() : heap_.data();
+  }
+
+  bool empty() const { return size_ == 0; }
+
+  size_type size() const { return size_; }
+
+  void shrink_to_fit() {
+    if (size_ > N) heap_.shrink_to_fit();
+  }
+
+  void push_back(const T &value) {
+    if (size_ < N) {
+      stack_[size_] = value;
+    } else {
+      if (size_ == N)
+        std::move(stack_.begin(), stack_.end(), std::back_inserter(heap_));
+      heap_.emplace_back(value);
+    }
+    size_ += 1;
+  }
+
+  void pop_back() {
+    if (size_ == 0) return;
+    if (size_ <= N) {
+      size_ -= 1;
+      std::destroy_at(&stack_[size_]);
+    } else {
+      // currently using heap
+      heap_.pop_back();
+      size_ -= 1;
+      // now check if all data can fit on stack
+      // if so, move back to stack
+      if (size_ <= N) {
+        std::uninitialized_move(heap_.begin(), heap_.end(), stack_.begin());
+        heap_.clear();
+      }
+    }
+  }
+
+  // Resizes the container to contain count elements.
+  void resize(size_type count, T value = T()) {
+    if (count <= N) {
+      // new `count` of elements completely fit on stack
+      if (size_ >= N) {
+        // currently, all data on heap
+        // move back to stack
+        std::uninitialized_move(heap_.begin(), heap_.begin() + count,
+                                stack_.begin());
+        heap_.clear();
+      } else {
+        if (size_ < count)
+          std::uninitialized_fill(stack_.begin() + size_,
+                                  stack_.begin() + count, value);
+        else if (count < size_)
+          std::destroy(stack_.begin() + count, stack_.begin() + size_);
+      }
+    } else {
+      // new `count` of data is going to be on the heap
+      // check if data is currently on the stack
+      if (size_ <= N)
+        std::move(stack_.begin(), stack_.begin() + size_,
+                  std::back_inserter(heap_));
+      heap_.resize(count, value);
+    }
+    size_ = count;
+  }
+
+  void clear() {
+    if (size_ > N) {
+      heap_.clear();
+    } else {
+      std::destroy(begin(), end());
+    }
+    size_ = 0;
+  }
+
+  void swap(small_vector &other) noexcept {
+    std::swap(stack_, other.stack_);
+    std::swap(heap_, other.heap_);
+    std::swap(size_, other.size_);
+  };
+
+  iterator begin() { return size_ <= N ? stack_.data() : heap_.data(); }
+
+  iterator end() { return (size_ <= N ? stack_.data() : heap_.data()) + size_; }
+
+  const_iterator cbegin() const {
+    return size_ <= N ? stack_.data() : heap_.data();
+  }
+
+  const_iterator cend() const {
+    return (size_ <= N ? stack_.data() : heap_.data()) + size_;
+  }
+
+  const_iterator begin() const { return cbegin(); }
+
+  const_iterator end() const { return cend(); }
+
+  void erase(iterator iter) {
+    if (size_ == 0) return;
+    size_type i = std::distance(begin(), iter);
+    if (size_ <= N) {
+      if (i < size_ - 1)
+        // probably need a custom loop if we want to work with non-trivial data
+        // type
+        std::move(stack_.begin() + i + 1, stack_.begin() + size_,
+                  stack_.begin() + i);
+    } else {
+      heap_.erase(heap_.begin() + i);
+      if (size_ == N + 1) {
+        std::uninitialized_move(heap_.begin(), heap_.end(), stack_.begin());
+        heap_.clear();
+      }
+    }
+    size_ -= 1;
+  }
+
+  void erase(const_iterator iter) {
+    erase(begin() + std::distance(cbegin(), iter));
+  }
+
+  void insert(iterator iter, const T &value) {
+    size_type i = std::distance(begin(), iter);
+    if (size_ < N) {
+      if (i < size_)
+        // probably need a custom loop if we want to work with non-trivial data
+        // type
+        std::move_backward(stack_.begin() + i, stack_.begin() + size_,
+                           stack_.begin() + size_ + 1);
+      stack_[i] = value;
+    } else {
+      if (size_ == N)
+        std::move(stack_.begin(), stack_.end(), std::back_inserter(heap_));
+      heap_.insert(heap_.begin() + i, value);
+    }
+    size_ += 1;
+  }
+
+  void insert(const_iterator iter, const T &value) {
+    insert(begin() + std::distance(cbegin(), iter), value);
+  }
+};
+
+}  // namespace manifold

--- a/src/vec.h
+++ b/src/vec.h
@@ -176,7 +176,7 @@ class Vec : public VecView<T> {
   }
 
   void resize(size_t newSize, T val = T()) {
-    bool shrink = this->size_ > 2 * newSize;
+    bool shrink = this->size_ > 2 * newSize && this->size_ > 16;
     reserve(newSize);
     if (this->size_ < newSize) {
       fill(autoPolicy(newSize - this->size_), this->ptr_ + this->size_,
@@ -187,7 +187,7 @@ class Vec : public VecView<T> {
   }
 
   void resize_nofill(size_t newSize) {
-    bool shrink = this->size_ > 2 * newSize;
+    bool shrink = this->size_ > 2 * newSize && this->size_ > 16;
     reserve(newSize);
     this->size_ = newSize;
     if (shrink) shrink_to_fit();

--- a/src/vec.h
+++ b/src/vec.h
@@ -193,7 +193,7 @@ class Vec : public VecView<T> {
     if (shrink) shrink_to_fit();
   }
 
-  void pop_back() { resize(this->size_ - 1); }
+  void pop_back() { resize_nofill(this->size_ - 1); }
 
   void clear(bool shrink = true) {
     this->size_ = 0;


### PR DESCRIPTION
Just found out https://github.com/KDE/heaptrack which can show the allocations. It turns out `std::function` requires allocation, and `std::stable_sort` also performs allocation.

This tries to get rid of most temporary allocations caused by these `std::function` and `std::stable_sort` on small vectors. This also use small vector to avoid allocation when the halfedge vector for `PairUp` is small.

Benchmark shows that this gives modest improvement, but this probably depends on the system allocator. Maybe the difference will be larger for, e.g. emscripten and windows. Will get some more detailed statistics later.