### PR TITLE
Add missing Manifold.simplify() method to Python API (#1281)

### DIFF
--- a/bindings/python/examples/all_apis.py
+++ b/bindings/python/examples/all_apis.py
@@ -92,6 +92,7 @@ def all_manifold():
     i = m.original_id()
     p = m.get_tolerance()
     pp = m.set_tolerance(0.0001)
+    m = m.simplify(0.001)
     c = m.project()
     m = m.refine(2)
     m = m.refine_to_length(0.1)

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -356,6 +356,7 @@ NB_MODULE(manifold3d, m) {
       .def("get_tolerance", &Manifold::GetTolerance, manifold__get_tolerance)
       .def("set_tolerance", &Manifold::SetTolerance,
            manifold__set_tolerance__tolerance)
+      .def("simplify", &Manifold::Simplify, manifold__simplify__tolerance)
       .def("as_original", &Manifold::AsOriginal, manifold__as_original)
       .def("is_empty", &Manifold::IsEmpty, manifold__is_empty)
       .def("decompose", &Manifold::Decompose, manifold__decompose)


### PR DESCRIPTION
* add binding to manifold3d.cpp

* add test call in all_apis.py