### PR TITLE
Fix Cross Section Mirror and add Test

### DIFF
--- a/src/cross_section/cross_section.cpp
+++ b/src/cross_section/cross_section.cpp
@@ -519,9 +519,9 @@ CrossSection CrossSection::Scale(const vec2 scale) const {
 }
 
 /**
- * Mirror this CrossSection over the arbitrary axis described by the unit form
- * of the given vector. If the length of the vector is zero, an empty
- * CrossSection is returned. This operation can be chained. Transforms are
+ * Mirror this CrossSection over the arbitrary axis whose normal is described by
+ * the unit form of the given vector. If the length of the vector is zero, an
+ * empty CrossSection is returned. This operation can be chained. Transforms are
  * combined and applied lazily.
  *
  * @param ax the axis to be mirrored over

--- a/src/cross_section/cross_section.cpp
+++ b/src/cross_section/cross_section.cpp
@@ -530,7 +530,7 @@ CrossSection CrossSection::Mirror(const vec2 ax) const {
   if (la::length(ax) == 0.) {
     return CrossSection();
   }
-  auto n = la::normalize(la::abs(ax));
+  auto n = la::normalize(ax);
   auto m = mat2x3(mat2(la::identity) - 2.0 * la::outerprod(n, n), vec2(0.0));
   return Transform(m);
 }

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -49,37 +49,21 @@ TEST(CrossSection, MirrorUnion) {
 TEST(CrossSection, MirrorCheckAxis) {
   auto tri = CrossSection({{0., 0.}, {5., 5.}, {0., 10.}});
 
-  auto a = tri.Mirror({1., 1.});
-  auto a_expected = CrossSection({{0., 0.}, {-10., 0.}, {-5., -5.}});
-  auto result_a = Manifold::Extrude(a.ToPolygons(), 5.) -
-                  Manifold::Extrude(a_expected.ToPolygons(), 5.);
-  auto result_a2 = Manifold::Extrude(a_expected.ToPolygons(), 5.) -
-                   Manifold::Extrude(a.ToPolygons(), 5.);
+  auto a = tri.Mirror({1., 1.}).Bounds();
+  auto a_expected = CrossSection({{0., 0.}, {-10., 0.}, {-5., -5.}}).Bounds();
 
-  auto b = tri.Mirror({-1., 1.});
-  auto b_expected = CrossSection({{0., 0.}, {10., 0.}, {5., 5.}});
-  auto result_b = Manifold::Extrude(b.ToPolygons(), 5.) -
-                  Manifold::Extrude(b_expected.ToPolygons(), 5.);
-  auto result_b2 = Manifold::Extrude(b_expected.ToPolygons(), 5.) -
-                   Manifold::Extrude(b.ToPolygons(), 5.);
+  EXPECT_NEAR(a.min.x, a_expected.min.x, 0.001);
+  EXPECT_NEAR(a.min.y, a_expected.min.y, 0.001);
+  EXPECT_NEAR(a.max.x, a_expected.max.x, 0.001);
+  EXPECT_NEAR(a.max.y, a_expected.max.y, 0.001);
 
-#ifdef MANIFOLD_EXPORT
-  if (options.exportModels) {
-    ExportMesh("cross_section_mirror_check_axis_a.glb", result_a.GetMeshGL(),
-               {});
-    ExportMesh("cross_section_mirror_check_axis_b.glb", result_b.GetMeshGL(),
-               {});
-    ExportMesh("cross_section_mirror_check_axis_a2.glb", result_a2.GetMeshGL(),
-               {});
-    ExportMesh("cross_section_mirror_check_axis_b2.glb", result_b2.GetMeshGL(),
-               {});
-  }
-#endif
+  auto b = tri.Mirror({-1., 1.}).Bounds();
+  auto b_expected = CrossSection({{0., 0.}, {10., 0.}, {5., 5.}}).Bounds();
 
-  EXPECT_FLOAT_EQ(result_a.Volume(), 0.);
-  EXPECT_FLOAT_EQ(result_a2.Volume(), 0.);
-  EXPECT_FLOAT_EQ(result_b.Volume(), 0.);
-  EXPECT_FLOAT_EQ(result_b2.Volume(), 0.);
+  EXPECT_NEAR(b.min.x, b_expected.min.x, 0.001);
+  EXPECT_NEAR(b.min.y, b_expected.min.y, 0.001);
+  EXPECT_NEAR(b.max.x, b_expected.max.x, 0.001);
+  EXPECT_NEAR(b.max.y, b_expected.max.y, 0.001);
 }
 
 TEST(CrossSection, RoundOffset) {

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -46,6 +46,42 @@ TEST(CrossSection, MirrorUnion) {
   EXPECT_TRUE(a.Mirror(vec2(0.0)).IsEmpty());
 }
 
+TEST(CrossSection, MirrorCheckAxis) {
+  auto tri = CrossSection({{0., 0.}, {5., 5.}, {0., 10.}});
+
+  auto a = tri.Mirror({1., 1.});
+  auto a_expected = CrossSection({{0., 0.}, {-10., 0.}, {-5., -5.}});
+  auto result_a = Manifold::Extrude(a.ToPolygons(), 5.) -
+                  Manifold::Extrude(a_expected.ToPolygons(), 5.);
+  auto result_a2 = Manifold::Extrude(a_expected.ToPolygons(), 5.) -
+                   Manifold::Extrude(a.ToPolygons(), 5.);
+
+  auto b = tri.Mirror({-1., 1.});
+  auto b_expected = CrossSection({{0., 0.}, {10., 0.}, {5., 5.}});
+  auto result_b = Manifold::Extrude(b.ToPolygons(), 5.) -
+                  Manifold::Extrude(b_expected.ToPolygons(), 5.);
+  auto result_b2 = Manifold::Extrude(b_expected.ToPolygons(), 5.) -
+                   Manifold::Extrude(b.ToPolygons(), 5.);
+
+#ifdef MANIFOLD_EXPORT
+  if (options.exportModels) {
+    ExportMesh("cross_section_mirror_check_axis_a.glb", result_a.GetMeshGL(),
+               {});
+    ExportMesh("cross_section_mirror_check_axis_b.glb", result_b.GetMeshGL(),
+               {});
+    ExportMesh("cross_section_mirror_check_axis_a2.glb", result_a2.GetMeshGL(),
+               {});
+    ExportMesh("cross_section_mirror_check_axis_b2.glb", result_b2.GetMeshGL(),
+               {});
+  }
+#endif
+
+  EXPECT_FLOAT_EQ(result_a.Volume(), 0.);
+  EXPECT_FLOAT_EQ(result_a2.Volume(), 0.);
+  EXPECT_FLOAT_EQ(result_b.Volume(), 0.);
+  EXPECT_FLOAT_EQ(result_b2.Volume(), 0.);
+}
+
 TEST(CrossSection, RoundOffset) {
   auto a = CrossSection::Square({20., 20.}, true);
   int segments = 20;


### PR DESCRIPTION
Fixes #1204 

Removes an extraneous `la::abs` call that would result in incorrect behavior for axes with mixed sign components (i.e. (-1, 1)) and adds a test to catch it.

Note: what initially caused me to think something was wrong was that mirroring something in quadrant 1 across the axis given by (1,1) ended up in quadrant 3. After looking at the code more intently, it appears this is actually intended behavior and the provided axis vector should be interpreted as being the normal to the axis we are mirroring over, not tangent to the axis. 

I believe this is done to avoid having to calculate any angles and seems like a reasonable thing to do; however, I was caught off guard because in 2D I would typically think of defining a line in terms of it's tangent vector. Unclear if this is just me having some bad intuition or if some additional clarification could also be useful.