### PR TITLE
fix: handle empty manifolds in SplitByPlane

### DIFF
--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -848,6 +848,7 @@ std::pair<Manifold, Manifold> Manifold::Split(const Manifold& cutter) const {
  */
 std::pair<Manifold, Manifold> Manifold::SplitByPlane(
     vec3 normal, double originOffset) const {
+  if (IsEmpty()) return {Manifold(), Manifold()};
   return Split(Halfspace(BoundingBox(), normal, originOffset));
 }
 

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -477,6 +477,20 @@ TEST(Boolean, Split) {
                   cube.Volume());
 }
 
+TEST(Boolean, SplitByPlaneEmpty) {
+  Manifold empty;
+  EXPECT_TRUE(empty.IsEmpty());
+  EXPECT_EQ(empty.Status(), Manifold::Error::NoError);
+
+  std::pair<Manifold, Manifold> split =
+      empty.SplitByPlane({1.0, 0.0, 0.0}, 0.0);
+
+  EXPECT_EQ(split.first.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(split.second.Status(), Manifold::Error::NoError);
+  EXPECT_TRUE(split.first.IsEmpty());
+  EXPECT_TRUE(split.second.IsEmpty());
+}
+
 TEST(Boolean, SplitByPlane) {
   Manifold cube = Manifold::Cube(vec3(2.0), true);
   cube = cube.Translate({0.0, 1.0, 0.0});


### PR DESCRIPTION
resolves #1515 

Changes:

- `src/manifold.cpp`: Added a simple early return in Manifold::SplitByPlane() for the IsEmpty() case so it doesn’t end up going through the non-finite BoundingBox() and Halfspace() path.
- `test/boolean_test.cpp`: Added a small regression test for that.