### PR TITLE
Add a Standard Pull Request Template to Improve Contribution Workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Description
+
+<!-- Briefly describe what this PR does and why. -->
+
+## Related Issues
+
+<!-- Link any related issues: "Fixes #123", "Closes #456", "Related to #789" -->
+
+## Changes
+
+<!-- List the key changes made in this PR. -->
+
+-
+
+## Testing
+
+<!-- Describe how you tested this change. -->
+
+- [ ] Existing tests pass (`cmake --build build && ctest --test-dir build`)
+- [ ] New tests added for new functionality
+- [ ] Manually verified with relevant examples
+
+## Checklist
+
+- [ ] Code follows the project style (ran `clang-format`)
+- [ ] Updated bindings (Python/JS) if C++ API changed
+- [ ] Updated documentation/comments where needed


### PR DESCRIPTION
## Summary

Adds a standard PR template to .github/PULL_REQUEST_TEMPLATE.md to help
contributors provide consistent, useful context when opening pull requests.

The template includes sections for description, related issues, key changes,
testing steps (with the project's CMake/ctest commands), and a checklist
covering code style, bindings updates, and documentation.


## Fixed issue 
- Closed  #1558 