### PR TITLE
Add Metal GPU compute backend for parallel primitives on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@
 
 cmake_minimum_required(VERSION 3.18)
 project(manifold LANGUAGES CXX)
+if(MANIFOLD_METAL AND APPLE)
+  enable_language(OBJCXX)
+endif()
 
 # Use C++17
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -47,6 +50,7 @@ option(
   ON
 )
 option(MANIFOLD_PAR "Enable Parallel backend" OFF)
+option(MANIFOLD_METAL "Enable Metal GPU compute backend (macOS)" OFF)
 option(
   MANIFOLD_OPTIMIZED
   "Force optimized build, even with debugging enabled"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,11 @@ set(
 # Include directories
 set(MANIFOLD_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/include)
 
+if(MANIFOLD_METAL AND APPLE)
+  list(APPEND MANIFOLD_SRCS metal_backend.mm)
+  list(APPEND MANIFOLD_PRIVATE_HDRS metal_backend.h)
+endif()
+
 add_library(manifold ${MANIFOLD_SRCS} ${MANIFOLD_PRIVATE_HDRS})
 
 target_link_libraries(manifold PUBLIC $<$<BOOL:${TRACY_ENABLE}>:TracyClient>)
@@ -68,6 +73,72 @@ target_link_libraries(
     $<$<BOOL:${MANIFOLD_PAR}>:TBB::tbb>
     $<$<BOOL:${MANIFOLD_CROSS_SECTION}>:Clipper2::Clipper2>
 )
+
+# Metal GPU compute backend (macOS / Apple Silicon)
+if(MANIFOLD_METAL AND APPLE)
+  find_library(METAL_FRAMEWORK Metal)
+  find_library(FOUNDATION_FRAMEWORK Foundation)
+  if(METAL_FRAMEWORK AND FOUNDATION_FRAMEWORK)
+    target_link_libraries(manifold PRIVATE ${METAL_FRAMEWORK} ${FOUNDATION_FRAMEWORK})
+    target_compile_options(manifold PUBLIC -DMANIFOLD_METAL)
+
+    # Compile Metal shaders to metallib (if Metal compiler is available)
+    set(METAL_SHADER_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/metal_kernels.metal)
+    set(METAL_AIR_FILE ${CMAKE_CURRENT_BINARY_DIR}/metal_kernels.air)
+    set(METAL_LIB_FILE ${CMAKE_CURRENT_BINARY_DIR}/metal_kernels.metallib)
+
+    # Check if xcrun metal compiler is actually usable
+    execute_process(
+      COMMAND xcrun -sdk macosx metal --version
+      RESULT_VARIABLE METAL_COMPILER_RESULT
+      OUTPUT_QUIET ERROR_QUIET
+    )
+
+    if(METAL_COMPILER_RESULT EQUAL 0)
+      add_custom_command(
+        OUTPUT ${METAL_AIR_FILE}
+        COMMAND xcrun -sdk macosx metal -c ${METAL_SHADER_SOURCE} -o ${METAL_AIR_FILE}
+        DEPENDS ${METAL_SHADER_SOURCE}
+        COMMENT "Compiling Metal shaders"
+      )
+      add_custom_command(
+        OUTPUT ${METAL_LIB_FILE}
+        COMMAND xcrun -sdk macosx metallib ${METAL_AIR_FILE} -o ${METAL_LIB_FILE}
+        DEPENDS ${METAL_AIR_FILE}
+        COMMENT "Linking Metal shader library"
+      )
+      add_custom_target(metal_shaders ALL DEPENDS ${METAL_LIB_FILE})
+      add_dependencies(manifold metal_shaders)
+
+      # Install the metallib alongside the binary
+      install(FILES ${METAL_LIB_FILE} DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+      # Also copy to the build output directory so it's found at runtime
+      add_custom_command(TARGET metal_shaders POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${METAL_LIB_FILE}
+                ${CMAKE_BINARY_DIR}/metal_kernels.metallib
+        COMMENT "Copying metallib to build directory"
+      )
+      message(STATUS "Metal shaders: pre-compiled (metallib)")
+    else()
+      # No Metal compiler — shaders will be compiled at runtime from source
+      # Copy the .metal source to the build directory for runtime compilation
+      configure_file(${METAL_SHADER_SOURCE}
+                     ${CMAKE_BINARY_DIR}/metal_kernels.metal COPYONLY)
+      message(STATUS "Metal shaders: runtime compilation (Metal toolchain not found, run: xcodebuild -downloadComponent MetalToolchain)")
+    endif()
+
+    # Enable Obj-C++ compilation for .mm files
+    set_source_files_properties(metal_backend.mm PROPERTIES
+      COMPILE_FLAGS "-fobjc-arc"
+    )
+
+    message(STATUS "Metal GPU compute: enabled")
+  else()
+    message(STATUS "Metal GPU compute: Metal framework not found, disabled")
+    set(MANIFOLD_METAL OFF PARENT_SCOPE)
+  endif()
+endif()
 
 target_compile_options(manifold PRIVATE ${MANIFOLD_FLAGS})
 # make sure users use appropriate c++ standard when including our headers

--- a/src/metal_backend.h
+++ b/src/metal_backend.h
@@ -1,0 +1,99 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Metal GPU compute backend for parallel operations on macOS/Apple Silicon.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+namespace manifold {
+namespace metal {
+
+// Minimum number of elements to justify GPU dispatch overhead.
+// On Apple Silicon with unified memory, the threshold can be lower since
+// there's no CPU↔GPU data transfer cost. The main overhead is command
+// buffer encoding + kernel launch (~5-15μs).
+constexpr size_t kGPUThreshold = 10000;
+
+// Initialize Metal compute backend. Returns true if Metal GPU is available.
+// Safe to call multiple times — subsequent calls are no-ops.
+bool Initialize();
+
+// Check if Metal backend is available and initialized.
+bool IsAvailable();
+
+// Shutdown and release Metal resources.
+void Shutdown();
+
+// ---------------------------------------------------------------------------
+// GPU-accelerated parallel primitives for typed numeric data
+// ---------------------------------------------------------------------------
+
+// Radix sort uint32_t array in-place. Returns true on success.
+bool RadixSortUint32(uint32_t* data, size_t count);
+
+// Radix sort key-value pairs where keys are uint32_t and values are int32_t.
+// Sorts by key, permuting values accordingly. Returns true on success.
+bool RadixSortKeyValue(uint32_t* keys, int32_t* values, size_t count);
+
+// Exclusive prefix scan (sum) on int32_t array.
+// output[i] = init + input[0] + input[1] + ... + input[i-1]
+// Input and output may alias. Returns true on success.
+bool ExclusiveScanInt(const int32_t* input, int32_t* output, size_t count,
+                      int32_t init = 0);
+
+// Inclusive prefix scan (sum) on int32_t array.
+// output[i] = input[0] + input[1] + ... + input[i]
+// Input and output may alias. Returns true on success.
+bool InclusiveScanInt(const int32_t* input, int32_t* output, size_t count);
+
+// Inclusive prefix scan (sum) on double array.
+bool InclusiveScanDouble(const double* input, double* output, size_t count);
+
+// Parallel reduce (sum) on double array.
+double ReduceSumDouble(const double* data, size_t count);
+
+// Parallel reduce (sum) on int32_t array.
+int32_t ReduceSumInt(const int32_t* data, size_t count);
+
+// Parallel reduce to find min/max of float array (returns {min, max}).
+std::pair<double, double> ReduceMinMaxDouble(const double* data, size_t count);
+
+// Fill int32_t array with sequential values starting from `start`.
+bool SequenceFill(int32_t* data, size_t count, int32_t start = 0);
+
+// Scatter: output[indices[i]] = input[i] for i in [0, count)
+bool ScatterInt(const int32_t* input, const int32_t* indices, int32_t* output,
+                size_t count);
+
+// Gather: output[i] = input[indices[i]] for i in [0, count)
+bool GatherInt(const int32_t* input, const int32_t* indices, int32_t* output,
+               size_t count);
+
+// Query GPU memory and compute capabilities
+struct DeviceInfo {
+  const char* name;
+  size_t maxBufferLength;       // Maximum single buffer size in bytes
+  size_t recommendedMaxMemory;  // Recommended working set size
+  uint32_t maxThreadsPerGroup;  // Max threads per threadgroup
+  bool hasUnifiedMemory;        // True on Apple Silicon
+};
+DeviceInfo GetDeviceInfo();
+
+}  // namespace metal
+}  // namespace manifold

--- a/src/metal_backend.mm
+++ b/src/metal_backend.mm
@@ -15,8 +15,8 @@
 // Metal GPU compute backend implementation for macOS/Apple Silicon.
 // Uses unified memory architecture for zero-copy GPU dispatch.
 
-#import <Metal/Metal.h>
 #import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
 
 #include "metal_backend.h"
 
@@ -80,11 +80,10 @@ id<MTLComputePipelineState> CreatePipeline(const char* functionName) {
   }
 
   NSError* error = nil;
-  id<MTLComputePipelineState> pso =
-      [g_metal.device newComputePipelineStateWithFunction:function error:&error];
+  id<MTLComputePipelineState> pso = [g_metal.device newComputePipelineStateWithFunction:function
+                                                                                  error:&error];
   if (error) {
-    NSLog(@"[Manifold Metal] Failed to create PSO for %s: %@", functionName,
-          error);
+    NSLog(@"[Manifold Metal] Failed to create PSO for %s: %@", functionName, error);
     return nil;
   }
   return pso;
@@ -112,8 +111,7 @@ void DoInitialize() {
     // Load the Metal shader library
     // First try to find the compiled .metallib next to the executable
     NSBundle* bundle = [NSBundle mainBundle];
-    NSString* libPath = [bundle pathForResource:@"metal_kernels"
-                                         ofType:@"metallib"];
+    NSString* libPath = [bundle pathForResource:@"metal_kernels" ofType:@"metallib"];
 
     if (libPath) {
       NSError* error = nil;
@@ -127,19 +125,15 @@ void DoInitialize() {
     // Fallback: compile from source at runtime
     if (!g_metal.library) {
       // Try to find the .metal source file
-      NSString* srcPath = [bundle pathForResource:@"metal_kernels"
-                                           ofType:@"metal"];
+      NSString* srcPath = [bundle pathForResource:@"metal_kernels" ofType:@"metal"];
       if (!srcPath) {
         // Try relative to executable for development builds
-        NSString* execPath =
-            [[NSProcessInfo processInfo].arguments firstObject];
+        NSString* execPath = [[NSProcessInfo processInfo].arguments firstObject];
         NSString* execDir = [execPath stringByDeletingLastPathComponent];
         NSArray* searchPaths = @[
           [execDir stringByAppendingPathComponent:@"metal_kernels.metal"],
-          [execDir stringByAppendingPathComponent:
-                       @"../Resources/metal_kernels.metal"],
-          [execDir stringByAppendingPathComponent:
-                       @"../share/openscad/metal_kernels.metal"],
+          [execDir stringByAppendingPathComponent:@"../Resources/metal_kernels.metal"],
+          [execDir stringByAppendingPathComponent:@"../share/openscad/metal_kernels.metal"],
         ];
         for (NSString* path in searchPaths) {
           if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
@@ -178,16 +172,11 @@ void DoInitialize() {
     g_metal.radixHistogramPSO = CreatePipeline("radix_histogram");
     g_metal.radixPrefixSumPSO = CreatePipeline("radix_prefix_sum");
     g_metal.radixScatterKVPSO = CreatePipeline("radix_scatter_kv");
-    g_metal.exclusiveScanIntBlockPSO =
-        CreatePipeline("exclusive_scan_int_block");
-    g_metal.scanAddBlockOffsetsPSO =
-        CreatePipeline("scan_add_block_offsets");
-    g_metal.inclusiveScanIntBlockPSO =
-        CreatePipeline("inclusive_scan_int_block");
-    g_metal.inclusiveScanDoubleBlockPSO =
-        CreatePipeline("inclusive_scan_double_block");
-    g_metal.scanAddBlockOffsetsDoublePSO =
-        CreatePipeline("scan_add_block_offsets_double");
+    g_metal.exclusiveScanIntBlockPSO = CreatePipeline("exclusive_scan_int_block");
+    g_metal.scanAddBlockOffsetsPSO = CreatePipeline("scan_add_block_offsets");
+    g_metal.inclusiveScanIntBlockPSO = CreatePipeline("inclusive_scan_int_block");
+    g_metal.inclusiveScanDoubleBlockPSO = CreatePipeline("inclusive_scan_double_block");
+    g_metal.scanAddBlockOffsetsDoublePSO = CreatePipeline("scan_add_block_offsets_double");
     g_metal.reduceSumIntPSO = CreatePipeline("reduce_sum_int");
     g_metal.reduceSumFloatPSO = CreatePipeline("reduce_sum_float");
     g_metal.reduceMinMaxFloatPSO = CreatePipeline("reduce_minmax_float");
@@ -195,22 +184,18 @@ void DoInitialize() {
     g_metal.scatterIntPSO = CreatePipeline("scatter_int");
     g_metal.gatherIntPSO = CreatePipeline("gather_int");
     g_metal.computeMortonCodesPSO = CreatePipeline("compute_morton_codes");
-    g_metal.computeFaceBoxMortonPSO =
-        CreatePipeline("compute_face_box_morton");
+    g_metal.computeFaceBoxMortonPSO = CreatePipeline("compute_face_box_morton");
     g_metal.reindexFacesPSO = CreatePipeline("reindex_faces");
-    g_metal.reindexVertsInHalfedgesPSO =
-        CreatePipeline("reindex_verts_in_halfedges");
+    g_metal.reindexVertsInHalfedgesPSO = CreatePipeline("reindex_verts_in_halfedges");
     g_metal.markUsedPropsPSO = CreatePipeline("mark_used_props");
     g_metal.compactPropertiesPSO = CreatePipeline("compact_properties");
     g_metal.updatePropVertsPSO = CreatePipeline("update_prop_verts");
 
-    g_metal.maxThreadsPerGroup =
-        (uint32_t)g_metal.radixHistogramPSO.maxTotalThreadsPerThreadgroup;
+    g_metal.maxThreadsPerGroup = (uint32_t)g_metal.radixHistogramPSO.maxTotalThreadsPerThreadgroup;
     if (g_metal.maxThreadsPerGroup > 1024) g_metal.maxThreadsPerGroup = 1024;
 
     g_metal.initialized = true;
-    NSLog(@"[Manifold Metal] GPU compute initialized: %s (unified memory: %@)",
-          g_metal.deviceName,
+    NSLog(@"[Manifold Metal] GPU compute initialized: %s (unified memory: %@)", g_metal.deviceName,
           g_metal.device.hasUnifiedMemory ? @"YES" : @"NO");
   }
 }
@@ -219,46 +204,38 @@ void DoInitialize() {
 id<MTLBuffer> WrapBuffer(const void* ptr, size_t size) {
   if (g_metal.device.hasUnifiedMemory) {
     // On Apple Silicon: shared memory, no copy needed
-    return [g_metal.device
-        newBufferWithBytesNoCopy:const_cast<void*>(ptr)
-                         length:size
-                        options:MTLResourceStorageModeShared
-                    deallocator:nil];
+    return [g_metal.device newBufferWithBytesNoCopy:const_cast<void*>(ptr)
+                                             length:size
+                                            options:MTLResourceStorageModeShared
+                                        deallocator:nil];
   } else {
     // On discrete GPU: must copy
-    return [g_metal.device newBufferWithBytes:ptr
-                                      length:size
-                                     options:MTLResourceStorageModeShared];
+    return [g_metal.device newBufferWithBytes:ptr length:size options:MTLResourceStorageModeShared];
   }
 }
 
 // Helper: create a mutable buffer wrapping existing memory
 id<MTLBuffer> WrapMutableBuffer(void* ptr, size_t size) {
   if (g_metal.device.hasUnifiedMemory) {
-    return [g_metal.device
-        newBufferWithBytesNoCopy:ptr
-                         length:size
-                        options:MTLResourceStorageModeShared
-                    deallocator:nil];
+    return [g_metal.device newBufferWithBytesNoCopy:ptr
+                                             length:size
+                                            options:MTLResourceStorageModeShared
+                                        deallocator:nil];
   } else {
-    return [g_metal.device newBufferWithBytes:ptr
-                                      length:size
-                                     options:MTLResourceStorageModeShared];
+    return [g_metal.device newBufferWithBytes:ptr length:size options:MTLResourceStorageModeShared];
   }
 }
 
 // Helper: create a new GPU buffer
 id<MTLBuffer> NewBuffer(size_t size) {
-  return [g_metal.device newBufferWithLength:size
-                                    options:MTLResourceStorageModeShared];
+  return [g_metal.device newBufferWithLength:size options:MTLResourceStorageModeShared];
 }
 
 // Helper: dispatch a compute kernel and wait
-void DispatchAndWait(id<MTLComputeCommandEncoder> encoder,
-                     id<MTLComputePipelineState> pso, uint32_t count) {
-  uint32_t threadGroupSize = std::min(
-      g_metal.maxThreadsPerGroup,
-      (uint32_t)pso.maxTotalThreadsPerThreadgroup);
+void DispatchAndWait(id<MTLComputeCommandEncoder> encoder, id<MTLComputePipelineState> pso,
+                     uint32_t count) {
+  uint32_t threadGroupSize =
+      std::min(g_metal.maxThreadsPerGroup, (uint32_t)pso.maxTotalThreadsPerThreadgroup);
   // Ensure power of 2 for reduction kernels
   uint32_t numGroups = (count + threadGroupSize - 1) / threadGroupSize;
 
@@ -361,8 +338,7 @@ bool RadixSortKeyValue(uint32_t* keys, int32_t* values, size_t count) {
 
       // Clear histogram
       id<MTLBlitCommandEncoder> blit = [cmdBuf blitCommandEncoder];
-      [blit fillBuffer:histogram range:NSMakeRange(0, 256 * sizeof(uint32_t))
-                 value:0];
+      [blit fillBuffer:histogram range:NSMakeRange(0, 256 * sizeof(uint32_t)) value:0];
       [blit endEncoding];
 
       // Phase 1: Compute histogram
@@ -375,8 +351,7 @@ bool RadixSortKeyValue(uint32_t* keys, int32_t* values, size_t count) {
         [enc setBytes:&shift length:sizeof(uint32_t) atIndex:3];
 
         uint32_t groupSize = std::min(g_metal.maxThreadsPerGroup, 256u);
-        uint32_t numGroups = std::min(
-            (uint32_t)((count + groupSize - 1) / groupSize), 64u);
+        uint32_t numGroups = std::min((uint32_t)((count + groupSize - 1) / groupSize), 64u);
         [enc dispatchThreadgroups:MTLSizeMake(numGroups, 1, 1)
             threadsPerThreadgroup:MTLSizeMake(groupSize, 1, 1)];
         [enc endEncoding];
@@ -457,14 +432,12 @@ bool RadixSortUint32(uint32_t* data, size_t count) {
 
 bool InclusiveScanInt(const int32_t* input, int32_t* output, size_t count) {
   if (!g_metal.initialized || count < kGPUThreshold) return false;
-  if (!g_metal.inclusiveScanIntBlockPSO || !g_metal.scanAddBlockOffsetsPSO)
-    return false;
+  if (!g_metal.inclusiveScanIntBlockPSO || !g_metal.scanAddBlockOffsetsPSO) return false;
 
   @autoreleasepool {
     uint32_t groupSize =
         std::min(g_metal.maxThreadsPerGroup,
-                 (uint32_t)g_metal.inclusiveScanIntBlockPSO
-                     .maxTotalThreadsPerThreadgroup);
+                 (uint32_t)g_metal.inclusiveScanIntBlockPSO.maxTotalThreadsPerThreadgroup);
     // Ensure power of 2
     groupSize = 1u << (31 - __builtin_clz(groupSize));
     if (groupSize > 1024) groupSize = 1024;
@@ -525,25 +498,21 @@ bool InclusiveScanInt(const int32_t* input, int32_t* output, size_t count) {
   }
 }
 
-bool ExclusiveScanInt(const int32_t* input, int32_t* output, size_t count,
-                      int32_t init) {
+bool ExclusiveScanInt(const int32_t* input, int32_t* output, size_t count, int32_t init) {
   if (!g_metal.initialized || count < kGPUThreshold) return false;
-  if (!g_metal.exclusiveScanIntBlockPSO || !g_metal.scanAddBlockOffsetsPSO)
-    return false;
+  if (!g_metal.exclusiveScanIntBlockPSO || !g_metal.scanAddBlockOffsetsPSO) return false;
 
   @autoreleasepool {
     uint32_t groupSize =
         std::min(g_metal.maxThreadsPerGroup,
-                 (uint32_t)g_metal.exclusiveScanIntBlockPSO
-                     .maxTotalThreadsPerThreadgroup);
+                 (uint32_t)g_metal.exclusiveScanIntBlockPSO.maxTotalThreadsPerThreadgroup);
     groupSize = 1u << (31 - __builtin_clz(groupSize));
     if (groupSize > 1024) groupSize = 1024;
 
     uint32_t numGroups = (uint32_t)((count + groupSize - 1) / groupSize);
 
     id<MTLBuffer> inputBuf = WrapBuffer(input, count * sizeof(int32_t));
-    id<MTLBuffer> outputBuf =
-        WrapMutableBuffer(output, count * sizeof(int32_t));
+    id<MTLBuffer> outputBuf = WrapMutableBuffer(output, count * sizeof(int32_t));
     id<MTLBuffer> blockSums = NewBuffer(numGroups * sizeof(int32_t));
 
     if (!inputBuf || !outputBuf || !blockSums) return false;
@@ -613,15 +582,13 @@ bool InclusiveScanDouble(const double* input, double* output, size_t count) {
 
     uint32_t groupSize =
         std::min(g_metal.maxThreadsPerGroup,
-                 (uint32_t)g_metal.inclusiveScanDoubleBlockPSO
-                     .maxTotalThreadsPerThreadgroup);
+                 (uint32_t)g_metal.inclusiveScanDoubleBlockPSO.maxTotalThreadsPerThreadgroup);
     groupSize = 1u << (31 - __builtin_clz(groupSize));
     if (groupSize > 1024) groupSize = 1024;
 
     uint32_t numGroups = (uint32_t)((count + groupSize - 1) / groupSize);
 
-    id<MTLBuffer> inputBuf =
-        WrapBuffer(floatInput.data(), count * sizeof(float));
+    id<MTLBuffer> inputBuf = WrapBuffer(floatInput.data(), count * sizeof(float));
     id<MTLBuffer> outputBuf = NewBuffer(count * sizeof(float));
     id<MTLBuffer> blockSums = NewBuffer(numGroups * sizeof(float));
 
@@ -686,8 +653,7 @@ double ReduceSumDouble(const double* data, size_t count) {
     if (groupSize > 1024) groupSize = 1024;
     uint32_t numGroups = (uint32_t)((count + groupSize - 1) / groupSize);
 
-    id<MTLBuffer> inputBuf =
-        WrapBuffer(floatData.data(), count * sizeof(float));
+    id<MTLBuffer> inputBuf = WrapBuffer(floatData.data(), count * sizeof(float));
     id<MTLBuffer> outputBuf = NewBuffer(numGroups * sizeof(float));
 
     {
@@ -714,8 +680,7 @@ double ReduceSumDouble(const double* data, size_t count) {
 }
 
 int32_t ReduceSumInt(const int32_t* data, size_t count) {
-  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.reduceSumIntPSO)
-    return 0;
+  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.reduceSumIntPSO) return 0;
 
   @autoreleasepool {
     uint32_t groupSize = g_metal.maxThreadsPerGroup;
@@ -749,10 +714,8 @@ int32_t ReduceSumInt(const int32_t* data, size_t count) {
 }
 
 std::pair<double, double> ReduceMinMaxDouble(const double* data, size_t count) {
-  if (!g_metal.initialized || count < kGPUThreshold ||
-      !g_metal.reduceMinMaxFloatPSO)
-    return {std::numeric_limits<double>::infinity(),
-            -std::numeric_limits<double>::infinity()};
+  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.reduceMinMaxFloatPSO)
+    return {std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity()};
 
   @autoreleasepool {
     std::vector<float> floatData(count);
@@ -763,8 +726,7 @@ std::pair<double, double> ReduceMinMaxDouble(const double* data, size_t count) {
     if (groupSize > 1024) groupSize = 1024;
     uint32_t numGroups = (uint32_t)((count + groupSize - 1) / groupSize);
 
-    id<MTLBuffer> inputBuf =
-        WrapBuffer(floatData.data(), count * sizeof(float));
+    id<MTLBuffer> inputBuf = WrapBuffer(floatData.data(), count * sizeof(float));
     id<MTLBuffer> minBuf = NewBuffer(numGroups * sizeof(float));
     id<MTLBuffer> maxBuf = NewBuffer(numGroups * sizeof(float));
 
@@ -801,12 +763,10 @@ std::pair<double, double> ReduceMinMaxDouble(const double* data, size_t count) {
 // ---------------------------------------------------------------------------
 
 bool SequenceFill(int32_t* data, size_t count, int32_t start) {
-  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.sequenceFillPSO)
-    return false;
+  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.sequenceFillPSO) return false;
 
   @autoreleasepool {
-    id<MTLBuffer> outputBuf =
-        WrapMutableBuffer(data, count * sizeof(int32_t));
+    id<MTLBuffer> outputBuf = WrapMutableBuffer(data, count * sizeof(int32_t));
     if (!outputBuf) return false;
 
     id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
@@ -828,17 +788,14 @@ bool SequenceFill(int32_t* data, size_t count, int32_t start) {
   }
 }
 
-bool ScatterInt(const int32_t* input, const int32_t* indices, int32_t* output,
-                size_t count) {
-  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.scatterIntPSO)
-    return false;
+bool ScatterInt(const int32_t* input, const int32_t* indices, int32_t* output, size_t count) {
+  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.scatterIntPSO) return false;
 
   @autoreleasepool {
     id<MTLBuffer> inputBuf = WrapBuffer(input, count * sizeof(int32_t));
     id<MTLBuffer> indicesBuf = WrapBuffer(indices, count * sizeof(int32_t));
     // Output size unknown (could be larger), use input size as estimate
-    id<MTLBuffer> outputBuf =
-        WrapMutableBuffer(output, count * sizeof(int32_t));
+    id<MTLBuffer> outputBuf = WrapMutableBuffer(output, count * sizeof(int32_t));
 
     if (!inputBuf || !indicesBuf || !outputBuf) return false;
 
@@ -862,16 +819,13 @@ bool ScatterInt(const int32_t* input, const int32_t* indices, int32_t* output,
   }
 }
 
-bool GatherInt(const int32_t* input, const int32_t* indices, int32_t* output,
-               size_t count) {
-  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.gatherIntPSO)
-    return false;
+bool GatherInt(const int32_t* input, const int32_t* indices, int32_t* output, size_t count) {
+  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.gatherIntPSO) return false;
 
   @autoreleasepool {
     id<MTLBuffer> inputBuf = WrapBuffer(input, count * sizeof(int32_t));
     id<MTLBuffer> indicesBuf = WrapBuffer(indices, count * sizeof(int32_t));
-    id<MTLBuffer> outputBuf =
-        WrapMutableBuffer(output, count * sizeof(int32_t));
+    id<MTLBuffer> outputBuf = WrapMutableBuffer(output, count * sizeof(int32_t));
 
     if (!inputBuf || !indicesBuf || !outputBuf) return false;
 

--- a/src/metal_backend.mm
+++ b/src/metal_backend.mm
@@ -1,0 +1,899 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Metal GPU compute backend implementation for macOS/Apple Silicon.
+// Uses unified memory architecture for zero-copy GPU dispatch.
+
+#import <Metal/Metal.h>
+#import <Foundation/Foundation.h>
+
+#include "metal_backend.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <mutex>
+#include <vector>
+
+namespace manifold {
+namespace metal {
+
+// ---------------------------------------------------------------------------
+// Metal backend singleton state
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct MetalState {
+  id<MTLDevice> device = nil;
+  id<MTLCommandQueue> commandQueue = nil;
+  id<MTLLibrary> library = nil;
+
+  // Pre-compiled pipeline states for each kernel
+  id<MTLComputePipelineState> radixHistogramPSO = nil;
+  id<MTLComputePipelineState> radixPrefixSumPSO = nil;
+  id<MTLComputePipelineState> radixScatterKVPSO = nil;
+  id<MTLComputePipelineState> exclusiveScanIntBlockPSO = nil;
+  id<MTLComputePipelineState> scanAddBlockOffsetsPSO = nil;
+  id<MTLComputePipelineState> inclusiveScanIntBlockPSO = nil;
+  id<MTLComputePipelineState> inclusiveScanDoubleBlockPSO = nil;
+  id<MTLComputePipelineState> scanAddBlockOffsetsDoublePSO = nil;
+  id<MTLComputePipelineState> reduceSumIntPSO = nil;
+  id<MTLComputePipelineState> reduceSumFloatPSO = nil;
+  id<MTLComputePipelineState> reduceMinMaxFloatPSO = nil;
+  id<MTLComputePipelineState> sequenceFillPSO = nil;
+  id<MTLComputePipelineState> scatterIntPSO = nil;
+  id<MTLComputePipelineState> gatherIntPSO = nil;
+  id<MTLComputePipelineState> computeMortonCodesPSO = nil;
+  id<MTLComputePipelineState> computeFaceBoxMortonPSO = nil;
+  id<MTLComputePipelineState> reindexFacesPSO = nil;
+  id<MTLComputePipelineState> reindexVertsInHalfedgesPSO = nil;
+  id<MTLComputePipelineState> markUsedPropsPSO = nil;
+  id<MTLComputePipelineState> compactPropertiesPSO = nil;
+  id<MTLComputePipelineState> updatePropVertsPSO = nil;
+
+  bool initialized = false;
+  uint32_t maxThreadsPerGroup = 256;
+  char deviceName[256] = {};
+};
+
+MetalState g_metal;
+std::once_flag g_initFlag;
+
+id<MTLComputePipelineState> CreatePipeline(const char* functionName) {
+  NSString* name = [NSString stringWithUTF8String:functionName];
+  id<MTLFunction> function = [g_metal.library newFunctionWithName:name];
+  if (!function) {
+    NSLog(@"[Manifold Metal] Failed to find kernel function: %s", functionName);
+    return nil;
+  }
+
+  NSError* error = nil;
+  id<MTLComputePipelineState> pso =
+      [g_metal.device newComputePipelineStateWithFunction:function error:&error];
+  if (error) {
+    NSLog(@"[Manifold Metal] Failed to create PSO for %s: %@", functionName,
+          error);
+    return nil;
+  }
+  return pso;
+}
+
+void DoInitialize() {
+  @autoreleasepool {
+    g_metal.device = MTLCreateSystemDefaultDevice();
+    if (!g_metal.device) {
+      NSLog(@"[Manifold Metal] No Metal device available");
+      return;
+    }
+
+    // Store device name
+    const char* name = [g_metal.device.name UTF8String];
+    strncpy(g_metal.deviceName, name, sizeof(g_metal.deviceName) - 1);
+
+    g_metal.commandQueue = [g_metal.device newCommandQueue];
+    if (!g_metal.commandQueue) {
+      NSLog(@"[Manifold Metal] Failed to create command queue");
+      g_metal.device = nil;
+      return;
+    }
+
+    // Load the Metal shader library
+    // First try to find the compiled .metallib next to the executable
+    NSBundle* bundle = [NSBundle mainBundle];
+    NSString* libPath = [bundle pathForResource:@"metal_kernels"
+                                         ofType:@"metallib"];
+
+    if (libPath) {
+      NSError* error = nil;
+      NSURL* libURL = [NSURL fileURLWithPath:libPath];
+      g_metal.library = [g_metal.device newLibraryWithURL:libURL error:&error];
+      if (error) {
+        NSLog(@"[Manifold Metal] Failed to load metallib: %@", error);
+      }
+    }
+
+    // Fallback: compile from source at runtime
+    if (!g_metal.library) {
+      // Try to find the .metal source file
+      NSString* srcPath = [bundle pathForResource:@"metal_kernels"
+                                           ofType:@"metal"];
+      if (!srcPath) {
+        // Try relative to executable for development builds
+        NSString* execPath =
+            [[NSProcessInfo processInfo].arguments firstObject];
+        NSString* execDir = [execPath stringByDeletingLastPathComponent];
+        NSArray* searchPaths = @[
+          [execDir stringByAppendingPathComponent:@"metal_kernels.metal"],
+          [execDir stringByAppendingPathComponent:
+                       @"../Resources/metal_kernels.metal"],
+          [execDir stringByAppendingPathComponent:
+                       @"../share/openscad/metal_kernels.metal"],
+        ];
+        for (NSString* path in searchPaths) {
+          if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
+            srcPath = path;
+            break;
+          }
+        }
+      }
+
+      if (srcPath) {
+        NSError* error = nil;
+        NSString* source = [NSString stringWithContentsOfFile:srcPath
+                                                     encoding:NSUTF8StringEncoding
+                                                        error:&error];
+        if (source && !error) {
+          MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+          options.fastMathEnabled = YES;
+          g_metal.library = [g_metal.device newLibraryWithSource:source
+                                                         options:options
+                                                           error:&error];
+          if (error) {
+            NSLog(@"[Manifold Metal] Shader compile error: %@", error);
+          }
+        }
+      }
+    }
+
+    if (!g_metal.library) {
+      NSLog(@"[Manifold Metal] Failed to load Metal shader library");
+      g_metal.commandQueue = nil;
+      g_metal.device = nil;
+      return;
+    }
+
+    // Create pipeline states for all kernels
+    g_metal.radixHistogramPSO = CreatePipeline("radix_histogram");
+    g_metal.radixPrefixSumPSO = CreatePipeline("radix_prefix_sum");
+    g_metal.radixScatterKVPSO = CreatePipeline("radix_scatter_kv");
+    g_metal.exclusiveScanIntBlockPSO =
+        CreatePipeline("exclusive_scan_int_block");
+    g_metal.scanAddBlockOffsetsPSO =
+        CreatePipeline("scan_add_block_offsets");
+    g_metal.inclusiveScanIntBlockPSO =
+        CreatePipeline("inclusive_scan_int_block");
+    g_metal.inclusiveScanDoubleBlockPSO =
+        CreatePipeline("inclusive_scan_double_block");
+    g_metal.scanAddBlockOffsetsDoublePSO =
+        CreatePipeline("scan_add_block_offsets_double");
+    g_metal.reduceSumIntPSO = CreatePipeline("reduce_sum_int");
+    g_metal.reduceSumFloatPSO = CreatePipeline("reduce_sum_float");
+    g_metal.reduceMinMaxFloatPSO = CreatePipeline("reduce_minmax_float");
+    g_metal.sequenceFillPSO = CreatePipeline("sequence_fill");
+    g_metal.scatterIntPSO = CreatePipeline("scatter_int");
+    g_metal.gatherIntPSO = CreatePipeline("gather_int");
+    g_metal.computeMortonCodesPSO = CreatePipeline("compute_morton_codes");
+    g_metal.computeFaceBoxMortonPSO =
+        CreatePipeline("compute_face_box_morton");
+    g_metal.reindexFacesPSO = CreatePipeline("reindex_faces");
+    g_metal.reindexVertsInHalfedgesPSO =
+        CreatePipeline("reindex_verts_in_halfedges");
+    g_metal.markUsedPropsPSO = CreatePipeline("mark_used_props");
+    g_metal.compactPropertiesPSO = CreatePipeline("compact_properties");
+    g_metal.updatePropVertsPSO = CreatePipeline("update_prop_verts");
+
+    g_metal.maxThreadsPerGroup =
+        (uint32_t)g_metal.radixHistogramPSO.maxTotalThreadsPerThreadgroup;
+    if (g_metal.maxThreadsPerGroup > 1024) g_metal.maxThreadsPerGroup = 1024;
+
+    g_metal.initialized = true;
+    NSLog(@"[Manifold Metal] GPU compute initialized: %s (unified memory: %@)",
+          g_metal.deviceName,
+          g_metal.device.hasUnifiedMemory ? @"YES" : @"NO");
+  }
+}
+
+// Helper: create a buffer wrapping existing memory (zero-copy on unified memory)
+id<MTLBuffer> WrapBuffer(const void* ptr, size_t size) {
+  if (g_metal.device.hasUnifiedMemory) {
+    // On Apple Silicon: shared memory, no copy needed
+    return [g_metal.device
+        newBufferWithBytesNoCopy:const_cast<void*>(ptr)
+                         length:size
+                        options:MTLResourceStorageModeShared
+                    deallocator:nil];
+  } else {
+    // On discrete GPU: must copy
+    return [g_metal.device newBufferWithBytes:ptr
+                                      length:size
+                                     options:MTLResourceStorageModeShared];
+  }
+}
+
+// Helper: create a mutable buffer wrapping existing memory
+id<MTLBuffer> WrapMutableBuffer(void* ptr, size_t size) {
+  if (g_metal.device.hasUnifiedMemory) {
+    return [g_metal.device
+        newBufferWithBytesNoCopy:ptr
+                         length:size
+                        options:MTLResourceStorageModeShared
+                    deallocator:nil];
+  } else {
+    return [g_metal.device newBufferWithBytes:ptr
+                                      length:size
+                                     options:MTLResourceStorageModeShared];
+  }
+}
+
+// Helper: create a new GPU buffer
+id<MTLBuffer> NewBuffer(size_t size) {
+  return [g_metal.device newBufferWithLength:size
+                                    options:MTLResourceStorageModeShared];
+}
+
+// Helper: dispatch a compute kernel and wait
+void DispatchAndWait(id<MTLComputeCommandEncoder> encoder,
+                     id<MTLComputePipelineState> pso, uint32_t count) {
+  uint32_t threadGroupSize = std::min(
+      g_metal.maxThreadsPerGroup,
+      (uint32_t)pso.maxTotalThreadsPerThreadgroup);
+  // Ensure power of 2 for reduction kernels
+  uint32_t numGroups = (count + threadGroupSize - 1) / threadGroupSize;
+
+  [encoder dispatchThreadgroups:MTLSizeMake(numGroups, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(threadGroupSize, 1, 1)];
+}
+
+}  // anonymous namespace
+
+// ---------------------------------------------------------------------------
+// Public API implementation
+// ---------------------------------------------------------------------------
+
+bool Initialize() {
+  std::call_once(g_initFlag, DoInitialize);
+  return g_metal.initialized;
+}
+
+bool IsAvailable() { return g_metal.initialized; }
+
+void Shutdown() {
+  @autoreleasepool {
+    // Release all pipeline states
+    g_metal.radixHistogramPSO = nil;
+    g_metal.radixPrefixSumPSO = nil;
+    g_metal.radixScatterKVPSO = nil;
+    g_metal.exclusiveScanIntBlockPSO = nil;
+    g_metal.scanAddBlockOffsetsPSO = nil;
+    g_metal.inclusiveScanIntBlockPSO = nil;
+    g_metal.inclusiveScanDoubleBlockPSO = nil;
+    g_metal.scanAddBlockOffsetsDoublePSO = nil;
+    g_metal.reduceSumIntPSO = nil;
+    g_metal.reduceSumFloatPSO = nil;
+    g_metal.reduceMinMaxFloatPSO = nil;
+    g_metal.sequenceFillPSO = nil;
+    g_metal.scatterIntPSO = nil;
+    g_metal.gatherIntPSO = nil;
+    g_metal.computeMortonCodesPSO = nil;
+    g_metal.computeFaceBoxMortonPSO = nil;
+    g_metal.reindexFacesPSO = nil;
+    g_metal.reindexVertsInHalfedgesPSO = nil;
+    g_metal.markUsedPropsPSO = nil;
+    g_metal.compactPropertiesPSO = nil;
+    g_metal.updatePropVertsPSO = nil;
+
+    g_metal.library = nil;
+    g_metal.commandQueue = nil;
+    g_metal.device = nil;
+    g_metal.initialized = false;
+  }
+}
+
+DeviceInfo GetDeviceInfo() {
+  DeviceInfo info = {};
+  if (!g_metal.initialized) return info;
+
+  info.name = g_metal.deviceName;
+  info.maxBufferLength = [g_metal.device maxBufferLength];
+  info.recommendedMaxMemory = [g_metal.device recommendedMaxWorkingSetSize];
+  info.maxThreadsPerGroup = g_metal.maxThreadsPerGroup;
+  info.hasUnifiedMemory = [g_metal.device hasUnifiedMemory];
+  return info;
+}
+
+// ---------------------------------------------------------------------------
+// Radix Sort (key-value)
+// ---------------------------------------------------------------------------
+
+bool RadixSortKeyValue(uint32_t* keys, int32_t* values, size_t count) {
+  if (!g_metal.initialized || count < kGPUThreshold) return false;
+
+  @autoreleasepool {
+    size_t keyBytes = count * sizeof(uint32_t);
+    size_t valBytes = count * sizeof(int32_t);
+
+    // Allocate GPU buffers. Use newBufferWithBytes for input (copies once),
+    // then all 4 passes run entirely on GPU without CPU round-trips.
+    id<MTLBuffer> keysA = [g_metal.device newBufferWithBytes:keys
+                                                      length:keyBytes
+                                                     options:MTLResourceStorageModeShared];
+    id<MTLBuffer> valsA = [g_metal.device newBufferWithBytes:values
+                                                      length:valBytes
+                                                     options:MTLResourceStorageModeShared];
+    id<MTLBuffer> keysB = NewBuffer(keyBytes);
+    id<MTLBuffer> valsB = NewBuffer(valBytes);
+    id<MTLBuffer> histogram = NewBuffer(256 * sizeof(uint32_t));
+
+    if (!keysA || !valsA || !keysB || !valsB || !histogram) return false;
+
+    // Single command buffer for all 4 radix sort passes — avoids
+    // 4x command buffer commit+wait overhead (~60μs per round-trip).
+    id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
+    if (!cmdBuf) return false;
+
+    bool swapped = false;
+    uint32_t cnt32 = (uint32_t)count;
+
+    for (uint32_t pass = 0; pass < 4; pass++) {
+      uint32_t shift = pass * 8;
+
+      // Clear histogram
+      id<MTLBlitCommandEncoder> blit = [cmdBuf blitCommandEncoder];
+      [blit fillBuffer:histogram range:NSMakeRange(0, 256 * sizeof(uint32_t))
+                 value:0];
+      [blit endEncoding];
+
+      // Phase 1: Compute histogram
+      {
+        id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+        [enc setComputePipelineState:g_metal.radixHistogramPSO];
+        [enc setBuffer:(swapped ? keysB : keysA) offset:0 atIndex:0];
+        [enc setBuffer:histogram offset:0 atIndex:1];
+        [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:2];
+        [enc setBytes:&shift length:sizeof(uint32_t) atIndex:3];
+
+        uint32_t groupSize = std::min(g_metal.maxThreadsPerGroup, 256u);
+        uint32_t numGroups = std::min(
+            (uint32_t)((count + groupSize - 1) / groupSize), 64u);
+        [enc dispatchThreadgroups:MTLSizeMake(numGroups, 1, 1)
+            threadsPerThreadgroup:MTLSizeMake(groupSize, 1, 1)];
+        [enc endEncoding];
+      }
+
+      // Phase 2: Prefix sum on histogram
+      {
+        id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+        [enc setComputePipelineState:g_metal.radixPrefixSumPSO];
+        [enc setBuffer:histogram offset:0 atIndex:0];
+        [enc dispatchThreadgroups:MTLSizeMake(1, 1, 1)
+            threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        [enc endEncoding];
+      }
+
+      // Phase 3: Scatter key-value pairs
+      {
+        id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+        [enc setComputePipelineState:g_metal.radixScatterKVPSO];
+        [enc setBuffer:(swapped ? keysB : keysA) offset:0 atIndex:0];
+        [enc setBuffer:(swapped ? valsB : valsA) offset:0 atIndex:1];
+        [enc setBuffer:(swapped ? keysA : keysB) offset:0 atIndex:2];
+        [enc setBuffer:(swapped ? valsA : valsB) offset:0 atIndex:3];
+        [enc setBuffer:histogram offset:0 atIndex:4];
+        [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:5];
+        [enc setBytes:&shift length:sizeof(uint32_t) atIndex:6];
+
+        uint32_t groupSize = g_metal.maxThreadsPerGroup;
+        uint32_t numGroups = (uint32_t)((count + groupSize - 1) / groupSize);
+        [enc dispatchThreadgroups:MTLSizeMake(numGroups, 1, 1)
+            threadsPerThreadgroup:MTLSizeMake(groupSize, 1, 1)];
+        [enc endEncoding];
+      }
+
+      swapped = !swapped;
+    }
+
+    [cmdBuf commit];
+    [cmdBuf waitUntilCompleted];
+
+    if (cmdBuf.status == MTLCommandBufferStatusError) {
+      NSLog(@"[Manifold Metal] Radix sort failed: %@", cmdBuf.error);
+      return false;
+    }
+
+    // Copy result back from whichever buffer has the final data
+    if (swapped) {
+      memcpy(keys, keysB.contents, keyBytes);
+      memcpy(values, valsB.contents, valBytes);
+    } else {
+      memcpy(keys, keysA.contents, keyBytes);
+      memcpy(values, valsA.contents, valBytes);
+    }
+
+    return true;
+  }
+}
+
+bool RadixSortUint32(uint32_t* data, size_t count) {
+  if (!g_metal.initialized || count < kGPUThreshold) return false;
+
+  // Create identity index array and sort as key-value
+  std::vector<int32_t> indices(count);
+  for (size_t i = 0; i < count; i++) indices[i] = (int32_t)i;
+
+  // For keys-only sort, we can use a simplified version
+  // but reuse the KV sort for correctness
+  std::vector<uint32_t> keyCopy(data, data + count);
+  if (!RadixSortKeyValue(keyCopy.data(), indices.data(), count)) return false;
+
+  memcpy(data, keyCopy.data(), count * sizeof(uint32_t));
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Prefix Scan
+// ---------------------------------------------------------------------------
+
+bool InclusiveScanInt(const int32_t* input, int32_t* output, size_t count) {
+  if (!g_metal.initialized || count < kGPUThreshold) return false;
+  if (!g_metal.inclusiveScanIntBlockPSO || !g_metal.scanAddBlockOffsetsPSO)
+    return false;
+
+  @autoreleasepool {
+    uint32_t groupSize =
+        std::min(g_metal.maxThreadsPerGroup,
+                 (uint32_t)g_metal.inclusiveScanIntBlockPSO
+                     .maxTotalThreadsPerThreadgroup);
+    // Ensure power of 2
+    groupSize = 1u << (31 - __builtin_clz(groupSize));
+    if (groupSize > 1024) groupSize = 1024;
+
+    uint32_t numGroups = (uint32_t)((count + groupSize - 1) / groupSize);
+
+    id<MTLBuffer> inputBuf = WrapBuffer(input, count * sizeof(int32_t));
+    id<MTLBuffer> outputBuf = WrapMutableBuffer(output, count * sizeof(int32_t));
+    id<MTLBuffer> blockSums = NewBuffer(numGroups * sizeof(int32_t));
+
+    if (!inputBuf || !outputBuf || !blockSums) return false;
+
+    // Phase 1: Block-level inclusive scan
+    {
+      id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
+      id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+      [enc setComputePipelineState:g_metal.inclusiveScanIntBlockPSO];
+      [enc setBuffer:inputBuf offset:0 atIndex:0];
+      [enc setBuffer:outputBuf offset:0 atIndex:1];
+      [enc setBuffer:blockSums offset:0 atIndex:2];
+      uint32_t cnt32 = (uint32_t)count;
+      [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:3];
+      [enc dispatchThreadgroups:MTLSizeMake(numGroups, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(groupSize, 1, 1)];
+      [enc endEncoding];
+      [cmdBuf commit];
+      [cmdBuf waitUntilCompleted];
+    }
+
+    // Phase 2: Scan block sums on CPU (small array)
+    if (numGroups > 1) {
+      int32_t* sums = (int32_t*)blockSums.contents;
+      for (uint32_t i = 1; i < numGroups; i++) {
+        sums[i] += sums[i - 1];
+      }
+
+      // Phase 3: Add block offsets
+      id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
+      id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+      [enc setComputePipelineState:g_metal.scanAddBlockOffsetsPSO];
+      [enc setBuffer:outputBuf offset:0 atIndex:0];
+      [enc setBuffer:blockSums offset:0 atIndex:1];
+      uint32_t cnt32 = (uint32_t)count;
+      [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:2];
+      [enc dispatchThreadgroups:MTLSizeMake(numGroups, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(groupSize, 1, 1)];
+      [enc endEncoding];
+      [cmdBuf commit];
+      [cmdBuf waitUntilCompleted];
+    }
+
+    // Copy back if not using unified memory wrapping
+    if (!g_metal.device.hasUnifiedMemory) {
+      memcpy(output, outputBuf.contents, count * sizeof(int32_t));
+    }
+
+    return true;
+  }
+}
+
+bool ExclusiveScanInt(const int32_t* input, int32_t* output, size_t count,
+                      int32_t init) {
+  if (!g_metal.initialized || count < kGPUThreshold) return false;
+  if (!g_metal.exclusiveScanIntBlockPSO || !g_metal.scanAddBlockOffsetsPSO)
+    return false;
+
+  @autoreleasepool {
+    uint32_t groupSize =
+        std::min(g_metal.maxThreadsPerGroup,
+                 (uint32_t)g_metal.exclusiveScanIntBlockPSO
+                     .maxTotalThreadsPerThreadgroup);
+    groupSize = 1u << (31 - __builtin_clz(groupSize));
+    if (groupSize > 1024) groupSize = 1024;
+
+    uint32_t numGroups = (uint32_t)((count + groupSize - 1) / groupSize);
+
+    id<MTLBuffer> inputBuf = WrapBuffer(input, count * sizeof(int32_t));
+    id<MTLBuffer> outputBuf =
+        WrapMutableBuffer(output, count * sizeof(int32_t));
+    id<MTLBuffer> blockSums = NewBuffer(numGroups * sizeof(int32_t));
+
+    if (!inputBuf || !outputBuf || !blockSums) return false;
+
+    // Phase 1: Block-level exclusive scan
+    {
+      id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
+      id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+      [enc setComputePipelineState:g_metal.exclusiveScanIntBlockPSO];
+      [enc setBuffer:inputBuf offset:0 atIndex:0];
+      [enc setBuffer:outputBuf offset:0 atIndex:1];
+      [enc setBuffer:blockSums offset:0 atIndex:2];
+      uint32_t cnt32 = (uint32_t)count;
+      [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:3];
+      [enc dispatchThreadgroups:MTLSizeMake(numGroups, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(groupSize, 1, 1)];
+      [enc endEncoding];
+      [cmdBuf commit];
+      [cmdBuf waitUntilCompleted];
+    }
+
+    // Phase 2: Scan block sums on CPU
+    if (numGroups > 1) {
+      int32_t* sums = (int32_t*)blockSums.contents;
+      for (uint32_t i = 1; i < numGroups; i++) {
+        sums[i] += sums[i - 1];
+      }
+
+      // Phase 3: Add block offsets
+      id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
+      id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+      [enc setComputePipelineState:g_metal.scanAddBlockOffsetsPSO];
+      [enc setBuffer:outputBuf offset:0 atIndex:0];
+      [enc setBuffer:blockSums offset:0 atIndex:1];
+      uint32_t cnt32 = (uint32_t)count;
+      [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:2];
+      [enc dispatchThreadgroups:MTLSizeMake(numGroups, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(groupSize, 1, 1)];
+      [enc endEncoding];
+      [cmdBuf commit];
+      [cmdBuf waitUntilCompleted];
+    }
+
+    // Add init value if non-zero
+    if (init != 0) {
+      for (size_t i = 0; i < count; i++) output[i] += init;
+    }
+
+    if (!g_metal.device.hasUnifiedMemory) {
+      memcpy(output, outputBuf.contents, count * sizeof(int32_t));
+    }
+
+    return true;
+  }
+}
+
+bool InclusiveScanDouble(const double* input, double* output, size_t count) {
+  if (!g_metal.initialized || count < kGPUThreshold) return false;
+  if (!g_metal.inclusiveScanDoubleBlockPSO) return false;
+
+  // Metal doesn't support double natively on all devices.
+  // Convert to float, scan, convert back. For scan this is acceptable
+  // since the cumulative error is bounded.
+  @autoreleasepool {
+    std::vector<float> floatInput(count);
+    for (size_t i = 0; i < count; i++) floatInput[i] = (float)input[i];
+
+    uint32_t groupSize =
+        std::min(g_metal.maxThreadsPerGroup,
+                 (uint32_t)g_metal.inclusiveScanDoubleBlockPSO
+                     .maxTotalThreadsPerThreadgroup);
+    groupSize = 1u << (31 - __builtin_clz(groupSize));
+    if (groupSize > 1024) groupSize = 1024;
+
+    uint32_t numGroups = (uint32_t)((count + groupSize - 1) / groupSize);
+
+    id<MTLBuffer> inputBuf =
+        WrapBuffer(floatInput.data(), count * sizeof(float));
+    id<MTLBuffer> outputBuf = NewBuffer(count * sizeof(float));
+    id<MTLBuffer> blockSums = NewBuffer(numGroups * sizeof(float));
+
+    if (!inputBuf || !outputBuf || !blockSums) return false;
+
+    {
+      id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
+      id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+      [enc setComputePipelineState:g_metal.inclusiveScanDoubleBlockPSO];
+      [enc setBuffer:inputBuf offset:0 atIndex:0];
+      [enc setBuffer:outputBuf offset:0 atIndex:1];
+      [enc setBuffer:blockSums offset:0 atIndex:2];
+      uint32_t cnt32 = (uint32_t)count;
+      [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:3];
+      [enc dispatchThreadgroups:MTLSizeMake(numGroups, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(groupSize, 1, 1)];
+      [enc endEncoding];
+      [cmdBuf commit];
+      [cmdBuf waitUntilCompleted];
+    }
+
+    if (numGroups > 1) {
+      float* sums = (float*)blockSums.contents;
+      for (uint32_t i = 1; i < numGroups; i++) sums[i] += sums[i - 1];
+
+      id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
+      id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+      [enc setComputePipelineState:g_metal.scanAddBlockOffsetsDoublePSO];
+      [enc setBuffer:outputBuf offset:0 atIndex:0];
+      [enc setBuffer:blockSums offset:0 atIndex:1];
+      uint32_t cnt32 = (uint32_t)count;
+      [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:2];
+      [enc dispatchThreadgroups:MTLSizeMake(numGroups, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(groupSize, 1, 1)];
+      [enc endEncoding];
+      [cmdBuf commit];
+      [cmdBuf waitUntilCompleted];
+    }
+
+    float* result = (float*)outputBuf.contents;
+    for (size_t i = 0; i < count; i++) output[i] = (double)result[i];
+
+    return true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reduction
+// ---------------------------------------------------------------------------
+
+double ReduceSumDouble(const double* data, size_t count) {
+  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.reduceSumFloatPSO)
+    return std::numeric_limits<double>::quiet_NaN();
+
+  @autoreleasepool {
+    // Convert to float for GPU
+    std::vector<float> floatData(count);
+    for (size_t i = 0; i < count; i++) floatData[i] = (float)data[i];
+
+    uint32_t groupSize = g_metal.maxThreadsPerGroup;
+    groupSize = 1u << (31 - __builtin_clz(groupSize));
+    if (groupSize > 1024) groupSize = 1024;
+    uint32_t numGroups = (uint32_t)((count + groupSize - 1) / groupSize);
+
+    id<MTLBuffer> inputBuf =
+        WrapBuffer(floatData.data(), count * sizeof(float));
+    id<MTLBuffer> outputBuf = NewBuffer(numGroups * sizeof(float));
+
+    {
+      id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
+      id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+      [enc setComputePipelineState:g_metal.reduceSumFloatPSO];
+      [enc setBuffer:inputBuf offset:0 atIndex:0];
+      [enc setBuffer:outputBuf offset:0 atIndex:1];
+      uint32_t cnt32 = (uint32_t)count;
+      [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:2];
+      [enc dispatchThreadgroups:MTLSizeMake(numGroups, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(groupSize, 1, 1)];
+      [enc endEncoding];
+      [cmdBuf commit];
+      [cmdBuf waitUntilCompleted];
+    }
+
+    // Final reduction on CPU (small array)
+    float* partials = (float*)outputBuf.contents;
+    double sum = 0.0;
+    for (uint32_t i = 0; i < numGroups; i++) sum += (double)partials[i];
+    return sum;
+  }
+}
+
+int32_t ReduceSumInt(const int32_t* data, size_t count) {
+  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.reduceSumIntPSO)
+    return 0;
+
+  @autoreleasepool {
+    uint32_t groupSize = g_metal.maxThreadsPerGroup;
+    groupSize = 1u << (31 - __builtin_clz(groupSize));
+    if (groupSize > 1024) groupSize = 1024;
+    uint32_t numGroups = (uint32_t)((count + groupSize - 1) / groupSize);
+
+    id<MTLBuffer> inputBuf = WrapBuffer(data, count * sizeof(int32_t));
+    id<MTLBuffer> outputBuf = NewBuffer(numGroups * sizeof(int32_t));
+
+    {
+      id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
+      id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+      [enc setComputePipelineState:g_metal.reduceSumIntPSO];
+      [enc setBuffer:inputBuf offset:0 atIndex:0];
+      [enc setBuffer:outputBuf offset:0 atIndex:1];
+      uint32_t cnt32 = (uint32_t)count;
+      [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:2];
+      [enc dispatchThreadgroups:MTLSizeMake(numGroups, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(groupSize, 1, 1)];
+      [enc endEncoding];
+      [cmdBuf commit];
+      [cmdBuf waitUntilCompleted];
+    }
+
+    int32_t* partials = (int32_t*)outputBuf.contents;
+    int32_t sum = 0;
+    for (uint32_t i = 0; i < numGroups; i++) sum += partials[i];
+    return sum;
+  }
+}
+
+std::pair<double, double> ReduceMinMaxDouble(const double* data, size_t count) {
+  if (!g_metal.initialized || count < kGPUThreshold ||
+      !g_metal.reduceMinMaxFloatPSO)
+    return {std::numeric_limits<double>::infinity(),
+            -std::numeric_limits<double>::infinity()};
+
+  @autoreleasepool {
+    std::vector<float> floatData(count);
+    for (size_t i = 0; i < count; i++) floatData[i] = (float)data[i];
+
+    uint32_t groupSize = g_metal.maxThreadsPerGroup;
+    groupSize = 1u << (31 - __builtin_clz(groupSize));
+    if (groupSize > 1024) groupSize = 1024;
+    uint32_t numGroups = (uint32_t)((count + groupSize - 1) / groupSize);
+
+    id<MTLBuffer> inputBuf =
+        WrapBuffer(floatData.data(), count * sizeof(float));
+    id<MTLBuffer> minBuf = NewBuffer(numGroups * sizeof(float));
+    id<MTLBuffer> maxBuf = NewBuffer(numGroups * sizeof(float));
+
+    {
+      id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
+      id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+      [enc setComputePipelineState:g_metal.reduceMinMaxFloatPSO];
+      [enc setBuffer:inputBuf offset:0 atIndex:0];
+      [enc setBuffer:minBuf offset:0 atIndex:1];
+      [enc setBuffer:maxBuf offset:0 atIndex:2];
+      uint32_t cnt32 = (uint32_t)count;
+      [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:3];
+      [enc dispatchThreadgroups:MTLSizeMake(numGroups, 1, 1)
+          threadsPerThreadgroup:MTLSizeMake(groupSize, 1, 1)];
+      [enc endEncoding];
+      [cmdBuf commit];
+      [cmdBuf waitUntilCompleted];
+    }
+
+    float* mins = (float*)minBuf.contents;
+    float* maxs = (float*)maxBuf.contents;
+    double globalMin = std::numeric_limits<double>::infinity();
+    double globalMax = -std::numeric_limits<double>::infinity();
+    for (uint32_t i = 0; i < numGroups; i++) {
+      globalMin = std::min(globalMin, (double)mins[i]);
+      globalMax = std::max(globalMax, (double)maxs[i]);
+    }
+    return {globalMin, globalMax};
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Utility operations
+// ---------------------------------------------------------------------------
+
+bool SequenceFill(int32_t* data, size_t count, int32_t start) {
+  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.sequenceFillPSO)
+    return false;
+
+  @autoreleasepool {
+    id<MTLBuffer> outputBuf =
+        WrapMutableBuffer(data, count * sizeof(int32_t));
+    if (!outputBuf) return false;
+
+    id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
+    id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+    [enc setComputePipelineState:g_metal.sequenceFillPSO];
+    [enc setBuffer:outputBuf offset:0 atIndex:0];
+    [enc setBytes:&start length:sizeof(int32_t) atIndex:1];
+    uint32_t cnt32 = (uint32_t)count;
+    [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:2];
+    DispatchAndWait(enc, g_metal.sequenceFillPSO, (uint32_t)count);
+    [enc endEncoding];
+    [cmdBuf commit];
+    [cmdBuf waitUntilCompleted];
+
+    if (!g_metal.device.hasUnifiedMemory) {
+      memcpy(data, outputBuf.contents, count * sizeof(int32_t));
+    }
+    return true;
+  }
+}
+
+bool ScatterInt(const int32_t* input, const int32_t* indices, int32_t* output,
+                size_t count) {
+  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.scatterIntPSO)
+    return false;
+
+  @autoreleasepool {
+    id<MTLBuffer> inputBuf = WrapBuffer(input, count * sizeof(int32_t));
+    id<MTLBuffer> indicesBuf = WrapBuffer(indices, count * sizeof(int32_t));
+    // Output size unknown (could be larger), use input size as estimate
+    id<MTLBuffer> outputBuf =
+        WrapMutableBuffer(output, count * sizeof(int32_t));
+
+    if (!inputBuf || !indicesBuf || !outputBuf) return false;
+
+    id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
+    id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+    [enc setComputePipelineState:g_metal.scatterIntPSO];
+    [enc setBuffer:inputBuf offset:0 atIndex:0];
+    [enc setBuffer:indicesBuf offset:0 atIndex:1];
+    [enc setBuffer:outputBuf offset:0 atIndex:2];
+    uint32_t cnt32 = (uint32_t)count;
+    [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:3];
+    DispatchAndWait(enc, g_metal.scatterIntPSO, (uint32_t)count);
+    [enc endEncoding];
+    [cmdBuf commit];
+    [cmdBuf waitUntilCompleted];
+
+    if (!g_metal.device.hasUnifiedMemory) {
+      memcpy(output, outputBuf.contents, count * sizeof(int32_t));
+    }
+    return true;
+  }
+}
+
+bool GatherInt(const int32_t* input, const int32_t* indices, int32_t* output,
+               size_t count) {
+  if (!g_metal.initialized || count < kGPUThreshold || !g_metal.gatherIntPSO)
+    return false;
+
+  @autoreleasepool {
+    id<MTLBuffer> inputBuf = WrapBuffer(input, count * sizeof(int32_t));
+    id<MTLBuffer> indicesBuf = WrapBuffer(indices, count * sizeof(int32_t));
+    id<MTLBuffer> outputBuf =
+        WrapMutableBuffer(output, count * sizeof(int32_t));
+
+    if (!inputBuf || !indicesBuf || !outputBuf) return false;
+
+    id<MTLCommandBuffer> cmdBuf = [g_metal.commandQueue commandBuffer];
+    id<MTLComputeCommandEncoder> enc = [cmdBuf computeCommandEncoder];
+    [enc setComputePipelineState:g_metal.gatherIntPSO];
+    [enc setBuffer:inputBuf offset:0 atIndex:0];
+    [enc setBuffer:indicesBuf offset:0 atIndex:1];
+    [enc setBuffer:outputBuf offset:0 atIndex:2];
+    uint32_t cnt32 = (uint32_t)count;
+    [enc setBytes:&cnt32 length:sizeof(uint32_t) atIndex:3];
+    DispatchAndWait(enc, g_metal.gatherIntPSO, (uint32_t)count);
+    [enc endEncoding];
+    [cmdBuf commit];
+    [cmdBuf waitUntilCompleted];
+
+    if (!g_metal.device.hasUnifiedMemory) {
+      memcpy(output, outputBuf.contents, count * sizeof(int32_t));
+    }
+    return true;
+  }
+}
+
+}  // namespace metal
+}  // namespace manifold

--- a/src/metal_kernels.metal
+++ b/src/metal_kernels.metal
@@ -1,0 +1,633 @@
+// Copyright 2024 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Metal compute shader kernels for GPU-accelerated parallel primitives.
+// These kernels are used by the Manifold boolean/CSG pipeline for
+// sorting, scanning, reducing, and transforming mesh data on the GPU.
+
+#include <metal_stdlib>
+using namespace metal;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+constant uint THREADS_PER_GROUP [[function_constant(0)]];
+
+// ---------------------------------------------------------------------------
+// Radix Sort Kernels (LSB radix sort, 8-bit passes)
+// ---------------------------------------------------------------------------
+
+// Per-threadgroup histogram for one radix digit pass
+kernel void radix_histogram(
+    device const uint* input [[buffer(0)]],
+    device atomic_uint* histograms [[buffer(1)]],
+    constant uint& count [[buffer(2)]],
+    constant uint& shift [[buffer(3)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint gid [[threadgroup_position_in_grid]],
+    uint groupSize [[threads_per_threadgroup]],
+    uint numGroups [[threadgroups_per_grid]])
+{
+    // Local histogram for this threadgroup
+    threadgroup uint localHist[256];
+    if (tid < 256) {
+        localHist[tid] = 0;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Each thread processes multiple elements
+    uint elementsPerGroup = (count + numGroups - 1) / numGroups;
+    uint start = gid * elementsPerGroup;
+    uint end = min(start + elementsPerGroup, count);
+
+    for (uint i = start + tid; i < end; i += groupSize) {
+        uint digit = (input[i] >> shift) & 0xFF;
+        atomic_fetch_add_explicit(
+            reinterpret_cast<threadgroup atomic_uint*>(&localHist[digit]),
+            1, memory_order_relaxed);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Write local histogram to global memory
+    if (tid < 256) {
+        atomic_fetch_add_explicit(&histograms[tid], localHist[tid],
+                                  memory_order_relaxed);
+    }
+}
+
+// Prefix sum on the 256-element histogram (single threadgroup)
+kernel void radix_prefix_sum(
+    device uint* histograms [[buffer(0)]],
+    uint tid [[thread_index_in_threadgroup]])
+{
+    threadgroup uint temp[256];
+    if (tid < 256) {
+        temp[tid] = histograms[tid];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Hillis-Steele inclusive scan
+    for (uint offset = 1; offset < 256; offset <<= 1) {
+        uint val = 0;
+        if (tid >= offset && tid < 256) {
+            val = temp[tid - offset];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (tid < 256) {
+            temp[tid] += val;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // Convert to exclusive scan
+    if (tid < 256) {
+        histograms[tid] = (tid > 0) ? temp[tid - 1] : 0;
+    }
+}
+
+// Scatter elements according to radix digit offsets
+kernel void radix_scatter(
+    device const uint* input [[buffer(0)]],
+    device uint* output [[buffer(1)]],
+    device const uint* offsets [[buffer(2)]],
+    constant uint& count [[buffer(3)]],
+    constant uint& shift [[buffer(4)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= count) return;
+
+    uint val = input[gid];
+    uint digit = (val >> shift) & 0xFF;
+
+    // Use atomic to get unique position for this digit
+    uint pos = atomic_fetch_add_explicit(
+        reinterpret_cast<device atomic_uint*>(&output[0]) + digit,
+        1, memory_order_relaxed);
+    // Note: this simple scatter is used with pre-computed offsets
+    // The actual implementation uses a two-pass approach
+}
+
+// Scatter key-value pairs for radix sort
+kernel void radix_scatter_kv(
+    device const uint* inputKeys [[buffer(0)]],
+    device const int* inputVals [[buffer(1)]],
+    device uint* outputKeys [[buffer(2)]],
+    device int* outputVals [[buffer(3)]],
+    device atomic_uint* digitOffsets [[buffer(4)]],
+    constant uint& count [[buffer(5)]],
+    constant uint& shift [[buffer(6)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= count) return;
+
+    uint key = inputKeys[gid];
+    uint digit = (key >> shift) & 0xFF;
+    uint pos = atomic_fetch_add_explicit(&digitOffsets[digit], 1,
+                                         memory_order_relaxed);
+    outputKeys[pos] = key;
+    outputVals[pos] = inputVals[gid];
+}
+
+// ---------------------------------------------------------------------------
+// Prefix Scan Kernels (Blelloch-style work-efficient scan)
+// ---------------------------------------------------------------------------
+
+// Block-level exclusive scan for int32
+kernel void exclusive_scan_int_block(
+    device const int* input [[buffer(0)]],
+    device int* output [[buffer(1)]],
+    device int* blockSums [[buffer(2)]],
+    constant uint& count [[buffer(3)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint gid [[thread_position_in_grid]],
+    uint groupId [[threadgroup_position_in_grid]],
+    uint groupSize [[threads_per_threadgroup]])
+{
+    threadgroup int shared[1024];
+
+    uint idx = gid;
+    shared[tid] = (idx < count) ? input[idx] : 0;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Up-sweep (reduce)
+    for (uint stride = 1; stride < groupSize; stride <<= 1) {
+        uint index = (tid + 1) * (stride << 1) - 1;
+        if (index < groupSize) {
+            shared[index] += shared[index - stride];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // Save block sum and clear last element
+    if (tid == groupSize - 1) {
+        if (blockSums) {
+            blockSums[groupId] = shared[tid];
+        }
+        shared[tid] = 0;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Down-sweep
+    for (uint stride = groupSize >> 1; stride > 0; stride >>= 1) {
+        uint index = (tid + 1) * (stride << 1) - 1;
+        if (index < groupSize) {
+            int temp = shared[index - stride];
+            shared[index - stride] = shared[index];
+            shared[index] += temp;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (idx < count) {
+        output[idx] = shared[tid];
+    }
+}
+
+// Add block offsets to complete multi-block scan
+kernel void scan_add_block_offsets(
+    device int* data [[buffer(0)]],
+    device const int* blockOffsets [[buffer(1)]],
+    constant uint& count [[buffer(2)]],
+    uint gid [[thread_position_in_grid]],
+    uint groupId [[threadgroup_position_in_grid]])
+{
+    if (gid < count && groupId > 0) {
+        data[gid] += blockOffsets[groupId];
+    }
+}
+
+// Inclusive scan for int32 (block-level)
+kernel void inclusive_scan_int_block(
+    device const int* input [[buffer(0)]],
+    device int* output [[buffer(1)]],
+    device int* blockSums [[buffer(2)]],
+    constant uint& count [[buffer(3)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint gid [[thread_position_in_grid]],
+    uint groupId [[threadgroup_position_in_grid]],
+    uint groupSize [[threads_per_threadgroup]])
+{
+    threadgroup int shared[1024];
+
+    uint idx = gid;
+    shared[tid] = (idx < count) ? input[idx] : 0;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Hillis-Steele inclusive scan
+    for (uint offset = 1; offset < groupSize; offset <<= 1) {
+        int val = 0;
+        if (tid >= offset) {
+            val = shared[tid - offset];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        shared[tid] += val;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (idx < count) {
+        output[idx] = shared[tid];
+    }
+
+    // Save block sum
+    if (tid == groupSize - 1 && blockSums) {
+        blockSums[groupId] = shared[tid];
+    }
+}
+
+// Inclusive scan for double (block-level)
+kernel void inclusive_scan_double_block(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    device float* blockSums [[buffer(2)]],
+    constant uint& count [[buffer(3)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint gid [[thread_position_in_grid]],
+    uint groupId [[threadgroup_position_in_grid]],
+    uint groupSize [[threads_per_threadgroup]])
+{
+    threadgroup float shared[1024];
+
+    uint idx = gid;
+    shared[tid] = (idx < count) ? input[idx] : 0.0;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Hillis-Steele inclusive scan
+    for (uint offset = 1; offset < groupSize; offset <<= 1) {
+        float val = 0.0;
+        if (tid >= offset) {
+            val = shared[tid - offset];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        shared[tid] += val;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (idx < count) {
+        output[idx] = shared[tid];
+    }
+
+    if (tid == groupSize - 1 && blockSums) {
+        blockSums[groupId] = shared[tid];
+    }
+}
+
+kernel void scan_add_block_offsets_double(
+    device float* data [[buffer(0)]],
+    device const float* blockOffsets [[buffer(1)]],
+    constant uint& count [[buffer(2)]],
+    uint gid [[thread_position_in_grid]],
+    uint groupId [[threadgroup_position_in_grid]])
+{
+    if (gid < count && groupId > 0) {
+        data[gid] += blockOffsets[groupId];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Reduction Kernels
+// ---------------------------------------------------------------------------
+
+// Sum reduction for int32
+kernel void reduce_sum_int(
+    device const int* input [[buffer(0)]],
+    device int* output [[buffer(1)]],
+    constant uint& count [[buffer(2)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint gid [[thread_position_in_grid]],
+    uint groupId [[threadgroup_position_in_grid]],
+    uint groupSize [[threads_per_threadgroup]])
+{
+    threadgroup int shared[1024];
+
+    uint idx = gid;
+    shared[tid] = (idx < count) ? input[idx] : 0;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Tree reduction
+    for (uint stride = groupSize / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            shared[tid] += shared[tid + stride];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (tid == 0) {
+        output[groupId] = shared[0];
+    }
+}
+
+// Sum reduction for float (used for double via two-pass)
+kernel void reduce_sum_float(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant uint& count [[buffer(2)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint gid [[thread_position_in_grid]],
+    uint groupId [[threadgroup_position_in_grid]],
+    uint groupSize [[threads_per_threadgroup]])
+{
+    threadgroup float shared[1024];
+
+    uint idx = gid;
+    shared[tid] = (idx < count) ? input[idx] : 0.0;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint stride = groupSize / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            shared[tid] += shared[tid + stride];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (tid == 0) {
+        output[groupId] = shared[0];
+    }
+}
+
+// Min/Max reduction for float
+kernel void reduce_minmax_float(
+    device const float* input [[buffer(0)]],
+    device float* outputMin [[buffer(1)]],
+    device float* outputMax [[buffer(2)]],
+    constant uint& count [[buffer(3)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint gid [[thread_position_in_grid]],
+    uint groupId [[threadgroup_position_in_grid]],
+    uint groupSize [[threads_per_threadgroup]])
+{
+    threadgroup float sharedMin[1024];
+    threadgroup float sharedMax[1024];
+
+    uint idx = gid;
+    float val = (idx < count) ? input[idx] : INFINITY;
+    sharedMin[tid] = val;
+    sharedMax[tid] = (idx < count) ? val : -INFINITY;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint stride = groupSize / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            sharedMin[tid] = min(sharedMin[tid], sharedMin[tid + stride]);
+            sharedMax[tid] = max(sharedMax[tid], sharedMax[tid + stride]);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (tid == 0) {
+        outputMin[groupId] = sharedMin[0];
+        outputMax[groupId] = sharedMax[0];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Utility Kernels
+// ---------------------------------------------------------------------------
+
+// Fill array with sequential integers
+kernel void sequence_fill(
+    device int* output [[buffer(0)]],
+    constant int& start [[buffer(1)]],
+    constant uint& count [[buffer(2)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid < count) {
+        output[gid] = start + int(gid);
+    }
+}
+
+// Scatter: output[indices[i]] = input[i]
+kernel void scatter_int(
+    device const int* input [[buffer(0)]],
+    device const int* indices [[buffer(1)]],
+    device int* output [[buffer(2)]],
+    constant uint& count [[buffer(3)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid < count) {
+        output[indices[gid]] = input[gid];
+    }
+}
+
+// Gather: output[i] = input[indices[i]]
+kernel void gather_int(
+    device const int* input [[buffer(0)]],
+    device const int* indices [[buffer(1)]],
+    device int* output [[buffer(2)]],
+    constant uint& count [[buffer(3)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid < count) {
+        output[gid] = input[indices[gid]];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CSG/Boolean-specific Kernels
+// ---------------------------------------------------------------------------
+
+// Morton code computation for 3D positions
+// Expands a 10-bit integer into 30 bits by inserting 2 zeros between each bit
+inline uint expandBits(uint v) {
+    v = (v * 0x00010001u) & 0xFF0000FFu;
+    v = (v * 0x00000101u) & 0x0F00F00Fu;
+    v = (v * 0x00000011u) & 0xC30C30C3u;
+    v = (v * 0x00000005u) & 0x49249249u;
+    return v;
+}
+
+// Compute Morton code for a 3D point within a bounding box
+kernel void compute_morton_codes(
+    device const float* positions [[buffer(0)]],  // packed xyz
+    device uint* mortonCodes [[buffer(1)]],
+    constant float3& bboxMin [[buffer(2)]],
+    constant float3& bboxMax [[buffer(3)]],
+    constant uint& count [[buffer(4)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= count) return;
+
+    float3 pos = float3(positions[gid * 3], positions[gid * 3 + 1],
+                        positions[gid * 3 + 2]);
+
+    // Check for NaN (marks removed vertices)
+    if (isnan(pos.x)) {
+        mortonCodes[gid] = 0xFFFFFFFF;
+        return;
+    }
+
+    float3 range = bboxMax - bboxMin;
+    float3 normalized = (pos - bboxMin) / range;
+    normalized = clamp(normalized, 0.0f, 1.0f);
+
+    uint x = uint(normalized.x * 1023.0f);
+    uint y = uint(normalized.y * 1023.0f);
+    uint z = uint(normalized.z * 1023.0f);
+
+    mortonCodes[gid] = expandBits(x) | (expandBits(y) << 1) |
+                       (expandBits(z) << 2);
+}
+
+// Compute face bounding boxes and Morton codes
+kernel void compute_face_box_morton(
+    device const float* vertPos [[buffer(0)]],       // xyz per vertex
+    device const int* halfedges [[buffer(1)]],        // packed halfedge data
+    device float* faceBoxMin [[buffer(2)]],           // xyz per face
+    device float* faceBoxMax [[buffer(3)]],           // xyz per face
+    device uint* faceMorton [[buffer(4)]],
+    constant float3& bboxMin [[buffer(5)]],
+    constant float3& bboxMax [[buffer(6)]],
+    constant uint& numTri [[buffer(7)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= numTri) return;
+
+    // Each face has 3 halfedges; halfedge stores startVert at offset 0
+    // Halfedge struct: { int startVert, endVert, pairedHalfedge, propVert }
+    int he0 = halfedges[gid * 3 * 4];  // startVert of first halfedge
+    int he1 = halfedges[(gid * 3 + 1) * 4];
+    int he2 = halfedges[(gid * 3 + 2) * 4];
+
+    // Check for removed face
+    int paired0 = halfedges[gid * 3 * 4 + 2];
+    if (paired0 < 0) {
+        faceMorton[gid] = 0xFFFFFFFF;
+        return;
+    }
+
+    float3 v0 = float3(vertPos[he0 * 3], vertPos[he0 * 3 + 1],
+                        vertPos[he0 * 3 + 2]);
+    float3 v1 = float3(vertPos[he1 * 3], vertPos[he1 * 3 + 1],
+                        vertPos[he1 * 3 + 2]);
+    float3 v2 = float3(vertPos[he2 * 3], vertPos[he2 * 3 + 1],
+                        vertPos[he2 * 3 + 2]);
+
+    float3 boxMin = min(v0, min(v1, v2));
+    float3 boxMax = max(v0, max(v1, v2));
+    float3 center = (v0 + v1 + v2) / 3.0f;
+
+    faceBoxMin[gid * 3] = boxMin.x;
+    faceBoxMin[gid * 3 + 1] = boxMin.y;
+    faceBoxMin[gid * 3 + 2] = boxMin.z;
+    faceBoxMax[gid * 3] = boxMax.x;
+    faceBoxMax[gid * 3 + 1] = boxMax.y;
+    faceBoxMax[gid * 3 + 2] = boxMax.z;
+
+    // Morton code for center
+    float3 range = bboxMax - bboxMin;
+    float3 normalized = (center - bboxMin) / range;
+    normalized = clamp(normalized, 0.0f, 1.0f);
+
+    uint x = uint(normalized.x * 1023.0f);
+    uint y = uint(normalized.y * 1023.0f);
+    uint z = uint(normalized.z * 1023.0f);
+
+    faceMorton[gid] = expandBits(x) | (expandBits(y) << 1) |
+                      (expandBits(z) << 2);
+}
+
+// Reindex halfedges after face sorting (parallel face gather)
+kernel void reindex_faces(
+    device const int* oldHalfedges [[buffer(0)]],     // source halfedge data
+    device int* newHalfedges [[buffer(1)]],            // destination
+    device const int* faceNew2Old [[buffer(2)]],
+    device const int* faceOld2New [[buffer(3)]],
+    constant uint& numTri [[buffer(4)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= numTri) return;
+
+    int oldFace = faceNew2Old[gid];
+    for (int i = 0; i < 3; i++) {
+        int oldEdge = 3 * oldFace + i;
+        int newEdge = 3 * int(gid) + i;
+
+        // Copy halfedge (4 ints per halfedge)
+        int startVert = oldHalfedges[oldEdge * 4];
+        int endVert = oldHalfedges[oldEdge * 4 + 1];
+        int paired = oldHalfedges[oldEdge * 4 + 2];
+        int propVert = oldHalfedges[oldEdge * 4 + 3];
+
+        // Remap pairedHalfedge to new face ordering
+        int pairedFace = paired / 3;
+        int offset = paired - 3 * pairedFace;
+        paired = 3 * faceOld2New[pairedFace] + offset;
+
+        newHalfedges[newEdge * 4] = startVert;
+        newHalfedges[newEdge * 4 + 1] = endVert;
+        newHalfedges[newEdge * 4 + 2] = paired;
+        newHalfedges[newEdge * 4 + 3] = propVert;
+    }
+}
+
+// Vertex reindexing: update halfedge vertex references after vertex sort
+kernel void reindex_verts_in_halfedges(
+    device int* halfedges [[buffer(0)]],
+    device const int* vertOld2New [[buffer(1)]],
+    constant uint& numHalfedges [[buffer(2)]],
+    constant int& hasProp [[buffer(3)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= numHalfedges) return;
+
+    int startVert = halfedges[gid * 4];
+    if (startVert < 0) return;
+
+    halfedges[gid * 4] = vertOld2New[startVert];
+    halfedges[gid * 4 + 1] = vertOld2New[halfedges[gid * 4 + 1]];
+    if (hasProp == 0) {
+        halfedges[gid * 4 + 3] = halfedges[gid * 4];  // propVert = startVert
+    }
+}
+
+// Property compaction: mark used property vertices
+kernel void mark_used_props(
+    device const int* halfedges [[buffer(0)]],
+    device atomic_int* keep [[buffer(1)]],
+    constant uint& numHalfedges [[buffer(2)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= numHalfedges) return;
+    int propVert = halfedges[gid * 4 + 3];
+    atomic_store_explicit(&keep[propVert], 1, memory_order_relaxed);
+}
+
+// Compact properties using scan results
+kernel void compact_properties(
+    device const float* oldProps [[buffer(0)]],
+    device float* newProps [[buffer(1)]],
+    device const int* propOld2New [[buffer(2)]],
+    device const int* keep [[buffer(3)]],
+    constant uint& numVerts [[buffer(4)]],
+    constant uint& numProp [[buffer(5)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= numVerts) return;
+    if (keep[gid] == 0) return;
+
+    int newIdx = propOld2New[gid + 1];  // +1 because exclusive scan
+    for (uint p = 0; p < numProp; p++) {
+        newProps[newIdx * numProp + p] = oldProps[gid * numProp + p];
+    }
+}
+
+// Update propVert in halfedges after property compaction
+kernel void update_prop_verts(
+    device int* halfedges [[buffer(0)]],
+    device const int* propOld2New [[buffer(1)]],
+    constant uint& numHalfedges [[buffer(2)]],
+    uint gid [[thread_position_in_grid]])
+{
+    if (gid >= numHalfedges) return;
+    int propVert = halfedges[gid * 4 + 3];
+    halfedges[gid * 4 + 3] = propOld2New[propVert];
+}

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -26,8 +26,9 @@
 #include <tbb/parallel_scan.h>
 #endif
 #ifdef MANIFOLD_METAL
-#include "metal_backend.h"
 #include <type_traits>
+
+#include "metal_backend.h"
 
 namespace manifold {
 namespace metal_detail {
@@ -36,8 +37,8 @@ namespace metal_detail {
 template <typename Iter, typename = void>
 struct is_contiguous_iter : std::false_type {};
 template <typename Iter>
-struct is_contiguous_iter<
-    Iter, std::void_t<decltype(&*std::declval<Iter&>())>> : std::true_type {};
+struct is_contiguous_iter<Iter, std::void_t<decltype(&*std::declval<Iter&>())>>
+    : std::true_type {};
 template <typename Iter>
 inline constexpr bool is_contiguous_iter_v = is_contiguous_iter<Iter>::value;
 }  // namespace metal_detail
@@ -278,8 +279,7 @@ struct SortedRange {
   __attribute__((no_sanitize("thread")))
 #endif
 #endif
-  void
-  operator()(const tbb::blocked_range<SizeType>& range) {
+  void operator()(const tbb::blocked_range<SizeType>& range) {
     SortedRange<T, SizeType> rhs(input, tmp, range.begin(),
                                  range.end() - range.begin());
     rhs.inTmp =
@@ -450,8 +450,8 @@ T reduce(ExecutionPolicy policy, InputIter first, InputIter last, T init,
     size_t n = std::distance(first, last);
     if (policy == ExecutionPolicy::Par && n >= metal::kGPUThreshold &&
         metal::IsAvailable()) {
-      int32_t result = metal::ReduceSumInt(
-          reinterpret_cast<const int32_t*>(&*first), n);
+      int32_t result =
+          metal::ReduceSumInt(reinterpret_cast<const int32_t*>(&*first), n);
       return init + result;
     }
   }
@@ -542,9 +542,8 @@ void inclusive_scan(ExecutionPolicy policy, InputIter first, InputIter last,
     size_t n = std::distance(first, last);
     if (policy == ExecutionPolicy::Par && n >= metal::kGPUThreshold &&
         metal::IsAvailable()) {
-      if (metal::InclusiveScanInt(
-              reinterpret_cast<const int32_t*>(&*first),
-              reinterpret_cast<int32_t*>(&*d_first), n))
+      if (metal::InclusiveScanInt(reinterpret_cast<const int32_t*>(&*first),
+                                  reinterpret_cast<int32_t*>(&*d_first), n))
         return;
     }
   }
@@ -622,9 +621,9 @@ void exclusive_scan(ExecutionPolicy policy, InputIter first, InputIter last,
     size_t n = std::distance(first, last);
     if (policy == ExecutionPolicy::Par && n >= metal::kGPUThreshold &&
         metal::IsAvailable()) {
-      if (metal::ExclusiveScanInt(
-              reinterpret_cast<const int32_t*>(&*first),
-              reinterpret_cast<int32_t*>(&*d_first), n, init))
+      if (metal::ExclusiveScanInt(reinterpret_cast<const int32_t*>(&*first),
+                                  reinterpret_cast<int32_t*>(&*d_first), n,
+                                  init))
         return;
     }
   }

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -279,7 +279,8 @@ struct SortedRange {
   __attribute__((no_sanitize("thread")))
 #endif
 #endif
-  void operator()(const tbb::blocked_range<SizeType>& range) {
+  void
+  operator()(const tbb::blocked_range<SizeType>& range) {
     SortedRange<T, SizeType> rhs(input, tmp, range.begin(),
                                  range.end() - range.begin());
     rhs.inTmp =

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -25,6 +25,24 @@
 #include <tbb/parallel_reduce.h>
 #include <tbb/parallel_scan.h>
 #endif
+#ifdef MANIFOLD_METAL
+#include "metal_backend.h"
+#include <type_traits>
+
+namespace manifold {
+namespace metal_detail {
+// Check if dereferencing an iterator yields an lvalue reference to a
+// contiguous element (i.e. we can take its address safely).
+template <typename Iter, typename = void>
+struct is_contiguous_iter : std::false_type {};
+template <typename Iter>
+struct is_contiguous_iter<
+    Iter, std::void_t<decltype(&*std::declval<Iter&>())>> : std::true_type {};
+template <typename Iter>
+inline constexpr bool is_contiguous_iter_v = is_contiguous_iter<Iter>::value;
+}  // namespace metal_detail
+}  // namespace manifold
+#endif
 #include <algorithm>
 #include <numeric>
 
@@ -426,6 +444,18 @@ T reduce(ExecutionPolicy policy, InputIter first, InputIter last, T init,
                     std::random_access_iterator_tag>,
                 "You can only parallelize RandomAccessIterator.");
   (void)policy;
+#ifdef MANIFOLD_METAL
+  if constexpr ((std::is_same_v<T, int> || std::is_same_v<T, int32_t>) &&
+                metal_detail::is_contiguous_iter_v<InputIter>) {
+    size_t n = std::distance(first, last);
+    if (policy == ExecutionPolicy::Par && n >= metal::kGPUThreshold &&
+        metal::IsAvailable()) {
+      int32_t result = metal::ReduceSumInt(
+          reinterpret_cast<const int32_t*>(&*first), n);
+      return init + result;
+    }
+  }
+#endif
 #if (MANIFOLD_PAR == 1)
   if (policy == ExecutionPolicy::Par) {
     // should we use deterministic reduce here?
@@ -505,6 +535,20 @@ void inclusive_scan(ExecutionPolicy policy, InputIter first, InputIter last,
           std::random_access_iterator_tag>,
       "You can only parallelize RandomAccessIterator.");
   (void)policy;
+#ifdef MANIFOLD_METAL
+  if constexpr ((std::is_same_v<T, int> || std::is_same_v<T, int32_t>) &&
+                metal_detail::is_contiguous_iter_v<InputIter> &&
+                metal_detail::is_contiguous_iter_v<OutputIter>) {
+    size_t n = std::distance(first, last);
+    if (policy == ExecutionPolicy::Par && n >= metal::kGPUThreshold &&
+        metal::IsAvailable()) {
+      if (metal::InclusiveScanInt(
+              reinterpret_cast<const int32_t*>(&*first),
+              reinterpret_cast<int32_t*>(&*d_first), n))
+        return;
+    }
+  }
+#endif
 #if (MANIFOLD_PAR == 1)
   if (policy == ExecutionPolicy::Par) {
     tbb::this_task_arena::isolate([&]() {
@@ -571,6 +615,20 @@ void exclusive_scan(ExecutionPolicy policy, InputIter first, InputIter last,
       "You can only parallelize RandomAccessIterator.");
   (void)policy;
   (void)identity;
+#ifdef MANIFOLD_METAL
+  if constexpr ((std::is_same_v<T, int> || std::is_same_v<T, int32_t>) &&
+                metal_detail::is_contiguous_iter_v<InputIter> &&
+                metal_detail::is_contiguous_iter_v<OutputIter>) {
+    size_t n = std::distance(first, last);
+    if (policy == ExecutionPolicy::Par && n >= metal::kGPUThreshold &&
+        metal::IsAvailable()) {
+      if (metal::ExclusiveScanInt(
+              reinterpret_cast<const int32_t*>(&*first),
+              reinterpret_cast<int32_t*>(&*d_first), n, init))
+        return;
+    }
+  }
+#endif
 #if (MANIFOLD_PAR == 1)
   if (policy == ExecutionPolicy::Par) {
     details::ScanBody<T, InputIter, OutputIter, BinOp> body(init, identity, f,
@@ -1037,6 +1095,16 @@ template <typename Iterator,
           typename T = typename std::iterator_traits<Iterator>::value_type>
 void stable_sort(ExecutionPolicy policy, Iterator first, Iterator last) {
   (void)policy;
+#ifdef MANIFOLD_METAL
+  if constexpr (std::is_same_v<T, uint32_t> &&
+                metal_detail::is_contiguous_iter_v<Iterator>) {
+    size_t n = std::distance(first, last);
+    if (policy == ExecutionPolicy::Par && n >= metal::kGPUThreshold &&
+        metal::IsAvailable()) {
+      if (metal::RadixSortUint32(&*first, n)) return;
+    }
+  }
+#endif
 #if (MANIFOLD_PAR == 1)
   details::SortFunctor<Iterator, T>()(policy, first, last);
 #else
@@ -1157,6 +1225,18 @@ void gather(InputIterator mapFirst, InputIterator mapLast,
 // Write `[0, last - first)` to the range `[first, last)`.
 template <typename Iterator>
 void sequence(ExecutionPolicy policy, Iterator first, Iterator last) {
+  using T = typename std::iterator_traits<Iterator>::value_type;
+#ifdef MANIFOLD_METAL
+  if constexpr ((std::is_same_v<T, int> || std::is_same_v<T, int32_t>) &&
+                metal_detail::is_contiguous_iter_v<Iterator>) {
+    size_t n = std::distance(first, last);
+    if (policy == ExecutionPolicy::Par && n >= metal::kGPUThreshold &&
+        metal::IsAvailable()) {
+      if (metal::SequenceFill(reinterpret_cast<int32_t*>(&*first), n, 0))
+        return;
+    }
+  }
+#endif
   for_each(policy, countAt(0),
            countAt(static_cast<size_t>(std::distance(first, last))),
            [first](size_t i) { first[i] = i; });


### PR DESCRIPTION
Adds a Metal compute backend that accelerates parallel primitives (sort, scan, reduce, sequence) on Apple Silicon using the GPU. Leverages unified memory for zero-copy dispatch. Falls back to TBB when Metal is unavailable or data is below threshold.

New files:
- metal_backend.h/mm: Metal device management and kernel dispatch
- metal_kernels.metal: Compute shaders for sort, scan, reduce, etc.

Modified:
- parallel.h: GPU dispatch paths gated on MANIFOLD_METAL
- CMakeLists.txt: MANIFOLD_METAL option, OBJCXX, Metal framework linking

To be used in conjunction with https://github.com/DatanoiseTV/openscad/tree/feature/metal-gpu-compute