### PR TITLE
Add test for Simplify adding cracks

### DIFF
--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -161,6 +161,23 @@ TEST(Boolean, Simplify) {
   EXPECT_EQ(result2.NumTri(), 20);
 }
 
+TEST(Boolean, DISABLED_SimplifyCracks) {
+  Manifold cylinder =
+      Manifold::Cylinder(2, 50, 50, 180)
+          .Rotate(
+              -89.999999999999)  // Rotating by -90 makes the result too perfect
+          .Translate(vec3(50, 0, 50));
+  Manifold cube = Manifold::Cube(vec3(100, 2, 50));
+  Manifold refined = (cylinder + cube).RefineToLength(0.13071895424836602);
+  Manifold deformed =
+      refined.Warp([](vec3& p) { p.y += p.x - (p.x * p.x) / 100.0; });
+  Manifold simplified = deformed.Simplify(0.005);
+
+  // If Simplify adds cracks, volume decreases and surface area increases
+  EXPECT_NEAR(simplified.Volume(), 17848, 1);
+  EXPECT_NEAR(simplified.SurfaceArea(), 20930, 1);
+}
+
 TEST(Boolean, NoRetainedVerts) {
   Manifold cube = Manifold::Cube(vec3(1), true);
   Manifold oct = Manifold::Sphere(1, 4);

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -331,12 +331,12 @@ TEST(Samples, CurvedWallSimplify) {
   Manifold cylinder =
       Manifold::Cylinder(2, 50, 50, 180)
           .Rotate(
-              -89.999999999999) // Rotating by -90 makes the result too perfect
+              -89.999999999999)  // Rotating by -90 makes the result too perfect
           .Translate(vec3(50, 0, 50));
   Manifold cube = Manifold::Cube(vec3(100, 2, 50));
   Manifold refined = (cylinder + cube).RefineToLength(0.13071895424836602);
   Manifold deformed =
-      refined.Warp([](vec3 &p) { p.y += p.x - (p.x * p.x) / 100.0; });
+      refined.Warp([](vec3& p) { p.y += p.x - (p.x * p.x) / 100.0; });
   Manifold simplified = deformed.Simplify(0.005);
 
   // If Simplify adds cracks, volume decreases and surface area increases

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -326,20 +326,3 @@ TEST(Samples, CondensedMatter64) {
 #endif
 }
 #endif
-
-TEST(Samples, CurvedWallSimplify) {
-  Manifold cylinder =
-      Manifold::Cylinder(2, 50, 50, 180)
-          .Rotate(
-              -89.999999999999)  // Rotating by -90 makes the result too perfect
-          .Translate(vec3(50, 0, 50));
-  Manifold cube = Manifold::Cube(vec3(100, 2, 50));
-  Manifold refined = (cylinder + cube).RefineToLength(0.13071895424836602);
-  Manifold deformed =
-      refined.Warp([](vec3& p) { p.y += p.x - (p.x * p.x) / 100.0; });
-  Manifold simplified = deformed.Simplify(0.005);
-
-  // If Simplify adds cracks, volume decreases and surface area increases
-  EXPECT_NEAR(simplified.Volume(), 17848, 1);
-  EXPECT_NEAR(simplified.SurfaceArea(), 20930, 1);
-}

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -326,3 +326,19 @@ TEST(Samples, CondensedMatter64) {
 #endif
 }
 #endif
+
+TEST(Samples, CurvedWallSimplify) {
+  Manifold cylinder = Manifold::Cylinder(2, 50, 50, 180)
+    .Rotate(-89.999999999999) // Rotating by -90 makes the result too perfect
+    .Translate(vec3(50, 0, 50));
+  Manifold cube = Manifold::Cube(vec3(100, 2, 50));
+  Manifold refined = (cylinder + cube).RefineToLength(0.13071895424836602);
+  Manifold deformed = refined.Warp([] (vec3 &p) {
+    p.y += p.x - (p.x * p.x) / 100.0;
+  });
+  Manifold simplified = deformed.Simplify(0.005);
+  
+  // If Simplify adds cracks, volume decreases and surface area increases
+  EXPECT_NEAR(simplified.Volume(), 17848, 1);
+  EXPECT_NEAR(simplified.SurfaceArea(), 20930, 1);
+}

--- a/test/samples_test.cpp
+++ b/test/samples_test.cpp
@@ -328,16 +328,17 @@ TEST(Samples, CondensedMatter64) {
 #endif
 
 TEST(Samples, CurvedWallSimplify) {
-  Manifold cylinder = Manifold::Cylinder(2, 50, 50, 180)
-    .Rotate(-89.999999999999) // Rotating by -90 makes the result too perfect
-    .Translate(vec3(50, 0, 50));
+  Manifold cylinder =
+      Manifold::Cylinder(2, 50, 50, 180)
+          .Rotate(
+              -89.999999999999) // Rotating by -90 makes the result too perfect
+          .Translate(vec3(50, 0, 50));
   Manifold cube = Manifold::Cube(vec3(100, 2, 50));
   Manifold refined = (cylinder + cube).RefineToLength(0.13071895424836602);
-  Manifold deformed = refined.Warp([] (vec3 &p) {
-    p.y += p.x - (p.x * p.x) / 100.0;
-  });
+  Manifold deformed =
+      refined.Warp([](vec3 &p) { p.y += p.x - (p.x * p.x) / 100.0; });
   Manifold simplified = deformed.Simplify(0.005);
-  
+
   // If Simplify adds cracks, volume decreases and surface area increases
   EXPECT_NEAR(simplified.Volume(), 17848, 1);
   EXPECT_NEAR(simplified.SurfaceArea(), 20930, 1);


### PR DESCRIPTION
See #1262

`Simplify` added weird cracks to my model. This failing test reproduces this case and checks the volume and surface area of the output of `Simplify`.