### PR TITLE
Correct CLI and add tests.

### DIFF
--- a/bindings/wasm/.gitignore
+++ b/bindings/wasm/.gitignore
@@ -7,3 +7,4 @@ lib/*.d.ts
 lib/*.d.ts.map
 dist/
 coverage/
+test/results

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -34,7 +34,7 @@ Please see our usage [examples](https://github.com/elalish/manifold/tree/master/
 
 ## Command Line Interface
 
-ManifoldCAD now has a [command line interface](./bin/manifold-cad).  It can be run directly as `./bin/manifold-cad`, or via npx: `npx manifold-cad`.
+ManifoldCAD has a [command line interface](./bin/manifold-cad).  It can be run directly as `./bin/manifold-cad`.  It can also be run via `npx`.  If Manifold is not already present, use `npx manifold-3d manifold-cad` or `npx manifold-3d`.  If Manifold is already installed, `npx manifold-cad` will suffice.
 
 ```
 Usage: manifold-cad [options] <infile.js> <outfile>

--- a/bindings/wasm/bin/manifold-cad
+++ b/bindings/wasm/bin/manifold-cad
@@ -18,11 +18,10 @@ import {extname} from 'node:path';
 
 import {Command} from 'commander';
 
-import {bundleFile} from '../lib/bundle.js';
+import {bundleFile} from '../lib/bundler.js';
 import {Export3MF} from '../lib/export-3mf.js';
 import {ExportGLTF} from '../lib/export-gltf.js';
 import * as worker from '../lib/worker.js';
-import {BundlerError,EvaluatorError} from '../lib/error.js';
 
 const exporters = [
   new Export3MF(),

--- a/bindings/wasm/lib/bundler.ts
+++ b/bindings/wasm/lib/bundler.ts
@@ -100,7 +100,8 @@ export const esbuildManifoldPlugin = (options: BundlerOptions = {}):
       (async () => {
         const {resolve, dirname} = await import('node:path');
         const {fileURLToPath} = await import('node:url');
-        const dir = __dirname ?? import.meta?.dirname ??
+        const dir = ('string' == typeof __dirname && __dirname) ||
+            ('string' == typeof import.meta?.dirname && import.meta.dirname) ||
             dirname(fileURLToPath(import.meta.url));
         manifoldCADExportPath = resolve(dir, './manifoldCAD.ts');
       })();

--- a/bindings/wasm/test/cli.test.ts
+++ b/bindings/wasm/test/cli.test.ts
@@ -1,0 +1,46 @@
+// Copyright 2025 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {exec as execSync} from 'child_process';
+import {glob} from 'glob';
+import * as fs from 'node:fs/promises';
+import * as path from 'path';
+import {promisify} from 'util';
+import {beforeAll, expect, suite, test} from 'vitest';
+
+const exec = promisify(execSync);
+
+const resultPath = path.resolve(import.meta.dirname, './results/cli/')
+
+beforeAll(async () => {
+  await fs.mkdir(resultPath, {recursive: true});
+});
+
+const execCLI =
+    async (infile: string, outfile: string = `${resultPath}/${infile}.glb`) => {
+  const cmd = [
+    '../bin/manifold-cad', `"./fixtures/${infile}"`, `"${outfile}"`
+  ].join(' ');
+  return await exec(cmd, {cwd: import.meta.dirname});
+};
+
+suite('When executed, the CLI will', () => {
+  test('Successfully build a known-good model', async () => {
+    await expect(execCLI('unitSphere.mjs')).resolves.toBeDefined();
+  });
+
+  test('Fail to build a known-bad model', async () => {
+    await expect(execCLI('unitSphereNoManifoldImport.mjs')).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
  * `bundle` -> `bundler`
  * Simple smoke tests
     * CLI should succeed or fail on known good/bad fixtures.
     * `manifold-cad` is directly called via `exec` in the hope of achieving a realistic result.
  * Documentation updated wrt `npx`:
     * If a package is not installed,  `npx package command` abbreviates to `npx package`.[^1]
     * If a package _is_ installed, `npx package command` also abbreviates to `npx command`.

Fixes #1424.

[^1]: Today I learned.