### PR TITLE
Check if manifold compile with C++17 since clipper dependency is requ…

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DMANIFOLD_PYBIND=ON -DMANIFOLD_DEBUG=ON -DMANIFOLD_ASSERT=ON -DMANIFOLD_FLAGS=-UNDEBUG -DMANIFOLD_CROSS_SECTION=${{matrix.cross_section}} -DMANIFOLD_EXPORT=ON -DMANIFOLD_PAR=${{matrix.parallelization}} .. && make
+        cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DCXX_STANDARD=17 -DMANIFOLD_PYBIND=ON -DMANIFOLD_DEBUG=ON -DMANIFOLD_ASSERT=ON -DMANIFOLD_FLAGS=-UNDEBUG -DMANIFOLD_CROSS_SECTION=${{matrix.cross_section}} -DMANIFOLD_EXPORT=ON -DMANIFOLD_PAR=${{matrix.parallelization}} .. && make
     - name: Test ${{matrix.parallelization}}
       if: matrix.parallelization != 'OFF'
       run: |


### PR DESCRIPTION
Trying to add manifold 3.2.0 to conan-center-index (https://github.com/conan-io/conan-center-index/pull/28017)
but doesn't compiles with -std=c++17 , imposed because clipper2 dependency requires C++17, see https://github.com/AngusJohnson/Clipper2/blob/main/CPP/CMakeLists.txt#L5

See for example https://c3i.jfrog.io/artifactory/cci-build-logs/cci/prod/PR-28017/3/package_build_logs/build_log_manifold_3_2_0_8fc4e7668952a9d6a8ed2f56ee5a17d0_75f17d6af1bca1edcc63ea112c6d42608dde6f1b.txt for build error. 