### PR TITLE
Make CurvatureAngles more robust to degenerate faces

### DIFF
--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -37,12 +37,24 @@ struct CurvatureAngles {
   void operator()(size_t tri) {
     vec3 edge[3];
     vec3 edgeLength(0.0);
+
+    // Checking for Degenerate Edges
     for (int i : {0, 1, 2}) {
       const int startVert = halfedge[3 * tri + i].startVert;
       const int endVert = halfedge[3 * tri + i].endVert;
       edge[i] = vertPos[endVert] - vertPos[startVert];
       edgeLength[i] = la::length(edge[i]);
+
+      if (!std::isfinite(edgeLength[i]) || edgeLength[i] == 0.0) {
+        return;
+      }
+    }
+
+    for (int i : {0, 1, 2}) {
       edge[i] /= edgeLength[i];
+
+      const int startVert = halfedge[3 * tri + i].startVert;
+      const int endVert = halfedge[3 * tri + i].endVert;
       const int neighborTri = halfedge[3 * tri + i].pairedHalfedge / 3;
       const double dihedral =
           0.25 * edgeLength[i] *
@@ -309,9 +321,13 @@ void Manifold::Impl::CalculateCurvature(int gaussianIdx, int meanIdx) {
   for_each_n(policy, countAt(0), NumVert(),
              [&vertMeanCurvature, &vertGaussianCurvature, &vertArea,
               &degree](const int vert) {
-               const double factor = degree[vert] / (6 * vertArea[vert]);
-               vertMeanCurvature[vert] *= factor;
-               vertGaussianCurvature[vert] *= factor;
+               // Degenerate vertices can have zero area, which can cause the
+               // curvature to become NaN
+               if (vertArea[vert] > 0.0) {
+                 const double factor = degree[vert] / (6.0 * vertArea[vert]);
+                 vertMeanCurvature[vert] *= factor;
+                 vertGaussianCurvature[vert] *= factor;
+               }
              });
 
   const int oldNumProp = NumProp();

--- a/test/properties_test.cpp
+++ b/test/properties_test.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "../src/impl.h"
 #include "../src/tri_dist.h"
 #include "../src/utils.h"
 #include "manifold/manifold.h"
@@ -118,6 +119,38 @@ TEST(Properties, CalculateCurvature) {
     EXPECT_NEAR(GetMaxProperty(sphereGL, meanIdx), 1, precision);
     EXPECT_NEAR(GetMinProperty(sphereGL, gaussianIdx), 0.25, 0.25 * precision);
     EXPECT_NEAR(GetMaxProperty(sphereGL, gaussianIdx), 0.25, 0.25 * precision);
+  }
+}
+
+// This test verifies that curvature calculation does not produce NaN values on
+// degenerate faces
+
+TEST(Properties, DegenerateCurvature) {
+  Manifold::Impl impl;
+
+  impl.vertPos_.resize(3);
+  impl.vertPos_[0] = vec3(0.0, 0.0, 0.0);
+  impl.vertPos_[1] = vec3(1.0, 0.0, 0.0);
+  impl.vertPos_[2] = vec3(1.0, 0.0, 0.0);
+
+  impl.halfedge_.resize(6);
+  impl.halfedge_[0] = Halfedge{0, 1, 5, 0};
+  impl.halfedge_[1] = Halfedge{1, 2, 4, 1};
+  impl.halfedge_[2] = Halfedge{2, 0, 3, 2};
+
+  impl.halfedge_[3] = Halfedge{0, 2, 2, 0};
+  impl.halfedge_[4] = Halfedge{2, 1, 1, 1};
+  impl.halfedge_[5] = Halfedge{1, 0, 0, 2};
+
+  impl.faceNormal_.resize(2);
+  impl.faceNormal_[0] = vec3(0.0, 0.0, 1.0);
+  impl.faceNormal_[1] = vec3(0.0, 0.0, 1.0);
+
+  impl.CalculateCurvature(-1, 0);
+
+  const Vec<double>& props = impl.properties_;
+  for (double x : props) {
+    EXPECT_TRUE(std::isfinite(x));
   }
 }
 


### PR DESCRIPTION
Fixes 7 in #1474. It implements a some checks for degenerate edges and faces within Curvature Angles, and creates a test case to ensure no NANs are produced when degenerate faces are inputted.