### PR TITLE
Clarify WASM objects to delete

### DIFF
--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -26,7 +26,7 @@ Also included are a novel and powerful suite of refining functions for smooth me
 
 ## Note on memory management
 
-Since Manifold is a WASM module, it does not automatically garbage-collect like regular JavaScript. You must manually `delete()` each manifold object constructed by your scripts, see [discussion](https://github.com/elalish/manifold/discussions/256#discussioncomment-3944287).
+Since Manifold is a WASM module, it does not automatically garbage-collect like regular JavaScript. You must manually `delete()` each object constructed by your scripts (both `Manifold` and `CrossSection`), see [discussion](https://github.com/elalish/manifold/discussions/256#discussioncomment-3944287).
 
 ## Examples
 


### PR DESCRIPTION
It wasn't clear (to me) whether only the `Manifold` objects had to be `.delete()`d manually or if `CrossSection` have to be deleted too. Am assuming this applies to both, though the manifoldcad.org [workaround](https://github.com/elalish/manifold/blob/0fb47693b3c8ab22bdf85e3e5ca55929fe4acbe6/bindings/wasm/examples/worker.js#L40) does not seem to track CrossSections. Let me know if the assumption is incorrect!