### PR TITLE
unified ManifoldParams and PolygonParams

### DIFF
--- a/extras/minimize_testcase.cpp
+++ b/extras/minimize_testcase.cpp
@@ -10,6 +10,7 @@
 #endif
 
 #include "../src/utils.h"
+#include "manifold/manifold.h"
 #include "manifold/polygon.h"
 
 using namespace manifold;
@@ -110,10 +111,10 @@ void Dump(const Polygons &polys) {
 }
 
 void DumpTriangulation(const Polygons &polys, double precision) {
-  ExecutionParams oldParams = PolygonParams();
-  manifold::PolygonParams().processOverlaps = true;
+  ExecutionParams oldParams = ManifoldParams();
+  manifold::ManifoldParams().processOverlaps = true;
   std::vector<ivec3> result = Triangulate(polys);
-  PolygonParams() = oldParams;
+  ManifoldParams() = oldParams;
   for (const ivec3 &tri : result) {
     std::pair<int, int> xid = findIndex(polys, tri.x);
     std::pair<int, int> yid = findIndex(polys, tri.y);
@@ -305,9 +306,9 @@ int isValid(const Polygons &polys, double precision = -1) {
 }
 
 int main(int argc, char **argv) {
-  PolygonParams().intermediateChecks = true;
-  PolygonParams().processOverlaps = false;
-  PolygonParams().suppressErrors = true;
+  ManifoldParams().intermediateChecks = true;
+  ManifoldParams().processOverlaps = false;
+  ManifoldParams().suppressErrors = true;
 
   if (argc < 2) {
     std::cerr << "Usage: " << argv[0] << " <input file>" << std::endl;

--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -577,6 +577,9 @@ struct ExecutionParams {
   /// Perform extra sanity checks and assertions on the intermediate data
   /// structures.
   bool intermediateChecks = false;
+  /// Perform 3D mesh self-intersection test on intermediate boolean results to
+  /// test for ϵ-validity. For debug purposes only.
+  bool selfIntersectionChecks = false;
   /// Verbose output primarily of the Boolean, including timing info and vector
   /// sizes.
   bool verbose = false;

--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -580,9 +580,6 @@ struct ExecutionParams {
   /// Perform 3D mesh self-intersection test on intermediate boolean results to
   /// test for ϵ-validity. For debug purposes only.
   bool selfIntersectionChecks = false;
-  /// Verbose output primarily of the Boolean, including timing info and vector
-  /// sizes.
-  bool verbose = false;
   /// If processOverlaps is false, a geometric check will be performed to assert
   /// all triangles are CCW.
   bool processOverlaps = true;
@@ -591,6 +588,12 @@ struct ExecutionParams {
   bool suppressErrors = false;
   /// Perform optional but recommended triangle cleanups in SimplifyTopology()
   bool cleanupTriangles = true;
+  /// Verbose level:
+  /// - 0 for no verbose output
+  /// - 1 for verbose output for the Boolean, including timing info and vector
+  /// sizes.
+  /// - 2 for verbose output with triangulator action as well.
+  int verbose = 0;
 };
 /** @} */
 

--- a/include/manifold/polygon.h
+++ b/include/manifold/polygon.h
@@ -56,7 +56,5 @@ std::vector<ivec3> TriangulateIdx(const PolygonsIdx &polys,
                                   double epsilon = -1);
 
 std::vector<ivec3> Triangulate(const Polygons &polygons, double epsilon = -1);
-
-ExecutionParams &PolygonParams();
 /** @} */
 }  // namespace manifold

--- a/src/boolean3.h
+++ b/src/boolean3.h
@@ -17,7 +17,7 @@
 
 #ifdef MANIFOLD_DEBUG
 #define PRINT(msg) \
-  if (ManifoldParams().verbose) std::cout << msg << std::endl;
+  if (ManifoldParams().verbose > 0) std::cout << msg << std::endl;
 #else
 #define PRINT(msg)
 #endif

--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -137,7 +137,7 @@ std::shared_ptr<CsgLeafNode> SimpleBoolean(const Manifold::Impl &a,
   try {
     Boolean3 boolean(a, b, op);
     auto impl = boolean.Result(op);
-    if (ManifoldParams().intermediateChecks && impl.IsSelfIntersecting()) {
+    if (ManifoldParams().selfIntersectionChecks && impl.IsSelfIntersecting()) {
       dump_lock.lock();
       std::cout << "self intersections detected" << std::endl;
       dump_lock.unlock();

--- a/src/edge_op.cpp
+++ b/src/edge_op.cpp
@@ -266,7 +266,7 @@ void Manifold::Impl::SimplifyTopology(int firstNewVert) {
     });
 
 #ifdef MANIFOLD_DEBUG
-    if (ManifoldParams().verbose && numFlagged > 0) {
+    if (ManifoldParams().verbose > 0 && numFlagged > 0) {
       std::cout << "collapsed " << numFlagged << " short edges" << std::endl;
     }
 #endif
@@ -284,7 +284,7 @@ void Manifold::Impl::SimplifyTopology(int firstNewVert) {
     if (numFlagged == 0) break;
 
 #ifdef MANIFOLD_DEBUG
-    if (ManifoldParams().verbose && numFlagged > 0) {
+    if (ManifoldParams().verbose > 0 && numFlagged > 0) {
       std::cout << "collapsed " << numFlagged << " colinear edges" << std::endl;
     }
 #endif
@@ -310,7 +310,7 @@ void Manifold::Impl::SimplifyTopology(int firstNewVert) {
     });
 
 #ifdef MANIFOLD_DEBUG
-    if (ManifoldParams().verbose && numFlagged > 0) {
+    if (ManifoldParams().verbose > 0 && numFlagged > 0) {
       std::cout << "swapped " << numFlagged << " edges" << std::endl;
     }
 #endif
@@ -897,7 +897,7 @@ void Manifold::Impl::DedupeEdges() {
     if (numFlagged == 0) break;
 
 #ifdef MANIFOLD_DEBUG
-    if (ManifoldParams().verbose) {
+    if (ManifoldParams().verbose > 0) {
       std::cout << "found " << numFlagged << " duplicate edges to split"
                 << std::endl;
     }

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -27,6 +27,8 @@
 namespace {
 using namespace manifold;
 
+constexpr int TRIANGULATOR_VERBOSE_LEVEL = 2;
+
 constexpr double kBest = -std::numeric_limits<double>::infinity();
 
 // it seems that MSVC cannot optimize la::determinant(mat2(a, b))
@@ -147,7 +149,8 @@ void PrintFailure(const std::exception &e, const PolygonsIdx &polys,
   std::cout << "-----------------------------------" << std::endl;
   std::cout << "Triangulation failed! Precision = " << epsilon << std::endl;
   std::cout << e.what() << std::endl;
-  if (triangles.size() > 1000 && !ManifoldParams().verbose) {
+  if (triangles.size() > 1000 &&
+      ManifoldParams().verbose < TRIANGULATOR_VERBOSE_LEVEL) {
     std::cout << "Output truncated due to producing " << triangles.size()
               << " triangles." << std::endl;
     return;
@@ -160,8 +163,9 @@ void PrintFailure(const std::exception &e, const PolygonsIdx &polys,
   }
 }
 
-#define PRINT(msg) \
-  if (ManifoldParams().verbose) std::cout << msg << std::endl;
+#define PRINT(msg)                                            \
+  if (ManifoldParams().verbose >= TRIANGULATOR_VERBOSE_LEVEL) \
+    std::cout << msg << std::endl;
 #else
 #define PRINT(msg)
 #endif
@@ -527,7 +531,7 @@ class EarClip {
 
     void PrintVert() const {
 #ifdef MANIFOLD_DEBUG
-      if (!ManifoldParams().verbose) return;
+      if (ManifoldParams().verbose < TRIANGULATOR_VERBOSE_LEVEL) return;
       std::cout << "vert: " << mesh_idx << ", left: " << left->mesh_idx
                 << ", right: " << right->mesh_idx << ", cost: " << cost
                 << std::endl;
@@ -747,7 +751,7 @@ class EarClip {
     JoinPolygons(start, connector);
 
 #ifdef MANIFOLD_DEBUG
-    if (ManifoldParams().verbose) {
+    if (ManifoldParams().verbose >= TRIANGULATOR_VERBOSE_LEVEL) {
       std::cout << "connected " << start->mesh_idx << " to "
                 << connector->mesh_idx << std::endl;
     }
@@ -895,7 +899,7 @@ class EarClip {
 
   void Dump(VertItrC start) const {
 #ifdef MANIFOLD_DEBUG
-    if (!ManifoldParams().verbose) return;
+    if (ManifoldParams().verbose < TRIANGULATOR_VERBOSE_LEVEL) return;
     VertItrC v = start;
     std::cout << "show(array([" << std::setprecision(15) << std::endl;
     do {

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -21,12 +21,11 @@
 #include "./parallel.h"
 #include "./tree2d.h"
 #include "./utils.h"
+#include "manifold/manifold.h"
 #include "manifold/optional_assert.h"
 
 namespace {
 using namespace manifold;
-
-static ExecutionParams params;
 
 constexpr double kBest = -std::numeric_limits<double>::infinity();
 
@@ -148,7 +147,7 @@ void PrintFailure(const std::exception &e, const PolygonsIdx &polys,
   std::cout << "-----------------------------------" << std::endl;
   std::cout << "Triangulation failed! Precision = " << epsilon << std::endl;
   std::cout << e.what() << std::endl;
-  if (triangles.size() > 1000 && !PolygonParams().verbose) {
+  if (triangles.size() > 1000 && !ManifoldParams().verbose) {
     std::cout << "Output truncated due to producing " << triangles.size()
               << " triangles." << std::endl;
     return;
@@ -162,7 +161,7 @@ void PrintFailure(const std::exception &e, const PolygonsIdx &polys,
 }
 
 #define PRINT(msg) \
-  if (params.verbose) std::cout << msg << std::endl;
+  if (ManifoldParams().verbose) std::cout << msg << std::endl;
 #else
 #define PRINT(msg)
 #endif
@@ -528,7 +527,7 @@ class EarClip {
 
     void PrintVert() const {
 #ifdef MANIFOLD_DEBUG
-      if (!params.verbose) return;
+      if (!ManifoldParams().verbose) return;
       std::cout << "vert: " << mesh_idx << ", left: " << left->mesh_idx
                 << ", right: " << right->mesh_idx << ", cost: " << cost
                 << std::endl;
@@ -748,7 +747,7 @@ class EarClip {
     JoinPolygons(start, connector);
 
 #ifdef MANIFOLD_DEBUG
-    if (params.verbose) {
+    if (ManifoldParams().verbose) {
       std::cout << "connected " << start->mesh_idx << " to "
                 << connector->mesh_idx << std::endl;
     }
@@ -896,7 +895,7 @@ class EarClip {
 
   void Dump(VertItrC start) const {
 #ifdef MANIFOLD_DEBUG
-    if (!params.verbose) return;
+    if (!ManifoldParams().verbose) return;
     VertItrC v = start;
     std::cout << "show(array([" << std::setprecision(15) << std::endl;
     do {
@@ -950,14 +949,14 @@ std::vector<ivec3> TriangulateIdx(const PolygonsIdx &polys, double epsilon) {
       updatedEpsilon = triangulator.GetPrecision();
     }
 #ifdef MANIFOLD_DEBUG
-    if (params.intermediateChecks) {
+    if (ManifoldParams().intermediateChecks) {
       CheckTopology(triangles, polys);
-      if (!params.processOverlaps) {
+      if (!ManifoldParams().processOverlaps) {
         CheckGeometry(triangles, polys, 2 * updatedEpsilon);
       }
     }
   } catch (const geometryErr &e) {
-    if (!params.suppressErrors) {
+    if (!ManifoldParams().suppressErrors) {
       PrintFailure(e, polys, triangles, updatedEpsilon);
     }
     throw;
@@ -993,7 +992,5 @@ std::vector<ivec3> Triangulate(const Polygons &polygons, double epsilon) {
   }
   return TriangulateIdx(polygonsIndexed, epsilon);
 }
-
-ExecutionParams &PolygonParams() { return params; }
 
 }  // namespace manifold

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -217,7 +217,7 @@ bool Manifold::Impl::IsSelfIntersecting() const {
   GetFaceBoxMorton(faceBox, faceMorton);
   SparseIndices collisions = collider_.Collisions<true>(faceBox.cview());
 
-  const bool verbose = ManifoldParams().verbose;
+  const bool verbose = ManifoldParams().verbose > 0;
   return !all_of(countAt(0), countAt(collisions.size()), [&](size_t i) {
     size_t x = collisions.Get(i, false);
     size_t y = collisions.Get(i, true);

--- a/test/boolean_complex_test.cpp
+++ b/test/boolean_complex_test.cpp
@@ -19,7 +19,6 @@
 #include <iostream>
 
 #include "manifold/manifold.h"
-#include "manifold/polygon.h"
 #include "test.h"
 
 using namespace manifold;
@@ -229,7 +228,7 @@ TEST(BooleanComplex, Subtract) {
 }
 
 TEST(BooleanComplex, Close) {
-  PolygonParams().processOverlaps = true;
+  ManifoldParams().processOverlaps = true;
 
   const double r = 10;
   Manifold a = Manifold::Sphere(r, 256);
@@ -246,7 +245,7 @@ TEST(BooleanComplex, Close) {
   if (options.exportModels) ExportMesh("close.glb", result.GetMeshGL(), {});
 #endif
 
-  PolygonParams().processOverlaps = false;
+  ManifoldParams().processOverlaps = false;
 }
 
 TEST(BooleanComplex, BooleanVolumes) {
@@ -291,7 +290,7 @@ TEST(BooleanComplex, Spiral) {
 
 #ifdef MANIFOLD_CROSS_SECTION
 TEST(BooleanComplex, Sweep) {
-  PolygonParams().processOverlaps = true;
+  ManifoldParams().processOverlaps = true;
 
   // generate the minimum equivalent positive angle
   auto minPosAngle = [](double angle) {
@@ -525,7 +524,7 @@ TEST(BooleanComplex, Sweep) {
   if (options.exportModels) ExportMesh("unionError.glb", shape.GetMeshGL(), {});
 #endif
 
-  PolygonParams().processOverlaps = false;
+  ManifoldParams().processOverlaps = false;
 }
 #endif
 
@@ -874,12 +873,12 @@ TEST(BooleanComplex, InterpolatedNormals) {
 
 #ifdef MANIFOLD_EXPORT
 TEST(BooleanComplex, SelfIntersect) {
-  manifold::PolygonParams().processOverlaps = true;
+  manifold::ManifoldParams().processOverlaps = true;
   Manifold m1 = ReadMesh("self_intersectA.glb");
   Manifold m2 = ReadMesh("self_intersectB.glb");
   Manifold res = m1 + m2;
   res.GetMeshGL();  // test crash
-  manifold::PolygonParams().processOverlaps = false;
+  manifold::ManifoldParams().processOverlaps = false;
 }
 
 TEST(BooleanComplex, GenericTwinBooleanTest7081) {
@@ -890,21 +889,21 @@ TEST(BooleanComplex, GenericTwinBooleanTest7081) {
 }
 
 TEST(BooleanComplex, GenericTwinBooleanTest7863) {
-  manifold::PolygonParams().processOverlaps = true;
+  manifold::ManifoldParams().processOverlaps = true;
   Manifold m1 = ReadMesh("Generic_Twin_7863.1.t0_left.glb");
   Manifold m2 = ReadMesh("Generic_Twin_7863.1.t0_right.glb");
   Manifold res = m1 + m2;  // Union
   res.GetMeshGL();         // test crash
-  manifold::PolygonParams().processOverlaps = false;
+  manifold::ManifoldParams().processOverlaps = false;
 }
 
 TEST(BooleanComplex, Havocglass8Bool) {
-  manifold::PolygonParams().processOverlaps = true;
+  manifold::ManifoldParams().processOverlaps = true;
   Manifold m1 = ReadMesh("Havocglass8_left.glb");
   Manifold m2 = ReadMesh("Havocglass8_right.glb");
   Manifold res = m1 + m2;  // Union
   res.GetMeshGL();         // test crash
-  manifold::PolygonParams().processOverlaps = false;
+  manifold::ManifoldParams().processOverlaps = false;
 }
 
 TEST(BooleanComplex, CraycloudBool) {
@@ -1022,8 +1021,8 @@ TEST(BooleanComplex, SimpleOffset) {
 }
 
 TEST(BooleanComplex, DISABLED_OffsetTriangulationFailure) {
-  const bool intermediateChecks = ManifoldParams().intermediateChecks;
-  ManifoldParams().intermediateChecks = true;
+  const bool selfIntersectionChecks = ManifoldParams().selfIntersectionChecks;
+  ManifoldParams().selfIntersectionChecks = true;
   std::string file = __FILE__;
   std::string dir = file.substr(0, file.rfind('/'));
   Manifold a, b;
@@ -1036,12 +1035,12 @@ TEST(BooleanComplex, DISABLED_OffsetTriangulationFailure) {
   f.close();
   Manifold result = a + b;
   EXPECT_EQ(result.Status(), Manifold::Error::NoError);
-  ManifoldParams().intermediateChecks = intermediateChecks;
+  ManifoldParams().selfIntersectionChecks = selfIntersectionChecks;
 }
 
 TEST(BooleanComplex, DISABLED_OffsetSelfIntersect) {
-  const bool intermediateChecks = ManifoldParams().intermediateChecks;
-  ManifoldParams().intermediateChecks = true;
+  const bool selfIntersectionChecks = ManifoldParams().selfIntersectionChecks;
+  ManifoldParams().selfIntersectionChecks = true;
   std::string file = __FILE__;
   std::string dir = file.substr(0, file.rfind('/'));
   Manifold a, b;
@@ -1055,7 +1054,7 @@ TEST(BooleanComplex, DISABLED_OffsetSelfIntersect) {
 
   Manifold result = a + b;
   EXPECT_EQ(result.Status(), Manifold::Error::NoError);
-  ManifoldParams().intermediateChecks = intermediateChecks;
+  ManifoldParams().selfIntersectionChecks = selfIntersectionChecks;
 }
 
 #endif

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -430,12 +430,13 @@ TEST(Boolean, Precision2) {
   EXPECT_FALSE((cube ^ cube2).IsEmpty());
 }
 
-TEST(Boolean, DISABLED_SimpleCubeRegression) {
-  ManifoldParams().intermediateChecks = true;
+TEST(Boolean, SimpleCubeRegression) {
+  const bool selfIntersectionChecks = ManifoldParams().selfIntersectionChecks;
+  ManifoldParams().selfIntersectionChecks = true;
   Manifold result =
       Manifold::Cube().Rotate(-0.10000000000000001, 0.10000000000000001, -1.) +
       Manifold::Cube() -
       Manifold::Cube().Rotate(-0.10000000000000001, -0.10000000000066571, -1.);
   EXPECT_EQ(result.Status(), Manifold::Error::NoError);
-  ManifoldParams().intermediateChecks = false;
+  ManifoldParams().selfIntersectionChecks = selfIntersectionChecks;
 }

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -430,7 +430,7 @@ TEST(Boolean, Precision2) {
   EXPECT_FALSE((cube ^ cube2).IsEmpty());
 }
 
-TEST(Boolean, SimpleCubeRegression) {
+TEST(Boolean, DISABLED_SimpleCubeRegression) {
   const bool selfIntersectionChecks = ManifoldParams().selfIntersectionChecks;
   ManifoldParams().selfIntersectionChecks = true;
   Manifold result =

--- a/test/polygon_test.cpp
+++ b/test/polygon_test.cpp
@@ -57,8 +57,6 @@ Polygons Duplicate(Polygons polys) {
 
 void TestPoly(const Polygons &polys, int expectedNumTri,
               double epsilon = -1.0) {
-  ManifoldParams().verbose = options.params.verbose;
-
   std::vector<ivec3> triangles;
   EXPECT_NO_THROW(triangles = Triangulate(polys, epsilon));
   EXPECT_EQ(triangles.size(), expectedNumTri) << "Basic";
@@ -68,8 +66,6 @@ void TestPoly(const Polygons &polys, int expectedNumTri,
 
   EXPECT_NO_THROW(triangles = Triangulate(Duplicate(polys), epsilon));
   EXPECT_EQ(triangles.size(), 2 * expectedNumTri) << "Duplicate";
-
-  ManifoldParams().verbose = false;
 }
 
 class PolygonTestFixture : public testing::Test {

--- a/test/polygon_test.cpp
+++ b/test/polygon_test.cpp
@@ -57,7 +57,7 @@ Polygons Duplicate(Polygons polys) {
 
 void TestPoly(const Polygons &polys, int expectedNumTri,
               double epsilon = -1.0) {
-  PolygonParams().verbose = options.params.verbose;
+  ManifoldParams().verbose = options.params.verbose;
 
   std::vector<ivec3> triangles;
   EXPECT_NO_THROW(triangles = Triangulate(polys, epsilon));
@@ -69,7 +69,7 @@ void TestPoly(const Polygons &polys, int expectedNumTri,
   EXPECT_NO_THROW(triangles = Triangulate(Duplicate(polys), epsilon));
   EXPECT_EQ(triangles.size(), 2 * expectedNumTri) << "Duplicate";
 
-  PolygonParams().verbose = false;
+  ManifoldParams().verbose = false;
 }
 
 class PolygonTestFixture : public testing::Test {

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -297,15 +297,15 @@ TEST(Samples, Sponge4) {
 
 TEST(Samples, CondensedMatter16) {
   // FIXME: Triangulation can be invalid
-  bool old = PolygonParams().processOverlaps;
-  PolygonParams().processOverlaps = true;
+  bool old = ManifoldParams().processOverlaps;
+  ManifoldParams().processOverlaps = true;
   Manifold cm = CondensedMatter(16);
   CheckGL(cm);
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels)
     ExportMesh("condensedMatter16.glb", cm.GetMeshGL(), {});
 #endif
-  PolygonParams().processOverlaps = old;
+  ManifoldParams().processOverlaps = old;
 }
 
 TEST(Samples, CondensedMatter64) {

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -42,6 +42,9 @@ void print_usage() {
   printf(
       "  -v: Enable verbose output (only works if compiled with MANIFOLD_DEBUG "
       "flag)\n");
+  printf(
+      "  -vv: Enable extra verbose output for triangulator (only works if "
+      "compiled with MANIFOLD_DEBUG flag)\n");
 }
 
 int main(int argc, char** argv) {
@@ -86,8 +89,10 @@ int main(int argc, char** argv) {
         options.exportModels = true;
         break;
       case 'v':
-        options.params.verbose = true;
-        manifold::ManifoldParams().verbose = true;
+        manifold::ManifoldParams().verbose = 1;
+        if (argv[i][2] == 'v') {
+          manifold::ManifoldParams().verbose = 2;
+        }
         break;
       case 'c':
         manifold::ManifoldParams().selfIntersectionChecks = true;

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -38,10 +38,9 @@ void print_usage() {
   printf("manifold_test specific options:\n");
   printf("  -h: Print this message\n");
   printf("  -e: Export GLB models of samples\n");
-  printf("  -c: Enable intermediate checks (needs MANIFOLD_DEBUG)\n");
+  printf("  -c: Enable self-intersection checks (needs MANIFOLD_DEBUG)\n");
   printf(
-      "  -v: Enable verbose output and intermediate checks (only works if "
-      "compiled with MANIFOLD_DEBUG "
+      "  -v: Enable verbose output (only works if compiled with MANIFOLD_DEBUG "
       "flag)\n");
 }
 
@@ -89,10 +88,9 @@ int main(int argc, char** argv) {
       case 'v':
         options.params.verbose = true;
         manifold::ManifoldParams().verbose = true;
-        manifold::ManifoldParams().intermediateChecks = true;
         break;
       case 'c':
-        manifold::ManifoldParams().intermediateChecks = true;
+        manifold::ManifoldParams().selfIntersectionChecks = true;
         break;
       default:
         fprintf(stderr, "Unknown option: %s\n", argv[i]);
@@ -101,8 +99,8 @@ int main(int argc, char** argv) {
     }
   }
 
-  manifold::PolygonParams().intermediateChecks = true;
-  manifold::PolygonParams().processOverlaps = false;
+  manifold::ManifoldParams().intermediateChecks = true;
+  manifold::ManifoldParams().processOverlaps = false;
 
   FrameMarkEnd(name);
 


### PR DESCRIPTION
The old way of specifying parameters for manifold and polygon separately is quite confusing. This merges them, and removed `PolygonParams` all together.

This is a small breaking that hopefully no one is using, except our own testing code. That said, the next release should still bump the minor version (3.1.0) together with other changes in decimation etc.