### PR TITLE
added MANIFOLD_ASSERT

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -128,6 +128,7 @@
     "-DMANIFOLD_PYBIND=ON",
     "-DMANIFOLD_EXPORT=ON",
     "-DMANIFOLD_DEBUG=ON",
+    "-DMANIFOLD_ASSERT=OFF",
     "-DMANIFOLD_PAR=ON",
     "-DCODE_COVERAGE=OFF",
     "-DCMAKE_CXX_FLAGS=''" //'-fsanitize=address,undefined'"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(
 # Primary user facing options
 option(MANIFOLD_CROSS_SECTION "Build CrossSection for 2D support" ON)
 option(MANIFOLD_DEBUG "Enable debug tracing/timing" OFF)
+option(MANIFOLD_ASSERT "Enable assertions - requires MANIFOLD_DEBUG" OFF)
 option(MANIFOLD_STRICT "Treat compile warnings as fatal build errors" ON)
 option(
   MANIFOLD_DOWNLOADS

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <optional>
-#include <string>
 
 #include "autogen_docstrings.inl"  // generated in build folder
 #include "manifold/cross_section.h"

--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -21,6 +21,7 @@
 #endif
 
 #include "linalg.h"
+#include "optional_assert.h"
 
 namespace manifold {
 /** @addtogroup Math
@@ -598,6 +599,40 @@ struct ExecutionParams {
 /** @} */
 
 #ifdef MANIFOLD_DEBUG
+template <class T>
+std::ostream &operator<<(std::ostream &out, const la::vec<T, 1> &v) {
+  return out << '{' << v[0] << '}';
+}
+template <class T>
+std::ostream &operator<<(std::ostream &out, const la::vec<T, 2> &v) {
+  return out << '{' << v[0] << ',' << v[1] << '}';
+}
+template <class T>
+std::ostream &operator<<(std::ostream &out, const la::vec<T, 3> &v) {
+  return out << '{' << v[0] << ',' << v[1] << ',' << v[2] << '}';
+}
+template <class T>
+std::ostream &operator<<(std::ostream &out, const la::vec<T, 4> &v) {
+  return out << '{' << v[0] << ',' << v[1] << ',' << v[2] << ',' << v[3] << '}';
+}
+
+template <class T, int M>
+std::ostream &operator<<(std::ostream &out, const la::mat<T, M, 1> &m) {
+  return out << '{' << m[0] << '}';
+}
+template <class T, int M>
+std::ostream &operator<<(std::ostream &out, const la::mat<T, M, 2> &m) {
+  return out << '{' << m[0] << ',' << m[1] << '}';
+}
+template <class T, int M>
+std::ostream &operator<<(std::ostream &out, const la::mat<T, M, 3> &m) {
+  return out << '{' << m[0] << ',' << m[1] << ',' << m[2] << '}';
+}
+template <class T, int M>
+std::ostream &operator<<(std::ostream &out, const la::mat<T, M, 4> &m) {
+  return out << '{' << m[0] << ',' << m[1] << ',' << m[2] << ',' << m[3] << '}';
+}
+
 inline std::ostream& operator<<(std::ostream& stream, const Box& box) {
   return stream << "min: " << box.min << ", "
                 << "max: " << box.max;

--- a/include/manifold/linalg.h
+++ b/include/manifold/linalg.h
@@ -39,12 +39,7 @@
 #include <cmath>        // For various unary math functions, such as std::sqrt
 #include <cstdlib>      // To resolve std::abs ambiguity on clang
 #include <functional>   // For std::hash declaration
-#include <iosfwd>       // For forward definitions of std::ostream
 #include <type_traits>  // For std::enable_if, std::is_same, std::declval
-
-#ifdef MANIFOLD_DEBUG
-#include <iostream>
-#endif
 
 // In Visual Studio 2015, `constexpr` applied to a member function implies
 // `const`, which causes ambiguous overload resolution
@@ -2363,42 +2358,6 @@ struct converter<std::array<T, 4>, vec<T, 4>> {
   }
 };
 /** @} */
-
-#ifdef MANIFOLD_DEBUG
-template <class T>
-std::ostream &operator<<(std::ostream &out, const vec<T, 1> &v) {
-  return out << '{' << v[0] << '}';
-}
-template <class T>
-std::ostream &operator<<(std::ostream &out, const vec<T, 2> &v) {
-  return out << '{' << v[0] << ',' << v[1] << '}';
-}
-template <class T>
-std::ostream &operator<<(std::ostream &out, const vec<T, 3> &v) {
-  return out << '{' << v[0] << ',' << v[1] << ',' << v[2] << '}';
-}
-template <class T>
-std::ostream &operator<<(std::ostream &out, const vec<T, 4> &v) {
-  return out << '{' << v[0] << ',' << v[1] << ',' << v[2] << ',' << v[3] << '}';
-}
-
-template <class T, int M>
-std::ostream &operator<<(std::ostream &out, const mat<T, M, 1> &m) {
-  return out << '{' << m[0] << '}';
-}
-template <class T, int M>
-std::ostream &operator<<(std::ostream &out, const mat<T, M, 2> &m) {
-  return out << '{' << m[0] << ',' << m[1] << '}';
-}
-template <class T, int M>
-std::ostream &operator<<(std::ostream &out, const mat<T, M, 3> &m) {
-  return out << '{' << m[0] << ',' << m[1] << ',' << m[2] << '}';
-}
-template <class T, int M>
-std::ostream &operator<<(std::ostream &out, const mat<T, M, 4> &m) {
-  return out << '{' << m[0] << ',' << m[1] << ',' << m[2] << ',' << m[3] << '}';
-}
-#endif
 }  // namespace linalg
 
 namespace std {

--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -16,11 +16,6 @@
 #include <functional>
 #include <memory>  // needed for shared_ptr
 
-#if defined(MANIFOLD_EXPORT) || defined(MANIFOLD_DEBUG)
-#include <iostream>
-#include <string>
-#endif
-
 #include "manifold/common.h"
 #include "manifold/vec_view.h"
 

--- a/include/manifold/meshIO.h
+++ b/include/manifold/meshIO.h
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #pragma once
-#include <string>
 
 #include "manifold/manifold.h"
 

--- a/include/manifold/optional_assert.h
+++ b/include/manifold/optional_assert.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #ifdef MANIFOLD_DEBUG
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
@@ -33,6 +34,8 @@ struct geometryErr : public virtual std::runtime_error {
   using std::runtime_error::runtime_error;
 };
 using logicErr = std::logic_error;
+
+#ifdef MANIFOLD_ASSERT
 
 template <typename Ex>
 void AssertFail(const char* file, int line, const char* cond, const char* msg) {
@@ -62,5 +65,6 @@ void AssertFail(const char* file, int line, const std::string& cond,
 #else
 #define DEBUG_ASSERT(condition, EX, msg)
 #define ASSERT(condition, EX)
+#endif
 #endif
 /** @} */

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -26,11 +26,6 @@
 #include "./parallel.h"
 #include "./svd.h"
 
-#if defined(MANIFOLD_EXPORT) || defined(MANIFOLD_DEBUG)
-#include <iomanip>
-#include <iostream>
-#endif
-
 namespace {
 using namespace manifold;
 

--- a/src/meshIO/meshIO.cpp
+++ b/src/meshIO/meshIO.cpp
@@ -14,8 +14,6 @@
 
 #include "manifold/meshIO.h"
 
-#include <iostream>
-
 #include "assimp/Exporter.hpp"
 #include "assimp/Importer.hpp"
 #include "assimp/material.h"

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -142,33 +142,8 @@ struct CheckCCW {
     for (int i : {0, 1, 2})
       v[i] = projection * vertPos[halfedges[3 * face + i].startVert];
 
-    int ccw = CCW(v[0], v[1], v[2], std::abs(tol));
-    bool check = tol > 0 ? ccw >= 0 : ccw == 0;
-
-#ifdef MANIFOLD_DEBUG
-    if (tol > 0 && !check) {
-      vec2 v1 = v[1] - v[0];
-      vec2 v2 = v[2] - v[0];
-      double area = v1.x * v2.y - v1.y * v2.x;
-      double base2 = std::max(la::dot(v1, v1), la::dot(v2, v2));
-      double base = std::sqrt(base2);
-      vec3 V0 = vertPos[halfedges[3 * face].startVert];
-      vec3 V1 = vertPos[halfedges[3 * face + 1].startVert];
-      vec3 V2 = vertPos[halfedges[3 * face + 2].startVert];
-      vec3 norm = la::cross(V1 - V0, V2 - V0);
-      printf(
-          "Tri %ld does not match normal, approx height = %g, base = %g\n"
-          "tol = %g, area2 = %g, base2*tol2 = %g\n"
-          "normal = %g, %g, %g\n"
-          "norm = %g, %g, %g\nverts: %d, %d, %d\n",
-          static_cast<long>(face), area / base, base, tol, area * area,
-          base2 * tol * tol, triNormal[face].x, triNormal[face].y,
-          triNormal[face].z, norm.x, norm.y, norm.z,
-          halfedges[3 * face].startVert, halfedges[3 * face + 1].startVert,
-          halfedges[3 * face + 2].startVert);
-    }
-#endif
-    return check;
+    const int ccw = CCW(v[0], v[1], v[2], std::abs(tol));
+    return tol > 0 ? ccw >= 0 : ccw == 0;
   }
 };
 }  // namespace

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -239,31 +239,33 @@ void Manifold::Impl::Finish() {
                "Not an even number of faces after sorting faces!");
 
 #ifdef MANIFOLD_DEBUG
-  auto MaxOrMinus = [](int a, int b) {
-    return std::min(a, b) < 0 ? -1 : std::max(a, b);
-  };
-  int face = 0;
-  Halfedge extrema = {0, 0, 0};
-  for (size_t i = 0; i < halfedge_.size(); i++) {
-    Halfedge e = halfedge_[i];
-    if (!e.IsForward()) std::swap(e.startVert, e.endVert);
-    extrema.startVert = std::min(extrema.startVert, e.startVert);
-    extrema.endVert = std::min(extrema.endVert, e.endVert);
-    extrema.pairedHalfedge =
-        MaxOrMinus(extrema.pairedHalfedge, e.pairedHalfedge);
-    face = MaxOrMinus(face, i / 3);
+  if (ManifoldParams().intermediateChecks) {
+    auto MaxOrMinus = [](int a, int b) {
+      return std::min(a, b) < 0 ? -1 : std::max(a, b);
+    };
+    int face = 0;
+    Halfedge extrema = {0, 0, 0};
+    for (size_t i = 0; i < halfedge_.size(); i++) {
+      Halfedge e = halfedge_[i];
+      if (!e.IsForward()) std::swap(e.startVert, e.endVert);
+      extrema.startVert = std::min(extrema.startVert, e.startVert);
+      extrema.endVert = std::min(extrema.endVert, e.endVert);
+      extrema.pairedHalfedge =
+          MaxOrMinus(extrema.pairedHalfedge, e.pairedHalfedge);
+      face = MaxOrMinus(face, i / 3);
+    }
+    DEBUG_ASSERT(extrema.startVert >= 0, topologyErr,
+                 "Vertex index is negative!");
+    DEBUG_ASSERT(extrema.endVert < static_cast<int>(NumVert()), topologyErr,
+                 "Vertex index exceeds number of verts!");
+    DEBUG_ASSERT(extrema.pairedHalfedge >= 0, topologyErr,
+                 "Halfedge index is negative!");
+    DEBUG_ASSERT(extrema.pairedHalfedge < 2 * static_cast<int>(NumEdge()),
+                 topologyErr, "Halfedge index exceeds number of halfedges!");
+    DEBUG_ASSERT(face >= 0, topologyErr, "Face index is negative!");
+    DEBUG_ASSERT(face < static_cast<int>(NumTri()), topologyErr,
+                 "Face index exceeds number of faces!");
   }
-  DEBUG_ASSERT(extrema.startVert >= 0, topologyErr,
-               "Vertex index is negative!");
-  DEBUG_ASSERT(extrema.endVert < static_cast<int>(NumVert()), topologyErr,
-               "Vertex index exceeds number of verts!");
-  DEBUG_ASSERT(extrema.pairedHalfedge >= 0, topologyErr,
-               "Halfedge index is negative!");
-  DEBUG_ASSERT(extrema.pairedHalfedge < 2 * static_cast<int>(NumEdge()),
-               topologyErr, "Halfedge index exceeds number of halfedges!");
-  DEBUG_ASSERT(face >= 0, topologyErr, "Face index is negative!");
-  DEBUG_ASSERT(face < static_cast<int>(NumTri()), topologyErr,
-               "Face index exceeds number of faces!");
 #endif
 
   DEBUG_ASSERT(meshRelation_.triRef.size() == NumTri() ||


### PR DESCRIPTION
Fixes #1224 

We incur about a 20% overhead for enabling assertions, which `MANIFOLD_DEBUG` did. Here I've added `MANIFOLD_ASSERT` to control that explicitly. `MANIFOLD_DEBUG` controls the inclusion of all string and stream related headers, and I've now centralized those includes. 