### PR TITLE
fix csg tree bug

### DIFF
--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -638,8 +638,8 @@ std::shared_ptr<CsgLeafNode> CsgOpNode::ToLeafNode() const {
                 *impl = {frame->positive_children[0]};
               } else {
                 auto negative = BatchUnion(frame->negative_children);
-                *impl = {SimpleBoolean(*positive->GetImpl(), *negative->GetImpl(),
-                                       OpType::Subtract)};
+                *impl = {SimpleBoolean(*positive->GetImpl(),
+                                       *negative->GetImpl(), OpType::Subtract)};
               }
             }
             break;


### PR DESCRIPTION
Closes #1378

Need to check the cache before computing, as we may have already computed the result and removed the set of children.