### PR TITLE
faster halfedge pairing for large meshes

### DIFF
--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -372,8 +372,8 @@ struct PrepHalfedges {
   void operator()(const int tri) {
     const ivec3& props = triProp[tri];
     for (const int i : {0, 1, 2}) {
-      const int j = NextHalfedge(i);
-      const int k = NextHalfedge(j);
+      const int j = Next3(i);
+      const int k = Next3(j);
       const int e = 3 * tri + i;
       const int v0 = useProp ? props[i] : triVert[tri][i];
       const int v1 = useProp ? props[j] : triVert[tri][j];

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -553,7 +553,8 @@ class EarClip {
 
   // Apply func to each un-clipped vert in a polygon and return an un-clipped
   // vert.
-  VertItrC Loop(VertItr first, std::function<void(VertItr)> func) const {
+  template <typename F>
+  VertItrC Loop(VertItr first, F func) const {
     VertItr v = first;
     do {
       if (Clipped(v)) {

--- a/src/tree2d.cpp
+++ b/src/tree2d.cpp
@@ -37,14 +37,16 @@ namespace manifold {
 // Recursive sorting is not the most efficient, but simple and guaranteed to
 // result in a balanced tree.
 void BuildTwoDTreeImpl(VecView<PolyVert> points, bool sortX) {
-  using CmpFn = std::function<bool(const PolyVert&, const PolyVert&)>;
-  CmpFn cmpx = [](const PolyVert& a, const PolyVert& b) {
+  auto cmpx = [](const PolyVert& a, const PolyVert& b) {
     return a.pos.x < b.pos.x;
   };
-  CmpFn cmpy = [](const PolyVert& a, const PolyVert& b) {
+  auto cmpy = [](const PolyVert& a, const PolyVert& b) {
     return a.pos.y < b.pos.y;
   };
-  manifold::stable_sort(points.begin(), points.end(), sortX ? cmpx : cmpy);
+  if (sortX)
+    manifold::stable_sort(points.begin(), points.end(), cmpx);
+  else
+    manifold::stable_sort(points.begin(), points.end(), cmpy);
   if (points.size() < 2) return;
   BuildTwoDTreeImpl(points.view(0, points.size() / 2), !sortX);
   BuildTwoDTreeImpl(points.view(points.size() / 2 + 1), !sortX);

--- a/src/tree2d.h
+++ b/src/tree2d.h
@@ -44,7 +44,7 @@ void QueryTwoDTree(VecView<PolyVert> points, Rect r, F f) {
   int stackPointer = 0;
 
   while (1) {
-    if (currentView.size() <= 2) {
+    if (currentView.size() <= 8) {
       for (const auto& p : currentView)
         if (r.Contains(p.pos)) f(p);
       if (--stackPointer < 0) break;


### PR DESCRIPTION
For larger vertex count, we separate the ids into slices for halfedges with the same smaller vertex.
We first copy them there (as HalfedgePairData), and then do sorting locally for each slice.
This helps with memory locality and is faster for larger meshes.

For large meshes, this reduces the time for preparing IDs by about half. EMBER benchmark results:

```
Old:
Total time
  avg : 17.035
  min : 2.130
  max : 177.936
Converting MeshGL to Manifold
  avg : 6.502
  min : 1.222
  max : 30.621
Manifold boolean
  avg : 10.353
  min : 0.828
  max : 157.637
Converting Manifold to MeshGL
  avg : 0.180
  min : 0.006
  max : 1.446

New
Total time
  avg : 14.775
  min : 1.699
  max : 168.734
Converting MeshGL to Manifold
  avg : 5.904
  min : 0.961
  max : 23.307
Manifold boolean
  avg : 8.686
  min : 0.619
  max : 151.385
Converting Manifold to MeshGL
  avg : 0.185
  min : 0.004
  max : 1.291
```

Basically improves on both average and worst-case time. And yields significant improvement for `perfTest` as well (~0.1s).

And bonus for triangulation, basically just avoid `std::function` and tuned the loop iteration slightly. Gives ~17% performance improvement for complex triangulation, e.g. Zebra and Zebra3.