### PR TITLE
disable async free when asan is enabled

### DIFF
--- a/src/vec.h
+++ b/src/vec.h
@@ -228,10 +228,14 @@ class Vec : public VecView<T> {
     // Currently it is set to 64 pages (4kB page).
     constexpr size_t ASYNC_FREE_THRESHOLD = 1 << 18;
     TracyFreeS(ptr, 3);
+#if defined(__has_feature)
+#if !__has_feature(address_sanitizer)
 #if (MANIFOLD_PAR == 1)
     if (size * sizeof(T) > ASYNC_FREE_THRESHOLD)
       gc_arena.enqueue([ptr]() { free(ptr); });
     else
+#endif
+#endif
 #endif
       free(ptr);
   }


### PR DESCRIPTION
Avoids race condition when tests terminate and things are not yet freed by the thread.