### PR TITLE
radix sort impl

### DIFF
--- a/extras/stl_test.cpp
+++ b/extras/stl_test.cpp
@@ -14,7 +14,7 @@
 
 static constexpr size_t g_Iterations = 5;
 static constexpr size_t g_IterationsDiscard = 1;
-static constexpr size_t g_Sizes[] = {1'000, 10'000, 100'000, 1'000'000,
+static constexpr size_t g_Sizes[] = {1'000, 5'000, 10'000, 50'000, 100'000, 1'000'000,
                                      10'000'000};
 
 template <class Tp>
@@ -238,7 +238,11 @@ struct sort_Rnd_size {  // 25.8.2.1, semi-random input
                         [&dist, &mt] { return dist(mt); });
         },
         [&] {
-          manifold::stable_sort(Policy, v.begin(), v.end());
+          if (Policy == manifold::ExecutionPolicy::Par)
+            manifold::radix_sort_with_key(v.begin(), v.end(),
+                                          [](auto x) { return x; });
+          else
+            std::stable_sort(v.begin(), v.end());
           noopt(v);
         });
   }
@@ -283,7 +287,11 @@ struct sort_Eq_size {  // 25.8.2.1, equal input
     std::vector<size_t> v;
     return measure([&] { v = std::vector<size_t>(size, 42); },
                    [&] {
-                     manifold::stable_sort(Policy, v.begin(), v.end());
+                     if (Policy == manifold::ExecutionPolicy::Par)
+                       manifold::radix_sort_with_key(v.begin(), v.end(),
+                                                     [](auto x) { return x; });
+                     else
+                       std::stable_sort(v.begin(), v.end());
                      noopt(v);
                    });
   }
@@ -328,7 +336,11 @@ struct sort_Asc_size {  // 25.8.2.1, ascending
           std::iota(v.begin(), v.end(), 0);
         },
         [&] {
-          manifold::stable_sort(Policy, v.begin(), v.end());
+          if (Policy == manifold::ExecutionPolicy::Par)
+            manifold::radix_sort_with_key(v.begin(), v.end(),
+                                          [](auto x) { return x; });
+          else
+            std::stable_sort(v.begin(), v.end());
           noopt(v);
         });
   }
