### PR TITLE
Simplify intel macos

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -251,12 +251,15 @@ jobs:
         $CMAKE -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DMANIFOLD_PYBIND=OFF -DMANIFOLD_CBIND=ON -DMANIFOLD_DEBUG=ON -DMANIFOLD_PAR=${{matrix.parallelization}} .. && make
 
   build_mac:
-    name: MacOS (TBB:${{matrix.parallelization == 'ON'}})
+    name: MacOS (TBB:${{matrix.parallelization == 'ON'}}, ${{matrix.os}})
     timeout-minutes: 30
     strategy:
       matrix:
         parallelization: [OFF, ON]
-    runs-on: macos-latest
+        # macos-13: intel
+        # macos-latest: arm
+        os: [macos-13, macos-latest]
+    runs-on: ${{matrix.os}}
     steps:
     - name: Install common dependencies
       run: |

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -572,11 +572,7 @@ TEST(Manifold, Simplify) {
   Manifold torus = Manifold::Revolve(polyCircle, 100);
   Manifold simplified = torus.Simplify(0.4);
   EXPECT_NEAR(torus.Volume(), simplified.Volume(), 20);
-
-  // TODO: The threshold for simplified.SurfaceArea() should be 10, set to 20 as
-  // a temporaily fix for platform deterministic issue build CI with Intel CPU
-  // Macos 13 Clang Build. See https://github.com/elalish/manifold/issues/1306
-  EXPECT_NEAR(torus.SurfaceArea(), simplified.SurfaceArea(), 20);
+  EXPECT_NEAR(torus.SurfaceArea(), simplified.SurfaceArea(), 10);
 
 #ifdef MANIFOLD_EXPORT
   if (options.exportModels) ExportMesh("torus.glb", simplified.GetMeshGL(), {});


### PR DESCRIPTION
It seems that #1306 is somehow fixed by the other fixes. At least the area and number of triangles are exactly the same across platforms now (checked via some previous CI runs).