### PR TITLE
Remove per-error hacks in favor of a "disable Werror" option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(
 # Primary user facing options
 option(MANIFOLD_CROSS_SECTION "Build CrossSection for 2D support" ON)
 option(MANIFOLD_DEBUG "Enable debug tracing/timing" OFF)
+option(MANIFOLD_STRICT "Treat compile warnings as fatal build errors" ON)
 option(
   MANIFOLD_DOWNLOADS
   "Allow Manifold build to download missing dependencies"
@@ -163,8 +164,11 @@ else()
       list(APPEND WARNING_FLAGS -Wno-format)
     endif()
   elseif(PROJECT_IS_TOP_LEVEL)
-    # only do -Werror if we are the top level project
-    list(APPEND WARNING_FLAGS -Werror)
+    # only do -Werror if we are the top level project and
+    # MANIFOLD_STRICT is on
+    if (MANIFOLD_STRICT)
+       list(APPEND WARNING_FLAGS -Werror)
+    endif()
   endif()
   list(APPEND MANIFOLD_FLAGS ${WARNING_FLAGS})
   if(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,8 +166,8 @@ else()
   elseif(PROJECT_IS_TOP_LEVEL)
     # only do -Werror if we are the top level project and
     # MANIFOLD_STRICT is on
-    if (MANIFOLD_STRICT)
-       list(APPEND WARNING_FLAGS -Werror)
+    if(MANIFOLD_STRICT)
+      list(APPEND WARNING_FLAGS -Werror)
     endif()
   endif()
   list(APPEND MANIFOLD_FLAGS ${WARNING_FLAGS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,14 +35,6 @@ set(
   $<$<BOOL:${MANIFOLD_EXPORT}>:meshIO/meshIO.cpp>
 )
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set_property(
-    SOURCE quickhull.cpp
-    APPEND
-    PROPERTY COMPILE_FLAGS "-Wno-array-bounds -Wno-stringop-overflow"
-  )
-endif()
-
 set(
   MANIFOLD_PRIVATE_HDRS
   boolean3.h


### PR DESCRIPTION
For users who are just looking to build and aren't interested in failing the build due to warnings, provide a MANIFOLD_STRICT option to control it.

By default it will remain on, since developers will generally want to fix errors found, but for user projects or those working with older compilers setting -DMANIFOLD_STRICT=OFF will allow them to avoid build failure when warnings are spurious.

Also should eliminate most of the motivation to suppress specific warnings per-file, although that may still be desirable in some specific instances if the newest compilers are the ones generating verifiably incorrect/unavoidable errors.