### PR TITLE
Explicitly check for text changes before converting an example into a new script.

### DIFF
--- a/bindings/wasm/examples/editor.js
+++ b/bindings/wasm/examples/editor.js
@@ -387,11 +387,6 @@ async function createEditor() {
   }
 
   editor.onDidChangeModelContent(e => {
-    // monaco-editor-auto-typings loaded types.  Do nothing.
-    if (autoTypings.isResolving && e.changes.isFlush) {
-      return;
-    }
-
     // The user switched models.
     if (switching) {
       switching = false;
@@ -402,11 +397,16 @@ async function createEditor() {
 
     // The user edited an example.
     // Copy it into a new script.
-    if (isExample) {
+    if (isExample && exampleFunctions.get(scriptName) != editor.getValue()) {
       const cursor = editor.getPosition();
       newItem(editor.getValue()).button.click();
       editor.setPosition(cursor);
       runButton.disabled = false;
+      return;
+    }
+
+    // monaco-editor-auto-typings loaded types.  Do nothing.
+    if (autoTypings.isResolving && e.changes.isFlush) {
       return;
     }
 


### PR DESCRIPTION
> The Voronoi example still (or regression?) has that behavior where once it downloads the modules in the background and the red underlines go away, it also turns it into a new script as though it was edited.

Yep, this is a regression.  Dunno why I didn't do this check the first time around.