### PR TITLE
feat(manifoldcad): implement human-readable units

### DIFF
--- a/bindings/wasm/lib/scene-builder.ts
+++ b/bindings/wasm/lib/scene-builder.ts
@@ -37,6 +37,7 @@ import {BaseGLTFNode, CrossSectionGLTFNode, GLTFNode, VisualizationGLTFNode} fro
 import {cleanup as cleanupImport} from './import-model.ts';
 import {cleanup as cleanupMaterial, getBackupMaterial, getCachedMaterial} from './material.ts';
 import {euler2quat} from './math.ts';
+import {formatArea, formatLength, formatVolume} from './util.ts';
 import {getManifoldModuleSync} from './wasm.ts';
 
 export {getAnimationDuration, getAnimationFPS, getAnimationMode, setAnimationDuration, setAnimationFPS, setAnimationMode, setMorphEnd, setMorphStart} from './animation.ts';
@@ -66,34 +67,6 @@ function log(...args: any[]) {
   if (typeof self !== 'undefined' && self.console) {
     self.console.log(...args);
   }
-}
-
-function formatLength(mm: number): string {
-  if (Math.abs(mm) >= 10000) {
-    return `${
-        (mm / 1000).toLocaleString(undefined, {maximumFractionDigits: 2})} m`;
-  }
-  return `${mm.toLocaleString(undefined, {maximumFractionDigits: 2})} mm`;
-}
-
-function formatArea(mm2: number): string {
-  const cm2 = mm2 / 100;
-  if (Math.abs(cm2) >= 10000) {
-    return `${(cm2 / 10000).toLocaleString(undefined, {
-      maximumFractionDigits: 2
-    })} m^2`;
-  }
-  return `${cm2.toLocaleString(undefined, {maximumFractionDigits: 2})} cm^2`;
-}
-
-function formatVolume(mm3: number): string {
-  const cm3 = mm3 / 1000;
-  if (Math.abs(cm3) >= 1_000_000) {
-    return `${(cm3 / 1_000_000).toLocaleString(undefined, {
-      maximumFractionDigits: 2
-    })} m^3`;
-  }
-  return `${cm3.toLocaleString(undefined, {maximumFractionDigits: 2})} cm^3`;
 }
 
 function applyTransformation(

--- a/bindings/wasm/lib/util.ts
+++ b/bindings/wasm/lib/util.ts
@@ -141,3 +141,31 @@ export const findExtension =
 export const findMimeType =
     (mimetype: string, list: Array<{mimetype: string}>) =>
         list.find(entry => entry.mimetype === mimetype);
+
+export function formatLength(mm: number): string {
+  if (Math.abs(mm) >= 10000) {
+    return `${
+        (mm / 1000).toLocaleString(undefined, {maximumFractionDigits: 2})} m`;
+  }
+  return `${mm.toLocaleString(undefined, {maximumFractionDigits: 2})} mm`;
+}
+
+export function formatArea(mm2: number): string {
+  const cm2 = mm2 / 100;
+  if (Math.abs(cm2) >= 10000) {
+    return `${(cm2 / 10000).toLocaleString(undefined, {
+      maximumFractionDigits: 2
+    })} m^2`;
+  }
+  return `${cm2.toLocaleString(undefined, {maximumFractionDigits: 2})} cm^2`;
+}
+
+export function formatVolume(mm3: number): string {
+  const cm3 = mm3 / 1000;
+  if (Math.abs(cm3) >= 1_000_000) {
+    return `${(cm3 / 1_000_000).toLocaleString(undefined, {
+      maximumFractionDigits: 2
+    })} m^3`;
+  }
+  return `${cm3.toLocaleString(undefined, {maximumFractionDigits: 2})} cm^3`;
+}


### PR DESCRIPTION
This PR addresses the readability of geometric data in the ManifoldCAD console by implementing dynamic unit scaling for large models.

#### Changes:

* **Centralized Formatting:** Added `formatLength`, `formatArea`, and `formatVolume` helper functions in `scene-builder.ts`.
* **Dynamic Scaling:** * **Length:** `mm` → `m` at $\ge 10,000$ mm.
* **Area:** `cm^2` → `m^2` at $\ge 10,000$ $cm^2$.
* **Volume:** `cm^3` → `m^3` at $\ge 1,000,000$ $cm^2$.


* **Precision:** Standardized to 2 decimal places with locale-aware grouping (commas).
* **Cleanup:** Removed legacy rounding math in favor of high-precision bounding box calculations and volume formatting.

Before
<img width="770" height="201" alt="image" src="https://github.com/user-attachments/assets/a976e565-71ca-4580-9361-0d6c186a149b" />

After
<img width="805" height="358" alt="image" src="https://github.com/user-attachments/assets/826cb89f-022e-43f3-87ba-3761643d6df4" />
