### PR TITLE
updated examples to sit on grid, fixed UX

### DIFF
--- a/bindings/wasm/examples/editor/editor.css
+++ b/bindings/wasm/examples/editor/editor.css
@@ -90,7 +90,7 @@ model-viewer {
   position: relative;
   flex: 3;
   width: 100%;
-  background-color: #ddd;
+  background-color: #fff;
 }
 
 #console {
@@ -100,7 +100,7 @@ model-viewer {
   max-height: none;
   /* draggable pane dividers-end */
   overflow-y: scroll;
-  background-color: #eee;
+  background-color: #fff;
   white-space: pre-wrap;
   font-size: 14px;
   font-weight: 100;
@@ -421,7 +421,7 @@ model-viewer {
 
 #play {
   position: relative;
-  background-color: #ccc;
+  background-color: #0004;
   margin: 8px;
 }
 
@@ -433,7 +433,7 @@ model-viewer {
   height: 10px;
   border-radius: 5px;
   margin-right: 16px;
-  background: #ffffff55;
+  background: #0002;
   outline: none;
 }
 
@@ -443,7 +443,7 @@ model-viewer {
   width: 25px;
   height: 25px;
   border-radius: 50%;
-  background: #ccc;
+  background: #0004;
   cursor: pointer;
 }
 

--- a/bindings/wasm/examples/editor/editor.js
+++ b/bindings/wasm/examples/editor/editor.js
@@ -683,8 +683,6 @@ const scrubber = document.querySelector('#scrubber');
 const edgeToggle = document.getElementById('edgesToggle');
 const sceneSym =
     Object.getOwnPropertySymbols(mv).find(x => x.description === 'scene');
-const needsRenderSym =
-    Object.getOwnPropertySymbols(mv).find(x => x.description === 'needsRender');
 
 let paused = false;
 let showEdges = false;
@@ -807,6 +805,13 @@ function updateOrientationGrid() {
 
   const center = mv.getBoundingBoxCenter();
   const extent = mv.getDimensions();
+  const maxDim = Math.max(extent.x, extent.y, extent.z);
+
+  if (center.y - extent.y / 2 > 0) {
+    mv.setAttribute('shadow-intensity', '0');
+  } else {
+    mv.setAttribute('shadow-intensity', '1');
+  }
 
   const extentX = Math.max(
       Math.abs(center.x + extent.x / 2), Math.abs(center.x - extent.x / 2));
@@ -827,6 +832,8 @@ function updateOrientationGrid() {
   const grid = new Group();
   grid.userData[ORIENTATION_GRID_FLAG] = true;
   grid.renderOrder = 2;
+  // Avoid shadow clash with animation
+  grid.position.y = -0.0005 * maxDim;
 
   const gridPlane = new Mesh(
       new PlaneGeometry(maxGridDimension, maxGridDimension),
@@ -966,7 +973,7 @@ function setEdgesVisible(visible) {
 
     if (obj.isMesh) {
       // Fix wireframe z-fighting.
-      obj.material.polygonOffset = true;
+      obj.material.polygonOffset = visible;
       obj.material.polygonOffsetFactor = 4;
       obj.material.polygonOffsetUnits = 4;
 
@@ -1002,9 +1009,6 @@ function setEdgesVisible(visible) {
   });
 
   scene.queueRender?.();
-  if (needsRenderSym) {
-    mv[needsRenderSym]?.();
-  }
 }
 
 function pause() {

--- a/bindings/wasm/examples/editor/index.html
+++ b/bindings/wasm/examples/editor/index.html
@@ -77,7 +77,7 @@
       <div id="split-x" class="splitter splitter-x" aria-hidden="true"></div>
       <div id="rightPane" class="col container pane-right" style="flex-direction: column;">
         <model-viewer id="viewer" camera-controls min-camera-orbit="auto 0deg auto" max-camera-orbit="auto 180deg auto"
-          min-field-of-view="1deg" shadow-intensity="0" tone-mapping="neutral" interaction-prompt="none" alt="Editor 3D output">
+          min-field-of-view="1deg" shadow-intensity="1" tone-mapping="neutral" interaction-prompt="none" alt="Editor 3D output">
           <div class="center" slot="poster">
             <p id="poster" style="text-align: center; line-height: 36px;"> Loading... </p>
           </div>

--- a/bindings/wasm/test/examples/auger.mjs
+++ b/bindings/wasm/test/examples/auger.mjs
@@ -8,10 +8,9 @@ const {revolve, sphere, union, extrude} = Manifold;
 const {circle} = CrossSection;
 setMinCircularEdgeLength(0.1);
 
-const bead1 =
-    revolve(circle(beadRadius).translate([outerRadius, 0]), 50, 90)
-        .add(sphere(beadRadius).translate([outerRadius, 0, 0]))
-        .translate([0, -outerRadius, 0]);
+const bead1 = revolve(circle(beadRadius).translate([outerRadius, 0]), 50, 90)
+                  .add(sphere(beadRadius).translate([outerRadius, 0, 0]))
+                  .translate([0, -outerRadius, 0]);
 
 const beads = [];
 for (let i = 0; i < 3; i++) {
@@ -21,6 +20,7 @@ const bead = union(beads);
 
 const auger = extrude(bead.slice(0), height, 50, twist);
 
-const result =
-    auger.add(bead).add(bead.translate(0, 0, height).rotate(0, 0, twist));
+const result = auger.add(bead)
+                   .add(bead.translate(0, 0, height).rotate(0, 0, twist))
+                   .translate([0, 0, beadRadius]);
 export default result;

--- a/bindings/wasm/test/examples/godel-escher-bach.ts
+++ b/bindings/wasm/test/examples/godel-escher-bach.ts
@@ -109,6 +109,6 @@ export default async () => {
     roughness: 0.4
   };
 
-  rootNode.rotation = [0, 0, -45];
+  rootNode.translation = [0, 0, height * 2];
   return [rootNode, csNodes, intersectionNode];
 }

--- a/bindings/wasm/test/examples/gyroid-module.ts
+++ b/bindings/wasm/test/examples/gyroid-module.ts
@@ -43,11 +43,14 @@ const gyroidModule = rhombicDodecahedron()
                          .intersect(gyroidOffset(-0.4))
                          .subtract(gyroidOffset(0.4));
 
+const root = new GLTFNode();
+root.translation = [-1.5 * size, -1.5 * size, 3 * size];
+
 if (m > 1) {
   for (let i = 0; i < m; ++i) {
     for (let j = i; j < m; ++j) {
       for (let k = j; k < m; ++k) {
-        const node = new GLTFNode();
+        const node = new GLTFNode(root);
         node.manifold = gyroidModule;
         node.translation = [(k + i - j) * size, (k - i) * size, (-j) * size];
         node.material = {

--- a/bindings/wasm/test/examples/heart.mjs
+++ b/bindings/wasm/test/examples/heart.mjs
@@ -3,7 +3,7 @@
 // https://www.thingiverse.com/thing:6190
 // It also demonstrates the use of setMorph to animate a warping function.
 
-import {Manifold, GLTFNode, setMorphStart} from 'manifold-3d/manifoldCAD';
+import {GLTFNode, Manifold, setMorphStart} from 'manifold-3d/manifoldCAD';
 
 
 const func = (v) => {
@@ -22,8 +22,7 @@ const func = (v) => {
     // Taubin's function: https://mathworld.wolfram.com/HeartSurface.html
     const f = a3 * r4 * r2 - b * r4 * r - 3 * a2 * r4 + 3 * a * r2 - 1;
     // Derivative
-    const df =
-        6 * a3 * r4 * r - 5 * b * r4 - 12 * a2 * r2 * r + 6 * a * r;
+    const df = 6 * a3 * r4 * r - 5 * b * r4 - 12 * a2 * r2 * r + 6 * a * r;
     return f / df;
   };
   // Newton's method for root finding
@@ -49,8 +48,9 @@ setMorphStart(ball, func);
 const node = new GLTFNode();
 node.manifold = ball;
 node.scale = [scale, scale, scale];
+node.translation = [0, 0, scale];
 
-setAnimationDuration(5); // seconds
+setAnimationDuration(5);  // seconds
 setAnimationMode('ping-pong');
 
 export default node;

--- a/bindings/wasm/test/examples/import-manifold.ts
+++ b/bindings/wasm/test/examples/import-manifold.ts
@@ -59,7 +59,7 @@ const csg = async () => {
     ]);
   });
 
-  return arranged;
+  return arranged.translate([0, 0, 50 * metres]);
 };
 
 // If the default export is a function, manifoldCAD will execute it,

--- a/bindings/wasm/test/examples/intro.mjs
+++ b/bindings/wasm/test/examples/intro.mjs
@@ -15,7 +15,7 @@ const ball = sphere(60, 100);
 // a GLTFNode, an array of Manifold or GLTFNode objects, or even a function
 // that returns one of those options.
 // See Menger Sponge, Gyroid Module and Involute Gear Library examples.
-const result = box.subtract(ball);
+const result = box.subtract(ball).translate([0, 0, 50]);
 export default result;
 
 // For visual debug, wrap any shape with show() and it and all of its

--- a/bindings/wasm/test/examples/menger-sponge.mjs
+++ b/bindings/wasm/test/examples/menger-sponge.mjs
@@ -43,6 +43,7 @@ const posColors = (newProp, pos) => {
 const result = mengerSponge(3)
                    .trimByPlane([1, 1, 1], 0)
                    .setProperties(3, posColors)
+                   .translate([0, 0, 0.5])
                    .scale(100);
 
 const node = new GLTFNode();

--- a/bindings/wasm/test/examples/rounded-frame.mjs
+++ b/bindings/wasm/test/examples/rounded-frame.mjs
@@ -21,9 +21,7 @@ function roundedFrame(edgeLength, radius, circularSegments = 0) {
   const edge4 =
       union(edge2, edge2.rotate([0, 0, 90])).translate([0, 0, -edgeLength / 2]);
 
-  return union(edge4, edge4.rotate([180, 0, 0])).translate([
-    0, 0, edgeLength / 2 + radius
-  ]);
+  return union(edge4, edge4.rotate([180, 0, 0]));
 }
 
 setMinCircularAngle(3);
@@ -33,10 +31,13 @@ const result = roundedFrame(100, 10);
 // a subtraction and an intersection at once
 const [inside, outside] = result.split(cube(100, true));
 
-const outsideNode = new GLTFNode();
+const root = new GLTFNode();
+root.translation = [0, 0, 60];
+
+const outsideNode = new GLTFNode(root);
 outsideNode.manifold = outside;
 
-const insideNode = new GLTFNode();
+const insideNode = new GLTFNode(root);
 insideNode.manifold = inside;
 insideNode.material = {
   baseColorFactor: [0, 1, 1]

--- a/bindings/wasm/test/examples/rounded-frame.mjs
+++ b/bindings/wasm/test/examples/rounded-frame.mjs
@@ -2,9 +2,8 @@
 // facets match up perfectly, for any choice of global resolution
 // parameters.
 
-import {
-  Manifold, GLTFNode, getGLTFNodes
-} from 'manifold-3d/manifoldCAD';
+import {getGLTFNodes, GLTFNode, Manifold} from 'manifold-3d/manifoldCAD';
+
 const {sphere, cylinder, union, cube} = Manifold;
 
 function roundedFrame(edgeLength, radius, circularSegments = 0) {
@@ -19,11 +18,12 @@ function roundedFrame(edgeLength, radius, circularSegments = 0) {
       union(edge1, edge1.rotate([0, 0, 180])),
       edge.translate([-edgeLength / 2, -edgeLength / 2, 0]));
 
-  const edge4 = union(edge2, edge2.rotate([0, 0, 90])).translate([
-    0, 0, -edgeLength / 2
-  ]);
+  const edge4 =
+      union(edge2, edge2.rotate([0, 0, 90])).translate([0, 0, -edgeLength / 2]);
 
-  return union(edge4, edge4.rotate([180, 0, 0]));
+  return union(edge4, edge4.rotate([180, 0, 0])).translate([
+    0, 0, edgeLength / 2 + radius
+  ]);
 }
 
 setMinCircularAngle(3);
@@ -38,7 +38,9 @@ outsideNode.manifold = outside;
 
 const insideNode = new GLTFNode();
 insideNode.manifold = inside;
-insideNode.material = {baseColorFactor: [0, 1, 1]};
+insideNode.material = {
+  baseColorFactor: [0, 1, 1]
+};
 
 const nodes = getGLTFNodes();
 export default nodes;

--- a/bindings/wasm/test/examples/scallop.mjs
+++ b/bindings/wasm/test/examples/scallop.mjs
@@ -2,7 +2,7 @@
 // smooth() and refine(), see more details at:
 // https://elalish.blogspot.com/2022/03/smoothing-triangle-meshes.html
 
-import {Manifold, Mesh, GLTFNode} from 'manifold-3d/manifoldCAD';
+import {GLTFNode, Manifold, Mesh} from 'manifold-3d/manifoldCAD';
 
 const height = 10;
 const radius = 30;
@@ -51,12 +51,13 @@ const colorCurvature = (color, pos, oldProp) => {
   }
 };
 const result = Manifold.smooth(scallop, sharpenedEdges)
-                    .refine(n)
-                    .calculateCurvature(-1, 0)
-                    .setProperties(3, colorCurvature);
+                   .refine(n)
+                   .calculateCurvature(-1, 0)
+                   .setProperties(3, colorCurvature);
 
 const node = new GLTFNode();
 node.manifold = result;
+node.translation = [0, 0, -result.boundingBox().min[2]];
 node.material = {
   baseColorFactor: [1, 1, 1],
   metallic: 0,

--- a/bindings/wasm/test/examples/torus-knot.mjs
+++ b/bindings/wasm/test/examples/torus-knot.mjs
@@ -64,4 +64,4 @@ const func = (v) => {
 };
 
 const result = Manifold.revolve(circle, m).warp(func);
-export default result;
+export default result.translate([0, 0, -result.boundingBox().min[2]]);

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -1010,6 +1010,7 @@ void Manifold::Impl::Refine(std::function<int(vec3, vec4, vec4)> edgeDivisions,
   SortGeometry();
   if (old.halfedgeTangent_.size() == old.halfedge_.size()) {
     SetNormalsAndCoplanar();
+    CalculateBBox();
   } else {
     CalculateVertNormals();
   }


### PR DESCRIPTION
Another follow-on to #1630. Now the examples sit on the grid plane properly, which caused me to noticed a bunch of problematic interactions of the grid and MV's shadow, especially for animations. I think I have all that fixed now, though somewhat hacky. 

I also found a bug where Refine was not recalculating bounding boxes, so that's fixed. I imagine that could have given our collider some real trouble...