### PR TITLE
fixed coplanar property collapse

### DIFF
--- a/test/properties_test.cpp
+++ b/test/properties_test.cpp
@@ -127,6 +127,7 @@ TEST(Properties, CalculateCurvature) {
 
 TEST(Properties, Coplanar) {
   Manifold peg = Manifold::Cube({1, 1, 2}).Translate({1, 1, 0}).AsOriginal();
+  const size_t pegID = peg.OriginalID();
   Manifold hole = Manifold::Cube({3, 3, 1}) - peg;
   hole = hole.AsOriginal();
   std::vector<MeshGL> input = {hole.GetMeshGL(), peg.GetMeshGL()};
@@ -140,7 +141,7 @@ TEST(Properties, Coplanar) {
   MeshGL resultGL = result.GetMeshGL();
   float minPegZ = std::numeric_limits<float>::max();
   for (size_t run = 0; run < resultGL.runOriginalID.size(); run++) {
-    if (resultGL.runOriginalID[run] == peg.OriginalID()) {
+    if (resultGL.runOriginalID[run] == pegID) {
       for (size_t t3 = resultGL.runIndex[run]; t3 < resultGL.runIndex[run + 1];
            t3++) {
         const size_t v = resultGL.triVerts[t3];

--- a/test/properties_test.cpp
+++ b/test/properties_test.cpp
@@ -139,11 +139,11 @@ TEST(Properties, Coplanar) {
 
   MeshGL resultGL = result.GetMeshGL();
   float minPegZ = std::numeric_limits<float>::max();
-  for (int run = 0; run < resultGL.runOriginalID.size(); run++) {
+  for (size_t run = 0; run < resultGL.runOriginalID.size(); run++) {
     if (resultGL.runOriginalID[run] == peg.OriginalID()) {
-      for (int t3 = resultGL.runIndex[run]; t3 < resultGL.runIndex[run + 1];
+      for (size_t t3 = resultGL.runIndex[run]; t3 < resultGL.runIndex[run + 1];
            t3++) {
-        const int v = resultGL.triVerts[t3];
+        const size_t v = resultGL.triVerts[t3];
         minPegZ = std::min(minPegZ,
                            resultGL.vertProperties[v * resultGL.numProp + 2]);
       }

--- a/test/properties_test.cpp
+++ b/test/properties_test.cpp
@@ -125,6 +125,37 @@ TEST(Properties, CalculateCurvature) {
   }
 }
 
+TEST(Properties, Coplanar) {
+  Manifold peg = Manifold::Cube({1, 1, 2}).Translate({1, 1, 0}).AsOriginal();
+  Manifold hole = Manifold::Cube({3, 3, 1}) - peg;
+  hole = hole.AsOriginal();
+  std::vector<MeshGL> input = {hole.GetMeshGL(), peg.GetMeshGL()};
+  EXPECT_EQ(peg.Genus(), 0);
+  EXPECT_EQ(hole.Genus(), 1);
+
+  Manifold result = hole + peg;
+  EXPECT_EQ(result.Genus(), 0);
+  RelatedGL(result, input);
+
+  MeshGL resultGL = result.GetMeshGL();
+  float minPegZ = std::numeric_limits<float>::max();
+  for (int run = 0; run < resultGL.runOriginalID.size(); run++) {
+    if (resultGL.runOriginalID[run] == peg.OriginalID()) {
+      for (int t3 = resultGL.runIndex[run]; t3 < resultGL.runIndex[run + 1];
+           t3++) {
+        const int v = resultGL.triVerts[t3];
+        minPegZ = std::min(minPegZ,
+                           resultGL.vertProperties[v * resultGL.numProp + 2]);
+      }
+    }
+  }
+  EXPECT_EQ(minPegZ, 0);
+
+#ifdef MANIFOLD_EXPORT
+  if (options.exportModels) ExportMesh("coplanar.glb", resultGL, {});
+#endif
+}
+
 // These tests verify the calculation of MinGap functions.
 
 TEST(Properties, MinGapCubeCube) {


### PR DESCRIPTION
Fixes https://github.com/openscad/openscad/issues/5738

I simplified the repro case into a test. This should solve both the overly aggressive collapsing of coplanar edges that were separating meshes/properties/faceIDs, as well as the potential to introduce too much edge motion when collapsing around sharp, saddle-shaped edges.