### PR TITLE
Deprecate `Manifold.compose()` in WASM bindings.

### DIFF
--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -623,14 +623,6 @@ Module.setup = function() {
     return Module._ReserveIDs(n);
   };
 
-  Module.Manifold.compose = function(manifolds) {
-    const vec = new Module.Vector_manifold();
-    toVec(vec, manifolds);
-    const result = Module._manifoldCompose(vec);
-    vec.delete();
-    return result;
-  };
-
   function manifoldBatchbool(name) {
     return function(...args) {
       if (args.length == 1) args = args[0];
@@ -643,6 +635,10 @@ Module.setup = function() {
   }
 
   Module.Manifold.union = manifoldBatchbool('Union');
+  // Aliasing compose to union.
+  // Native compose has some issues, and is deprecated.
+  Module.Manifold.compose = Module.Manifold.union;
+
   Module.Manifold.difference = manifoldBatchbool('Difference');
   Module.Manifold.intersection = manifoldBatchbool('Intersection');
 

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -889,6 +889,7 @@ export class Manifold {
    * overlapping results. It is the inverse operation of Decompose().
    *
    * @param manifolds A list of Manifolds to lazy-union together.
+   * @deprecated Please use {@link add} or {@link union} instead.
    */
   static compose(manifolds: readonly Manifold[]): Manifold;
 

--- a/bindings/wasm/manifold.d.ts
+++ b/bindings/wasm/manifold.d.ts
@@ -834,6 +834,7 @@ export declare class Manifold {
    * overlapping results. It is the inverse operation of Decompose().
    *
    * @param manifolds A list of Manifolds to lazy-union together.
+   * @deprecated Please use {@link add} or {@link union} instead.
    */
   static compose(manifolds: readonly Manifold[]): Manifold;
 

--- a/bindings/wasm/test/examples/import-manifold.ts
+++ b/bindings/wasm/test/examples/import-manifold.ts
@@ -9,7 +9,7 @@
 // or combined like any other manifoldCAD object.
 
 import {importManifold, Manifold} from 'manifold-3d/manifoldCAD';
-const {compose} = Manifold;
+const {union} = Manifold;
 
 const csg = async () => {
   // glTF (.glb or .gltf) models have a defined scale of 1 unit to 1 metre.  On
@@ -53,7 +53,7 @@ const csg = async () => {
     const {max: [rightside]} = acc.boundingBox();
     const {min: [leftside]} = cur.boundingBox();
 
-    return compose([
+    return union([
       acc.translate([-rightside, 0, 0]),
       cur.translate([-leftside + 20 * metres, 0, 0])
     ]);

--- a/bindings/wasm/test/examples/intro.mjs
+++ b/bindings/wasm/test/examples/intro.mjs
@@ -29,7 +29,8 @@ export default result;
 
 // See the script drop-down above ("Intro") for usage examples.
 
-// Use GLTFNode for disjoint manifolds rather than compose(), as this will
-// keep them better organized in the GLB. This will also allow you to
-// specify animation, material properties, and even vertex colors via
-// setProperties(). See Tetrahedron Puzzle example.
+// Use GLTFNode for disjoint manifolds (rather than union() or add()),
+// as this will keep them better organized in the GLB. This will also
+// allow you to specify animation, material properties, and even vertex
+// colors via setProperties().
+// See Tetrahedron Puzzle example.

--- a/bindings/wasm/test/examples/menger-sponge.mjs
+++ b/bindings/wasm/test/examples/menger-sponge.mjs
@@ -23,7 +23,7 @@ function mengerSponge(n) {
   const holes = [];
   fractal(holes, result, 1.0, [0.0, 0.0], 1, n);
 
-  const hole = Manifold.compose(holes);
+  const hole = Manifold.union(holes);
 
   result = Manifold.difference([
     result,


### PR DESCRIPTION

 - [x] Update examples.
 - [x] Mark compose as deprecated in docs.
 - [x] Alias compose to union in JS api.

See #1464