### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -15,7 +15,6 @@ jobs:
     - uses: DoozyX/clang-format-lint-action@v0.20
       with:
         source: '.'
-        exclude: '*/third_party'
         extensions: 'h,cpp,js,ts,html'
         clangFormatVersion: 20
     - uses: actions/setup-python@v5

--- a/cmake/manifoldDeps.cmake
+++ b/cmake/manifoldDeps.cmake
@@ -122,8 +122,8 @@ if(MANIFOLD_CROSS_SECTION)
     FetchContent_Declare(
       Clipper2
       GIT_REPOSITORY https://github.com/AngusJohnson/Clipper2.git
-      # Jun 15, 2025
-      GIT_TAG 11ef6ca611a732e7d75fcc1b4abe89387523fa64
+      # Mar 05, 2026
+      GIT_TAG 46f639177fe418f9689e8ddb74f08a870c71f5b4
       GIT_PROGRESS TRUE
       SOURCE_SUBDIR
       CPP
@@ -192,12 +192,12 @@ if(MANIFOLD_PYBIND)
     FetchContent_Declare(
       nanobind
       GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-      GIT_TAG v2.5.0
+      GIT_TAG v2.12.0
       GIT_PROGRESS TRUE
       EXCLUDE_FROM_ALL
     )
     FetchContent_MakeAvailable(nanobind)
-    set(NB_VERSION 2.2.0)
+    set(NB_VERSION 2.12.0)
   endif()
 
   if(NB_VERSION VERSION_LESS 2.1.0)
@@ -218,7 +218,7 @@ if(MANIFOLD_TEST)
     FetchContent_Declare(
       googletest
       GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG v1.14.0
+      GIT_TAG v1.17.0
       GIT_SHALLOW TRUE
       GIT_PROGRESS TRUE
       FIND_PACKAGE_ARGS NAMES GTest gtest

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "clipper2-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1749977025,
-        "narHash": "sha256-nkajY57+6xDjL8fJWK31Y75Id6Go3pwtAOVgat3sf5E=",
+        "lastModified": 1772678590,
+        "narHash": "sha256-4z40oGEZ5DI6M2Nw7HzyBSk+gJkn6HgAg6lAukKFueE=",
         "owner": "AngusJohnson",
         "repo": "Clipper2",
-        "rev": "11ef6ca611a732e7d75fcc1b4abe89387523fa64",
+        "rev": "46f639177fe418f9689e8ddb74f08a870c71f5b4",
         "type": "github"
       },
       "original": {
@@ -34,47 +34,13 @@
         "type": "github"
       }
     },
-    "gersemi-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1729957417,
-        "narHash": "sha256-t9W27lwNKRFAraynAGEawFb1qCW9/b3RCm/jeb9zJXg=",
-        "owner": "BlankSpruce",
-        "repo": "gersemi",
-        "rev": "27f279333ec3308f9910d53fe4dd69d622e4bc55",
-        "type": "github"
-      },
-      "original": {
-        "owner": "BlankSpruce",
-        "ref": "0.17.0",
-        "repo": "gersemi",
-        "type": "github"
-      }
-    },
-    "gtest-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1690989893,
-        "narHash": "sha256-t0RchAHTJbuI5YW4uyBPykTvcjy90JW9AOPNjIhwh6U=",
-        "owner": "google",
-        "repo": "googletest",
-        "rev": "f8d7d77c06936315286eb55f8de22cd23c188571",
-        "type": "github"
-      },
-      "original": {
-        "owner": "google",
-        "ref": "v1.14.0",
-        "repo": "googletest",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739214665,
-        "narHash": "sha256-26L8VAu3/1YRxS8MHgBOyOM8xALdo6N0I04PgorE7UM=",
+        "lastModified": 1772624091,
+        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64e75cd44acf21c7933d61d7721e812eac1b5a0a",
+        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
         "type": "github"
       },
       "original": {
@@ -83,31 +49,11 @@
         "type": "indirect"
       }
     },
-    "onetbb-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1730395391,
-        "narHash": "sha256-XOlC1+rf65oEGKDba9N561NuFo1YJhn3Q1CTGtvkn7A=",
-        "owner": "oneapi-src",
-        "repo": "oneTBB",
-        "rev": "0c0ff192a2304e114bc9e6557582dfba101360ff",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oneapi-src",
-        "ref": "v2022.0.0",
-        "repo": "oneTBB",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "clipper2-src": "clipper2-src",
         "flake-utils": "flake-utils",
