### PR TITLE
Fix calculateNormals with minSharpAngle=0 producing ripples

### DIFF
--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -37,6 +37,11 @@ double Wrap(double radians) {
                          : radians;
 }
 
+// Minimum sharp angle in degrees, below which edges are considered coplanar.
+// Floating point noise in the dihedral angle computation can reach ~1e-6
+// degrees for nearly-parallel face normals; this threshold must exceed that.
+constexpr double kMinSharpAngle = 1e-4;
+
 // Get the angle between two unit-vectors.
 double AngleBetween(vec3 a, vec3 b) {
   const double dot = la::dot(a, b);
@@ -408,12 +413,13 @@ Vec<int> Manifold::Impl::VertHalfedge() const {
 std::vector<Smoothness> Manifold::Impl::SharpenEdges(
     double minSharpAngle, double minSmoothness) const {
   std::vector<Smoothness> sharpenedEdges;
+  minSharpAngle = std::max(minSharpAngle, kMinSharpAngle);
   const double minRadians = radians(minSharpAngle);
   for (size_t e = 0; e < halfedge_.size(); ++e) {
     if (!halfedge_[e].IsForward()) continue;
     const size_t pair = halfedge_[e].pairedHalfedge;
     const double dihedral =
-        math::acos(la::dot(faceNormal_[e / 3], faceNormal_[pair / 3]));
+        AngleBetween(faceNormal_[e / 3], faceNormal_[pair / 3]);
     if (dihedral > minRadians) {
       sharpenedEdges.push_back({e, minSmoothness});
       sharpenedEdges.push_back({pair, minSmoothness});
@@ -441,6 +447,9 @@ void Manifold::Impl::SharpenTangent(int halfedge, double smoothness) {
 void Manifold::Impl::SetNormals(int normalIdx, double minSharpAngle) {
   if (IsEmpty()) return;
   if (normalIdx < 0) return;
+  // Ensure minSharpAngle is large enough to avoid treating nearly-coplanar
+  // faces as sharp due to floating point noise in the dihedral computation.
+  minSharpAngle = std::max(minSharpAngle, kMinSharpAngle);
   halfedge_.MakeUnique();
 
   const int oldNumProp = NumProp();
@@ -454,7 +463,7 @@ void Manifold::Impl::SetNormals(int normalIdx, double minSharpAngle) {
     const int tri1 = e / 3;
     const int tri2 = pair / 3;
     const double dihedral =
-        degrees(math::acos(la::dot(faceNormal_[tri1], faceNormal_[tri2])));
+        degrees(AngleBetween(faceNormal_[tri1], faceNormal_[tri2]));
     if (dihedral > minSharpAngle) {
       ++vertNumSharp[halfedge_[e].startVert];
       ++vertNumSharp[halfedge_[e].endVert];
@@ -528,8 +537,8 @@ void Manifold::Impl::SetNormals(int normalIdx, double minSharpAngle) {
         int next = NextHalfedge(halfedge_[current].pairedHalfedge);
         const int face = next / 3;
 
-        const double dihedral = degrees(
-            math::acos(la::dot(faceNormal_[face], faceNormal_[prevFace])));
+        const double dihedral =
+            degrees(AngleBetween(faceNormal_[face], faceNormal_[prevFace]));
         if (dihedral > minSharpAngle ||
             triIsFlatFace[face] != triIsFlatFace[prevFace] ||
             (triIsFlatFace[face] && triIsFlatFace[prevFace] &&
@@ -573,8 +582,8 @@ void Manifold::Impl::SetNormals(int normalIdx, double minSharpAngle) {
           },
           [this, &triIsFlatFace, &normals, &group, minSharpAngle](
               int, const FaceEdge& here, FaceEdge& next) {
-            const double dihedral = degrees(math::acos(
-                la::dot(faceNormal_[here.face], faceNormal_[next.face])));
+            const double dihedral = degrees(
+                AngleBetween(faceNormal_[here.face], faceNormal_[next.face]));
             if (dihedral > minSharpAngle ||
                 triIsFlatFace[here.face] != triIsFlatFace[next.face] ||
                 (triIsFlatFace[here.face] && triIsFlatFace[next.face] &&

--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -169,6 +169,27 @@ TEST(Smooth, Normals) {
   if (options.exportModels) WriteTestOBJ("smoothNormals.obj", byNormals);
 }
 
+TEST(Smooth, FacetedNormals) {
+  // calculateNormals with minSharpAngle=0 should produce a faceted result
+  // where smoothing and refinement do not change the volume or surface area.
+  // Regression test for https://github.com/elalish/manifold/issues/1577
+  Manifold cylinder = Manifold::Cylinder(10, 10);
+  Manifold faceted =
+      cylinder.CalculateNormals(0, 0).SmoothByNormals(0).RefineToLength(0.1);
+  EXPECT_EQ(faceted.Status(), Manifold::Error::NoError);
+  EXPECT_FLOAT_EQ(cylinder.Volume(), faceted.Volume());
+  EXPECT_FLOAT_EQ(cylinder.SurfaceArea(), faceted.SurfaceArea());
+
+  // The fix must survive rotation and translation, which change the face
+  // normals and shift the dot products into different float neighborhoods.
+  Manifold rotated = cylinder.Rotate(30, 45, 60).Translate({5, 10, 15});
+  Manifold facetedRot =
+      rotated.CalculateNormals(0, 0).SmoothByNormals(0).RefineToLength(0.1);
+  EXPECT_EQ(facetedRot.Status(), Manifold::Error::NoError);
+  EXPECT_FLOAT_EQ(rotated.Volume(), facetedRot.Volume());
+  EXPECT_FLOAT_EQ(rotated.SurfaceArea(), facetedRot.SurfaceArea());
+}
+
 TEST(Smooth, NormalTransform) {
   Manifold cube1 = Manifold::Cube().Rotate(30).CalculateNormals(0);
   Manifold cube2 =


### PR DESCRIPTION
## Summary

- Fix `CalculateNormals` and `SmoothOut` producing rippled surfaces when
  `minSharpAngle` is zero or very small.
- Two root causes, both in `src/smoothing.cpp`:
  - **Unclamped acos**: `math::acos(la::dot(n1, n2))` returns NaN when the dot
    product exceeds 1.0 due to float error. `NaN > minSharpAngle` is always
    false, so these edges were silently treated as smooth. Fixed by using the
    existing `AngleBetween()` helper which clamps the input.
  - **Float-noise false positives**: with `minSharpAngle=0`, `dihedral > 0`
    catches edges between nearly-coplanar faces where the dihedral angle is
    nonzero only due to float noise (~1e-6 degrees). This corrupts
    `vertNumSharp` counts, breaking the normal grouping. Fixed by clamping
    `minSharpAngle` to a minimum of `kMinSharpAngle` (1e-4 degrees), safely
    above float noise but negligible for real geometry.

Fixes #1577

## Test plan

- [x] New test `Smooth.FacetedNormals`: verifies `CalculateNormals(0, 0)` +
  `SmoothByNormals(0)` + `RefineToLength(0.1)` preserves volume and surface
  area exactly, both axis-aligned and after rotation + translation
- [x] Test fails without the fix, passes with it
- [x] All 320 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)