### PR TITLE
Make GCC floating-point operations standard conforming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ else()
     # disable fp math optimizations, e.g. FMA for supported architectures, as
     # this changes floating-point results
     # clang defaults to -ffp-contract=off so we don't have to set that
-    list(APPEND MANIFOLD_FLAGS -ffp-contract=off)
+    list(APPEND MANIFOLD_FLAGS -ffp-contract=off -fexcess-precision=standard)
   endif()
   if(CODE_COVERAGE)
     list(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,12 @@ else()
   if("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
     list(APPEND MANIFOLD_FLAGS -fno-omit-frame-pointer)
   endif()
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # disable fp math optimizations, e.g. FMA for supported architectures, as
+    # this changes floating-point results
+    # clang defaults to -ffp-contract=off so we don't have to set that
+    list(APPEND MANIFOLD_FLAGS -ffp-contract=off)
+  endif()
   if(CODE_COVERAGE)
     list(
       APPEND


### PR DESCRIPTION
Closes #1266. GCC defaults to `-ffp-contract=fast`, i.e., it will optimize things into FMA. It will also perform things with excess precision if that is faster, and is now disabled via `-fexcess-precision=standard`. I don't see any performance degradation.