@@ -358,7 +370,7 @@ struct sort_roughly_Asc {  // 25.8.2.1, ascending + random swaps
     return measure(
         [&] {
           std::mt19937 mt{42};
-          std::uniform_int_distribution<size_t> dist{0, size - 1};
+          std::uniform_int_distribution<size_t> dist{size / 2, size - 1};
           v = std::vector<double>(size);
           std::iota(v.begin(), v.end(), 0.);
           for (int i = 0; i < std::sqrt(size); i++) {
@@ -379,7 +391,7 @@ struct sort_roughly_Asc_size {  // 25.8.2.1, ascending + random swaps
     return measure(
         [&] {
           std::mt19937 mt{42};
-          std::uniform_int_distribution<size_t> dist{0, size - 1};
+          std::uniform_int_distribution<size_t> dist{size / 2, size - 1};
           v = std::vector<size_t>(size);
           std::iota(v.begin(), v.end(), 0.);
           for (int i = 0; i < std::sqrt(size); i++) {
@@ -387,7 +399,11 @@ struct sort_roughly_Asc_size {  // 25.8.2.1, ascending + random swaps
           }
         },
         [&] {
-          manifold::stable_sort(Policy, v.begin(), v.end());
+          if (Policy == manifold::ExecutionPolicy::Par)
+            manifold::radix_sort_with_key(v.begin(), v.end(),
+                                          [](auto x) { return x; });
+          else
+            std::stable_sort(v.begin(), v.end());
           noopt(v);
         });
   }
@@ -400,7 +416,7 @@ struct sort_roughly_Asc_size_merge {  // 25.8.2.1, ascending + random swaps
     return measure(
         [&] {
           std::mt19937 mt{42};
-          std::uniform_int_distribution<size_t> dist{0, size - 1};
+          std::uniform_int_distribution<size_t> dist{size / 2, size - 1};
           v = std::vector<size_t>(size);
           std::iota(v.begin(), v.end(), 0.);
           for (int i = 0; i < std::sqrt(size); i++) {
@@ -447,7 +463,11 @@ struct sort_Des_size {  // 25.8.2.1, descending
                         });
         },
         [&] {
-          manifold::stable_sort(Policy, v.begin(), v.end());
+          if (Policy == manifold::ExecutionPolicy::Par)
+            manifold::radix_sort_with_key(v.begin(), v.end(),
+                                          [](auto x) { return x; });
+          else
+            std::stable_sort(v.begin(), v.end());
           noopt(v);
         });
   }

--- a/extras/stl_test.cpp
+++ b/extras/stl_test.cpp
@@ -14,8 +14,8 @@
 
 static constexpr size_t g_Iterations = 5;
 static constexpr size_t g_IterationsDiscard = 1;
-static constexpr size_t g_Sizes[] = {1'000, 5'000, 10'000, 50'000, 100'000, 1'000'000,
-                                     10'000'000};
+static constexpr size_t g_Sizes[] = {1'000,   5'000,     10'000,    50'000,
+                                     100'000, 1'000'000, 10'000'000};
 
 template <class Tp>
 inline void noopt(Tp const &value) {

--- a/src/face_op.cpp
+++ b/src/face_op.cpp
@@ -282,9 +282,8 @@ void Manifold::Impl::FlattenFaces() {
 
   Vec<size_t> newHalf2Old(halfedge_.size());
   sequence(newHalf2Old.begin(), newHalf2Old.end());
-  stable_sort(
-      newHalf2Old.begin(), newHalf2Old.end(),
-      [&edgeFace](size_t a, size_t b) { return edgeFace[a] < edgeFace[b]; });
+  radix_sort_with_key(newHalf2Old.begin(), newHalf2Old.end(),
+                      [&edgeFace](size_t i) { return edgeFace[i]; });
   newHalf2Old.resize(std::find_if(countAt(0_uz), countAt(halfedge_.size()),
                                   [&](const size_t i) {
                                     return edgeFace[newHalf2Old[i]] == remove;

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -338,9 +338,8 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
   // degenerate situations the triangulator can add the same internal edge in
   // two different faces, causing this edge to not be 2-manifold. These are
   // fixed by duplicating verts in SimplifyTopology.
-  stable_sort(ids.begin(), ids.end(), [&edge](const int& a, const int& b) {
-    return edge[a] < edge[b];
-  });
+  radix_sort_with_key(ids.begin(), ids.end(),
+                      [&edge](size_t i) { return edge[i]; });
 
   // Mark opposed triangles for removal - this may strand unreferenced verts
   // which are removed later by RemoveUnreferencedVerts() and Finish().

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -339,7 +339,7 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
   // two different faces, causing this edge to not be 2-manifold. These are
   // fixed by duplicating verts in SimplifyTopology.
   radix_sort_with_key(ids.begin(), ids.end(),
-                      [&edge](size_t i) { return edge[i]; });
+                      [&edge](int i) { return edge[i]; });
 
   // Mark opposed triangles for removal - this may strand unreferenced verts
   // which are removed later by RemoveUnreferencedVerts() and Finish().

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -177,12 +177,7 @@ void radix_sort_with_key_rec(I start, I end, J dest, int bytes, KeyFn &keyfn,
           prev = x;
           hists[i][getByte(curr, bytes)]++;
         }
-        metadata[i] = {.localMin = localMin,
-                       .localMax = localMax,
-                       .prefixMax = localMax,
-                       .suffixMin = localMin,
-                       .sorted = sorted,
-                       .canSkip = false};
+        metadata[i] = {localMin, localMax, localMax, localMin, sorted, false};
       });
     }
     taskgroup.wait();

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -126,24 +126,9 @@ void radix_sort_with_key_rec(I start, I end, J dest, int bytes, KeyFn &keyfn,
                              bool writeback) {
   using T = std::remove_reference_t<decltype(*start)>;
   using U = std::invoke_result_t<KeyFn, T>;
-  constexpr size_t MIN_BLOCK_SIZE = 10'000;
+  constexpr size_t MIN_BLOCK_SIZE = 100'000;
   size_t n = std::distance(start, end);
-
-  if ((n <= kSeqThreshold && bytes >= 1) || (n < 2'000)) {
-    if (writeback) {
-      std::stable_sort(start, end, [&keyfn](const T &a, const T &b) {
-        return keyfn(a) < keyfn(b);
-      });
-    } else {
-      std::copy(start, end, dest);
-      std::stable_sort(dest, dest + n, [&keyfn](const T &a, const T &b) {
-        return keyfn(a) < keyfn(b);
-      });
-    }
-    return;
-  }
   auto getByte = ByteGetter(keyfn);
-
   unsigned int hardware_concurrency = std::thread::hardware_concurrency();
   size_t blocks =
       std::max(std::min(hardware_concurrency,

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -172,10 +172,8 @@ bool MergeMeshGLP(MeshGLP<Precision, I>& mesh) {
   Vec<int> vertNew2Old(numOpenVert);
   sequence(vertNew2Old.begin(), vertNew2Old.end());
 
-  stable_sort(vertNew2Old.begin(), vertNew2Old.end(),
-              [&vertMorton](const int& a, const int& b) {
-                return vertMorton[a] < vertMorton[b];
-              });
+  radix_sort_with_key(vertNew2Old.begin(), vertNew2Old.end(),
+                      [&vertMorton](size_t i) { return vertMorton[i]; });
 
   Permute(vertMorton, vertNew2Old);
   Permute(vertBox, vertNew2Old);
@@ -292,10 +290,8 @@ void Manifold::Impl::SortVerts() {
   Vec<int> vertNew2Old(numVert);
   sequence(vertNew2Old.begin(), vertNew2Old.end());
 
-  stable_sort(vertNew2Old.begin(), vertNew2Old.end(),
-              [&vertMorton](const int& a, const int& b) {
-                return vertMorton[a] < vertMorton[b];
-              });
+  radix_sort_with_key(vertNew2Old.begin(), vertNew2Old.end(),
+                      [&vertMorton](size_t i) { return vertMorton[i]; });
 
   ReindexVerts(vertNew2Old, numVert);
 
@@ -407,10 +403,8 @@ void Manifold::Impl::SortFaces(Vec<Box>& faceBox, Vec<uint32_t>& faceMorton) {
   Vec<int> faceNew2Old(NumTri());
   sequence(faceNew2Old.begin(), faceNew2Old.end());
 
-  stable_sort(faceNew2Old.begin(), faceNew2Old.end(),
-              [&faceMorton](const int& a, const int& b) {
-                return faceMorton[a] < faceMorton[b];
-              });
+  radix_sort_with_key(faceNew2Old.begin(), faceNew2Old.end(),
+                      [&faceMorton](size_t i) { return faceMorton[i]; });
 
   // Tris were flagged for removal with pairedHalfedge = -1 and assigned kNoCode
   // to sort them to the end, which allows them to be removed.

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -173,7 +173,7 @@ bool MergeMeshGLP(MeshGLP<Precision, I>& mesh) {
   sequence(vertNew2Old.begin(), vertNew2Old.end());
 
   radix_sort_with_key(vertNew2Old.begin(), vertNew2Old.end(),
-                      [&vertMorton](size_t i) { return vertMorton[i]; });
+                      [&vertMorton](int i) { return vertMorton[i]; });
 
   Permute(vertMorton, vertNew2Old);
   Permute(vertBox, vertNew2Old);
@@ -291,7 +291,7 @@ void Manifold::Impl::SortVerts() {
   sequence(vertNew2Old.begin(), vertNew2Old.end());
 
   radix_sort_with_key(vertNew2Old.begin(), vertNew2Old.end(),
-                      [&vertMorton](size_t i) { return vertMorton[i]; });
+                      [&vertMorton](int i) { return vertMorton[i]; });
 
   ReindexVerts(vertNew2Old, numVert);
 
@@ -404,7 +404,7 @@ void Manifold::Impl::SortFaces(Vec<Box>& faceBox, Vec<uint32_t>& faceMorton) {
   sequence(faceNew2Old.begin(), faceNew2Old.end());
 
   radix_sort_with_key(faceNew2Old.begin(), faceNew2Old.end(),
-                      [&faceMorton](size_t i) { return faceMorton[i]; });
+                      [&faceMorton](int i) { return faceMorton[i]; });
 
   // Tris were flagged for removal with pairedHalfedge = -1 and assigned kNoCode
   // to sort them to the end, which allows them to be removed.

--- a/src/sparse.h
+++ b/src/sparse.h
@@ -90,7 +90,7 @@ class SparseIndices {
 
   void Sort() {
     VecView<int64_t> view = AsVec64();
-    radix_sort_with_key(view.begin(), view.end(), [](size_t i) { return i; });
+    radix_sort_with_key(view.begin(), view.end(), [](int64_t i) { return i; });
   }
 
   void Resize(size_t size) { data_.resize(size * sizeof(int64_t), -1); }

--- a/src/sparse.h
+++ b/src/sparse.h
@@ -90,7 +90,7 @@ class SparseIndices {
 
   void Sort() {
     VecView<int64_t> view = AsVec64();
-    stable_sort(view.begin(), view.end());
+    radix_sort_with_key(view.begin(), view.end(), [](size_t i) { return i; });
   }
 
   void Resize(size_t size) { data_.resize(size * sizeof(int64_t), -1); }


### PR DESCRIPTION
Closes #1176. This is a rather large change to the algorithm implementation, but it scales much better now.

```
                               1K    5K   10K   50K  100K    1M   10M 
sort_Rnd                     2.41  1.09  1.01  4.96  8.53 17.33 11.96 
sort_Rnd_size                1.08  1.08  1.04  8.76 15.27 28.58 28.37 
sort_Rnd_size_merge          2.24  1.07  1.02  4.81  9.15 15.66 10.51 
sort_roughly_Asc             1.25  1.03  0.99  1.40  2.30  2.73  2.64 
sort_roughly_Asc_size        1.00  1.06  1.02  1.09  1.62  6.52 12.00 
sort_roughly_Asc_size_merge  1.29  1.00  1.00  1.54  2.03  2.66  2.61 
sort_Des                     1.01  0.95  0.94  1.12  1.87  2.54  2.57 
sort_Des_size                1.02  0.98  0.99  0.86  1.34  4.33  5.64 
sort_Des_size_merge          1.01  0.94  0.96  2.13  2.73  3.28  2.95 
```

Speedup for radix sort for larger data size is increasing. Previously, it is not increasing due to merge being quite sequential:

```
                               1K   10K  100K    1M   10M 
sort_Rnd                     2.39  1.17 10.01 17.68 11.36 
sort_Rnd_size                1.67  2.86 12.66 22.35 11.90 
sort_Rnd_size_merge          2.42  1.04  9.25 16.13 10.71 
sort_roughly_Asc             1.31  1.02  2.13  3.14  2.69 
sort_roughly_Asc_size        1.13  1.50  3.16  4.86  7.29 
sort_roughly_Asc_size_merge  1.23  0.99  2.28  2.87  2.57 
sort_Des                     0.96  0.95  1.89  2.70  2.53 
sort_Des_size                1.26  1.37  2.05  2.63  2.94 
sort_Des_size_merge          0.93  0.91  2.36  3.03  2.82 
```

The new result is not as fast for smaller input instances, but that can probably be tuned.

On my computer, `Samples.CondensedMatter64` runtime reduced from 7785ms to 5365ms due to the huge sparse indices it has to sort. For other benchmarks, the improvement is not as significant (e.g. `Samples.Sponge4` from 2682ms to 2433ms). For perfTest, there is not much improvement, the collider is the slowest part there.