### PR TITLE
Add Otterplans to users in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here is an incomplete list of our users, whose integrations may be anywhere from
 | [Valence 3D](https://apps.apple.com/us/app/valence-3d/id6450967410?mt=8&platform=ipad) | [bitbybit.dev](https://bitbybit.dev) | [PythonOpenSCAD](https://github.com/owebeeone/pythonopenscad) |
 | [Conversation](https://james-bern.github.io/conversation.html) | [AnchorSCAD](https://github.com/owebeeone/anchorscad-core) | [Dactyl Web Configurator](https://github.com/rianadon/dactyl-configurator) |
 | [Arcol](https://arcol.io) | [Bento3D](https://bento3d.design) | [SKÅPA](https://skapa.build) |
-| [Cadova](https://github.com/tomasf/Cadova) | [BREP.io](https://github.com/mmiscool/BREP)  |
+| [Cadova](https://github.com/tomasf/Cadova) | [BREP.io](https://github.com/mmiscool/BREP)  | [Otterplans](https://otterplans.com) |
 ### Bindings & Packages
 
 Manifold has bindings to many other languages, some maintained in this repository, and others elsewhere. It can also be built in C++ via [vcpkg](https://github.com/microsoft/vcpkg.git).


### PR DESCRIPTION
I've added my side project ([otterplans](https://otterplans.com)) to the table. It's an app that can generate woodworking plans and instructions based on the users' dimensions. Your library made it possible ! If I ever get dollars with this project, I'll forward some to you for support and gratitude.