### PR TITLE
doc update Handling Precision Issues

### DIFF
--- a/bindings/wasm/documents/bindings.md
+++ b/bindings/wasm/documents/bindings.md
@@ -39,33 +39,6 @@ const result = box.subtract(ball);
 You must manually `delete()` each object constructed by your scripts (both `Manifold` and `CrossSection`).
 See [discussion](https://github.com/elalish/manifold/discussions/256#discussioncomment-3944287).
 
-## Handling Precision Issues
-
-> [!WARNING]
-> JavaScript uses IEEE 754 binary floating point, which means expressions like `0.1 + 0.2` evaluate to `0.30000000000000004`. Manifold intentionally follows standard floating point math and does not compensate for this in its transform pipeline.
-
-This becomes a problem when two manifolds are meant to share a face. For example, translating a cube by `[0.2, 0.2, 0.2]` with size `[0.1, 0.1, 0.1]` produces a bounding box maximum of `0.30000000000000004` instead of `0.3`. That tiny epsilon gap means an adjacent manifold at exactly `0.3` will not properly union with it.
-
-The recommended workaround is to **work in larger, integer-friendly units**:
-
-1. Scale coordinates up by a round factor (e.g., 1000) so your values are whole numbers
-2. Use `Math.round()` after any arithmetic to eliminate accumulated drift
-3. Perform all Manifold operations
-4. Scale the result back down if needed
-
-```js
-const scale = 1000;
-
-// Instead of cube([0.1, 0.1, 0.1]) translated by [0.2, 0.2, 0.2]:
-const size = Math.round(0.1 * scale);   // 100
-const offset = Math.round(0.2 * scale); // 200
-
-const { cube } = Manifold;
-const box = cube([size, size, size]).translate([offset, offset, offset]);
-```
-
-See [discussion #1135](https://github.com/elalish/manifold/discussions/1135) for more context.
-
 ## Examples
 
 See [Examples](./bindings-examples.md).

--- a/bindings/wasm/documents/tips.md
+++ b/bindings/wasm/documents/tips.md
@@ -1,0 +1,32 @@
+---
+title: Tips and Tricks
+---
+## Handling Precision Issues
+
+> [!WARNING]
+> Geometry where two manifolds are meant to share a face exactly is called **marginal geometry** and should generally be avoided. Manifold uses symbolic perturbation, which means multiple topologically valid results may be within rounding error of each other — so even small imprecisions can produce unexpected output.
+
+Two common sources of trouble:
+
+- **Floating point drift** — JavaScript uses IEEE 754 binary floating point, so `0.1 + 0.2` evaluates to `0.30000000000000004`. Manifold does not compensate for this in its transform pipeline. A bounding box maximum of `0.30000000000000004` instead of `0.3` is enough to prevent a union from closing properly.
+- **Different triangulations** — even with floating-point identical coordinates, if two coplanar faces are triangulated differently, that can also lead to gaps and slivers.
+
+Where marginal geometry is unavoidable, the recommended workaround for floating point drift is to **work in larger, integer-friendly units**:
+
+1. Scale coordinates up by a round factor (e.g., 1000) so your values are whole numbers
+2. Use `Math.round()` after any arithmetic to eliminate accumulated drift
+3. Perform all Manifold operations
+4. Scale the result back down if needed
+
+```js
+const scale = 1000;
+
+// Instead of cube([0.1, 0.1, 0.1]) translated by [0.2, 0.2, 0.2]:
+const size = Math.round(0.1 * scale);   // 100
+const offset = Math.round(0.2 * scale); // 200
+
+const { cube } = Manifold;
+const box = cube([size, size, size]).translate([offset, offset, offset]);
+```
+
+See [discussion #1135](https://github.com/elalish/manifold/discussions/1135) for more context.

--- a/bindings/wasm/types/manifoldCAD.d.ts
+++ b/bindings/wasm/types/manifoldCAD.d.ts
@@ -45,6 +45,8 @@
  *
  * {@include ../documents/using-manifoldcad.md}
  *
+ * {@include ../documents/tips.md}
+ *
  * @packageDocumentation
  * @module manifoldCAD
  */


### PR DESCRIPTION
Adds a "Handling Precision Issues" section to bindings/wasm/documents/bindings.md explaining that IEEE 754 floating point drift (e.g. 0.1 + 0.2 = 0.30000000000000004) can silently break operations like union() when adjacent manifolds fail to share a face.

Documents the recommended workaround: scale coordinates up to integer-friendly units, use Math.round() to eliminate drift, then scale back down. Includes a concrete code example and links to discussion.

reference:
https://github.com/elalish/manifold/issues/1460  ->(doc update part)
https://github.com/elalish/manifold/discussions/1135 
