### PR TITLE
default offset to round

### DIFF
--- a/bindings/python/examples/all_apis.py
+++ b/bindings/python/examples/all_apis.py
@@ -40,7 +40,7 @@ def all_cross_section():
     c = c.mirror((0, 1))
     n = c.num_contour()
     n = c.num_vert()
-    c = c.offset(1, JoinType.Round)
+    c = c.offset(1)
     m = c.revolve()
     c = c.rotate(90)
     c = c.scale((2, 2))

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -817,8 +817,8 @@ NB_MODULE(manifold3d, m) {
            cross_section__simplify__epsilon)
       .def(
           "offset", &CrossSection::Offset, nb::arg("delta"),
-          nb::arg("join_type"), nb::arg("miter_limit") = 2.0,
-          nb::arg("circular_segments") = 0,
+          nb::arg("join_type") = CrossSection::JoinType::Round,
+          nb::arg("miter_limit") = 2.0, nb::arg("circular_segments") = 0,
           cross_section__offset__delta__jointype__miter_limit__circular_segments)
       .def(nb::self + nb::self, cross_section__operator_plus__q)
       .def(nb::self - nb::self, cross_section__operator_minus__q)

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -159,7 +159,7 @@ Module.setup = function() {
   };
 
   Module.CrossSection.prototype.offset = function(
-      delta, joinType = 'Square', miterLimit = 2.0, circularSegments = 0) {
+      delta, joinType = 'Round', miterLimit = 2.0, circularSegments = 0) {
     return this._Offset(
         delta, joinTypeToInt(joinType), miterLimit, circularSegments);
   };

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -216,7 +216,7 @@ export class CrossSection {
    * to expand, and retraction of inner (hole) contours. Negative deltas will
    * have the opposite effect.
    * @param joinType The join type specifying the treatment of contour joins
-   * (corners).
+   * (corners). Defaults to Round
    * @param miterLimit The maximum distance in multiples of delta that vertices
    * can be offset from their original positions with before squaring is
    * applied, **when the join type is Miter** (default is 2, which is the

--- a/include/manifold/cross_section.h
+++ b/include/manifold/cross_section.h
@@ -136,8 +136,8 @@ class CrossSection {
   CrossSection Warp(std::function<void(vec2&)> warpFunc) const;
   CrossSection WarpBatch(std::function<void(VecView<vec2>)> warpFunc) const;
   CrossSection Simplify(double epsilon = 1e-6) const;
-  CrossSection Offset(double delta, JoinType jt, double miter_limit = 2.0,
-                      int circularSegments = 0) const;
+  CrossSection Offset(double delta, JoinType jt = JoinType::Round,
+                      double miter_limit = 2.0, int circularSegments = 0) const;
   ///@}
 
   /** @name Boolean

--- a/src/cross_section/cross_section.cpp
+++ b/src/cross_section/cross_section.cpp
@@ -652,7 +652,7 @@ CrossSection CrossSection::Simplify(double epsilon) const {
  * to expand, and retraction of inner (hole) contours. Negative deltas will
  * have the opposite effect.
  * @param jointype The join type specifying the treatment of contour joins
- * (corners).
+ * (corners). Defaults to Round.
  * @param miter_limit The maximum distance in multiples of delta that vertices
  * can be offset from their original positions with before squaring is
  * applied, <B>when the join type is Miter</B> (default is 2, which is the


### PR DESCRIPTION
I noticed that our JS bindings had the cross section offset method default the join type to Square, which doesn't seem like the most common use case. However, the rest of the APIs didn't have a default value there at all. I decided Round would be the most expected, so now that's the default for C++, JS, and Python.