-        "gersemi-src": "gersemi-src",
-        "gtest-src": "gtest-src",
-        "nixpkgs": "nixpkgs",
-        "onetbb-src": "onetbb-src"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,30 +1,15 @@
 {
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
-  inputs.gtest-src = {
-    url = "github:google/googletest/v1.14.0";
-    flake = false;
-  };
   inputs.clipper2-src = {
     url = "github:AngusJohnson/Clipper2";
-    flake = false;
-  };
-  inputs.onetbb-src = {
-    url = "github:oneapi-src/oneTBB/v2022.0.0";
-    flake = false;
-  };
-  inputs.gersemi-src = {
-    url = "github:BlankSpruce/gersemi/0.17.0";
     flake = false;
   };
   outputs =
     { self
     , nixpkgs
     , flake-utils
-    , gtest-src
     , clipper2-src
-    , onetbb-src
-    , gersemi-src
     }:
     flake-utils.lib.eachDefaultSystem
       (system:
@@ -34,23 +19,13 @@
           inherit system;
           overlays = [
             (final: prev: {
-              clipper2 = prev.clipper2.overrideAttrs (_: {
+              clipper2 = prev.clipper2.overrideAttrs (_: rec {
                 version = clipper2-src.rev;
                 src = clipper2-src;
+                sourceRoot = "source/CPP";
               });
             })
           ];
-        };
-        gersemi = with pkgs.python3Packages; buildPythonPackage {
-          pname = "gersemi";
-          version = "0.17.0";
-          src = gersemi-src;
-          propagatedBuildInputs = [
-            appdirs
-            lark
-            pyyaml
-          ];
-          doCheck = true;
         };
         manifold =
           { parallel ? true }: pkgs.stdenv.mkDerivation {
@@ -63,7 +38,7 @@
               (python3.withPackages
                 (ps: with ps; [ nanobind trimesh pytest ]))
               gtest
-            ]) ++ (if parallel then [ pkgs.tbb_2021_11 ] else [ ]);
+            ]) ++ (if parallel then [ pkgs.onetbb ] else [ ]);
             buildInputs = with pkgs; [
               clipper2
             ];
@@ -84,7 +59,7 @@
           name = "manifold-js";
           version = manifold-version;
           src = self;
-          nativeBuildInputs = (with pkgs; [ cmake python39 ]);
+          nativeBuildInputs = (with pkgs; [ cmake python3 ]);
           buildInputs = [ pkgs.nodejs ];
           configurePhase = ''
             cp -r ${clipper2-src} clipper2
@@ -97,8 +72,8 @@
             -DMANIFOLD_STRICT=ON \
             -DMANIFOLD_PAR=${if parallel then "ON" else "OFF"} \
             -DMANIFOLD_USE_BUILTIN_TBB=${if parallel then "ON" else "OFF"} \
-            -DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=${gtest-src} \
-            -DFETCHCONTENT_SOURCE_DIR_TBB=${onetbb-src} \
+            -DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=${pkgs.gtest.src} \
+            -DFETCHCONTENT_SOURCE_DIR_TBB=${pkgs.onetbb.src} \
             -DFETCHCONTENT_SOURCE_DIR_CLIPPER2=../clipper2 ..
           '';
           buildPhase = ''
@@ -132,7 +107,7 @@
             version = manifold-version;
             src = self;
             propagatedBuildInputs = [ numpy ];
-            buildInputs = with pkgs; [ clipper2 tbb_2021_11 ];
+            buildInputs = with pkgs; [ clipper2 onetbb ];
             nativeBuildInputs = with pkgs; [
               cmake
               ninja
@@ -160,26 +135,27 @@
               pytest
 
               # formatting tools
-              gersemi
               black
 
               # misc
               matplotlib
             ]))
 
+            gersemi
             ninja
             cmake
-            tbb_2021_11
+            onetbb
             gtest
             assimp
             clipper2
             pkg-config
 
             # useful tools
-            clang-tools_18
             clang_18
+            llvmPackages_18.clang-tools
             llvmPackages_18.bintools
             tracy
+            f3d
           ];
         };
       }


### PR DESCRIPTION
Some dependencies are getting old, e.g., clipper2 had bug fixes recently.

Tracy 0.13.1 is released, but I am waiting for https://github.com/NixOS/nixpkgs/pull/476455 before updating tracy. The primary user of tracy is me, so that should not affect anyone.