### PR TITLE
Small bundler improvements.

### DIFF
--- a/bindings/wasm/esbuild.mjs
+++ b/bindings/wasm/esbuild.mjs
@@ -9,6 +9,6 @@ await esbuild.build({
   sourcemap: 'inline',
   sourcesContent: true,
   external: [
-    'node:path', 'module',
+    'node:path', 'node:url', 'module',
   ]
 });


### PR DESCRIPTION
On my local copy of manifold-vscode-extension I'm trying to bundle at the extension level, while running manifoldCAD in the webview.  The extension can see the filesystem, while a webview is blocked from doing so.

If all goes well, this approach would allow the extension as a whole to seamlessly include local files and packages (and even honour `package.json`).  However, it will still fall back to fetching modules from a CDN if needed.

This PR:

* Disables the esbuild worker by default.  We're running it in the manifoldCAD worker anyhow, so it will not block the UI thread.
* Does some defensive coding to infer the local path whether running in CommonJS (`__dirname`) or ES Module (`import.meta.dirname` or `import.meta.url`) mode within node.