### PR TITLE
Remove CLA requirement from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,19 +3,6 @@
 We'd love to accept your patches and contributions to this project. There are
 just a few small guidelines you need to follow.
 
-## Contributor License Agreement
-
-Contributions to this project must be accompanied by a Contributor License
-Agreement (CLA). You (or your employer) retain the copyright to your
-contribution; this simply gives us permission to use and redistribute your
-contributions as part of the project. Head over to
-<https://cla.developers.google.com/> to see your current agreements on file or
-to sign a new one.
-
-You generally only need to submit a CLA once, so if you've already submitted one
-(even if it was for a different project), you probably don't need to do it
-again.
-
 ## Code Reviews
 
 All submissions, including submissions by project members, require review. We


### PR DESCRIPTION
AFAICT it isn't needed. https://github.com/elalish/manifold/pull/149 added the text, but I don't see any CLA-bot comments on https://github.com/elalish/manifold/pull/220 from a couple months later or from any recent PRs like
https://github.com/elalish/manifold/pull/1439