### PR TITLE
updated examples

### DIFF
--- a/bindings/wasm/examples/editor-examples.js
+++ b/bindings/wasm/examples/editor-examples.js
@@ -1,6 +1,6 @@
 import auger from '../test/examples/auger.mjs?raw';
 import gearBearing from '../test/examples/gear-bearing.ts?raw';
-import gyroidModule from '../test/examples/gyroid-module.mjs?raw';
+import gyroidModule from '../test/examples/gyroid-module.ts?raw';
 import heart from '../test/examples/heart.mjs?raw';
 import intro from '../test/examples/intro.mjs?raw';
 import involuteGearLibrary from '../test/examples/involute-gear-library.ts?raw';

--- a/bindings/wasm/test/examples/gyroid-module.ts
+++ b/bindings/wasm/test/examples/gyroid-module.ts
@@ -3,8 +3,7 @@
 // use of a Signed Distance Function (SDF) to create smooth, complex
 // manifolds.
 
-import {Manifold, GLTFNode, getGLTFNodes} from 'manifold-3d/manifoldCAD';
-import {vec3} from 'gl-matrix';
+import {Box, getGLTFNodes, GLTFNode, Manifold} from 'manifold-3d/manifoldCAD';
 
 // number of modules along pyramid edge (use 1 for print orientation)
 const m = 4;
@@ -26,23 +25,21 @@ function gyroid(p) {
 function gyroidOffset(level) {
   const period = 2 * pi;
   const box = {
-    min: vec3.fromValues(-period, -period, -period),
-    max: vec3.fromValues(period, period, period)
-  };
-  return Manifold.levelSet(gyroid, box, period / n, level)
-      .scale(size / period);
+    min: [-period, -period, -period],
+    max: [period, period, period]
+  } as Box;
+  return Manifold.levelSet(gyroid, box, period / n, level).scale(size / period);
 };
 
 function rhombicDodecahedron() {
   const box = Manifold.cube([1, 1, 2], true).scale(size * Math.sqrt(2));
-  const result =
-      box.rotate([90, 45, 0]).intersect(box.rotate([90, 45, 90]));
+  const result = box.rotate([90, 45, 0]).intersect(box.rotate([90, 45, 90]));
   return result.intersect(box.rotate([0, 0, 45]));
 }
 
 const gyroidModule = rhombicDodecahedron()
