### PR TITLE
fix CheckHalfedges()

### DIFF
--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -73,8 +73,8 @@ struct CheckHalfedges {
 
   bool operator()(size_t edge) const {
     const Halfedge halfedge = halfedges[edge];
-    if (halfedge.startVert == -1 || halfedge.endVert == -1) return true;
     if (halfedge.pairedHalfedge == -1) return false;
+    if (halfedge.startVert == -1 || halfedge.endVert == -1) return true;
 
     const Halfedge paired = halfedges[halfedge.pairedHalfedge];
     bool good = true;

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -73,8 +73,11 @@ struct CheckHalfedges {
 
   bool operator()(size_t edge) const {
     const Halfedge halfedge = halfedges[edge];
-    if (halfedge.pairedHalfedge == -1) return false;
+    if (halfedge.startVert == -1 && halfedge.endVert == -1 &&
+        halfedge.pairedHalfedge == -1)
+      return false;
     if (halfedge.startVert == -1 || halfedge.endVert == -1) return true;
+    if (halfedge.pairedHalfedge == -1) return false;
 
     const Halfedge paired = halfedges[halfedge.pairedHalfedge];
     bool good = true;


### PR DESCRIPTION
fixes #1309

This fix will properly generate `logicErr exception` if `ManifoldParams().intermediateChecks` is set to `true`.

What cause this is a halfedge, both startVert, endVert and pairedHalfedge were set to -1, lead to a invalid access in `SplitPinchedVerts()` and infinte loop.