### PR TITLE
Require explicit imports in/of manifoldCAD

### DIFF
--- a/bindings/wasm/esbuild.mjs
+++ b/bindings/wasm/esbuild.mjs
@@ -7,7 +7,7 @@ await esbuild.build({
   format: 'esm',
   target: 'esnext',
   sourcemap: 'inline',
-  sourcesContent: true,
+  sourcesContent: false,
   external: [
     'node:path', 'node:url', 'module',
   ]

--- a/bindings/wasm/examples/vite.config.js
+++ b/bindings/wasm/examples/vite.config.js
@@ -20,6 +20,10 @@ export default defineConfig({
         src: '../dist/manifoldCAD.d.ts',
         dest: './',  // Targets are relative to 'dist'.
       },
+      {
+        src: '../types/globalDefaults.d.ts',
+        dest: './',
+      },
       // If 'dist/manifold-encapsulated-types.d.ts' and
       // 'dist/manifold-global-types.d.ts' are missing, the web editor can't
       // load them, and type validation won't work for our core modules.

--- a/bindings/wasm/lib/bundler.ts
+++ b/bindings/wasm/lib/bundler.ts
@@ -119,7 +119,10 @@ export const esbuildManifoldPlugin = (options: BundlerOptions = {}):
       if (args.path.match(/^https?:\/\//)) return null;
 
       // Is this a manifoldCAD context import?
-      const pluginData = {toplevel: args.importer === options.filename};
+      const pluginData = {
+        toplevel:
+            args.importer === options.filename || args.importer === '<stdin>'
+      };
       if (args.path.match(ManifoldCADExportMatch)) {
         return {namespace: 'manifold-cad-globals', path: args.path, pluginData};
       }
@@ -166,12 +169,9 @@ export const esbuildManifoldPlugin = (options: BundlerOptions = {}):
         {filter: /.*/, namespace: 'manifold-cad-globals'},
         (args): esbuild.OnLoadResult => {
           // This is a string replace.
-
-          let globals = `{..._manifold_cad_globals, isManifoldCAD: () => true}`;
-          if (args?.pluginData?.toplevel) {
-            globals = `{..._manifold_cad_top_level}`;
-          }
-
+          const globals = args.pluginData?.toplevel ?
+              '_manifold_cad_top_level' :
+              '_manifold_cad_library';
           return {
             // Type hinting isn't necessary.  Only esbuild will see the swap,
             // and it doesn't do type validation.

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -58,16 +58,23 @@
     "lib/manifoldCAD.js",
     "lib/manifoldCAD.d.ts",
     "types/manifoldCAD.d.ts",
+    "types/globalDefaults.d.ts",
     "dist/manifoldCAD.d.ts",
     "dist/worker.bundled.js"
   ],
   "exports": {
-    ".": "./manifold.js",
-    "./manifold.wasm": "./manifold.wasm",
-    "./lib/worker.bundled.js": "./dist/worker.bundled.js",
+    "./manifoldCAD": {
+      "import": "./lib/manifoldCAD.js",
+      "types": "./dist/manifoldCAD.d.ts"
+    },
+    "./manifoldCAD.d.ts": "./dist/manifoldCAD.d.ts",
+    "./lib/worker.bundled.js": {
+      "import": "./dist/worker.bundled.js",
+      "types": "./lib/worker.js"
+    },
     "./lib/*": "./lib/*",
-    "./manifoldCAD": "./lib/manifoldCAD.js",
-    "./manifoldCAD.d.ts": "./dist/manifoldCAD.d.ts"
+    "./manifold.wasm": "./manifold.wasm",
+    ".": "./manifold.js"
   },
   "typings": "manifold.d.ts",
   "types": "manifold.d.ts",

--- a/bindings/wasm/test/examples/animated-gears.mjs
+++ b/bindings/wasm/test/examples/animated-gears.mjs
@@ -1,6 +1,7 @@
 // Demonstrate using a library.
 
 import {involuteGear2d} from './Involute Gear Library';
+import {GLTFNode, getGLTFNodes} from 'manifold-3d/manifoldCAD';
 
 const gear1teeth = 12;
 const gear2teeth = 15;

--- a/bindings/wasm/test/examples/auger.mjs
+++ b/bindings/wasm/test/examples/auger.mjs
@@ -3,6 +3,7 @@ const beadRadius = 2;
 const height = 40;
 const twist = 90;
 
+import {CrossSection, Manifold, setMinCircularEdgeLength} from 'manifold-3d/manifoldCAD';
 const {revolve, sphere, union, extrude} = Manifold;
 const {circle} = CrossSection;
 setMinCircularEdgeLength(0.1);

--- a/bindings/wasm/test/examples/gyroid-module.mjs
+++ b/bindings/wasm/test/examples/gyroid-module.mjs
@@ -2,6 +2,8 @@
 // https://www.thingiverse.com/thing:25477. This sample demonstrates the
 // use of a Signed Distance Function (SDF) to create smooth, complex
 // manifolds.
+
+import {Manifold, GLTFNode, getGLTFNodes} from 'manifold-3d/manifoldCAD';
 import {vec3} from 'gl-matrix';
 
 // number of modules along pyramid edge (use 1 for print orientation)

--- a/bindings/wasm/test/examples/heart.mjs
+++ b/bindings/wasm/test/examples/heart.mjs
@@ -3,6 +3,9 @@
 // https://www.thingiverse.com/thing:6190
 // It also demonstrates the use of setMorph to animate a warping function.
 
+import {Manifold, GLTFNode, setMorphStart} from 'manifold-3d/manifoldCAD';
+
+
 const func = (v) => {
   const x2 = v[0] * v[0];
   const y2 = v[1] * v[1];

--- a/bindings/wasm/test/examples/intro.mjs
+++ b/bindings/wasm/test/examples/intro.mjs
@@ -4,7 +4,10 @@
 // respectively. Type "module." to see the static API - these functions
 // can also be used bare. Use console.log() to print output (lower-right).
 // This editor defines Z as up and units of mm.
+
+import {Manifold} from 'manifold-3d/manifoldCAD';
 const {cube, sphere} = Manifold;
+
 const box = cube([100, 100, 100], true);
 const ball = sphere(60, 100);
 

--- a/bindings/wasm/test/examples/menger-sponge.mjs
+++ b/bindings/wasm/test/examples/menger-sponge.mjs
@@ -1,5 +1,7 @@
 // This example demonstrates how symbolic perturbation correctly creates
 // holes even though the subtracted objects are exactly coplanar.
+
+import {Manifold, GLTFNode} from 'manifold-3d/manifoldCAD';
 import {vec2} from 'gl-matrix';
 
 function fractal(holes, hole, w, position, depth, maxDepth) {

--- a/bindings/wasm/test/examples/rounded-frame.mjs
+++ b/bindings/wasm/test/examples/rounded-frame.mjs
@@ -1,7 +1,11 @@
 // Demonstrates how at 90-degree intersections, the sphere and cylinder
 // facets match up perfectly, for any choice of global resolution
-
 // parameters.
+
+import {
+  Manifold, GLTFNode, getGLTFNodes,
+  setMinCircularAngle, setMinCircularEdgeLength
+} from 'manifold-3d/manifoldCAD';
 const {sphere, cylinder, union, cube} = Manifold;
 
 function roundedFrame(edgeLength, radius, circularSegments = 0) {

--- a/bindings/wasm/test/examples/scallop.mjs
+++ b/bindings/wasm/test/examples/scallop.mjs
@@ -2,6 +2,8 @@
 // smooth() and refine(), see more details at:
 // https://elalish.blogspot.com/2022/03/smoothing-triangle-meshes.html
 
+import {Manifold, Mesh, GLTFNode} from 'manifold-3d/manifoldCAD';
+
 const height = 10;
 const radius = 30;
 const offset = 20;

--- a/bindings/wasm/test/examples/stretchy-bracelet.mjs
+++ b/bindings/wasm/test/examples/stretchy-bracelet.mjs
@@ -1,5 +1,7 @@
 // Recreates Stretchy Bracelet by Emmett Lalish:
 // https://www.thingiverse.com/thing:13505
+
+import {Manifold} from 'manifold-3d/manifoldCAD';
 import {vec2} from 'gl-matrix';
 
 function base(

--- a/bindings/wasm/test/examples/tetrahedron-puzzle.mjs
+++ b/bindings/wasm/test/examples/tetrahedron-puzzle.mjs
@@ -4,6 +4,8 @@
 // assemblies. Based on the screw puzzle by George Hart:
 // https://www.thingiverse.com/thing:186372
 
+import {Manifold, GLTFNode, getGLTFNodes, setMaterial} from 'manifold-3d/manifoldCAD';
+
 const edgeLength = 50;  // Length of each edge of the overall tetrahedron.
 const gap = 0.2;  // Spacing between the two halves to allow sliding.
 const nDivisions = 50;  // Divisions (both ways) in the screw surface.

--- a/bindings/wasm/test/examples/torus-knot.mjs
+++ b/bindings/wasm/test/examples/torus-knot.mjs
@@ -4,6 +4,8 @@
 // an example of using the warp() method, thus avoiding any direct
 // handling of triangles.
 
+import {Manifold, CrossSection, getCircularSegments} from 'manifold-3d/manifoldCAD';
+
 // The number of times the thread passes through the donut hole.
 const p = 1;
 // The number of times the thread circles the donut.

--- a/bindings/wasm/test/examples/voronoi.mjs
+++ b/bindings/wasm/test/examples/voronoi.mjs
@@ -1,5 +1,7 @@
 // Generate an organic looking Voronoi pattern.
 
+import {CrossSection} from 'manifold-3d/manifoldCAD';
+
 // When run through manifoldcad.org or the `manifold-cad` CLI,
 // imported npm packages will automatically be retrieved from
 // a content delivery network (Such as jsDelivr or esm.sh) and

--- a/bindings/wasm/test/import.test.ts
+++ b/bindings/wasm/test/import.test.ts
@@ -19,7 +19,6 @@ import {resolve} from 'node:path';
 import {afterEach, beforeEach, expect, suite, test, vi} from 'vitest';
 
 import {bundleFile} from '../lib/bundler.ts';
-import * as scenebuilder from '../lib/scene-builder';
 import * as worker from '../lib/worker.ts';
 
 const countVertices = (doc: Document) => {
@@ -83,12 +82,13 @@ suite('From a string, the worker will', () => {
     expect(countVertices(result)).toBeGreaterThan(0);
   });
 
-  test('Build even if missing a top-level manifoldCAD import', async () => {
-    const filename =
-        resolve(import.meta.dirname, './fixtures/importUnitSphere.mjs');
+  test('Fails if missing a top-level manifoldCAD import', async () => {
+    const filename = resolve(
+        import.meta.dirname, './fixtures/unitSphereNoManifoldImport.mjs');
     const code = await readFile(filename, 'utf-8');
-    const result = await worker.evaluate(code, {filename});
-    expect(countVertices(result)).toBeGreaterThan(0);
+    const ev = async () => await worker.evaluate(code, {filename});
+    await expect(ev()).rejects.toThrowError(
+        /Import it by adding.*manifold-3d\/manifoldCAD/);
   });
 
   test('Have a specific error when missing gl-matrix', async () => {
@@ -166,12 +166,13 @@ suite('From the filesystem, the worker will', () => {
     expect(countVertices(result)).toBeGreaterThan(0);
   });
 
-  test('Build even if missing a top-level manifoldCAD import', async () => {
-    const filename =
-        resolve(import.meta.dirname, './fixtures/importUnitSphere.mjs');
+  test('Fail if missing a top-level manifoldCAD import', async () => {
+    const filename = resolve(
+        import.meta.dirname, './fixtures/unitSphereNoManifoldImport.mjs');
     const bundle = await bundleFile(filename);
     const ev = async () => await worker.evaluate(bundle, {doNotBundle: true});
-    await expect(ev()).resolves.toBeInstanceOf(Document);
+    await expect(ev()).rejects.toThrowError(
+        /Import it by adding.*manifold-3d\/manifoldCAD/);
   });
 
   test('Bundle npm imports from a CDN', async () => {

--- a/bindings/wasm/types/globalDefaults.d.ts
+++ b/bindings/wasm/types/globalDefaults.d.ts
@@ -1,0 +1,35 @@
+// Copyright 2025 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The globalDefaults object is shared between a manifoldCAD script and the
+ * scene builder.
+ *
+ * It can be used to set parameters elsewhere in ManifoldCAD.  For example, the
+ * GLTF exporter will look for animation type and framerate.
+ *
+ * It is only accessable as a global object, by a top level script evaluated by
+ * the worker.  Libraries will not have access to it.
+ *
+ * See 'Tetrahedron Puzzle' for an example.
+ */
+export declare const globalDefaults: {
+  roughness: number,
+  metallic: number,
+  baseColorFactor: [number, number, number],
+  alpha: number,
+  unlit: boolean,
+  animationLength: number,
+  animationMode: 'loop'|'ping-pong';
+}

--- a/bindings/wasm/types/manifoldCAD.d.ts
+++ b/bindings/wasm/types/manifoldCAD.d.ts
@@ -44,16 +44,6 @@ export declare class GLTFMaterial {
   name?: string;
 }
 
-export declare const globalDefaults: {
-  roughness: number,
-  metallic: number,
-  baseColorFactor: [number, number, number],
-  alpha: number,
-  unlit: boolean,
-  animationLength: number,
-  animationMode: 'loop'|'ping-pong';
-}
-
 /**
  * Returns a shallow copy of the input manifold with the given material
  * properties applied. They will be carried along through operations.
@@ -61,8 +51,8 @@ export declare const globalDefaults: {
  * @param manifold The input object.
  * @param material A set of material properties to apply to this manifold.
  */
-export declare function setMaterial(manifold: Manifold, material: GLTFMaterial):
-    Manifold;
+export declare function setMaterial(
+    manifold: Manifold, material: GLTFMaterial): Manifold;
 
 /**
  * Apply a morphing animation to the input manifold. Specify the start


### PR DESCRIPTION
One last part of #1395, as per discussion over in #1397.

* Require models to explicitly import `manifold-3d/manifoldCAD`, rather than implicitly including it.
* Added a custom message if a member of `manifoldCAD` (e.g.: `Manifold` or `setMorphStart`) is mentioned in a reference error.
* Update tests and examples to match.
* Broke out `globalDefaults` into a separate dts as it still needs to be global for top level scripts.  All top-level vs top-level-import vs library-import logic is now in `lib/worker.ts`.
* Tweaked exports in `package.json`, so hopefully manifoldCAD types will be discoverable.