-                          .intersect(gyroidOffset(-0.4))
-                          .subtract(gyroidOffset(0.4));
+                         .intersect(gyroidOffset(-0.4))
+                         .subtract(gyroidOffset(0.4));
 
 if (m > 1) {
   for (let i = 0; i < m; ++i) {
@@ -50,11 +47,9 @@ if (m > 1) {
       for (let k = j; k < m; ++k) {
         const node = new GLTFNode();
         node.manifold = gyroidModule;
-        node.translation =
-            [(k + i - j) * size, (k - i) * size, (-j) * size];
+        node.translation = [(k + i - j) * size, (k - i) * size, (-j) * size];
         node.material = {
-          baseColorFactor:
-              [(k + i - j + 1) / m, (k - i + 1) / m, (j + 1) / m]
+          baseColorFactor: [(k + i - j + 1) / m, (k - i + 1) / m, (j + 1) / m]
         };
       }
     }

--- a/bindings/wasm/test/examples/intro.mjs
+++ b/bindings/wasm/test/examples/intro.mjs
@@ -27,11 +27,9 @@ export default result;
 // This means it will work equally well offline once loaded.
 // Consider installing it (icon in the search bar) for easy access.
 
-// See the script drop-down above ("Intro") for usage examples. The
-// gl-matrix package from npm is automatically imported for convenience -
-// its API is available in the top-level glMatrix object.
+// See the script drop-down above ("Intro") for usage examples.
 
 // Use GLTFNode for disjoint manifolds rather than compose(), as this will
 // keep them better organized in the GLB. This will also allow you to
-// specify material properties, and even vertex colors via
+// specify animation, material properties, and even vertex colors via
 // setProperties(). See Tetrahedron Puzzle example.

--- a/bindings/wasm/test/examples/menger-sponge.mjs
+++ b/bindings/wasm/test/examples/menger-sponge.mjs
@@ -1,8 +1,7 @@
 // This example demonstrates how symbolic perturbation correctly creates
 // holes even though the subtracted objects are exactly coplanar.
 
-import {Manifold, GLTFNode} from 'manifold-3d/manifoldCAD';
-import {vec2} from 'gl-matrix';
+import {GLTFNode, Manifold} from 'manifold-3d/manifoldCAD';
 
 function fractal(holes, hole, w, position, depth, maxDepth) {
   w /= 3;
@@ -10,15 +9,13 @@ function fractal(holes, hole, w, position, depth, maxDepth) {
       hole.scale([w, w, 1.0]).translate([position[0], position[1], 0.0]));
   if (depth == maxDepth) return;
   const offsets = [
-    vec2.fromValues(-w, -w), vec2.fromValues(-w, 0.0),
-    vec2.fromValues(-w, w), vec2.fromValues(0.0, w),
-    vec2.fromValues(w, w), vec2.fromValues(w, 0.0),
-    vec2.fromValues(w, -w), vec2.fromValues(0.0, -w)
+    [-w, -w], [-w, 0.0], [-w, w], [0.0, w], [w, w], [w, 0.0], [w, -w], [0.0, -w]
   ];
-  for (let offset of offsets)
-    fractal(
-        holes, hole, w, vec2.add(offset, position, offset), depth + 1,
-        maxDepth);
+  for (let offset of offsets) {
+    offset[0] += position[0];
+    offset[1] += position[1];
+    fractal(holes, hole, w, offset, depth + 1, maxDepth);
+  }
 }
 
 function mengerSponge(n) {
@@ -44,11 +41,14 @@ const posColors = (newProp, pos) => {
 };
 
 const result = mengerSponge(3)
-                    .trimByPlane([1, 1, 1], 0)
-                    .setProperties(3, posColors)
-                    .scale(100);
+                   .trimByPlane([1, 1, 1], 0)
+                   .setProperties(3, posColors)
+                   .scale(100);
 
 const node = new GLTFNode();
 node.manifold = result;
-node.material = {baseColorFactor: [1, 1, 1], attributes: ['COLOR_0']};
+node.material = {
+  baseColorFactor: [1, 1, 1],
+  attributes: ['COLOR_0']
+};
 export default node;

--- a/bindings/wasm/test/examples/stretchy-bracelet.mjs
+++ b/bindings/wasm/test/examples/stretchy-bracelet.mjs
@@ -2,11 +2,16 @@
 // https://www.thingiverse.com/thing:13505
 
 import {Manifold} from 'manifold-3d/manifoldCAD';
-import {vec2} from 'gl-matrix';
+
+function rotate2D(point, angleRad) {
+  const cosA = Math.cos(angleRad);
+  const sinA = Math.sin(angleRad);
+  return [point[0] * cosA - point[1] * sinA, point[0] * sinA + point[1] * cosA];
+}
 
 function base(
-    width, radius, decorRadius, twistRadius, nDecor, innerRadius,
-    outerRadius, cut, nCut, nDivision) {
+    width, radius, decorRadius, twistRadius, nDecor, innerRadius, outerRadius,
+    cut, nCut, nDivision) {
   let b = Manifold.cylinder(width, radius + twistRadius / 2);
   const circle = [];
   const dPhiDeg = 180 / nDivision;
@@ -24,18 +29,16 @@ function base(
   const stretch = [];
   const dPhiRad = 2 * Math.PI / nCut;
 
-  const o = vec2.fromValues(0, 0);
-  const p0 = vec2.fromValues(outerRadius, 0);
-  const p1 = vec2.fromValues(innerRadius, -cut);
-  const p2 = vec2.fromValues(innerRadius, cut);
+  const p0 = [outerRadius, 0];
+  const p1 = [innerRadius, -cut];
+  const p2 = [innerRadius, cut];
   for (let i = 0; i < nCut; ++i) {
-    stretch.push(vec2.rotate([0, 0], p0, o, dPhiRad * i));
-    stretch.push(vec2.rotate([0, 0], p1, o, dPhiRad * i));
-    stretch.push(vec2.rotate([0, 0], p2, o, dPhiRad * i));
-    stretch.push(vec2.rotate([0, 0], p0, o, dPhiRad * i));
+    stretch.push(rotate2D(p0, dPhiRad * i));
+    stretch.push(rotate2D(p1, dPhiRad * i));
+    stretch.push(rotate2D(p2, dPhiRad * i));
+    stretch.push(rotate2D(p0, dPhiRad * i));
   }
-  const result =
-      Manifold.intersection(Manifold.extrude(stretch, width), b);
+  const result = Manifold.intersection(Manifold.extrude(stretch, width), b);
   return result;
 }
 
@@ -56,8 +59,7 @@ function stretchyBracelet(
           cut - adjThickness, nCut, nDivision),
       base(
           width, radius - thickness, decorRadius, twistRadius, nDecor,
-          innerRadius, outerRadius + 3 * adjThickness, cut, nCut,
-          nDivision));
+          innerRadius, outerRadius + 3 * adjThickness, cut, nCut, nDivision));
 }
 
 const result = stretchyBracelet();


### PR DESCRIPTION
I removed gl-matrix - I was tired of the underlines and we weren't really using it for much anyway. I can't believe there isn't a decent small vector library for TS - I blame JS's lack of operator overloading. 

Now there aren't any more red underlines on ManifoldCAD.org. 