### PR TITLE
Fixes different verbose levels

### DIFF
--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -523,9 +523,8 @@ struct ExecutionParams {
   bool cleanupTriangles = true;
   /// Verbose level:
   /// - 0 for no verbose output
-  /// - 1 for verbose output for the Boolean, including timing info and vector
-  /// sizes.
-  /// - 2 for verbose output with triangulator action as well.
+  /// - 1 for Boolean debug dumps on failures and invalid intermediate meshes.
+  /// - 2 for Boolean timing and size statistics, plus triangulator action.
   int verbose = 0;
 };
 /** @} */

--- a/src/boolean3.cpp
+++ b/src/boolean3.cpp
@@ -521,7 +521,7 @@ Boolean3::Boolean3(const Manifold::Impl& inP, const Manifold::Impl& inQ,
 #ifdef MANIFOLD_DEBUG
   intersections.Stop();
 
-  if (ManifoldParams().verbose) {
+  if (ManifoldParams().verbose >= 2) {
     intersections.Print("Intersections");
   }
 #endif

--- a/src/boolean3.h
+++ b/src/boolean3.h
@@ -17,7 +17,7 @@
 
 #ifdef MANIFOLD_DEBUG
 #define PRINT(msg) \
-  if (ManifoldParams().verbose > 0) std::cout << msg << std::endl;
+  if (ManifoldParams().verbose >= 2) std::cout << msg << std::endl;
 #else
 #define PRINT(msg)
 #endif

--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -882,7 +882,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
 
 #ifdef MANIFOLD_DEBUG
   sort.Stop();
-  if (ManifoldParams().verbose) {
+  if (ManifoldParams().verbose >= 2) {
     assemble.Print("Assembly");
     triangulate.Print("Triangulation");
     simplify.Print("Simplification");

--- a/src/edge_op.cpp
+++ b/src/edge_op.cpp
@@ -276,7 +276,7 @@ void Manifold::Impl::CollapseShortEdges(int firstNewVert) {
   });
 
 #ifdef MANIFOLD_DEBUG
-  if (ManifoldParams().verbose > 0 && numFlagged > 0) {
+  if (ManifoldParams().verbose >= 2 && numFlagged > 0) {
     std::cout << "collapsed " << numFlagged << " short edges" << std::endl;
   }
 #endif
@@ -306,7 +306,7 @@ void Manifold::Impl::CollapseColinearEdges(int firstNewVert) {
     if (numFlagged == 0) break;
 
 #ifdef MANIFOLD_DEBUG
-    if (ManifoldParams().verbose > 0 && numFlagged > 0) {
+    if (ManifoldParams().verbose >= 2 && numFlagged > 0) {
       std::cout << "collapsed " << numFlagged << " colinear edges" << std::endl;
     }
 #endif
@@ -337,7 +337,7 @@ void Manifold::Impl::SwapDegenerates(int firstNewVert) {
   });
 
 #ifdef MANIFOLD_DEBUG
-  if (ManifoldParams().verbose > 0 && numFlagged > 0) {
+  if (ManifoldParams().verbose >= 2 && numFlagged > 0) {
     std::cout << "swapped " << numFlagged << " edges" << std::endl;
   }
 #endif
@@ -962,7 +962,7 @@ void Manifold::Impl::DedupeEdges() {
     if (numFlagged == 0) break;
 
 #ifdef MANIFOLD_DEBUG
-    if (ManifoldParams().verbose > 0) {
+    if (ManifoldParams().verbose >= 2) {
       std::cout << "found " << numFlagged << " duplicate edges to split"
                 << std::endl;
     }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -41,11 +41,12 @@ void print_usage() {
   printf("  -e: Export OBJ models of samples\n");
   printf("  -c: Enable self-intersection checks (needs MANIFOLD_DEBUG)\n");
   printf(
-      "  -v: Enable verbose output (only works if compiled with MANIFOLD_DEBUG "
-      "flag)\n");
+      "  -v: Enable Boolean debug dumps (only works if compiled with "
+      "MANIFOLD_DEBUG flag)\n");
   printf(
-      "  -vv: Enable extra verbose output for triangulator (only works if "
-      "compiled with MANIFOLD_DEBUG flag)\n");
+      "  -vv: Enable Boolean stats and extra triangulator output (only works "
+      "if compiled with MANIFOLD_DEBUG "
+      "flag)\n");
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
fixes #1107
This separates the Boolean debug output levels so verbose=1 and verbose=2 no longer behave almost the same.
Changes
This PR moves routine Boolean stats output to verbose >= 2, including:

intersection timing
assembly / triangulation / simplification / sorting timing
vertex / triangle count summaries
edge cleanup statistics
It keeps failure-oriented debug output at verbose > 0, including:
operand dumps from SimpleBoolean()
self-intersection triangle dumps
It also updates the verbose-level documentation and test CLI help text to match the intended behavior.

Resulting behavior
verbose = 0: no verbose output
verbose = 1: Boolean debug dumps for failures / invalid intermediate meshes
verbose = 2: Boolean stats/timing output plus triangulator verbose output


