### PR TITLE
Use Python_EXECUTABLE from FindPython instead of hardcoding the command

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -16,6 +16,8 @@ nanobind_add_module(manifold3d NB_STATIC STABLE_ABI LTO autogen_docstrings.inl
                     manifold3d.cpp
 )
 
+message(Python_EXECUTABLE = ${Python_EXECUTABLE})
+
 if(MANIFOLD_PYBIND_STUBGEN)
   nanobind_add_stub(
     manifold3d_stub
@@ -30,7 +32,8 @@ if(MANIFOLD_PYBIND_STUBGEN)
     TARGET manifold3d_stub
     POST_BUILD
     COMMAND
-      python "${PROJECT_SOURCE_DIR}/bindings/python/stub_postbuild.py"
+      "${Python_EXECUTABLE}"
+      "${PROJECT_SOURCE_DIR}/bindings/python/stub_postbuild.py"
       "${CMAKE_CURRENT_BINARY_DIR}/manifold3d.pyi"
     VERBATIM
   )
@@ -43,7 +46,6 @@ target_compile_options(
 )
 set_target_properties(manifold3d PROPERTIES OUTPUT_NAME "manifold3d")
 
-message(Python_EXECUTABLE = ${Python_EXECUTABLE})
 # ideally we should generate a dependency file from python...
 set(
   DOCSTRING_DEPS


### PR DESCRIPTION
on many linux distributions /usr/bin/python would refer to python 2 which no longer exists. python 3.x is usually /usr/bin/python3.

The finder handles this for us.

Fixes #1327 