### PR TITLE
skip halfedges that are removed

### DIFF
--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -316,6 +316,7 @@ void Manifold::Impl::DedupePropVerts() {
   for_each_n(autoPolicy(halfedge_.size(), 1e4), countAt(0), halfedge_.size(),
              [&vert2vert, numProp, this](const int edgeIdx) {
                const Halfedge edge = halfedge_[edgeIdx];
+               if (edge.pairedHalfedge < 0) return;
                const int edgeFace = edgeIdx / 3;
                const int pairFace = edge.pairedHalfedge / 3;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/107994.

I looked around, and it seems to me that this is the only function that has this bug because it is relatively new. I tried to make this a test case by exporting to our special obj format, but we need mergeToVert and we do not yet support writing that to obj. I will leave it for later.