### PR TITLE
Add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior, ideally a minimal code snippet:
+
+```cpp
+// C++ example
+```
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+What actually happened, including any error messages or incorrect output.
+
+**Environment**
+- OS: [e.g. Ubuntu 22.04, macOS 13, Windows 11]
+- Manifold version: [e.g. 2.5.0 or commit hash]
+- Build type: [e.g. C++, Python (manifold3d), JS/WASM (manifold-3d)]
+- Compiler/Runtime version: [e.g. GCC 12, Python 3.11, Node 20]
+
+**Additional context**
+Add any other context, screenshots, or sample meshes that help explain the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I often need to [...] but currently there's no way to do it.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen, including any proposed API changes or additions.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or workarounds you've considered.
+
+**Additional context**
+Add any other context, references, or examples that support the feature request.


### PR DESCRIPTION
## Summary

- Add The Standard Isssue template


## Fixed Issue
- Closed #1557
## Changes To Suggest

- Add `.github/ISSUE_TEMPLATE/bug_report.md` with fields for reproduction steps, expected/actual behavior, and environment details (OS, Manifold version, build type).
- Add`.github/ISSUE_TEMPLATE/feature_request.md` with fields for problem description, proposed solution, and alternatives considered.

## Motivation

Without issue templates, bug reports and feature requests often lack the information needed to reproduce or evaluate them. These templates guide contributors to provide the right context upfront, reducing back-and-forth.
