### PR TITLE
Material transparency implies doubleSided.

### DIFF
--- a/bindings/wasm/lib/material.ts
+++ b/bindings/wasm/lib/material.ts
@@ -120,14 +120,13 @@ function makeDefaultMaterial(
   }
 
   if (alpha < 1) {
-    material.setAlphaMode(GLTFTransform.Material.AlphaMode.BLEND)
-        .setDoubleSided(true);
+    material.setAlphaMode(GLTFTransform.Material.AlphaMode.BLEND);
   }
 
   return material.setRoughnessFactor(roughness)
       .setMetallicFactor(metallic)
       .setBaseColorFactor([...baseColorFactor, alpha])
-      .setDoubleSided(!!doubleSided);
+      .setDoubleSided(!!doubleSided || alpha < 1);
 }
 
 /**


### PR DESCRIPTION
Bug introduced in #1507.  The flag was intended to make doubleSided materials available for CrossSections, but failed to take alpha into account.