### PR TITLE
Fix meshgl merge functions returning input pointer on no-op

### DIFF
--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -548,11 +548,8 @@ ManifoldMeshGL* manifold_meshgl_copy(void* mem, ManifoldMeshGL* m) {
 
 ManifoldMeshGL* manifold_meshgl_merge(void* mem, ManifoldMeshGL* m) {
   auto duplicate = new (mem) MeshGL(*from_c(m));
-  if (duplicate->Merge()) {
-    return to_c(duplicate);
-  }
-  duplicate->~MeshGL();
-  return m;
+  duplicate->Merge();
+  return to_c(duplicate);
 }
 
 ManifoldMeshGL64* manifold_get_meshgl64(void* mem, ManifoldManifold* m) {
@@ -573,11 +570,8 @@ ManifoldMeshGL64* manifold_meshgl64_copy(void* mem, ManifoldMeshGL64* m) {
 
 ManifoldMeshGL64* manifold_meshgl64_merge(void* mem, ManifoldMeshGL64* m) {
   auto duplicate = new (mem) MeshGL64(*from_c(m));
-  if (duplicate->Merge()) {
-    return to_c(duplicate);
-  }
-  duplicate->~MeshGL64();
-  return m;
+  duplicate->Merge();
+  return to_c(duplicate);
 }
 
 size_t manifold_meshgl_num_prop(ManifoldMeshGL* m) {

--- a/test/manifoldc_test.cpp
+++ b/test/manifoldc_test.cpp
@@ -466,3 +466,61 @@ TEST(CBIND, triangulation) {
   manifold_delete_triangulation(triangulation);
   free(tri_verts);
 }
+
+TEST(CBIND, meshgl_merge_returns_mem) {
+  // Create a cube and get its meshgl (which already has merge vectors).
+  ManifoldManifold* cube =
+      manifold_cube(alloc_manifold_buffer(), 1.0, 1.0, 1.0, 0);
+  ManifoldMeshGL* original = manifold_get_meshgl(alloc_meshgl_buffer(), cube);
+
+  // This mesh is already manifold, so Merge() internally returns false.
+  // The bug: old code returned the input pointer instead of the output buffer.
+  void* mem = alloc_meshgl_buffer();
+  ManifoldMeshGL* merged = manifold_meshgl_merge(mem, original);
+
+  // The returned pointer must always come from mem, never from original.
+  EXPECT_EQ(reinterpret_cast<void*>(merged), mem);
+  EXPECT_NE(merged, original);
+
+  // The merged mesh should still be valid — construct a Manifold from it.
+  ManifoldManifold* result =
+      manifold_of_meshgl(alloc_manifold_buffer(), merged);
+  EXPECT_EQ(manifold_status(result), MANIFOLD_NO_ERROR);
+  EXPECT_NEAR(manifold_volume(result), 1.0, 0.0001);
+
+  manifold_destruct_manifold(result);
+  manifold_destruct_meshgl(merged);
+  manifold_destruct_meshgl(original);
+  manifold_destruct_manifold(cube);
+  free(result);
+  free(mem);
+  free(original);
+  free(cube);
+}
+
+TEST(CBIND, meshgl64_merge_returns_mem) {
+  ManifoldManifold* cube =
+      manifold_cube(alloc_manifold_buffer(), 1.0, 1.0, 1.0, 0);
+  ManifoldMeshGL64* original =
+      manifold_get_meshgl64(alloc_meshgl64_buffer(), cube);
+
+  void* mem = alloc_meshgl64_buffer();
+  ManifoldMeshGL64* merged = manifold_meshgl64_merge(mem, original);
+
+  EXPECT_EQ(reinterpret_cast<void*>(merged), mem);
+  EXPECT_NE(merged, original);
+
+  ManifoldManifold* result =
+      manifold_of_meshgl64(alloc_manifold_buffer(), merged);
+  EXPECT_EQ(manifold_status(result), MANIFOLD_NO_ERROR);
+  EXPECT_NEAR(manifold_volume(result), 1.0, 0.0001);
+
+  manifold_destruct_manifold(result);
+  manifold_destruct_meshgl64(merged);
+  manifold_destruct_meshgl64(original);
+  manifold_destruct_manifold(cube);
+  free(result);
+  free(mem);
+  free(original);
+  free(cube);
+}


### PR DESCRIPTION
## Summary

`manifold_meshgl_merge` and `manifold_meshgl64_merge` always return the caller-owned copy now, instead of returning the input pointer when `Merge()` finds nothing to do.

## Problem

When `Merge()` returns `false` (mesh is already manifold), both functions destruct the valid copy in `mem` and return the input pointer `m`. This violates the C API's ownership convention: every function taking `void* mem` returns a pointer into that buffer. Callers (including binding layers) that assume the returned pointer is the output allocation will double-free or leak `mem`.

This appears to have been an oversight in the original implementation (#820), which also used `delete` on a placement-new'd object. #1196 correctly fixed the UB by switching to an explicit destructor call, but the `return m` remained.

## Fix

`Merge()` mutates in place and leaves the mesh valid regardless of its return value — when it returns `false`, it simply means nothing needed to change. The copy is always a correct result, so we can return it unconditionally. This matches the pattern of `manifold_meshgl_copy` and every other `void* mem` function in the C API.

## Test plan

- [x] New `CBIND.meshgl_merge_returns_mem` and `CBIND.meshgl64_merge_returns_mem` tests: verify the returned pointer comes from `mem` and the result constructs a valid Manifold
- [x] Full test suite (321 tests) passes