### PR TITLE
Update ts definitions

### DIFF
--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -821,7 +821,7 @@ export class Manifold {
    *
    * @param cutter
    */
-  split(cutter: Manifold): Manifold[];
+  split(cutter: Manifold): [Manifold,Manifold];
 
   /**
    * Convenient version of Split() for a half-space.
@@ -833,7 +833,7 @@ export class Manifold {
    * @param originOffset The distance of the plane from the origin in the
    * direction of the normal vector.
    */
-  splitByPlane(normal: Readonly<Vec3>, originOffset: number): Manifold[];
+  splitByPlane(normal: Readonly<Vec3>, originOffset: number): [Manifold,Manifold];
 
   /**
    * Removes everything behind the given half-space plane.

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -107,7 +107,7 @@ export class CrossSection {
    * @param size The X, and Y dimensions of the square.
    * @param center Set to true to shift the center to the origin.
    */
-  static square(size?: Vec2|number, center?: boolean): CrossSection;
+  static square(size?: Readonly<Vec2>|number, center?: boolean): CrossSection;
 
   /**
    * Constructs a circle of a given radius.
@@ -138,7 +138,7 @@ export class CrossSection {
    */
   extrude(
       height: number, nDivisions?: number, twistDegrees?: number,
-      scaleTop?: Vec2|number, center?: boolean): Manifold;
+      scaleTop?: Readonly<Vec2>|number, center?: boolean): Manifold;
 
   /**
    * Constructs a manifold by revolving this cross-section around its Y-axis and
@@ -168,7 +168,7 @@ export class CrossSection {
    *
    * @param v The vector to add to every vertex.
    */
-  translate(v: Vec2): CrossSection;
+  translate(v: Readonly<Vec2>): CrossSection;
   translate(x: number, y?: number): CrossSection;
 
   /**
@@ -185,7 +185,7 @@ export class CrossSection {
    *
    * @param v The vector to multiply every vertex by per component.
    */
-  scale(v: Vec2|number): CrossSection;
+  scale(v: Readonly<Vec2>|number): CrossSection;
 
 
   /**
@@ -196,7 +196,7 @@ export class CrossSection {
    *
    * @param ax the axis to be mirrored over
    */
-  mirror(ax: Vec2): CrossSection;
+  mirror(ax: Readonly<Vec2>): CrossSection;
 
   /**
    * Move the vertices of this CrossSection (creating a new one) according to
@@ -288,17 +288,17 @@ export class CrossSection {
   /**
    * Boolean union of a list of cross-sections
    */
-  static union(polygons: (CrossSection|Polygons)[]): CrossSection;
+  static union(polygons: readonly (CrossSection|Polygons)[]): CrossSection;
 
   /**
    * Boolean difference of the tail of a list of cross-sections from its head
    */
-  static difference(polygons: (CrossSection|Polygons)[]): CrossSection;
+  static difference(polygons: readonly (CrossSection|Polygons)[]): CrossSection;
 
   /**
    * Boolean intersection of a list of cross-sections
    */
-  static intersection(polygons: (CrossSection|Polygons)[]): CrossSection;
+  static intersection(polygons: readonly (CrossSection|Polygons)[]): CrossSection;
 
   // Convex Hulls
 
