### PR TITLE
Properly integrate manifold_test into ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,13 +224,6 @@ endif("${isSystemDir}" STREQUAL "-1")
 include(${PROJECT_SOURCE_DIR}/cmake/manifoldDeps.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/configHelper.cmake)
 
-if(WIN32)
-  # Standardize output locations so .exe and .dll files end up together.
-  # Should be right before `add_subdirectory(src)`
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-endif()
 add_subdirectory(src)
 add_subdirectory(bindings)
 if(MANIFOLD_TEST)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,7 +61,13 @@ endif()
 target_compile_options(manifold_test PRIVATE ${MANIFOLD_FLAGS})
 exportbin(manifold_test)
 
-gtest_discover_tests(manifold_test)
+if(WIN32)
+  # If you want to fix the DLL availability at build time, be my guest.
+  add_test(NAME manifold_test COMMAND manifold_test)
+else()
+  # *nix users get the tests individually broken out!
+  gtest_discover_tests(manifold_test)
+endif()
 
 if(MANIFOLD_FUZZ)
   fuzztest_setup_fuzzing_flags()


### PR DESCRIPTION
Now each test is a separate entry when running `ctest`

except Windows. What a PITA.