### PR TITLE
Add Bracket Engineer to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Here is an incomplete list of our users, whose integrations may be anywhere from
 | [Conversation](https://james-bern.github.io/conversation.html) | [AnchorSCAD](https://github.com/owebeeone/anchorscad-core) | [Dactyl Web Configurator](https://github.com/rianadon/dactyl-configurator) |
 | [Arcol](https://arcol.io) | [Bento3D](https://bento3d.design) | [SKÅPA](https://skapa.build) |
 | [Cadova](https://github.com/tomasf/Cadova) | [BREP.io](https://github.com/mmiscool/BREP)  | [Otterplans](https://otterplans.com) |
+| [Bracket Engineer](https://bracket.engineer) | | |
+
 ### Bindings & Packages
 
 Manifold has bindings to many other languages, some maintained in this repository, and others elsewhere. It can also be built in C++ via [vcpkg](https://github.com/microsoft/vcpkg.git).


### PR DESCRIPTION
I built this site about a year ago with Manifold's Javascript library after being frustrated with the speed of OpenSCAD on the web. https://bracket.engineer

It's a power supply bracket generator which users can download and 3D print.

Not sure if it's big enough to include in the readme, so feel free to close. I really enjoy this library! 