### PR TITLE
Simplify 180° Edges

### DIFF
--- a/src/edge_op.cpp
+++ b/src/edge_op.cpp
@@ -95,6 +95,29 @@ struct FlagEdge {
   }
 };
 
+struct AntiparallelEdge {
+  VecView<const Halfedge> halfedge;
+  VecView<const vec3> triNormal;
+  const int firstNewVert;
+  const double angleThreshold;  // Threshold for considering normals antiparallel
+
+  bool operator()(int edge) const {
+    const Halfedge& half = halfedge[edge];
+    if (half.pairedHalfedge < 0) return false;
+    // Only process edges where at least one vertex is new
+    if (half.startVert < firstNewVert && half.endVert < firstNewVert) return false;
+    
+    // Check if the adjacent triangle normals are antiparallel (180 degrees apart)
+    const int tri1 = edge / 3;
+    const int tri2 = half.pairedHalfedge / 3;
+    const double dotProduct = la::dot(triNormal[tri1], triNormal[tri2]);
+    
+    // If normals are pointing in opposite directions (dot product close to -1)
+    // This indicates a sliver where triangles are nearly coplanar but facing opposite directions
+    return dotProduct < angleThreshold;  // e.g., -0.99 for nearly antiparallel
+  }
+};
+
 struct SwappableEdge {
   VecView<const Halfedge> halfedge;
   VecView<const vec3> vertPos;
@@ -237,6 +260,7 @@ void Manifold::Impl::SimplifyTopology(int firstNewVert) {
 
   CleanupTopology();
   CollapseShortEdges(firstNewVert);
+  CollapseAntiparallelEdges(firstNewVert);
   CollapseColinearEdges(firstNewVert);
   SwapDegenerates(firstNewVert);
 }
@@ -246,6 +270,7 @@ void Manifold::Impl::RemoveDegenerates(int firstNewVert) {
 
   CleanupTopology();
   CollapseShortEdges(firstNewVert);
+  CollapseAntiparallelEdges(firstNewVert);
   SwapDegenerates(firstNewVert);
 }
 
@@ -304,6 +329,30 @@ void Manifold::Impl::CollapseColinearEdges(int firstNewVert) {
     }
 #endif
   }
+}
+
+void Manifold::Impl::CollapseAntiparallelEdges(int firstNewVert) {
+  ZoneScopedN("CollapseAntiparallelEdges");
+  FlagStore s;
+  size_t numFlagged = 0;
+  const size_t nbEdges = halfedge_.size();
+  std::vector<int> scratchBuffer;
+  scratchBuffer.reserve(10);
+  
+  // Use -0.9999 as threshold - edges where normals are nearly opposite (angle > ~179.982 degrees)
+  // This targets slivers where triangles are nearly coplanar but facing opposite directions
+  AntiparallelEdge ae{halfedge_, faceNormal_, firstNewVert, -0.9999};
+  s.run(nbEdges, ae, [&](size_t i) {
+    const bool didCollapse = CollapseEdge(i, scratchBuffer);
+    if (didCollapse) numFlagged++;
+    scratchBuffer.resize(0);
+  });
+
+#ifdef MANIFOLD_DEBUG
+  if (ManifoldParams().verbose > 0 && numFlagged > 0) {
+    std::cout << "collapsed " << numFlagged << " antiparallel edges" << std::endl;
+  }
+#endif
 }
 
 void Manifold::Impl::SwapDegenerates(int firstNewVert) {

--- a/src/impl.h
+++ b/src/impl.h
@@ -342,6 +342,7 @@ struct Manifold::Impl {
   void RemoveDegenerates(int firstNewVert = 0);
   void CollapseShortEdges(int firstNewVert = 0);
   void CollapseColinearEdges(int firstNewVert = 0);
+  void CollapseAntiparallelEdges(int firstNewVert = 0);
   void SwapDegenerates(int firstNewVert = 0);
   void DedupeEdge(int edge);
   bool CollapseEdge(int edge, std::vector<int>& edges);


### PR DESCRIPTION
Adds a routine to simplify antiparallel edges, which should largely eliminate the slivers resulting from CSG on coplanar faces.

Test cases coming soon...

Previous discussion here: https://github.com/elalish/manifold/pull/666#issuecomment-3239755814