### PR TITLE
Compatability fixes.

### DIFF
--- a/bindings/wasm/lib/export-3mf.ts
+++ b/bindings/wasm/lib/export-3mf.ts
@@ -79,8 +79,7 @@ const defaultHeader: Header = {
  * @returns A blob containing the converted model.
  */
 export async function toArrayBuffer(
-    doc: GLTFTransform.Document,
-    header: Header = {}): Promise<Uint8Array<ArrayBufferLike>> {
+    doc: GLTFTransform.Document, header: Header = {}): Promise<ArrayBuffer> {
   const to3mf = {
     meshes: [],
     components: [],
@@ -196,11 +195,11 @@ export async function toArrayBuffer(
   files[fileForContentTypes.name] = strToU8(fileForContentTypes.content);
   files[fileForRelThumbnail.name] = strToU8(fileForRelThumbnail.content);
   const zipFile = zipSync(files);
-  return zipFile;
+  return zipFile.buffer as ArrayBuffer;
 };
 
 export async function toBlob(doc: GLTFTransform.Document, header: Header = {}) {
-  const buffer: Uint8Array<ArrayBufferLike> = await toArrayBuffer(doc, header);
-  return new Blob(
-      [buffer as Uint8Array<ArrayBuffer>], {type: supportedFormat.mimetype});
+  const buffer =
+      new Uint8Array(await toArrayBuffer(doc, header) as ArrayBuffer);
+  return new Blob([buffer], {type: supportedFormat.mimetype});
 }

--- a/bindings/wasm/lib/export-model.ts
+++ b/bindings/wasm/lib/export-model.ts
@@ -44,8 +44,7 @@ interface Format {
 
 export interface Exporter {
   exportFormats: Array<Format>;
-  toArrayBuffer:
-      (doc: GLTFTransform.Document) => Promise<Uint8Array<ArrayBufferLike>>;
+  toArrayBuffer: (doc: GLTFTransform.Document) => Promise<ArrayBuffer>;
 }
 
 /**
@@ -118,7 +117,7 @@ export async function toBlob(
     doc: GLTFTransform.Document, identifier: string): Promise<Blob> {
   const format = getFormat(identifier);
   const buffer = await getExporter(identifier).toArrayBuffer(doc);
-  return new Blob([buffer as Uint8Array<ArrayBuffer>], {type: format.mimetype});
+  return new Blob([buffer], {type: format.mimetype});
 }
 
 /**
@@ -130,8 +129,7 @@ export async function toBlob(
  * @group Low Level Functions
  */
 export async function toArrayBuffer(
-    doc: GLTFTransform.Document,
-    identifier: string): Promise<Uint8Array<ArrayBufferLike>> {
+    doc: GLTFTransform.Document, identifier: string): Promise<ArrayBuffer> {
   return await getExporter(identifier).toArrayBuffer(doc);
 }
 
@@ -149,5 +147,5 @@ export async function writeFile(
 
   const exporter = getExporter(options.mimetype ?? filename);
   const buffer = await exporter.toArrayBuffer(doc);
-  return await fs.writeFile(filename, buffer);
+  return await fs.writeFile(filename, new Uint8Array(buffer));
 }

--- a/bindings/wasm/lib/gltf-io.ts
+++ b/bindings/wasm/lib/gltf-io.ts
@@ -450,10 +450,10 @@ const getIO = (): GLTFTransform.PlatformIO => {
 };
 
 export async function toArrayBuffer(doc: GLTFTransform.Document):
-    Promise<Uint8Array<ArrayBufferLike>> {
-  return await getIO().writeBinary(doc) as Uint8Array<ArrayBufferLike>;
+    Promise<ArrayBuffer> {
+  return (await getIO().writeBinary(doc)).buffer as ArrayBuffer;
 }
 
-export async function fromArrayBuffer(buffer: Uint8Array<ArrayBufferLike>) {
-  return await getIO().readBinary(buffer);
+export async function fromArrayBuffer(buffer: ArrayBuffer) {
+  return await getIO().readBinary(new Uint8Array(buffer));
 }

--- a/bindings/wasm/lib/import-model.ts
+++ b/bindings/wasm/lib/import-model.ts
@@ -48,8 +48,7 @@ interface Format {
 
 export interface Importer {
   importFormats: Array<Format>;
-  fromArrayBuffer:
-      (buffer: Uint8Array<ArrayBufferLike>) => Promise<GLTFTransform.Document>;
+  fromArrayBuffer: (buffer: ArrayBuffer) => Promise<GLTFTransform.Document>;
 }
 
 /**
@@ -259,7 +258,7 @@ export async function fetchModel(
   const importer = getImporter(options.mimetype ?? uri);
   const response = await fetch(uri);
   const blob = await response.blob();
-  return await importer.fromArrayBuffer(await blob.bytes());
+  return await importer.fromArrayBuffer(await blob.arrayBuffer());
 }
 
 /**
@@ -270,7 +269,7 @@ export async function fetchModel(
 export async function fromBlob(
     blob: Blob, options: ImportOptions = {}): Promise<GLTFTransform.Document> {
   const importer = getImporter(options.mimetype ?? blob.type);
-  return await importer.fromArrayBuffer(await blob.bytes());
+  return await importer.fromArrayBuffer(await blob.arrayBuffer());
 }
 
 /**
@@ -279,8 +278,7 @@ export async function fromBlob(
  * @group Low Level Functions
  **/
 export async function fromArrayBuffer(
-    buffer: Uint8Array<ArrayBufferLike>,
-    identifier: string): Promise<GLTFTransform.Document> {
+    buffer: ArrayBuffer, identifier: string): Promise<GLTFTransform.Document> {
   const importer = getImporter(identifier);
   return await importer.fromArrayBuffer(buffer);
 }
@@ -299,7 +297,7 @@ export async function readFile(filename: string, options: ImportOptions = {}) {
 
   const path =
       filename.startsWith('file:') ? fileURLToPath(filename) : filename;
-  const buffer = await fs.readFile(path);
+  const buffer = (await fs.readFile(path)).buffer as ArrayBuffer;
   return await importer.fromArrayBuffer(buffer);
 }
 


### PR DESCRIPTION
Fixes #1448

@Loosetooth caught this.

`ArrayBuffer().bytes()` is not in wide use, and fails on Chromium browsers.

While fixing this, it made sense to adjust the import/export interfaces to use high level ArrayBuffer objects.  Implementations should be allowed to create their own data views.

Tested on Chrome and Firefox.