### PR TITLE
Add transformation methods to GLTFNodes.

### DIFF
--- a/bindings/wasm/documents/contributing.md
+++ b/bindings/wasm/documents/contributing.md
@@ -27,6 +27,8 @@ The ManifoldCAD User Guide is generated from the declaration files present in `t
 
 TypeDoc reflections (comments) flagged as `@internal` will _not_ be visible in the User Guide, but will be present in the Developer Guide.  Reflections tagged as `@hidden` will not be visible in either guide.
 
+The `@privateRemarks` section of a comment will be visible in the Developer Guide but not the User Guide.
+
 ### WASM Bindings
 
 The manifold library itself is documented in three files:

--- a/bindings/wasm/lib/animation.ts
+++ b/bindings/wasm/lib/animation.ts
@@ -114,7 +114,7 @@ export function cleanup() {
 export function addMotion(
     doc: Document, type: 'translation'|'rotation'|'scale', node: BaseGLTFNode,
     out: Node): Vec3|null {
-  const motion = node[type];
+  const motion = node[type === 'scale' ? 'scaling' : type];
   if (motion == null) {
     return null;
   }

--- a/bindings/wasm/lib/math.ts
+++ b/bindings/wasm/lib/math.ts
@@ -17,14 +17,15 @@
  * @packageDocumentation
  */
 
-import type {Vec3} from '../manifold.d.ts';
+import type {Mat4, Vec3} from '../manifold.d.ts';
 
-const {cos, sin, PI} = Math;
+const {atan2, cos, sin, sqrt, PI} = Math;
 const TAU = PI * 2;
 
 export type Vec4 = [number, number, number, number];
+export type Quat = Vec4;
 
-export function euler2quat(rotation: Vec3): Vec4 {
+export function euler2quat(rotation: Vec3): Quat {
   // https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles#Source_code
   const cr = cos(rotation[2] * 0.5 * TAU / 360);
   const sr = sin(rotation[2] * 0.5 * TAU / 360);
@@ -33,11 +34,155 @@ export function euler2quat(rotation: Vec3): Vec4 {
   const cy = cos(rotation[0] * 0.5 * TAU / 360);
   const sy = sin(rotation[0] * 0.5 * TAU / 360);
 
-  const q: Vec4 = [0, 0, 0, 0];
+  const q: Quat = [0, 0, 0, 0];
   q[3] = cr * cp * cy + sr * sp * sy;
   q[2] = sr * cp * cy - cr * sp * sy;
   q[1] = cr * sp * cy + sr * cp * sy;
   q[0] = cr * cp * sy - sr * sp * cy;
 
   return q;
-};
+}
+
+export function quat2euler(quat: Quat): Vec3 {
+  // https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles#Source_code
+  // https://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/
+  const rotation: Vec3 = [0, 0, 0];
+
+  const sr_cp = 2 * (quat[0] * quat[1] + quat[2] * quat[3]);
+  const cr_cp = 1 - 2 * (quat[1] * quat[1] + quat[2] * quat[2]);
+  rotation[0] = atan2(sr_cp, cr_cp) * 360 / TAU;
+
+  const sp = sqrt(1 + 2 * (quat[0] * quat[1] - quat[2] * quat[3]));
+  const cp = sqrt(1 - 2 * (quat[0] * quat[2] - quat[1] * quat[3]));
+  rotation[1] = atan2(sp, cp) * 360 / TAU;
+
+  const sy_cp = 2 * (quat[0] * quat[3] + quat[1] * quat[2]);
+  const cy_cp = 1 - 2 * (quat[2] * quat[2] + quat[3] * quat[3]);
+  rotation[2] = atan2(sy_cp, cy_cp) * 360 / TAU;
+
+  return rotation;
+}
+
+/**
+ * Return an identity matrix.
+ *
+ * @group Transformation Matrix
+ */
+export function identityMat4(): Mat4 {
+  // Column major storage, so, uh, just imagine it flipped around a little.
+  // No that it matters for an identity matrix; they look the same in both
+  // row major and column major order.
+
+  // clang-format off
+  return [
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1,
+  ];
+  // clang-format on
+}
+
+// Get storage location for a matrix element.
+const idx4 = (col: number, row: number) => col * 4 + row;
+
+function lengthVec3(v: Vec3) {
+  const [x, y, z] = v;
+  return sqrt(x ** 2 + y ** 2 + z ** 2);
+}
+
+function normalizeVec3(v: Vec3) {
+  const result = [0, 0, 0];
+  const len = lengthVec3(v);
+  result[0] = v[0] / len;
+  result[1] = v[1] / len;
+  result[2] = v[2] / len;
+  return result;
+}
+
+/**
+ * Multiply two matrices.
+ * @group Transformation Matrix
+ */
+export function multiplyMat4(a: Mat4, b: Mat4): Mat4 {
+  const range = [...Array(4).keys()];
+  const result = identityMat4();
+  for (const i of range) {
+    for (const j of range) {
+      for (const k of range) {
+        result[idx4(i, j)] += a[idx4(i, k)] * b[idx4(k, j)];
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Create a rotation matrix, in ZYX order.
+ * @group Transformation Matrix
+ */
+export function rotateMat4(x: number, y: number, z: number): Mat4 {
+  const result = identityMat4();
+  const sx = sin(x * TAU / 360);
+  const cx = cos(x * TAU / 360);
+  const sy = sin(y * TAU / 360);
+  const cy = cos(y * TAU / 360);
+  const sz = sin(z * TAU / 360);
+  const cz = cos(z * TAU / 360);
+
+  result[idx4(0, 0)] = sz * cy;
+  result[idx4(1, 0)] = cz * sy * sx - sz * cx;
+  result[idx4(2, 0)] = cz * sy * cx + sz * sx;
+
+  result[idx4(0, 1)] = sz * cy;
+  result[idx4(1, 1)] = sz * sy * sx + cz * cx;
+  result[idx4(2, 1)] = cz * sy * cx + sz * sx;
+
+  result[idx4(0, 2)] = -sy;
+  result[idx4(1, 2)] = cz * sy;
+  result[idx4(2, 2)] = cz * cy;
+
+  return result
+}
+
+/**
+ * Create a translation matrix.
+ * @group Transformation Matrix
+ */
+export function translateMat4(x: number, y: number, z: number): Mat4 {
+  const result = identityMat4();
+  result[idx4(3, 0)] = x
+  result[idx4(3, 1)] = y
+  result[idx4(3, 2)] = z
+  return result
+}
+
+/**
+ * Create a scaling matrix.
+ * @group Transformation Matrix
+ */
+export function scaleMat4(x: number, y: number, z: number): Mat4 {
+  const result = identityMat4();
+  result[idx4(0, 0)] = x
+  result[idx4(1, 1)] = y
+  result[idx4(2, 2)] = z
+  return result
+}
+
+/**
+ * Create a reflection matrix.
+ * @param normal The normal vector of the plane to be mirrored over
+ * @group Transformation Matrix
+ */
+
+export function mirrorMat4(normal: Vec3): Mat4 {
+  const result = identityMat4();
+  const n = normalizeVec3(normal);
+  const range = [...Array(3).keys()];
+  for (const j of range) {
+    for (const i of range) {
+      result[idx4(i, j)] -= 2 * n[i] * n[j];
+    }
+  }
+  return result;
+}

--- a/bindings/wasm/test/examples/heart.mjs
+++ b/bindings/wasm/test/examples/heart.mjs
@@ -48,7 +48,7 @@ const scale = 100 / (box.max[0] - box.min[0]);
 setMorphStart(ball, func);
 const node = new GLTFNode();
 node.manifold = ball;
-node.scale = [scale, scale, scale];
+node.scaling = [scale, scale, scale];
 
 setAnimationDuration(5); // seconds
 setAnimationMode('ping-pong');

--- a/bindings/wasm/typedoc.api.json
+++ b/bindings/wasm/typedoc.api.json
@@ -24,5 +24,13 @@
     "includeGroups": true,
   },
   "groupReferencesByType": true,
-  "defaultCategory": "none"
+  "defaultCategory": "none",
+  "excludeTags": [
+    "@override",
+    "@virtual",
+    "@satisfies",
+    "@overload",
+    "@inline",
+    "@inlineType"
+  ]
 }


### PR DESCRIPTION
This PR is intended to give `GLTFNode` type objects the same transformation API as `Manifold` objects.

This involves a breaking change: The current `scale` property has been renamed `scaling` in order to accommodate a `scale` method.

- [x] Add transformation methods.
- [ ] Should throw if an animation function has already been applied.
- [ ] Documentation.
    - Note that these transformations are applied to the GLTFNode immediately, but to the model at render time.  There's no CSG tree waiting in memory.
- [ ] Call signatures must match `Manifold` objects.
- [ ] Tests.

Part of the [Villianous Task List](https://github.com/elalish/manifold/issues/1460).