### PR TITLE
Fix face removal (#1191)

### DIFF
--- a/src/edge_op.cpp
+++ b/src/edge_op.cpp
@@ -752,6 +752,7 @@ void Manifold::Impl::SplitPinchedVerts() {
             if (local[i]) continue;
             local[i] = true;
             const int vert = halfedge_[i].startVert;
+            if (vert == -1) continue;
             size_t largest = i;
             ForVert(i, [&local, &largest](int current) {
               local[current] = true;
@@ -791,6 +792,7 @@ void Manifold::Impl::SplitPinchedVerts() {
     for (size_t i = 0; i < nbEdges; ++i) {
       if (halfedgeProcessed[i]) continue;
       int vert = halfedge_[i].startVert;
+      if (vert == -1) continue;
       if (vertProcessed[vert]) {
         vertPos_.push_back(vertPos_[vert]);
         vert = NumVert() - 1;

--- a/src/face_op.cpp
+++ b/src/face_op.cpp
@@ -115,9 +115,6 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
     const vec3 normal = faceNormal_[face];
 
     if (numEdge == 3) {  // Single triangle
-      int mapping[3] = {halfedge_[firstEdge].startVert,
-                        halfedge_[firstEdge + 1].startVert,
-                        halfedge_[firstEdge + 2].startVert};
       ivec3 tri(halfedge_[firstEdge].startVert,
                 halfedge_[firstEdge + 1].startVert,
                 halfedge_[firstEdge + 2].startVert);
@@ -132,10 +129,6 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
 
       addTri(face, tri, normal, halfedgeRef[firstEdge]);
     } else if (numEdge == 4) {  // Pair of triangles
-      int mapping[4] = {halfedge_[firstEdge].startVert,
-                        halfedge_[firstEdge + 1].startVert,
-                        halfedge_[firstEdge + 2].startVert,
-                        halfedge_[firstEdge + 3].startVert};
       const mat2x3 projection = GetAxisAlignedProjection(normal);
       auto triCCW = [&projection, this](const ivec3 tri) {
         return CCW(projection * this->vertPos_[tri[0]],
@@ -269,6 +262,10 @@ void Manifold::Impl::FlattenFaces() {
                for (const int i : {0, 1, 2}) {
                  const int edge = 3 * tri + i;
                  const int pair = halfedge_[edge].pairedHalfedge;
+                 if (pair < 0) {
+                   edgeFace[edge] = remove;
+                   return;
+                 }
                  const auto& ref = meshRelation_.triRef[tri];
                  if (ref.SameFace(meshRelation_.triRef[pair / 3])) {
                    edgeFace[edge] = remove;

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -312,6 +312,7 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
   // which are removed later by RemoveUnreferencedVerts() and Finish().
   const int numEdge = numHalfedge / 2;
 
+  constexpr int removedHalfedge = -2;
   const auto body = [&](int i, int consecutiveStart, int segmentEnd) {
     const int pair0 = ids[i];
     Halfedge& h0 = halfedge_[pair0];
@@ -322,7 +323,7 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
       if (h0.startVert != h1.endVert || h0.endVert != h1.startVert) break;
       if (halfedge_[NextHalfedge(pair0)].endVert ==
           halfedge_[NextHalfedge(pair1)].endVert) {
-        h0.pairedHalfedge = h1.pairedHalfedge = -2;
+        h0.pairedHalfedge = h1.pairedHalfedge = removedHalfedge;
         // Reorder so that remaining edges pair up
         if (k != i + numEdge) std::swap(ids[i + numEdge], ids[k]);
         break;
@@ -374,7 +375,7 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
   for_each_n(policy, countAt(0), numEdge, [this, &ids, numEdge](int i) {
     const int pair0 = ids[i];
     const int pair1 = ids[i + numEdge];
-    if (halfedge_[pair0].pairedHalfedge != -2) {
+    if (halfedge_[pair0].pairedHalfedge != removedHalfedge) {
       halfedge_[pair0].pairedHalfedge = pair1;
       halfedge_[pair1].pairedHalfedge = pair0;
     } else {

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -174,7 +174,10 @@ void Manifold::Impl::CreateFaces() {
   for_each_n(autoPolicy(numTri), countAt(0), numTri,
              [&triPriority, this](int tri) {
                meshRelation_.triRef[tri].faceID = -1;
-               if (halfedge_[3 * tri].startVert < 0) return;
+               if (halfedge_[3 * tri].startVert < 0) {
+                 triPriority[tri] = {0, tri};
+                 return;
+               }
                const vec3 v = vertPos_[halfedge_[3 * tri].startVert];
                triPriority[tri] = {
                    length2(cross(vertPos_[halfedge_[3 * tri].endVert] - v,

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -313,7 +313,8 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
   const int numEdge = numHalfedge / 2;
 
   constexpr int removedHalfedge = -2;
-  const auto body = [&, removedHalfedge](int i, int consecutiveStart, int segmentEnd) {
+  const auto body = [&, removedHalfedge](int i, int consecutiveStart,
+                                         int segmentEnd) {
     const int pair0 = ids[i];
     Halfedge& h0 = halfedge_[pair0];
     int k = consecutiveStart + numEdge;
@@ -372,16 +373,17 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
   // Once sorted, the first half of the range is the forward halfedges, which
   // correspond to their backward pair at the same offset in the second half
   // of the range.
-  for_each_n(policy, countAt(0), numEdge, [this, &ids, numEdge, removedHalfedge](int i) {
-    const int pair0 = ids[i];
-    const int pair1 = ids[i + numEdge];
-    if (halfedge_[pair0].pairedHalfedge != removedHalfedge) {
-      halfedge_[pair0].pairedHalfedge = pair1;
-      halfedge_[pair1].pairedHalfedge = pair0;
-    } else {
-      halfedge_[pair0] = halfedge_[pair1] = {-1, -1, -1};
-    }
-  });
+  for_each_n(policy, countAt(0), numEdge,
+             [this, &ids, numEdge, removedHalfedge](int i) {
+               const int pair0 = ids[i];
+               const int pair1 = ids[i + numEdge];
+               if (halfedge_[pair0].pairedHalfedge != removedHalfedge) {
+                 halfedge_[pair0].pairedHalfedge = pair1;
+                 halfedge_[pair1].pairedHalfedge = pair0;
+               } else {
+                 halfedge_[pair0] = halfedge_[pair1] = {-1, -1, -1};
+               }
+             });
 }
 
 /**

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -313,7 +313,7 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
   const int numEdge = numHalfedge / 2;
 
   constexpr int removedHalfedge = -2;
-  const auto body = [&](int i, int consecutiveStart, int segmentEnd) {
+  const auto body = [&, removedHalfedge](int i, int consecutiveStart, int segmentEnd) {
     const int pair0 = ids[i];
     Halfedge& h0 = halfedge_[pair0];
     int k = consecutiveStart + numEdge;
@@ -372,7 +372,7 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
   // Once sorted, the first half of the range is the forward halfedges, which
   // correspond to their backward pair at the same offset in the second half
   // of the range.
-  for_each_n(policy, countAt(0), numEdge, [this, &ids, numEdge](int i) {
+  for_each_n(policy, countAt(0), numEdge, [this, &ids, numEdge, removedHalfedge](int i) {
     const int pair0 = ids[i];
     const int pair1 = ids[i + numEdge];
     if (halfedge_[pair0].pairedHalfedge != removedHalfedge) {

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -190,6 +190,7 @@ void Manifold::Impl::CreateFaces() {
     if (meshRelation_.triRef[tp.tri].faceID >= 0) continue;
 
     meshRelation_.triRef[tp.tri].faceID = tp.tri;
+    if (halfedge_[3 * tp.tri].startVert < 0) continue;
     const vec3 base = vertPos_[halfedge_[3 * tp.tri].startVert];
     const vec3 normal = faceNormal_[tp.tri];
     interiorHalfedges.resize(3);

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -371,15 +371,23 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
     // Remove the marked halfedges
     manifold::stable_sort(removedHalfedges.begin(), removedHalfedges.end());
     Vec<Halfedge> newHalfedge;
+    Vec<vec4> newHalfedgeTangent;
     Vec<TriRef> newTriRef;
     Vec<ivec3> newTriProperties;
+    Vec<vec3> newFaceNormal;
     newHalfedge.resize_nofill(halfedge_.size() - removedHalfedges.size());
+    if (!halfedgeTangent_.empty())
+      newHalfedgeTangent.resize_nofill(halfedgeTangent_.size() -
+                                       removedHalfedges.size());
     if (!meshRelation_.triRef.empty())
       newTriRef.resize_nofill(meshRelation_.triRef.size() -
                               removedHalfedges.size() / 3);
     if (!meshRelation_.triProperties.empty())
       newTriProperties.resize_nofill(meshRelation_.triProperties.size() -
                                      removedHalfedges.size() / 3);
+    if (!faceNormal_.empty())
+      newFaceNormal.resize_nofill(faceNormal_.size() -
+                                  removedHalfedges.size() / 3);
 
     // starting valid triangle index
     int prevStart = 0;
@@ -390,6 +398,10 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
       manifold::copy(halfedge_.begin() + prevStart * 3,
                      halfedge_.begin() + endTri * 3,
                      newHalfedge.begin() + numTri * 3);
+      if (!newHalfedgeTangent.empty())
+        manifold::copy(halfedgeTangent_.begin() + prevStart * 3,
+                       halfedgeTangent_.begin() + endTri * 3,
+                       newHalfedgeTangent.begin() + numTri * 3);
       if (!newTriRef.empty())
         manifold::copy(meshRelation_.triRef.begin() + prevStart,
                        meshRelation_.triRef.begin() + endTri,
@@ -398,12 +410,22 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
         manifold::copy(meshRelation_.triProperties.begin() + prevStart,
                        meshRelation_.triProperties.begin() + endTri,
                        newTriProperties.begin() + numTri);
+      if (!newFaceNormal.empty())
+        manifold::copy(faceNormal_.begin() + prevStart,
+                       faceNormal_.begin() + endTri,
+                       newFaceNormal.begin() + numTri);
       numTri += endTri - prevStart;
       prevStart = endTri + 1;
     }
     manifold::copy(halfedge_.begin() + prevStart * 3, halfedge_.end(),
                    newHalfedge.begin() + numTri * 3);
     halfedge_ = std::move(newHalfedge);
+    if (!newHalfedgeTangent.empty()) {
+      manifold::copy(halfedgeTangent_.begin() + prevStart * 3,
+                     halfedgeTangent_.end(),
+                     newHalfedgeTangent.begin() + numTri * 3);
+      halfedgeTangent_ = std::move(newHalfedgeTangent);
+    }
     if (!newTriRef.empty()) {
       manifold::copy(meshRelation_.triRef.begin() + prevStart,
                      meshRelation_.triRef.end(), newTriRef.begin() + numTri);
@@ -414,6 +436,11 @@ void Manifold::Impl::CreateHalfedges(const Vec<ivec3>& triVerts) {
                      meshRelation_.triProperties.end(),
                      newTriProperties.begin() + numTri);
       meshRelation_.triProperties = std::move(newTriProperties);
+    }
+    if (!newFaceNormal.empty()) {
+      manifold::copy(faceNormal_.begin() + prevStart, faceNormal_.end(),
+                     newFaceNormal.begin() + numTri);
+      faceNormal_ = std::move(newFaceNormal);
     }
   }
 

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -117,6 +117,55 @@ TEST(Manifold, InvalidInput6) {
   EXPECT_EQ(tet.Status(), Manifold::Error::VertexOutOfBounds);
 }
 
+TEST(Manifold, OppositeFace) {
+  MeshGL gl;
+  gl.vertProperties = {
+      0, 0, 0,  //
+      1, 0, 0,  //
+      0, 1, 0,  //
+      1, 1, 0,  //
+      0, 0, 1,  //
+      1, 0, 1,  //
+      0, 1, 1,  //
+      1, 1, 1,  //
+      //
+      2, 0, 0,  //
+      2, 1, 0,  //
+      2, 0, 1,  //
+      2, 1, 1,  //
+  };
+  gl.triVerts = {
+      0, 1,  4,   //
+      0, 2,  3,   //
+      0, 3,  1,   //
+      0, 4,  2,   //
+      1, 3,  5,   //
+      1, 3,  9,   //
+      1, 5,  3,   //
+      1, 5,  4,   //
+      1, 8,  5,   //
+      1, 9,  8,   //
+      2, 4,  6,   //
+      2, 6,  7,   //
+      2, 7,  3,   //
+      3, 5,  7,   //
+      3, 7,  5,   //
+      3, 7,  11,  //
+      3, 11, 9,   //
+      4, 5,  6,   //
+      5, 7,  6,   //
+      5, 8,  10,  //
+      5, 10, 7,   //
+      7, 10, 11,  //
+      8, 9,  10,  //
+      9, 11, 10,  //
+  };
+  Manifold man(gl);
+  EXPECT_EQ(man.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(man.NumVert(), 8);
+  EXPECT_FLOAT_EQ(man.Volume(), 2);
+}
+
 /**
  * ExpectMeshes performs a decomposition, so this test ensures that compose and
  * decompose are inverse operations.

--- a/test/sdf_test.cpp
+++ b/test/sdf_test.cpp
@@ -42,7 +42,7 @@ TEST(SDF, SphereShell) {
       },
       {vec3(-1.1), vec3(1.1)}, 0.01, 0, 0.0001);
 
-  EXPECT_NEAR(sphere.Genus(), 11500, 1000);
+  EXPECT_NEAR(sphere.Genus(), 14235, 1000);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels)


### PR DESCRIPTION
Closes #1191.

The bulk of the code is handling removed faces. Instead of letting them sit in the vector, I remove them and reorder properties dependent on this. This avoids the need to make other functions accept removed halfedges.

While writing this, something that comes to my mind is that we are not really trying our best to handle cases that are not 2-manifold. The current matching method may produce pairs that cross-cross together. I think one way to handle this is to sort the duplicated halfedges according to the face normals, so we will not produce any criss-crossing pairs. Probably for another issue, though.