### PR TITLE
Misc changes

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -55,6 +55,7 @@ jobs:
       url: https://pypi.org/p/manifold3d
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    if: ${{ github.event_name == 'release' }}
     steps:
     - uses: actions/download-artifact@v4
       with:

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -6,7 +6,7 @@
 1. Make a new branch called the version, e.g. v2.3.0.
 1. Use VSCode to search and replace the old version with the new - so far in test-cmake.sh, flake.nix, pyproject.toml, and package.json.
 1. Also update CMakeLists.txt version by searching for "set(MANIFOLD_VERSION_".
-1. Commit, push, open a PR, verify tests pass, merge.
+1. Commit, push, open a PR, verify tests pass, manually trigger PyPI CI, merge.
 1. On Github, draft a new release, make a new tag with the version number, add release notes, and publish.
 1. Check the Actions and verify that both PyPI and npm publishing actions ran successfully.
 1. Verify the npm [package](https://www.npmjs.com/package/manifold-3d?activeTab=code) looks good - unpacked size should be close to 1MB.

--- a/cmake/manifoldDeps.cmake
+++ b/cmake/manifoldDeps.cmake
@@ -113,8 +113,8 @@ if(MANIFOLD_CROSS_SECTION)
     FetchContent_Declare(
       Clipper2
       GIT_REPOSITORY https://github.com/AngusJohnson/Clipper2.git
-      # Nov 22, 2024
-      GIT_TAG a8269cafe92cdbf92572bceda5e9fdacc4684b51
+      # Jan 27, 2025
+      GIT_TAG Clipper2_1.5.2
       GIT_PROGRESS TRUE
       SOURCE_SUBDIR CPP
       EXCLUDE_FROM_ALL
@@ -131,7 +131,7 @@ if(TRACY_ENABLE)
   FetchContent_Declare(
     tracy
     GIT_REPOSITORY https://github.com/wolfpld/tracy.git
-    GIT_TAG v0.10
+    GIT_TAG v0.11.1
     GIT_SHALLOW TRUE
     GIT_PROGRESS TRUE
     EXCLUDE_FROM_ALL
@@ -180,8 +180,7 @@ if(MANIFOLD_PYBIND)
     FetchContent_Declare(
       nanobind
       GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-      GIT_TAG
-        784efa2a0358a4dc5432c74f5685ee026e20f2b6 # v2.2.0
+      GIT_TAG v2.5.0
       GIT_PROGRESS TRUE
       EXCLUDE_FROM_ALL
     )

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -124,6 +124,7 @@ void CheckGeometry(const std::vector<ivec3> &triangles,
 }
 
 void Dump(const PolygonsIdx &polys, double epsilon) {
+  std::cout << std::setprecision(16);
   std::cout << "Polygon 0 " << epsilon << " " << polys.size() << std::endl;
   for (auto poly : polys) {
     std::cout << poly.size() << std::endl;

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -432,12 +432,10 @@ TEST(Boolean, Precision2) {
 
 TEST(Boolean, DISABLED_SimpleCubeRegression) {
   ManifoldParams().intermediateChecks = true;
-  ManifoldParams().processOverlaps = false;
   Manifold result =
       Manifold::Cube().Rotate(-0.10000000000000001, 0.10000000000000001, -1.) +
       Manifold::Cube() -
       Manifold::Cube().Rotate(-0.10000000000000001, -0.10000000000066571, -1.);
   EXPECT_EQ(result.Status(), Manifold::Error::NoError);
   ManifoldParams().intermediateChecks = false;
-  ManifoldParams().processOverlaps = true;
 }

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -295,13 +295,17 @@ TEST(Samples, Sponge4) {
 #endif
 #endif
 
-TEST(Samples, DISABLED_CondensedMatter16) {
+TEST(Samples, CondensedMatter16) {
+  // FIXME: Triangulation can be invalid
+  bool old = PolygonParams().processOverlaps;
+  PolygonParams().processOverlaps = true;
   Manifold cm = CondensedMatter(16);
   CheckGL(cm);
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels)
     ExportMesh("condensedMatter16.glb", cm.GetMeshGL(), {});
 #endif
+  PolygonParams().processOverlaps = old;
 }
 
 TEST(Samples, CondensedMatter64) {


### PR DESCRIPTION
1. Avoid uploading to PyPI when manual triggering the python build CI. This should allow us to test the release PR before actually doing a release. Closes #1161.
2. Update dependencies, some are quite old now.
3. Re-enable `Samples.CondensedMatter16` test with triangulation check disabled. It can produce bad triangulation, but the output looks kind of fine.

To test 1, we need to merge this PR first because manually triggering CI uses the file in the master branch iirc.