### PR TITLE
Restore ManifoldCAD PWA paths and manifest metadata

### DIFF
--- a/bindings/wasm/examples/editor/editor.js
+++ b/bindings/wasm/examples/editor/editor.js
@@ -28,8 +28,9 @@ const CODE_START = '<code>';
 const exampleFunctions = self.examples;
 
 if (navigator.serviceWorker) {
-  navigator.serviceWorker.register(
-      '/service-worker.js', {scope: './index.html'});
+  // Resolve against the current module URL so registration works on subpaths.
+  const serviceWorkerUrl = new URL('./service-worker.js', import.meta.url);
+  navigator.serviceWorker.register(serviceWorkerUrl, {scope: './'});
 }
 
 let editor = undefined;

--- a/bindings/wasm/examples/editor/index.html
+++ b/bindings/wasm/examples/editor/index.html
@@ -15,7 +15,7 @@
   <meta property="og:image:width" content="850">
   <meta property="og:image:height" content="850">
   <link rel="shortcut icon" type="image/png" href="https://elalish.github.io/manifold/samples/models/favicon.png">
-  <link rel="manifest" href="/manifest.json">
+  <link rel="manifest" href="./manifest.json">
   <link type="text/css" href="editor.css" rel="stylesheet">
   <script type="application/ld+json">
     {

--- a/bindings/wasm/examples/editor/public/manifest.json
+++ b/bindings/wasm/examples/editor/public/manifest.json
@@ -2,22 +2,26 @@
   "name": "ManifoldCAD",
   "icons": [
     {
-      "src": "/icons/mengerSponge192.png",
+      "src": "./icons/mengerSponge192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "/icons/mengerSponge512.png",
+      "src": "./icons/mengerSponge512.png",
       "type": "image/png",
       "sizes": "512x512"
     }
   ],
-  "id": "/",
-  "start_url": "/",
+  "id": "./",
+  "start_url": "./",
   "background_color": "#FFFFFF",
+  "display_override": [
+    "window-controls-overlay",
+    "standalone"
+  ],
   "display": "standalone",
   "orientation": "landscape",
-  "scope": "/",
+  "scope": "./",
   "theme_color": "#A288B3",
   "description": "Fast, reliable, parametric solid modeling web app. Programmatic 3D design with JavaScript, inspired by and improving upon OpenSCAD & JSCAD. Demonstrates a new GPU-parallel, open-source geometry kernel: Manifold.",
   "categories": [
@@ -27,16 +31,24 @@
     "graphics",
     "productivity"
   ],
+  "protocol_handlers": [
+    {
+      "protocol": "web+manifoldcad",
+      "url": "./?open=%s"
+    }
+  ],
   "screenshots": [
     {
-      "src": "/icons/manifoldCAD.png",
+      "src": "./icons/manifoldCAD.png",
       "type": "image/png",
-      "sizes": "2906x1980"
+      "sizes": "2906x1980",
+      "form_factor": "wide"
     },
     {
-      "src": "/icons/manifoldCADonly.png",
+      "src": "./icons/manifoldCADonly.png",
       "type": "image/png",
-      "sizes": "2906x1980"
+      "sizes": "2906x1980",
+      "form_factor": "narrow"
     }
   ]
 }


### PR DESCRIPTION
This updates ManifoldCAD PWA configuration so it works reliably in local/dev and non-root hosting setups.

What changed
1. Switched PWA asset references from root-absolute paths to relative paths.
2. Updated service worker registration to use a URL resolved from the current module and a sane app scope.
3. Added screenshot form factors in the manifest so install UI checks pass on desktop.
4. Added optional manifest fields recommended by DevTools:
- protocol_handlers
- display_override

Files touched
- editor.js
- index.html
- manifest.json

Why
The previous setup assumed root deployment for manifest/service worker/icon URLs. That can break PWA behavior when served from subpaths. This change keeps behavior the same for root hosting and fixes path resolution for other environments.

Manual verification
1. Start editor locally and open http://localhost:5173/
2. DevTools → Application → Manifest
- manifest loads correctly
- screenshots show wide and narrow form factors
3. DevTools → Application → Service Workers
- service worker registers successfully
- update on reload works as expected
4. Reload once online, then offline reload confirms app shell caching behavior


