### PR TITLE
Fix intersection behavior in CrossSection::BatchBoolean

### DIFF
--- a/src/cross_section/cross_section.cpp
+++ b/src/cross_section/cross_section.cpp
@@ -380,8 +380,8 @@ CrossSection CrossSection::BatchBoolean(
   if (op == OpType::Intersect) {
     auto res = subjs->paths_;
     for (size_t i = 1; i < crossSections.size(); ++i) {
-      res = C2::BooleanOp(C2::ClipType::Intersection, C2::FillRule::Positive, res,
-                          crossSections[i].GetPaths()->paths_, precision_);
+      res = C2::BooleanOp(C2::ClipType::Intersection, C2::FillRule::Positive,
+                          res, crossSections[i].GetPaths()->paths_, precision_);
     }
     return CrossSection(shared_paths(res));
   }

--- a/src/cross_section/cross_section.cpp
+++ b/src/cross_section/cross_section.cpp
@@ -376,6 +376,16 @@ CrossSection CrossSection::BatchBoolean(
     return crossSections[0];
 
   auto subjs = crossSections[0].GetPaths();
+
+  if (op == OpType::Intersect) {
+    auto res = subjs->paths_;
+    for (size_t i = 1; i < crossSections.size(); ++i) {
+      res = C2::BooleanOp(C2::ClipType::Intersection, C2::FillRule::Positive, res,
+                          crossSections[i].GetPaths()->paths_, precision_);
+    }
+    return CrossSection(shared_paths(res));
+  }
+
   int n_clips = 0;
   for (size_t i = 1; i < crossSections.size(); ++i) {
     n_clips += crossSections[i].GetPaths()->paths_.size();


### PR DESCRIPTION
`CrossSection::BatchBoolean` builds a big list of clip paths from the tail of the `crossSections` list and then performs the boolean operation with the head. This works fine for union and difference, but when _intersecting more than two_ cross sections, it produces incorrect results.

This PR adds a special case for `OpType::Intersect` where `C2::BooleanOp` is instead called repeatedly for every part of the tail.

I'm not a C++ guy, so take the code with a scoop of salt.