@@ -310,7 +310,7 @@ export class CrossSection {
   /**
    * Compute the convex hull of all points in a list of polygons/cross-sections.
    */
-  static hull(polygons: (CrossSection|Polygons)[]): CrossSection;
+  static hull(polygons: readonly (CrossSection|Polygons)[]): CrossSection;
 
   // Topological Operations
 
@@ -318,7 +318,7 @@ export class CrossSection {
    * Construct a CrossSection from a vector of other Polygons (batch
    * boolean union).
    */
-  static compose(polygons: (CrossSection|Polygons)[]): CrossSection;
+  static compose(polygons: readonly (CrossSection|Polygons)[]): CrossSection;
 
   /**
    * This operation returns a vector of CrossSections that are topologically
@@ -438,7 +438,7 @@ export class Manifold {
    * @param size The X, Y, and Z dimensions of the box.
    * @param center Set to true to shift the center to the origin.
    */
-  static cube(size?: Vec3|number, center?: boolean): Manifold;
+  static cube(size?: Readonly<Vec3>|number, center?: boolean): Manifold;
 
   /**
    * A convenience constructor for the common case of extruding a circle. Can
@@ -491,7 +491,7 @@ export class Manifold {
    */
   static extrude(
       polygons: CrossSection|Polygons, height: number, nDivisions?: number,
-      twistDegrees?: number, scaleTop?: Vec2|number,
+      twistDegrees?: number, scaleTop?: Readonly<Vec2>|number,
       center?: boolean): Manifold;
 
   /**
@@ -553,7 +553,7 @@ export class Manifold {
    * can be sharpened by sharping all edges that are incident on it, allowing
    * cones to be formed.
    */
-  static smooth(mesh: Mesh, sharpenedEdges?: Smoothness[]): Manifold;
+  static smooth(mesh: Mesh, sharpenedEdges?: readonly Smoothness[]): Manifold;
 
   // Signed Distance Functions
 
@@ -600,7 +600,7 @@ export class Manifold {
    *
    * @param v The vector to add to every vertex.
    */
-  translate(v: Vec3): Manifold;
+  translate(v: Readonly<Vec3>): Manifold;
   translate(x: number, y?: number, z?: number): Manifold;
 
   /**
@@ -613,7 +613,7 @@ export class Manifold {
    *
    * @param v [X, Y, Z] rotation in degrees.
    */
-  rotate(v: Vec3): Manifold;
+  rotate(v: Readonly<Vec3>): Manifold;
   rotate(x: number, y?: number, z?: number): Manifold;
 
   /**
@@ -622,7 +622,7 @@ export class Manifold {
    *
    * @param v The vector to multiply every vertex by per component.
    */
-  scale(v: Vec3|number): Manifold;
+  scale(v: Readonly<Vec3>|number): Manifold;
 
   /**
    * Mirror this Manifold over the plane described by the unit form of the given
@@ -632,7 +632,7 @@ export class Manifold {
    *
    * @param normal The normal vector of the plane to be mirrored over
    */
-  mirror(normal: Vec3): Manifold;
+  mirror(normal: Readonly<Vec3>): Manifold;
 
   /**
    * This function does not change the topology, but allows the vertices to be
@@ -802,17 +802,17 @@ export class Manifold {
   /**
    * Boolean union of a list of manifolds
    */
-  static union(manifolds: Manifold[]): Manifold;
+  static union(manifolds: readonly Manifold[]): Manifold;
 
   /**
    * Boolean difference of the tail of a list of manifolds from its head
    */
-  static difference(manifolds: Manifold[]): Manifold;
+  static difference(manifolds: readonly Manifold[]): Manifold;
 
   /**
    * Boolean intersection of a list of manifolds
    */
-  static intersection(manifolds: Manifold[]): Manifold;
+  static intersection(manifolds: readonly Manifold[]): Manifold;
 
   /**
    * Split cuts this manifold in two using the cutter manifold. The first result
@@ -833,7 +833,7 @@ export class Manifold {
    * @param originOffset The distance of the plane from the origin in the
    * direction of the normal vector.
    */
-  splitByPlane(normal: Vec3, originOffset: number): Manifold[];
+  splitByPlane(normal: Readonly<Vec3>, originOffset: number): Manifold[];
 
   /**
    * Removes everything behind the given half-space plane.
@@ -844,7 +844,7 @@ export class Manifold {
    * @param originOffset The distance of the plane from the origin in the
    *     direction of the normal vector.
    */
-  trimByPlane(normal: Vec3, originOffset: number): Manifold;
+  trimByPlane(normal: Readonly<Vec3>, originOffset: number): Manifold;
 
   /**
    * Returns the cross section of this object parallel to the X-Y plane at the
@@ -873,7 +873,7 @@ export class Manifold {
    * Compute the convex hull of all points contained within a set of Manifolds
    * and point vectors.
    */
-  static hull(points: (Manifold|Vec3)[]): Manifold;
+  static hull(points: readonly (Manifold|Vec3)[]): Manifold;
 
   // Topological Operations
 
@@ -884,7 +884,7 @@ export class Manifold {
    *
    * @param manifolds A list of Manifolds to lazy-union together.
    */
-  static compose(manifolds: Manifold[]): Manifold;
+  static compose(manifolds: readonly Manifold[]): Manifold;
 
   /**
    * This operation returns a vector of Manifolds that are topologically

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -288,17 +288,18 @@ export class CrossSection {
   /**
    * Boolean union of a list of cross-sections
    */
-  static union(polygons: readonly (CrossSection|Polygons)[]): CrossSection;
+  static union(polygons: readonly(CrossSection|Polygons)[]): CrossSection;
 
   /**
    * Boolean difference of the tail of a list of cross-sections from its head
    */
-  static difference(polygons: readonly (CrossSection|Polygons)[]): CrossSection;
+  static difference(polygons: readonly(CrossSection|Polygons)[]): CrossSection;
 
   /**
    * Boolean intersection of a list of cross-sections
    */
-  static intersection(polygons: readonly (CrossSection|Polygons)[]): CrossSection;
+  static intersection(polygons: readonly(CrossSection|Polygons)[]):
+      CrossSection;
 
   // Convex Hulls
 
@@ -310,7 +311,7 @@ export class CrossSection {
   /**
    * Compute the convex hull of all points in a list of polygons/cross-sections.
    */
-  static hull(polygons: readonly (CrossSection|Polygons)[]): CrossSection;
+  static hull(polygons: readonly(CrossSection|Polygons)[]): CrossSection;
 
   // Topological Operations
 
@@ -318,7 +319,7 @@ export class CrossSection {
    * Construct a CrossSection from a vector of other Polygons (batch
    * boolean union).
    */
-  static compose(polygons: readonly (CrossSection|Polygons)[]): CrossSection;
+  static compose(polygons: readonly(CrossSection|Polygons)[]): CrossSection;
 
   /**
    * This operation returns a vector of CrossSections that are topologically
@@ -821,7 +822,7 @@ export class Manifold {
    *
    * @param cutter
    */
-  split(cutter: Manifold): [Manifold,Manifold];
+  split(cutter: Manifold): [Manifold, Manifold];
 
   /**
    * Convenient version of Split() for a half-space.
@@ -833,7 +834,8 @@ export class Manifold {
    * @param originOffset The distance of the plane from the origin in the
    * direction of the normal vector.
    */
-  splitByPlane(normal: Readonly<Vec3>, originOffset: number): [Manifold,Manifold];
+  splitByPlane(normal: Readonly<Vec3>, originOffset: number):
+      [Manifold, Manifold];
 
   /**
    * Removes everything behind the given half-space plane.
@@ -873,7 +875,7 @@ export class Manifold {
    * Compute the convex hull of all points contained within a set of Manifolds
    * and point vectors.
    */
-  static hull(points: readonly (Manifold|Vec3)[]): Manifold;
+  static hull(points: readonly(Manifold|Vec3)[]): Manifold;
 
   // Topological Operations
 


### PR DESCRIPTION
Hi,

thanks for the cool lib! I have been using it for a bit now, and it's really handy!

I just found two small inconveniences in the TS bindings.

- Multiple functions accept arrays of parameters. The TS definitions require these arrays to be modifiable even though the arrays are never modified. I have marked these arrays as read-only.
- The split and splitByPlane methods always return exactly two results (according to the docs). Therefore, they should return a tuple with two items and not an array of items with an arbitrary length. I have changed that.

Best wishes,
Kaladum