### PR TITLE
Update esbuild.mjs to work with emscripten v5

### DIFF
--- a/bindings/wasm/esbuild.mjs
+++ b/bindings/wasm/esbuild.mjs
@@ -9,6 +9,6 @@ await esbuild.build({
   sourcemap: 'inline',
   sourcesContent: false,
   external: [
-    'node:path', 'node:url', 'node:fs', 'module',
+    'node:path', 'node:url', 'node:fs', 'node:module', 'module',
   ]
 });


### PR DESCRIPTION
Was setting up a fresh clone of the repo and noticed this was broken during an `npm install`. I had just installed the latest emscripten from homebrew (v5.0.0) which now emits `import("node:module")`.