### PR TITLE
fix pyi vert_properties type

### DIFF
--- a/bindings/python/stub_pattern.txt
+++ b/bindings/python/stub_pattern.txt
@@ -11,3 +11,11 @@ manifold3d.__prefix__:
   DoubleNx3 = np.ndarray[tuple[N, Literal[3]], np.dtype[np.double]]
   Intx3 = Union[np.ndarray[tuple[Literal[3]], np.dtype[np.integer]], tuple[int, int, int], list[int]]
   IntNx3 = np.ndarray[tuple[N, Literal[3]], np.dtype[np.integer]]
+
+manifold3d.Mesh.vert_properties:
+  @property
+  def vert_properties(self) -> np.typing.NDArray[np.float32]: ...
+
+manifold3d.Mesh64.vert_properties:
+  @property
+  def vert_properties(self) -> np.typing.NDArray[np.float64]: ...


### PR DESCRIPTION
Fix #1290.


Before:
PyCharm
![image](https://github.com/user-attachments/assets/94551122-b7ab-464d-a4c2-6eb0b4cb75d9)
VSCode
![image](https://github.com/user-attachments/assets/c4e1e325-36b8-41c3-a54a-046fbb68d6e0)

After
![image](https://github.com/user-attachments/assets/f5fbcd4a-cacf-42fa-adb5-2fafaf03f286)
![image](https://github.com/user-attachments/assets/de2fe25f-5bc7-4a07-a97e-319ceb81125f)

