### PR TITLE
Fall back to packaged type files if not built.

### DIFF
--- a/bindings/wasm/examples/vite.config.js
+++ b/bindings/wasm/examples/vite.config.js
@@ -17,10 +17,31 @@ export default defineConfig({
   },
   plugins: [
     viteStaticCopy({
-      targets: [{
-        src: '../types/manifoldCAD.d.ts',
-        dest: './',
-      }],
+      targets: [
+        {
+          src: '../types/manifoldCAD.d.ts',
+          dest: './',  // Targets are relative to 'dist'.
+        },
+        // If 'dist/manifold-encapsulated-types.d.ts' and
+        // 'dist/manifold-global-types.d.ts' are missing, the web editor can't
+        // load them, and type validation won't work for our core modules.
+        //
+        // They are generated when building the wasm module.  But we don't
+        // really need to build the whole thing when working up here in JS/TS
+        // territory.  Additionally, they rarely change.  In the case where the
+        // binding files are not present, grab the checked in copies, and use
+        // those instead.  But if they _are_ present, don't overwrite them.
+        {
+          src: '../manifold-encapsulated-types.d.ts',
+          dest: './',
+          overwrite: false,
+        },
+        {
+          src: '../manifold-global-types.d.ts',
+          dest: './',
+          overwrite: false,
+        }
+      ],
     }),
   ],
   build: {


### PR DESCRIPTION
Suggestion from @Loosetooth, [over here](https://github.com/elalish/manifold/pull/1387#issuecomment-3408447532).