### PR TITLE
Fix SIGSEGV in AssembleHalfedges on broken face topology

### DIFF
--- a/src/face_op.cpp
+++ b/src/face_op.cpp
@@ -56,8 +56,23 @@ std::vector<std::vector<int>> AssembleHalfedges(VecView<Halfedge>::IterC start,
       polys.push_back({});
     }
     polys.back().push_back(startHalfedgeIdx + thisEdge);
+    const int numEdges = static_cast<int>(end - start);
+    if (thisEdge < 0 || thisEdge >= numEdges) {
+      // Out-of-bounds edge index — topology is broken, bail out and drain
+      // the remaining edges to prevent an infinite loop.
+      vert_edge.clear();
+      break;
+    }
     const auto result = vert_edge.find((start + thisEdge)->endVert);
-    DEBUG_ASSERT(result != vert_edge.end(), topologyErr, "non-manifold edge");
+    if (result == vert_edge.end()) {
+      // Non-manifold or broken topology: the endVert of this edge has no
+      // matching startVert among the remaining edges. This should not
+      // happen on valid geometry, but can occur when boolean operations
+      // produce degenerate faces. Drain and move on rather than crashing.
+      DEBUG_ASSERT(false, topologyErr, "non-manifold edge");
+      vert_edge.clear();
+      break;
+    }
     thisEdge = result->second;
     vert_edge.erase(result);
   }
@@ -127,8 +142,11 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
         std::swap(tri[1], tri[2]);
         std::swap(ends[1], ends[2]);
       }
-      DEBUG_ASSERT(ends[0] == tri[1] && ends[1] == tri[2] && ends[2] == tri[0],
-                   topologyErr, "These 3 edges do not form a triangle!");
+      if (ends[0] != tri[1] && ends[1] != tri[2] && ends[2] != tri[0]) {
+        DEBUG_ASSERT(false, topologyErr,
+                     "These 3 edges do not form a triangle!");
+        return;  // Skip degenerate triangle rather than producing garbage
+      }
 
       addTri(face, triEdge, normal, halfedgeRef[firstEdge]);
     } else if (numEdge == 4) {  // Pair of triangles
@@ -140,30 +158,38 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
                    epsilon_) >= 0;
       };
 
-      std::vector<int> quad = AssembleHalfedges(
+      auto assembled = AssembleHalfedges(
           halfedge_.cbegin() + faceEdge[face],
-          halfedge_.cbegin() + faceEdge[face + 1], faceEdge[face])[0];
-
-      const la::mat<int, 3, 2> tris[2] = {
-          {{quad[0], quad[1], quad[2]}, {quad[0], quad[2], quad[3]}},
-          {{quad[1], quad[2], quad[3]}, {quad[0], quad[1], quad[3]}}};
-
-      int choice = 0;
-
-      if (!(triCCW(tris[0][0]) && triCCW(tris[0][1]))) {
-        choice = 1;
-      } else if (triCCW(tris[1][0]) && triCCW(tris[1][1])) {
-        vec3 diag0 = vertPos_[halfedge_[quad[0]].startVert] -
-                     vertPos_[halfedge_[quad[2]].startVert];
-        vec3 diag1 = vertPos_[halfedge_[quad[1]].startVert] -
-                     vertPos_[halfedge_[quad[3]].startVert];
-        if (la::length2(diag0) > la::length2(diag1)) {
-          choice = 1;
+          halfedge_.cbegin() + faceEdge[face + 1], faceEdge[face]);
+      if (assembled.empty() || assembled[0].size() < 4) {
+        // Degenerate quad — fall through to general triangulation
+        for (const auto& tri : general(face)) {
+          addTri(face, tri, normal, halfedgeRef[firstEdge]);
         }
-      }
+      } else {
+        std::vector<int>& quad = assembled[0];
 
-      for (const auto& tri : tris[choice]) {
-        addTri(face, tri, normal, halfedgeRef[firstEdge]);
+        const la::mat<int, 3, 2> tris[2] = {
+            {{quad[0], quad[1], quad[2]}, {quad[0], quad[2], quad[3]}},
+            {{quad[1], quad[2], quad[3]}, {quad[0], quad[1], quad[3]}}};
+
+        int choice = 0;
+
+        if (!(triCCW(tris[0][0]) && triCCW(tris[0][1]))) {
+          choice = 1;
+        } else if (triCCW(tris[1][0]) && triCCW(tris[1][1])) {
+          vec3 diag0 = vertPos_[halfedge_[quad[0]].startVert] -
+                       vertPos_[halfedge_[quad[2]].startVert];
+          vec3 diag1 = vertPos_[halfedge_[quad[1]].startVert] -
+                       vertPos_[halfedge_[quad[3]].startVert];
+          if (la::length2(diag0) > la::length2(diag1)) {
+            choice = 1;
+          }
+        }
+
+        for (const auto& tri : tris[choice]) {
+          addTri(face, tri, normal, halfedgeRef[firstEdge]);
+        }
       }
     } else {  // General triangulation
       for (const auto& tri : general(face)) {


### PR DESCRIPTION
## Summary

Fixes a crash (`SIGSEGV` / `EXC_BAD_ACCESS`) in `AssembleHalfedges` (`face_op.cpp`) that occurs during `Face2Tri` in release builds when boolean operations produce degenerate faces with broken halfedge topology.

- **Root cause:** `vert_edge.find()` returns `end()` when a face's halfedge chain is broken (endVert has no matching startVert). The only guard was `DEBUG_ASSERT`, which is a no-op in release builds. Dereferencing `end()` is UB — it produces a garbage edge index causing an out-of-bounds read on the halfedge array.
- **Reproduction:** Triggered by complex CSG unions (`BatchBoolean` → `Boolean3::Result` → `Face2Tri`) with high-polygon meshes under TBB parallelism. Reproducible on macOS with Apple Silicon (M5 Pro) but the bug is platform-independent.
- **Crash signature:** `SIGSEGV` in `(anonymous namespace)::AssembleHalfedges` at various offsets (+108, +184, +224), always accessing an address just past the end of a `MALLOC_LARGE` region.

## Changes

Three layers of defense in `face_op.cpp`:

1. **`AssembleHalfedges`**: Added bounds check on `thisEdge` before dereferencing, and replaced the `DEBUG_ASSERT`-only check with a hard check that breaks out of the loop gracefully (drains remaining edges)
2. **Quad path (4-edge faces)**: Verify `AssembleHalfedges` returned at least 4 edges before indexing `quad[0..3]`; fall through to general triangulation if not
3. **Triangle path (3-edge faces)**: Skip degenerate triangles where edges don't form a valid closed loop

The fix is conservative — it prevents the crash and skips degenerate faces rather than producing corrupt geometry. The underlying cause (boolean operations producing faces with broken topology) may warrant a separate investigation.

## Test plan

- [x] Headless render of 201 high-polygon sphere unions (3.3M facets) completes without crash
- [x] GUI render of complex CSG models no longer crashes on F6
- [ ] Upstream test suite passes (CI will confirm)