### PR TITLE
docs: document degrees vs. radians in JS/TS rotation API

### DIFF
--- a/bindings/wasm/documents/tips.md
+++ b/bindings/wasm/documents/tips.md
@@ -30,3 +30,24 @@ const box = cube([size, size, size]).translate([offset, offset, offset]);
 ```
 
 See [discussion #1135](https://github.com/elalish/manifold/discussions/1135) for more context.
+
+## Degrees vs. Radians
+
+Manifold's rotation API takes **degrees**, not radians. This is a deliberate design choice: Manifold can eliminate floating point error entirely for multiples of 90°, and uses more efficient code paths when it detects such rotations.
+
+```js
+// Pass degrees directly
+box.rotate([90, 0, 0]);
+box.rotate([0, 45, 0]);
+```
+
+If your own code works in radians (e.g. when using `Math.atan2`), convert to degrees before passing to Manifold:
+
+```js
+const toDeg = (rad) => rad * (180 / Math.PI);
+
+const angle = Math.atan2(y, x); // radians
+box.rotate([0, 0, toDeg(angle)]);
+```
+
+For common angles, always prefer the exact degree value (`90`, `45`, `30`, etc.) over a computed approximation to get the precision guarantee. See [issue #1262](https://github.com/elalish/manifold/issues/1262) for a real-world example where a rotation of `-89.999999999999` instead of `-90` caused mesh cracks.


### PR DESCRIPTION


Adds a "Degrees vs. Radians" section to bindings/wasm/documents/bindings.md clarifying that Manifold's .rotate() takes degrees, not radians a deliberate design choice that eliminates floating point error entirely for multiples of 90° and enables faster code paths.

Shows a correct vs. wrong usage example (Math.PI / 2 vs. 90), and includes a helper snippet for converting from radians-based math (e.g. Math.atan2). Links to issue #1262 where passing -89.999999999999 instead of -90 caused visible mesh cracks.

Closes part of #1460.