### PR TITLE
Suppress quickhull.cpp warnings with g++ compiler

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,11 @@ set(
 )
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set_property(SOURCE quickhull.cpp APPEND PROPERTY COMPILE_FLAGS "-Wno-array-bounds -Wno-stringop-overflow")
+  set_property(
+    SOURCE quickhull.cpp
+    APPEND
+    PROPERTY COMPILE_FLAGS "-Wno-array-bounds -Wno-stringop-overflow"
+  )
 endif()
 
 set(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,10 @@ set(
   $<$<BOOL:${MANIFOLD_EXPORT}>:meshIO/meshIO.cpp>
 )
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set_property(SOURCE quickhull.cpp APPEND PROPERTY COMPILE_FLAGS "-Wno-array-bounds -Wno-stringop-overflow")
+endif()
+
 set(
   MANIFOLD_PRIVATE_HDRS
   boolean3.h


### PR DESCRIPTION
Observed with gcc 12 (array-bounds) and 13 (stringop-overflow):

inlined from ‘void manifold::QuickHull::createConvexHalfedgeMesh()’ at /home/user/manifold/src/quickhull.cpp:442:40: /usr/include/c++/13/bits/stl_algobase.h:931:18: error: ‘void* __builtin_memset(void*, int, long unsigned int)’ specified bound 18446744073709551608 exceeds maximum object size 9223372036854775807 [-Werror=stringop-overflow=]
  931 |         *__first = __tmp;
      |         ~~~~~~~~~^~~~~~~

inlined from ‘void manifold::QuickHull::createConvexHalfedgeMesh()’ at /home/user/manifold/src/quickhull.cpp:442:40: /usr/include/c++/12/bits/stl_algobase.h:922:18: error: ‘void* __builtin_memset(void*, int, long unsigned int)’ pointer overflow between offset 0 and size 18446744073709551608 [-Werror=array-bounds]
  922 |         *__first = __tmp;
      |         ~~~~~~~~~^~~~~~~