### PR TITLE
fix: implement manifold_cross_section_warp_context C binding

### DIFF
--- a/bindings/c/cross.cpp
+++ b/bindings/c/cross.cpp
@@ -194,22 +194,6 @@ ManifoldCrossSection* manifold_cross_section_warp_context(
   return to_c(new (mem) CrossSection(warped));
 }
 
-ManifoldCrossSection* manifold_cross_section_warp(
-    void* mem, ManifoldCrossSection* cs,
-    ManifoldVec2 (*fun)(double, double)) {
-  struct Ctx {
-    ManifoldVec2 (*fun)(double, double);
-  };
-  Ctx ctx = {fun};
-
-  auto thunk = [](double x, double y, void* vctx) -> ManifoldVec2 {
-    auto* ctx = static_cast<Ctx*>(vctx);
-    return ctx->fun(x, y);
-  };
-
-  return manifold_cross_section_warp_context(mem, cs, thunk, &ctx);
-}
-
 ManifoldCrossSection* manifold_cross_section_simplify(void* mem,
                                                       ManifoldCrossSection* cs,
                                                       double epsilon) {

--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -313,8 +313,6 @@ ManifoldCrossSection* manifold_cross_section_transform(void* mem,
                                                        double x1, double y1,
                                                        double x2, double y2,
                                                        double x3, double y3);
-ManifoldCrossSection* manifold_cross_section_warp(
-    void* mem, ManifoldCrossSection* cs, ManifoldVec2 (*fun)(double, double));
 ManifoldCrossSection* manifold_cross_section_warp_context(
     void* mem, ManifoldCrossSection* cs,
     ManifoldVec2 (*fun)(double, double, void*), void* ctx);


### PR DESCRIPTION
resolves #1531 

Changes:
`bindings/c/cross.cpp`
Renamed the existing context-style implementation to manifold_cross_section_warp_context that matches the header, and added the correct non-context manifold_cross_section_warp overload that takes ManifoldVec2 (*fun)(double,double) and forwards via a small thunk.

