### PR TITLE
misc performance improvements

### DIFF
--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -147,6 +147,10 @@ int GetLabels(std::vector<int>& components,
 
 namespace manifold {
 
+#if (MANIFOLD_PAR == 1)
+tbb::task_arena gc_arena(1, 1, tbb::task_arena::priority::low);
+#endif
+
 std::atomic<uint32_t> Manifold::Impl::meshIDCounter_(1);
 
 uint32_t Manifold::Impl::ReserveIDs(uint32_t n) {

--- a/src/vec.h
+++ b/src/vec.h
@@ -26,6 +26,10 @@
 
 namespace manifold {
 
+#if (MANIFOLD_PAR == 1)
+extern tbb::task_arena gc_arena;
+#endif
+
 template <typename T>
 class Vec;
 
@@ -92,8 +96,7 @@ class Vec : public VecView<T> {
 
   ~Vec() {
     if (this->ptr_ != nullptr) {
-      TracyFreeS(this->ptr_, 3);
-      free(this->ptr_);
+      free_async(this->ptr_, capacity_);
     }
     this->ptr_ = nullptr;
     this->size_ = 0;
@@ -103,8 +106,7 @@ class Vec : public VecView<T> {
   Vec<T>& operator=(const Vec<T>& other) {
     if (&other == this) return *this;
     if (this->ptr_ != nullptr) {
-      TracyFreeS(this->ptr_, 3);
-      free(this->ptr_);
+      free_async(this->ptr_, capacity_);
     }
     this->size_ = other.size_;
     capacity_ = other.size_;
@@ -120,8 +122,7 @@ class Vec : public VecView<T> {
   Vec<T>& operator=(Vec<T>&& other) {
     if (&other == this) return *this;
     if (this->ptr_ != nullptr) {
-      TracyFreeS(this->ptr_, 3);
-      free(this->ptr_);
+      free_async(this->ptr_, capacity_);
     }
     this->size_ = other.size_;
     capacity_ = other.capacity_;
@@ -166,8 +167,7 @@ class Vec : public VecView<T> {
         manifold::copy(autoPolicy(this->size_), this->ptr_,
                        this->ptr_ + this->size_, newBuffer);
       if (this->ptr_ != nullptr) {
-        TracyFreeS(this->ptr_, 3);
-        free(this->ptr_);
+        free_async(this->ptr_, capacity_);
       }
       this->ptr_ = newBuffer;
       capacity_ = n;
@@ -208,8 +208,7 @@ class Vec : public VecView<T> {
       manifold::copy(this->ptr_, this->ptr_ + this->size_, newBuffer);
     }
     if (this->ptr_ != nullptr) {
-      TracyFreeS(this->ptr_, 3);
-      free(this->ptr_);
+      free_async(this->ptr_, capacity_);
     }
     this->ptr_ = newBuffer;
     capacity_ = this->size_;
@@ -221,5 +220,19 @@ class Vec : public VecView<T> {
   size_t capacity_ = 0;
 
   static_assert(std::is_trivially_destructible<T>::value);
+
+  static void free_async(T* ptr, size_t size) {
+    TracyFreeS(ptr, 3);
+    // only do async free if the size is large, because otherwise we may be able
+    // to reuse the allocation, and the deallocation probably won't trigger
+    // munmap.
+    // Currently it is set to 64 pages.
+#if (MANIFOLD_PAR == 1)
+    if (size * sizeof(T) > 1 << 18)
+      gc_arena.enqueue([ptr]() { free(ptr); });
+    else
+#endif
+      free(ptr);
+  }
 };
 }  // namespace manifold


### PR DESCRIPTION
Misc changes, they are mainly optimized for large meshes and have small to no impact to smaller meshes which are the majority of our benchmarks, so I am skipping them here.

Old perf:

```
nTri = 512, time = 0.00102039 sec
nTri = 2048, time = 0.00176623 sec
nTri = 8192, time = 0.00433313 sec
nTri = 32768, time = 0.00954862 sec
nTri = 131072, time = 0.0269745 sec
nTri = 524288, time = 0.107106 sec
nTri = 2097152, time = 0.492739 sec
nTri = 8388608, time = 1.93114 sec
```



1. Allow the collider to take a function for queries. This avoids the need to construct a `TmpEdge` and `Box` vector for `Intersect12`, which makes things slightly faster when the mesh is particularly huge.
  
  ```
  nTri = 512, time = 0.00129358 sec
  nTri = 2048, time = 0.0016819 sec
  nTri = 8192, time = 0.0040756 sec
  nTri = 32768, time = 0.00914949 sec
  nTri = 131072, time = 0.0252436 sec
  nTri = 524288, time = 0.0948401 sec
  nTri = 2097152, time = 0.407921 sec
  nTri = 8388608, time = 1.66111 sec
  ```

2. Free large vectors asynchronously. Large allocations are typically treated differently by the allocator, they are requested from and released to the OS directly. For allocation, there isn't much we can do unless we reuse the buffer (this will be fun to try). However, for deallocation, we can just move it to a separate thread to do all the munmap work, improving performance. This one is quite significant:

  ```
  nTri = 512, time = 0.0010744 sec
  nTri = 2048, time = 0.00183495 sec
  nTri = 8192, time = 0.00467922 sec
  nTri = 32768, time = 0.00894273 sec
  nTri = 131072, time = 0.0235959 sec
  nTri = 524288, time = 0.0874061 sec
  nTri = 2097152, time = 0.376126 sec
  nTri = 8388608, time = 1.51217 sec
  ```