### PR TITLE
Enable standard way of finding nanobind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,11 @@ option(
 )
 option(MANIFOLD_TEST "Enable testing suite" ON)
 option(MANIFOLD_PYBIND "Build python bindings" OFF)
+option(
+  MANIFOLD_PYBIND_SHARED_MANIFOLD
+  "Link Python bindings to shared Mainfold library"
+  OFF
+)
 # MANIFOLD_CBIND is only available when MANIFOLD_CROSS_SECTION is enabled
 cmake_dependent_option(
   MANIFOLD_CBIND
@@ -114,6 +119,16 @@ endif()
 
 if(TRACY_ENABLE)
   option(CMAKE_BUILD_TYPE "Build type" RelWithDebInfo)
+endif()
+
+if(MANIFOLD_PYBIND)
+  find_package(Python COMPONENTS Interpreter Development REQUIRED)
+  execute_process(
+    COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE nanobind_ROOT
+  )
+  find_package(nanobind CONFIG REQUIRED)
 endif()
 
 if(EMSCRIPTEN)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -39,7 +39,11 @@ if(MANIFOLD_PYBIND_STUBGEN)
   )
 endif()
 
-target_link_libraries(manifold3d PRIVATE manifold)
+if(MANIFOLD_PYBIND_SHARED_MANIFOLD)
+  target_link_libraries(manifold3d PUBLIC manifold)
+else()
+  target_link_libraries(manifold3d PRIVATE manifold)
+endif()
 target_compile_options(
   manifold3d
   PRIVATE ${MANIFOLD_FLAGS} -DMODULE_NAME=manifold3d


### PR DESCRIPTION
Allow using an installed manifold shared library.

closes #1404 