### PR TITLE
update Clipper2 to 1.5.4 and fix CrossSection::Offset

### DIFF
--- a/cmake/manifoldDeps.cmake
+++ b/cmake/manifoldDeps.cmake
@@ -113,8 +113,8 @@ if(MANIFOLD_CROSS_SECTION)
     FetchContent_Declare(
       Clipper2
       GIT_REPOSITORY https://github.com/AngusJohnson/Clipper2.git
-      # Jun 6, 2025
-      GIT_TAG Clipper2_1.5.4
+      # Jun 15, 2025
+      GIT_TAG 11ef6ca611a732e7d75fcc1b4abe89387523fa64
       GIT_PROGRESS TRUE
       SOURCE_SUBDIR CPP
       EXCLUDE_FROM_ALL

--- a/cmake/manifoldDeps.cmake
+++ b/cmake/manifoldDeps.cmake
@@ -113,8 +113,8 @@ if(MANIFOLD_CROSS_SECTION)
     FetchContent_Declare(
       Clipper2
       GIT_REPOSITORY https://github.com/AngusJohnson/Clipper2.git
-      # Jan 27, 2025
-      GIT_TAG Clipper2_1.5.2
+      # Jun 6, 2025
+      GIT_TAG Clipper2_1.5.4
       GIT_PROGRESS TRUE
       SOURCE_SUBDIR CPP
       EXCLUDE_FROM_ALL

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "clipper2-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1739063104,
-        "narHash": "sha256-HlqSh/b05pi1I5iS2QjBUagseUJcQ7ehEgfwJNx39NI=",
+        "lastModified": 1749977025,
+        "narHash": "sha256-nkajY57+6xDjL8fJWK31Y75Id6Go3pwtAOVgat3sf5E=",
         "owner": "AngusJohnson",
         "repo": "Clipper2",
-        "rev": "c86619cf4feb470a91464b06cfdaad0ca6012914",
+        "rev": "11ef6ca611a732e7d75fcc1b4abe89387523fa64",
         "type": "github"
       },
       "original": {

--- a/src/cross_section/cross_section.cpp
+++ b/src/cross_section/cross_section.cpp
@@ -675,8 +675,7 @@ CrossSection CrossSection::Offset(double delta, JoinType jointype,
     // (radius) in order to get back the same number of segments in Clipper2:
     // steps_per_360 = PI / acos(1 - arc_tol / abs_delta)
     const double abs_delta = std::fabs(delta);
-    const double scaled_delta = abs_delta * std::pow(10, precision_);
-    arc_tol = (std::cos(Clipper2Lib::PI / n) - 1) * -scaled_delta;
+    arc_tol = (std::cos(Clipper2Lib::PI / n) - 1) * -abs_delta;
   }
   auto ps =
       C2::InflatePaths(GetPaths()->paths_, delta, jt(jointype),


### PR DESCRIPTION
Fix #1289 
Caused by https://github.com/AngusJohnson/Clipper2/commit/ca6e8fd58e30521115d5b83ee785b90cea07c059
This commit add scale to arc_tolerance as followed. 
```
inline PathsD InflatePaths(const PathsD& paths, double delta,
    JoinType jt, EndType et, double miter_limit = 2.0,
    int precision = 2, double arc_tolerance = 0.0)
  {
  ...
  const double scale = std::pow(10, precision);
  ClipperOffset clip_offset(miter_limit, arc_tolerance * scale);
  ...
   }
```

But it processed in manifold warpper manually before. So remove preprocess fix it.
https://github.com/elalish/manifold/blob/8c63b864d870ac049c2fefaadeb610e17614c2df/src/cross_section/cross_section.cpp#L677-L683

```
[----------] Global test environment tear-down
[==========] 286 tests from 11 test suites ran. (950576 ms total)
[  PASSED  ] 286 tests.

  YOU HAVE 3 DISABLED TESTS
```