### PR TITLE
using static_cast<float> in ImportMesh to support assimp with double-precision

### DIFF
--- a/src/meshIO/meshIO.cpp
+++ b/src/meshIO/meshIO.cpp
@@ -147,13 +147,17 @@ MeshGL ImportMesh(const std::string& filename, bool forceCleanup) {
   for (size_t i = 0; i < scene->mNumMeshes; ++i) {
     const aiMesh* mesh_i = scene->mMeshes[i];
     for (size_t j = 0; j < mesh_i->mNumVertices; ++j) {
-      const aiVector3D vert = mesh_i->mVertices[j];
+      const aiVector3t<float> vert = mesh_i->mVertices[j];
       if (isYup)
-        mesh_out.vertProperties.insert(mesh_out.vertProperties.end(),
-                                       {vert.z, vert.x, vert.y});
+        mesh_out.vertProperties.insert(
+            mesh_out.vertProperties.end(),
+            {static_cast<float>(vert.z), static_cast<float>(vert.x),
+             static_cast<float>(vert.y)});
       else
-        mesh_out.vertProperties.insert(mesh_out.vertProperties.end(),
-                                       {vert.x, vert.y, vert.z});
+        mesh_out.vertProperties.insert(
+            mesh_out.vertProperties.end(),
+            {static_cast<float>(vert.z), static_cast<float>(vert.x),
+             static_cast<float>(vert.y)});
     }
     for (size_t j = 0; j < mesh_i->mNumFaces; ++j) {
       const aiFace face = mesh_i->mFaces[j];


### PR DESCRIPTION
When assimp was compiled with ASSIMP_DOUBLE_PRECISION=ON the ImportMesh function will not compile because of narrowing doubles to floats.
To fix it I used aiVector3f instead of aiVector3D.

This fixes https://github.com/elalish/manifold/issues/1388#issuecomment-3407964647
