### PR TITLE
Fix `triangulate` js bindings

### DIFF
--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -705,7 +705,8 @@ Module.setup = function() {
   Module.triangulate = function(polygons, epsilon = -1, allowConvex = true) {
     const polygonsVec = polygons2vec(polygons);
     const result = fromVec(
-        Module._Triangulate(polygonsVec, epsilon, allowConvex), (x) => [x[0], x[1], x[2]]);
+        Module._Triangulate(polygonsVec, epsilon, allowConvex),
+        (x) => [x[0], x[1], x[2]]);
     disposePolygons(polygonsVec);
     return result;
   };

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -702,10 +702,10 @@ Module.setup = function() {
 
   // Top-level functions
 
-  Module.triangulate = function(polygons, epsilon = -1) {
+  Module.triangulate = function(polygons, epsilon = -1, allowConvex = true) {
     const polygonsVec = polygons2vec(polygons);
     const result = fromVec(
-        Module._Triangulate(polygonsVec, epsilon), (x) => [x[0], x[1], x[2]]);
+        Module._Triangulate(polygonsVec, epsilon, allowConvex), (x) => [x[0], x[1], x[2]]);
     disposePolygons(polygonsVec);
     return result;
   };

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -26,7 +26,8 @@ import {Box, FillRule, JoinType, Mat3, Mat4, Polygons, Rect, SealedFloat32Array,
  * optimization.
  * @return The triangles, referencing the original polygon points in order.
  */
-export function triangulate(polygons: Polygons, epsilon?: number, allowConvex?: boolean): Vec3[];
+export function triangulate(
+    polygons: Polygons, epsilon?: number, allowConvex?: boolean): Vec3[];
 
 /**
  * Sets an angle constraint the default number of circular segments for the

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -19,10 +19,14 @@ import {Box, FillRule, JoinType, Mat3, Mat4, Polygons, Rect, SealedFloat32Array,
  *
  * @param polygons The set of polygons, wound CCW and representing multiple
  * polygons and/or holes.
- * @param epsilon The value of epsilon, bounding the uncertainty of the input
+ * @param epsilon The value of epsilon, bounding the uncertainty of the input.
+ * @param allowConvex If true (default), the triangulator will use a fast
+ * triangulation if the input is convex, falling back to ear-clipping if not.
+ * The triangle quality may be lower, so set to false to disable this
+ * optimization.
  * @return The triangles, referencing the original polygon points in order.
  */
-export function triangulate(polygons: Polygons, epsilon?: number): Vec3[];
+export function triangulate(polygons: Polygons, epsilon?: number, allowConvex?: boolean): Vec3[];
 
 /**
  * Sets an angle constraint the default number of circular segments for the


### PR DESCRIPTION
There was a missing 3rd parameter for the `Module._Triangulate` function. Emscripten is not able to fill the default parameter values for the bindings automatically.