### PR TITLE
Minor fixes.

### DIFF
--- a/bindings/wasm/lib/gltf-io.ts
+++ b/bindings/wasm/lib/gltf-io.ts
@@ -254,8 +254,11 @@ export function writeMesh(
     doc: GLTFTransform.Document, manifoldMesh: ManifoldMesh,
     id2properties: Map<number, Properties>,
     EXT_mesh_manifold: boolean = true): GLTFTransform.Mesh {
-  const mesh = doc.createMesh();
+  if (doc.getRoot().listBuffers().length === 0) {
+    doc.createBuffer();
+  }
 
+  const mesh = doc.createMesh();
   writePrimitiveAttributes(doc, mesh, manifoldMesh, id2properties);
   if (EXT_mesh_manifold) {
     writeExtMeshManifoldIndices(doc, mesh, manifoldMesh);

--- a/bindings/wasm/lib/gltf-node.ts
+++ b/bindings/wasm/lib/gltf-node.ts
@@ -286,7 +286,7 @@ export class VisualizationGLTFNode extends BaseGLTFNode {
  * allows it to be included in the final exported file, complete with
  * transformations.
  *
- * > [!NOTICE]
+ * > [!NOTE]
  * >
  * > CrossSections are not -- and can never be -- manifold.  That means
  * > some exporters (like `.3mf`) will just skip over them entirely.


### PR DESCRIPTION
Two small things I noticed reviewing the site:

  * NOTICE -> NOTE in documentation ([for reference](https://typedoc.org/example/documents/Markdown_Showcase.html#alerts))
  * `writeMesh()` once again defensively checks for the presence of a buffer, and creates it if necessary.  I refactored this out in #1507, and while it doesn't affect ManifoldCAD, it *did* affect the model-viewer example.