### PR TITLE
use input faceID

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
       "program": "${workspaceFolder}/build/test/manifold_test",
       "args": [
         "--gtest_catch_exceptions=0",
-        "--gtest_filter=Boolean.Tetra"
+        "--gtest_filter=Samples.Scallop"
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/build/test",

--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -644,6 +644,11 @@ inline std::ostream& operator<<(std::ostream& stream, const Rect& box) {
                 << "max: " << box.max;
 }
 
+inline std::ostream& operator<<(std::ostream& stream, const Smoothness& s) {
+  return stream << "halfedge: " << s.halfedge << ", "
+                << "smoothness: " << s.smoothness;
+}
+
 /**
  * Print the contents of this vector to standard output. Only exists if compiled
  * with MANIFOLD_DEBUG flag.

--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -413,9 +413,9 @@ class Manifold {
   Manifold RefineToTolerance(double) const;
   Manifold SmoothByNormals(int normalIdx) const;
   Manifold SmoothOut(double minSharpAngle = 60, double minSmoothness = 0) const;
-  static Manifold Smooth(MeshGL,
+  static Manifold Smooth(const MeshGL&,
                          const std::vector<Smoothness>& sharpenedEdges = {});
-  static Manifold Smooth(MeshGL64,
+  static Manifold Smooth(const MeshGL64&,
                          const std::vector<Smoothness>& sharpenedEdges = {});
   ///@}
 

--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -149,10 +149,11 @@ struct MeshGLP {
   /// This matrix is stored in column-major order and the length of the overall
   /// vector is 12 * runOriginalID.size().
   std::vector<Precision> runTransform;
-  /// Optional: Length NumTri, contains the source face ID this
-  /// triangle comes from. When auto-generated, this ID will be a triangle index
-  /// into the original mesh. This index/ID is purely for external use (e.g.
-  /// recreating polygonal faces) and will not affect Manifold's algorithms.
+  /// Optional: Length NumTri, contains the source face ID this triangle comes
+  /// from. Simplification will maintain all edges between triangles with
+  /// different faceIDs. Input faceIDs will be maintained to the outputs, but if
+  /// none are given, they will be filled in with Manifold's coplanar face
+  /// calculation based on mesh tolerance.
   std::vector<I> faceID;
   /// Optional: The X-Y-Z-W weighted tangent vectors for smooth Refine(). If
   /// non-empty, must be exactly four times as long as Mesh.triVerts. Indexed
@@ -412,9 +413,9 @@ class Manifold {
   Manifold RefineToTolerance(double) const;
   Manifold SmoothByNormals(int normalIdx) const;
   Manifold SmoothOut(double minSharpAngle = 60, double minSmoothness = 0) const;
-  static Manifold Smooth(const MeshGL&,
+  static Manifold Smooth(MeshGL,
                          const std::vector<Smoothness>& sharpenedEdges = {});
-  static Manifold Smooth(const MeshGL64&,
+  static Manifold Smooth(MeshGL64,
                          const std::vector<Smoothness>& sharpenedEdges = {});
   ///@}
 

--- a/src/constructors.cpp
+++ b/src/constructors.cpp
@@ -47,14 +47,28 @@ namespace manifold {
  * can be sharpened by sharping all edges that are incident on it, allowing
  * cones to be formed.
  */
-Manifold Manifold::Smooth(const MeshGL& meshGL,
+Manifold Manifold::Smooth(MeshGL meshGL,
                           const std::vector<Smoothness>& sharpenedEdges) {
   DEBUG_ASSERT(meshGL.halfedgeTangent.empty(), std::runtime_error,
                "when supplying tangents, the normal constructor should be used "
                "rather than Smooth().");
 
+  const std::vector<uint32_t> faceIDin = meshGL.faceID;
+  meshGL.faceID.resize(meshGL.NumTri());
+  std::iota(meshGL.faceID.begin(), meshGL.faceID.end(), 0);
+
   std::shared_ptr<Impl> impl = std::make_shared<Impl>(meshGL);
   impl->CreateTangents(impl->UpdateSharpenedEdges(sharpenedEdges));
+  // Restore the original faceID
+  const size_t numTri = impl->NumTri();
+  for (size_t i = 0; i < numTri; ++i) {
+    if (faceIDin.size() == numTri) {
+      impl->meshRelation_.triRef[i].faceID =
+          faceIDin[impl->meshRelation_.triRef[i].faceID];
+    } else {
+      impl->meshRelation_.triRef[i].faceID = -1;
+    }
+  }
   return Manifold(impl);
 }
 
@@ -86,14 +100,28 @@ Manifold Manifold::Smooth(const MeshGL& meshGL,
  * can be sharpened by sharping all edges that are incident on it, allowing
  * cones to be formed.
  */
-Manifold Manifold::Smooth(const MeshGL64& meshGL64,
+Manifold Manifold::Smooth(MeshGL64 meshGL64,
                           const std::vector<Smoothness>& sharpenedEdges) {
   DEBUG_ASSERT(meshGL64.halfedgeTangent.empty(), std::runtime_error,
                "when supplying tangents, the normal constructor should be used "
                "rather than Smooth().");
 
+  const std::vector<uint64_t> faceIDin = meshGL64.faceID;
+  meshGL64.faceID.resize(meshGL64.NumTri());
+  std::iota(meshGL64.faceID.begin(), meshGL64.faceID.end(), 0);
+
   std::shared_ptr<Impl> impl = std::make_shared<Impl>(meshGL64);
   impl->CreateTangents(impl->UpdateSharpenedEdges(sharpenedEdges));
+  // Restore the original faceID
+  const size_t numTri = impl->NumTri();
+  for (size_t i = 0; i < numTri; ++i) {
+    if (faceIDin.size() == numTri) {
+      impl->meshRelation_.triRef[i].faceID =
+          faceIDin[impl->meshRelation_.triRef[i].faceID];
+    } else {
+      impl->meshRelation_.triRef[i].faceID = -1;
+    }
+  }
   return Manifold(impl);
 }
 

--- a/src/face_op.cpp
+++ b/src/face_op.cpp
@@ -295,19 +295,18 @@ void Manifold::Impl::FlattenFaces() {
     if (edgeTri[b] == kRemove) return true;
     const TriRef& refA = meshRelation_.triRef[edgeTri[a]];
     const TriRef& refB = meshRelation_.triRef[edgeTri[b]];
-    return refA.meshID < refB.meshID || (refA.meshID == refB.meshID &&
-                                         (refA.coplanarID < refB.coplanarID ||
-                                          (refA.coplanarID == refB.coplanarID &&
-                                           refA.faceID < refB.faceID)));
+    return std::tie(refA.meshID, refA.coplanarID, refA.faceID) <
+           std::tie(refB.meshID, refB.coplanarID, refB.faceID);
   };
 
   Vec<size_t> newHalf2Old(halfedge_.size());
   sequence(newHalf2Old.begin(), newHalf2Old.end());
   stable_sort(newHalf2Old.begin(), newHalf2Old.end(), comp);
-  newHalf2Old.resize(std::find_if(countAt(0_uz), countAt(halfedge_.size()),
-                                  [&](const size_t i) {
-                                    return edgeTri[newHalf2Old[i]] == kRemove;
-                                  }) -
+  newHalf2Old.resize(std::lower_bound(countAt(0_uz), countAt(halfedge_.size()),
+                                      kRemove,
+                                      [&](const size_t i, const size_t val) {
+                                        return edgeTri[newHalf2Old[i]] < val;
+                                      }) -
                      countAt(0_uz));
 
   Vec<Halfedge> newHalfedge(newHalf2Old.size());

--- a/src/face_op.cpp
+++ b/src/face_op.cpp
@@ -259,10 +259,10 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
   CreateHalfedges(triProp, triVerts);
 }
 
-constexpr uint64_t kRemove = std::numeric_limits<uint64_t>::max();
+constexpr size_t kRemove = std::numeric_limits<size_t>::max();
 
 void Manifold::Impl::FlattenFaces() {
-  Vec<uint64_t> edgeFace(halfedge_.size());
+  Vec<size_t> edgeTri(halfedge_.size());
   const size_t numTri = NumTri();
   const auto policy = autoPolicy(numTri);
 
@@ -271,33 +271,42 @@ void Manifold::Impl::FlattenFaces() {
            [](auto& v) { v.store(0); });
 
   for_each_n(policy, countAt(0_uz), numTri,
-             [&edgeFace, &vertDegree, this](size_t tri) {
+             [&edgeTri, &vertDegree, this](size_t tri) {
+               const auto& ref = meshRelation_.triRef[tri];
                for (const int i : {0, 1, 2}) {
                  const int edge = 3 * tri + i;
                  const int pair = halfedge_[edge].pairedHalfedge;
                  if (pair < 0) {
-                   edgeFace[edge] = kRemove;
+                   edgeTri[edge] = kRemove;
                    return;
                  }
-                 const auto& ref = meshRelation_.triRef[tri];
                  if (ref.SameFace(meshRelation_.triRef[pair / 3])) {
-                   edgeFace[edge] = kRemove;
+                   edgeTri[edge] = kRemove;
                  } else {
-                   edgeFace[edge] = (static_cast<uint64_t>(ref.meshID) << 32) +
-                                    static_cast<uint64_t>(ref.coplanarID);
+                   edgeTri[edge] = tri;
                    ++vertDegree[halfedge_[edge].startVert];
                  }
                }
              });
 
+  auto comp = [&edgeTri, this](size_t a, size_t b) {
+    if (edgeTri[a] == edgeTri[b]) return false;
+    if (edgeTri[a] == kRemove) return false;
+    if (edgeTri[b] == kRemove) return true;
+    const TriRef& refA = meshRelation_.triRef[edgeTri[a]];
+    const TriRef& refB = meshRelation_.triRef[edgeTri[b]];
+    return refA.meshID < refB.meshID || (refA.meshID == refB.meshID &&
+                                         (refA.coplanarID < refB.coplanarID ||
+                                          (refA.coplanarID == refB.coplanarID &&
+                                           refA.faceID < refB.faceID)));
+  };
+
   Vec<size_t> newHalf2Old(halfedge_.size());
   sequence(newHalf2Old.begin(), newHalf2Old.end());
-  stable_sort(
-      newHalf2Old.begin(), newHalf2Old.end(),
-      [&edgeFace](size_t a, size_t b) { return edgeFace[a] < edgeFace[b]; });
+  stable_sort(newHalf2Old.begin(), newHalf2Old.end(), comp);
   newHalf2Old.resize(std::find_if(countAt(0_uz), countAt(halfedge_.size()),
                                   [&](const size_t i) {
-                                    return edgeFace[newHalf2Old[i]] == kRemove;
+                                    return edgeTri[newHalf2Old[i]] == kRemove;
                                   }) -
                      countAt(0_uz));
 
@@ -307,7 +316,7 @@ void Manifold::Impl::FlattenFaces() {
 
   Vec<int> faceEdge(1, 0);
   for (size_t i = 1; i < newHalf2Old.size(); ++i) {
-    if (edgeFace[newHalf2Old[i]] != edgeFace[newHalf2Old[i - 1]]) {
+    if (comp(newHalf2Old[i - 1], newHalf2Old[i])) {
       faceEdge.push_back(i);
     }
   }

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -231,7 +231,7 @@ void Manifold::Impl::InitializeOriginal(bool keepFaceID) {
   triRef.resize_nofill(NumTri());
   for_each_n(autoPolicy(NumTri(), 1e5), countAt(0), NumTri(),
              [meshID, keepFaceID, &triRef](const int tri) {
-               triRef[tri] = {meshID, meshID, tri,
+               triRef[tri] = {meshID, meshID, -1,
                               keepFaceID ? triRef[tri].coplanarID : tri};
              });
   meshRelation_.meshIDtransform.clear();

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -110,7 +110,7 @@ MeshGLP<Precision, I> GetMeshGLImpl(const manifold::Manifold::Impl& impl,
     const auto ref = triRef[oldTri];
     const int meshID = ref.meshID;
 
-    out.faceID[tri] = ref.faceID;
+    out.faceID[tri] = ref.faceID >= 0 ? ref.faceID : ref.coplanarID;
     for (const int i : {0, 1, 2})
       out.triVerts[3 * tri + i] = impl.halfedge_[3 * oldTri + i].startVert;
 

--- a/src/shared.h
+++ b/src/shared.h
@@ -147,7 +147,8 @@ struct TriRef {
   int coplanarID;
 
   bool SameFace(const TriRef& other) const {
-    return meshID == other.meshID && coplanarID == other.coplanarID;
+    return meshID == other.meshID && coplanarID == other.coplanarID &&
+           faceID == other.faceID;
   }
 };
 

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -317,13 +317,12 @@ bool Manifold::Impl::IsMarkedInsideQuad(int halfedge) const {
 
 // sharpenedEdges are referenced to the input Mesh, but the triangles have
 // been sorted in creating the Manifold, so the indices are converted using
-// meshRelation_.
+// meshRelation_.faceID, which temporarily holds the mapping.
 std::vector<Smoothness> Manifold::Impl::UpdateSharpenedEdges(
     const std::vector<Smoothness>& sharpenedEdges) const {
   std::unordered_map<int, int> oldHalfedge2New;
   for (size_t tri = 0; tri < NumTri(); ++tri) {
-    int oldTri =
-        meshRelation_.triRef[tri].faceID;  // TODO: should not use faceID
+    int oldTri = meshRelation_.triRef[tri].faceID;
     for (int i : {0, 1, 2}) oldHalfedge2New[3 * oldTri + i] = 3 * tri + i;
   }
   std::vector<Smoothness> newSharp = sharpenedEdges;
@@ -982,7 +981,9 @@ void Manifold::Impl::Refine(std::function<int(vec3, vec4, vec4)> edgeDivisions,
 
   halfedgeTangent_.clear();
   Finish();
-  MarkCoplanar();
+  if (old.halfedgeTangent_.size() == old.halfedge_.size()) {
+    MarkCoplanar();
+  }
   meshRelation_.originalID = -1;
 }
 

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -275,11 +275,12 @@ void Manifold::Impl::SortVerts() {
 
   // Verts were flagged for removal with NaNs and assigned kNoCode to sort
   // them to the end, which allows them to be removed.
-  const auto newNumVert = std::find_if(vertNew2Old.begin(), vertNew2Old.end(),
-                                       [&vertMorton](const int vert) {
-                                         return vertMorton[vert] == kNoCode;
-                                       }) -
-                          vertNew2Old.begin();
+  const auto newNumVert =
+      std::lower_bound(vertNew2Old.begin(), vertNew2Old.end(), kNoCode,
+                       [&vertMorton](const int vert, const uint32_t val) {
+                         return vertMorton[vert] < val;
+                       }) -
+      vertNew2Old.begin();
 
   vertNew2Old.resize(newNumVert);
   Permute(vertPos_, vertNew2Old);
@@ -400,11 +401,12 @@ void Manifold::Impl::SortFaces(Vec<Box>& faceBox, Vec<uint32_t>& faceMorton) {
 
   // Tris were flagged for removal with pairedHalfedge = -1 and assigned kNoCode
   // to sort them to the end, which allows them to be removed.
-  const int newNumTri = std::find_if(faceNew2Old.begin(), faceNew2Old.end(),
-                                     [&faceMorton](const int face) {
-                                       return faceMorton[face] == kNoCode;
-                                     }) -
-                        faceNew2Old.begin();
+  const int newNumTri =
+      std::lower_bound(faceNew2Old.begin(), faceNew2Old.end(), kNoCode,
+                       [&faceMorton](const int face, const uint32_t val) {
+                         return faceMorton[face] < val;
+                       }) -
+      faceNew2Old.begin();
   faceNew2Old.resize(newNumTri);
 
   Permute(faceMorton, faceNew2Old);

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -139,11 +139,26 @@ TEST(Boolean, Cubes) {
 }
 
 TEST(Boolean, Simplify) {
-  Manifold cube = Manifold::Cube().Refine(10);
+  const int n = 10;
+  MeshGL cubeGL = Manifold::Cube().Refine(n).GetMeshGL();
+  size_t tri = 0;
+  for (auto& id : cubeGL.faceID) {
+    id = tri++;
+  }
+  Manifold cube(cubeGL);
+
+  const int nExpected = 20 * n * n;
   Manifold result = cube + cube.Translate({1, 0, 0});
-  EXPECT_EQ(result.NumTri(), 1928);
+  EXPECT_EQ(result.NumTri(), nExpected);
   result = result.Simplify();
-  EXPECT_EQ(result.NumTri(), 20);
+  EXPECT_EQ(result.NumTri(), nExpected);
+
+  MeshGL resultGL = result.GetMeshGL();
+  resultGL.faceID.clear();
+  Manifold result2(resultGL);
+  EXPECT_EQ(result2.NumTri(), nExpected);
+  result2 = result2.Simplify();
+  EXPECT_EQ(result2.NumTri(), 20);
 }
 
 TEST(Boolean, NoRetainedVerts) {

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -743,7 +743,7 @@ TEST(Manifold, FaceIDRoundTrip) {
   const Manifold cube = Manifold::Cube();
   ASSERT_GE(cube.OriginalID(), 0);
   MeshGL inGL = cube.GetMeshGL();
-  ASSERT_EQ(NumUnique(inGL.faceID), 12);
+  ASSERT_EQ(NumUnique(inGL.faceID), 6);
   inGL.faceID = {3, 3, 3, 3, 3, 3, 5, 5, 5, 5, 5, 5};
 
   const Manifold cube2(inGL);


### PR DESCRIPTION
Fixes #1238 

@howardt I believe this fixes the rest of the problem, so now you can use different `faceID`s to maintain edges through simplification. This definitely makes the API more consistent, and caused me to find and fix a few other bugs along the way. Let me know if anything is still missing. 