### PR TITLE
Stop using deprecated macos-13 images in CI

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-14-intel: x86-64
+        # macos-15-intel: x86-64
         # macos-15: arm64
-        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2025, macos-14-intel, macos-15]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2025, macos-15-intel, macos-15]
     steps:
       - run: |
           git config --global submodule.fetchJobs 8

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -280,9 +280,9 @@ jobs:
       matrix:
         parallelization: [OFF, ON]
         shared: [OFF, ON]
-        # macos-14-intel: intel
+        # macos-15-intel: intel
         # macos-latest: arm
-        os: [macos-14-intel, macos-latest]
+        os: [macos-15-intel, macos-latest]
     runs-on: ${{matrix.os}}
     steps:
     - name: Install common dependencies


### PR DESCRIPTION
I made the smallest bump possible. Could also jump to macos-15-intel at the appropriate places, but I figured you may be trying to keep this running for (barely-)older OS versions.

https://github.com/actions/runner-images/issues/13046