### PR TITLE
Add PythonOpenSCAD and AnchorSCAD as 'users'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Here is an incomplete list of our users, whose integrations may be anywhere from
 | [Godot Engine](https://godotengine.org/) | [OCADml](https://github.com/OCADml/OManifold) | [Flitter](https://flitter.readthedocs.io/en/latest/) |
 | [BRL-CAD](https://brlcad.org/) | [PolygonJS](https://polygonjs.com/) | [Spherene](https://spherene.ch/) |
 | [Babylon.js](https://doc.babylonjs.com/features/featuresDeepDive/mesh/mergeMeshes#merging-meshes-with-constructive-solid-geometry) | [trimesh](https://trimesh.org/) | [Gypsum](https://github.com/playkostudios/gypsum) |
-| [Valence 3D](https://apps.apple.com/us/app/valence-3d/id6450967410?mt=8&platform=ipad) | | [bitbybit.dev](https://bitbybit.dev) |
+| [Valence 3D](https://apps.apple.com/us/app/valence-3d/id6450967410?mt=8&platform=ipad) | [bitbybit.dev](https://bitbybit.dev) | [PythonOpenSCAD](https://github.com/owebeeone/pythonopenscad) |
+| [AnchorSCAD](https://github.com/owebeeone/anchorscad-core) | | |
 
 ### Bindings & Packages
 


### PR DESCRIPTION
PythonOpenSCAD 2.0,0 now provides mesh render support.  AnchorSCAD (anchorscad-core) will follow.