### PR TITLE
Fix crashing on an empty MeshGL with one runIndex element

### DIFF
--- a/src/impl.h
+++ b/src/impl.h
@@ -163,6 +163,8 @@ struct Manifold::Impl {
       runIndex = {0, static_cast<I>(runEnd)};
     } else if (runIndex.size() == meshGL.runOriginalID.size()) {
       runIndex.push_back(runEnd);
+    } else if (runIndex.size() == 1) {
+      runIndex.push_back(runEnd);
     }
 
     const auto startID = Impl::ReserveIDs(meshGL.runOriginalID.size());

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -103,6 +103,14 @@ TEST(Manifold, ValidInput) {
   EXPECT_EQ(tet.Status(), Manifold::Error::NoError);
 }
 
+TEST(Manifold, ValidInputOneRunIndex) {
+  MeshGL emptyMesh;
+  emptyMesh.runIndex = {0};
+  Manifold empty(emptyMesh);
+  EXPECT_TRUE(empty.IsEmpty());
+  EXPECT_EQ(empty.Status(), Manifold::Error::NoError);
+}
+
 TEST(Manifold, InvalidInput1) {
   MeshGL in = TetGL();
   in.vertProperties[2 * 3 + 1] = NAN;
@@ -153,6 +161,14 @@ TEST(Manifold, InvalidInput6) {
   Manifold tet(tetGL);
   EXPECT_TRUE(tet.IsEmpty());
   EXPECT_EQ(tet.Status(), Manifold::Error::VertexOutOfBounds);
+}
+
+TEST(Manifold, InvalidInput7) {
+  MeshGL cube = CubeUV();
+  cube.runIndex = {0, 1, static_cast<uint32_t>(cube.triVerts.size())};
+  Manifold tet(cube);
+  EXPECT_TRUE(tet.IsEmpty());
+  EXPECT_EQ(tet.Status(), Manifold::Error::RunIndexWrongLength);
 }
 
 TEST(Manifold, OppositeFace) {


### PR DESCRIPTION
Fixes #1260

- Added a condition to check if `runIndex == 1` to prevent out-of-bounds access; otherwise, it failed and raised `RunIndexWrongLength`.
- Added tests related to `runIndex`

Anyway, I just read the description of `runIndex`. It appears that its length can be equal to the size of `runOriginalID` or `runOriginalID + 1`. Therefore, an empty `runOriginalID` (length = 0) followed by a single element `runIndex` may actually be valid. Given this, I think it shouldn't drop the error `RunIndexWrongLength` and let the input pass. (like my workaround)

Any ideas ?

CC @elalish