### PR TITLE
Fix failing npm publish.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
         run_id: ${{github.event.workflow_run.id}}
         # do not download from old run
         check_artifacts: true 
-        name: wasm
+        name: wasmpublic
         path: ./public
 
     - name: Deploy to Github Pages

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -179,8 +179,16 @@ jobs:
       uses: actions/upload-artifact@v4
       if: github.event_name == 'push' && matrix.parallelization == 'OFF' && matrix.debug == 'OFF'
       with:
-        name: wasm
+        name: wasmpublic
         path: bindings/wasm/public/
+        retention-days: 90
+        overwrite: true
+    - name: Upload complete wasm build.
+      uses: actions/upload-artifact@v4
+      if: github.event_name == 'push' && matrix.parallelization == 'OFF' && matrix.debug == 'OFF'
+      with:
+        name: wasm
+        path: bindings/wasm/
         retention-days: 90
         overwrite: true
 

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Publish to npm
       run: |
         cd ./bindings/wasm/
-        npm install
+        npm ci
         npm publish
       env:
         NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
I got clever with the site build, and didn't look at the `publish_npm` pipeline.  This fixes it by uploading two copies of the build. `wasmpublic` contains the editor, examples, and documentation ready for deployment to github pages.  `wasm` contains the entire `bindings/wasm` tree, ready for publication to npm.

Fixes #1548.