### PR TITLE
Early return when result size too large

### DIFF
--- a/bindings/c/conv.cpp
+++ b/bindings/c/conv.cpp
@@ -106,6 +106,9 @@ ManifoldError to_c(manifold::Manifold::Error error) {
     case Manifold::Error::InvalidConstruction:
       e = MANIFOLD_INVALID_CONSTRUCTION;
       break;
+    case Manifold::Error::ResultTooLarge:
+      e = MANIFOLD_RESULT_TOO_LARGE;
+      break;
   };
   return e;
 }

--- a/bindings/c/include/manifold/types.h
+++ b/bindings/c/include/manifold/types.h
@@ -91,6 +91,7 @@ typedef enum ManifoldError {
   MANIFOLD_RUN_INDEX_WRONG_LENGTH,
   MANIFOLD_FACE_ID_WRONG_LENGTH,
   MANIFOLD_INVALID_CONSTRUCTION,
+  MANIFOLD_RESULT_TOO_LARGE,
 } ManifoldError;
 
 typedef enum ManifoldFillRule {

--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -263,6 +263,7 @@ class Manifold {
     RunIndexWrongLength,
     FaceIDWrongLength,
     InvalidConstruction,
+    ResultTooLarge,
   };
 
   /** @name Information
@@ -430,6 +431,8 @@ inline std::string ToString(const Manifold::Error& error) {
       return "Face ID Wrong Length";
     case Manifold::Error::InvalidConstruction:
       return "Invalid Construction";
+    case Manifold::Error::ResultTooLarge:
+      return "Result Too Large";
     default:
       return "Unknown Error";
   };

--- a/src/boolean3.cpp
+++ b/src/boolean3.cpp
@@ -497,6 +497,8 @@ Boolean3::Boolean3(const Manifold::Impl &inP, const Manifold::Impl &inQ,
   // Symbolic perturbation:
   // Union -> expand inP
   // Difference, Intersection -> contract inP
+  constexpr size_t INT_MAX_SZ =
+      static_cast<size_t>(std::numeric_limits<int>::max());
 
 #ifdef MANIFOLD_DEBUG
   Timer broad;
@@ -530,6 +532,11 @@ Boolean3::Boolean3(const Manifold::Impl &inP, const Manifold::Impl &inQ,
   SparseIndices p2q0 = inP.VertexCollisionsZ(inQ.vertPos_, true);  // inverted
   p2q0.Sort();
   PRINT("p2q0 size = " << p2q0.size());
+
+  if (3 * p1q2_.size() + 3 * p2q1_.size() > INT_MAX_SZ) {
+    valid = false;
+    return;
+  }
 
   // Find involved edge pairs from Level 3
   SparseIndices p1q1 = Filter11(inP_, inQ_, p1q2_, p2q1_);
@@ -572,6 +579,11 @@ Boolean3::Boolean3(const Manifold::Impl &inP, const Manifold::Impl &inQ,
   std::tie(x21_, v21_) =
       Intersect12(inQ, inP, s20, p2q0, s11, p1q1, z20, xyzz11, p2q1_, false);
   PRINT("x21 size = " << x21_.size());
+
+  if (x12_.size() > INT_MAX_SZ || x21_.size() > INT_MAX_SZ) {
+    valid = false;
+    return;
+  }
 
   s11.clear();
   xyzz11.clear();

--- a/src/boolean3.h
+++ b/src/boolean3.h
@@ -56,5 +56,6 @@ class Boolean3 {
   SparseIndices p1q2_, p2q1_;
   Vec<int> x12_, x21_, w03_, w30_;
   Vec<vec3> v12_, v21_;
+  bool valid = true;
 };
 }  // namespace manifold

--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -697,6 +697,12 @@ Manifold::Impl Boolean3::Result(OpType op) const {
     return inP_;
   }
 
+  if (!valid) {
+    auto impl = Manifold::Impl();
+    impl.status_ = Manifold::Error::ResultTooLarge;
+    return impl;
+  }
+
   const bool invertQ = op == OpType::Subtract;
 
   // Convert winding numbers to inclusion values based on operation type.


### PR DESCRIPTION
Closes #1164.

I have looked at the code for cases where the result size can be too large, and it seems that not a lot can cause integer overflow if we limit the input size (halfedge count).

@howardt can you check if this can avoid the crash?