### PR TITLE
Add ray casting language bindings

### DIFF
--- a/bindings/c/conv.cpp
+++ b/bindings/c/conv.cpp
@@ -37,6 +37,10 @@ ManifoldCrossSectionVec* to_c(CrossSectionVec* csv) {
   return reinterpret_cast<ManifoldCrossSectionVec*>(csv);
 }
 
+ManifoldRayHitVec* to_c(RayHitVec* v) {
+  return reinterpret_cast<ManifoldRayHitVec*>(v);
+}
+
 ManifoldSimplePolygon* to_c(manifold::SimplePolygon* m) {
   return reinterpret_cast<ManifoldSimplePolygon*>(m);
 }
@@ -148,6 +152,10 @@ manifold::CrossSection* from_c(ManifoldCrossSection* cs) {
 
 CrossSectionVec* from_c(ManifoldCrossSectionVec* csv) {
   return reinterpret_cast<CrossSectionVec*>(csv);
+}
+
+RayHitVec* from_c(ManifoldRayHitVec* v) {
+  return reinterpret_cast<RayHitVec*>(v);
 }
 
 manifold::SimplePolygon* from_c(ManifoldSimplePolygon* m) {

--- a/bindings/c/conv.h
+++ b/bindings/c/conv.h
@@ -24,6 +24,7 @@
 using namespace manifold;
 using ManifoldVec = std::vector<Manifold>;
 using CrossSectionVec = std::vector<CrossSection>;
+using RayHitVec = std::vector<RayHit>;
 
 ManifoldManifold* to_c(manifold::Manifold* m);
 ManifoldManifoldVec* to_c(ManifoldVec* ms);
@@ -40,6 +41,7 @@ ManifoldVec2 to_c(vec2 v);
 ManifoldVec3 to_c(vec3 v);
 ManifoldIVec3 to_c(ivec3 v);
 ManifoldTriangulation* to_c(std::vector<ivec3>* m);
+ManifoldRayHitVec* to_c(RayHitVec* v);
 
 manifold::Manifold* from_c(ManifoldManifold* m);
 ManifoldVec* from_c(ManifoldManifoldVec* ms);
@@ -59,6 +61,7 @@ vec3 from_c(ManifoldVec3 v);
 ivec3 from_c(ManifoldIVec3 v);
 vec4 from_c(ManifoldVec4 v);
 std::vector<ivec3>* from_c(ManifoldTriangulation* m);
+RayHitVec* from_c(ManifoldRayHitVec* v);
 
 std::vector<vec3> vector_of_vec_array(ManifoldVec3* vs, size_t length);
 std::vector<ivec3> vector_of_vec_array(ManifoldIVec3* vs, size_t length);

--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -241,6 +241,14 @@ ManifoldManifold* manifold_calculate_normals(void* mem, ManifoldManifold* m,
                                              int normal_idx,
                                              double min_sharp_angle);
 
+// Ray Casting
+ManifoldRayHitVec* manifold_ray_cast(void* mem, ManifoldManifold* m,
+                                     double origin_x, double origin_y,
+                                     double origin_z, double end_x,
+                                     double end_y, double end_z);
+size_t manifold_ray_hit_vec_length(ManifoldRayHitVec* v);
+ManifoldRayHit manifold_ray_hit_vec_get(ManifoldRayHitVec* v, size_t idx);
+
 // CrossSection Shapes/Constructors
 ManifoldCrossSection* manifold_cross_section_empty(void* mem);
 ManifoldCrossSection* manifold_cross_section_copy(void* mem,
@@ -462,6 +470,7 @@ size_t manifold_manifold_size();
 size_t manifold_manifold_vec_size();
 size_t manifold_cross_section_size();
 size_t manifold_cross_section_vec_size();
+size_t manifold_ray_hit_vec_size();
 size_t manifold_simple_polygon_size();
 size_t manifold_polygons_size();
 size_t manifold_manifold_pair_size();
@@ -477,6 +486,7 @@ ManifoldManifold* manifold_alloc_manifold();
 ManifoldManifoldVec* manifold_alloc_manifold_vec();
 ManifoldCrossSection* manifold_alloc_cross_section();
 ManifoldCrossSectionVec* manifold_alloc_cross_section_vec();
+ManifoldRayHitVec* manifold_alloc_ray_hit_vec();
 ManifoldSimplePolygon* manifold_alloc_simple_polygon();
 ManifoldPolygons* manifold_alloc_polygons();
 ManifoldMeshGL* manifold_alloc_meshgl();
@@ -491,6 +501,7 @@ void manifold_destruct_manifold(ManifoldManifold* m);
 void manifold_destruct_manifold_vec(ManifoldManifoldVec* ms);
 void manifold_destruct_cross_section(ManifoldCrossSection* m);
 void manifold_destruct_cross_section_vec(ManifoldCrossSectionVec* csv);
+void manifold_destruct_ray_hit_vec(ManifoldRayHitVec* v);
 void manifold_destruct_simple_polygon(ManifoldSimplePolygon* p);
 void manifold_destruct_polygons(ManifoldPolygons* p);
 void manifold_destruct_meshgl(ManifoldMeshGL* m);
@@ -505,6 +516,7 @@ void manifold_delete_manifold(ManifoldManifold* m);
 void manifold_delete_manifold_vec(ManifoldManifoldVec* ms);
 void manifold_delete_cross_section(ManifoldCrossSection* cs);
 void manifold_delete_cross_section_vec(ManifoldCrossSectionVec* csv);
+void manifold_delete_ray_hit_vec(ManifoldRayHitVec* v);
 void manifold_delete_simple_polygon(ManifoldSimplePolygon* p);
 void manifold_delete_polygons(ManifoldPolygons* p);
 void manifold_delete_meshgl(ManifoldMeshGL* m);

--- a/bindings/c/include/manifold/types.h
+++ b/bindings/c/include/manifold/types.h
@@ -22,6 +22,7 @@ typedef struct ManifoldManifold ManifoldManifold;
 typedef struct ManifoldManifoldVec ManifoldManifoldVec;
 typedef struct ManifoldCrossSection ManifoldCrossSection;
 typedef struct ManifoldCrossSectionVec ManifoldCrossSectionVec;
+typedef struct ManifoldRayHitVec ManifoldRayHitVec;
 typedef struct ManifoldSimplePolygon ManifoldSimplePolygon;
 typedef struct ManifoldPolygons ManifoldPolygons;
 typedef struct ManifoldMeshGL ManifoldMeshGL;
@@ -87,6 +88,13 @@ typedef struct ManifoldMeshGL64Options {
   size_t merge_verts_length;
   double* halfedge_tangents;
 } ManifoldMeshGL64Options;
+
+typedef struct ManifoldRayHit {
+  uint64_t face_id;
+  double distance;
+  ManifoldVec3 position;
+  ManifoldVec3 normal;
+} ManifoldRayHit;
 
 // enums
 

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -837,6 +837,24 @@ double manifold_min_gap(ManifoldManifold* m, ManifoldManifold* other,
   return from_c(m)->MinGap(*from_c(other), searchLength);
 }
 
+ManifoldRayHitVec* manifold_ray_cast(void* mem, ManifoldManifold* m,
+                                     double origin_x, double origin_y,
+                                     double origin_z, double end_x,
+                                     double end_y, double end_z) {
+  auto hits = from_c(m)->RayCast(vec3(origin_x, origin_y, origin_z),
+                                 vec3(end_x, end_y, end_z));
+  return to_c(new (mem) RayHitVec(std::move(hits)));
+}
+
+size_t manifold_ray_hit_vec_length(ManifoldRayHitVec* v) {
+  return from_c(v)->size();
+}
+
+ManifoldRayHit manifold_ray_hit_vec_get(ManifoldRayHitVec* v, size_t idx) {
+  const auto& hit = (*from_c(v))[idx];
+  return {hit.faceID, hit.distance, to_c(hit.position), to_c(hit.normal)};
+}
+
 ManifoldManifold* manifold_calculate_normals(void* mem, ManifoldManifold* m,
                                              int normal_idx,
                                              double min_sharp_angle) {
@@ -883,6 +901,7 @@ size_t manifold_cross_section_size() { return sizeof(CrossSection); }
 size_t manifold_cross_section_vec_size() {
   return sizeof(std::vector<CrossSection>);
 }
+size_t manifold_ray_hit_vec_size() { return sizeof(RayHitVec); }
 size_t manifold_simple_polygon_size() { return sizeof(SimplePolygon); }
 size_t manifold_polygons_size() { return sizeof(Polygons); }
 size_t manifold_manifold_size() { return sizeof(Manifold); }
@@ -907,6 +926,7 @@ ManifoldCrossSection* manifold_alloc_cross_section() {
 ManifoldCrossSectionVec* manifold_alloc_cross_section_vec() {
   return to_c(new std::vector<CrossSection>);
 }
+ManifoldRayHitVec* manifold_alloc_ray_hit_vec() { return to_c(new RayHitVec); }
 ManifoldSimplePolygon* manifold_alloc_simple_polygon() {
   return to_c(new SimplePolygon);
 }
@@ -928,6 +948,7 @@ void manifold_delete_cross_section(ManifoldCrossSection* c) {
 void manifold_delete_cross_section_vec(ManifoldCrossSectionVec* csv) {
   delete from_c(csv);
 }
+void manifold_delete_ray_hit_vec(ManifoldRayHitVec* v) { delete from_c(v); }
 void manifold_delete_simple_polygon(ManifoldSimplePolygon* p) {
   delete from_c(p);
 }
@@ -950,6 +971,9 @@ void manifold_destruct_cross_section(ManifoldCrossSection* cs) {
 }
 void manifold_destruct_cross_section_vec(ManifoldCrossSectionVec* csv) {
   from_c(csv)->~CrossSectionVec();
+}
+void manifold_destruct_ray_hit_vec(ManifoldRayHitVec* v) {
+  from_c(v)->~RayHitVec();
 }
 void manifold_destruct_simple_polygon(ManifoldSimplePolygon* p) {
   from_c(p)->~SimplePolygon();

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -320,6 +320,9 @@ NB_MODULE(manifold3d, m) {
            nb::arg("search_length"),
            "Returns the minimum gap between two manifolds."
            "Returns a double between 0 and searchLength.")
+      .def("ray_cast", &Manifold::RayCast, nb::arg("origin"),
+           nb::arg("endpoint"),
+           "Cast a ray segment, returning all hits sorted by distance.")
       .def("calculate_normals", &Manifold::CalculateNormals,
            nb::arg("normal_idx"), nb::arg("min_sharp_angle") = 60,
            manifold__calculate_normals__normal_idx__min_sharp_angle)
@@ -705,6 +708,12 @@ NB_MODULE(manifold3d, m) {
       .def_ro("run_original_id", &MeshGL64::runOriginalID)
       .def_ro("face_id", &MeshGL64::faceID)
       .def("merge", &MeshGL64::Merge, mesh_gl__merge);
+
+  nb::class_<RayHit>(m, "RayHit")
+      .def_ro("face_id", &RayHit::faceID)
+      .def_ro("distance", &RayHit::distance)
+      .def_ro("position", &RayHit::position)
+      .def_ro("normal", &RayHit::normal);
 
   nb::enum_<Manifold::Error>(m, "Error")
       .value("NoError", Manifold::Error::NoError)

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -104,6 +104,13 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .field("halfedge", &Smoothness::halfedge)
       .field("smoothness", &Smoothness::smoothness);
 
+  value_object<RayHit>("rayHit")
+      .field("faceID", &RayHit::faceID)
+      .field("distance", &RayHit::distance)
+      .field("position", &RayHit::position)
+      .field("normal", &RayHit::normal);
+
+  register_vector<RayHit>("Vector_rayHit");
   register_vector<ivec3>("Vector_ivec3");
   register_vector<vec3>("Vector_vec3");
   register_vector<vec2>("Vector_vec2");
@@ -193,6 +200,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("volume", &Manifold::Volume)
       .function("surfaceArea", &Manifold::SurfaceArea)
       .function("minGap", &Manifold::MinGap)
+      .function("_RayCast", &man_js::RayCast)
       .function("calculateCurvature", &Manifold::CalculateCurvature)
       .function("_CalculateNormals", &Manifold::CalculateNormals)
       .function("originalID", &Manifold::OriginalID)

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -325,6 +325,20 @@ Module.setup = function() {
     return result;
   };
 
+  Module.Manifold.prototype.rayCast = function(origin, endpoint) {
+    const vec = this._RayCast(vararg2vec3([origin]), vararg2vec3([endpoint]));
+    const result =
+        fromVec(vec, hit => ({
+                       faceID: hit.faceID,
+                       distance: hit.distance,
+                       position: ['x', 'y', 'z'].map(f => hit.position[f]),
+                       normal: ['x', 'y', 'z'].map(f => hit.normal[f]),
+                     }));
+    vec.delete();
+    return result;
+  };
+
+
   Module.Manifold.prototype.split = function(manifold) {
     const vec = this._Split(manifold);
     const result = fromVec(vec);

--- a/bindings/wasm/helpers.cpp
+++ b/bindings/wasm/helpers.cpp
@@ -291,6 +291,10 @@ std::vector<Manifold> SplitByPlane(Manifold& m, vec3 normal,
   return {a, b};
 }
 
+std::vector<RayHit> RayCast(const Manifold& m, vec3 origin, vec3 endpoint) {
+  return m.RayCast(origin, endpoint);
+}
+
 void CollectVertices(std::vector<vec3>& verts, const Manifold& manifold) {
   const MeshGL64 mesh = manifold.GetMeshGL64();
   const auto numVert = mesh.NumVert();

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -16,7 +16,7 @@
  * @primaryExport
  */
 
-import {Box, ErrorStatus, FillRule, JoinType, Mat3, Mat4, Polygons, Rect, SealedFloat32Array, SealedUint32Array, SimplePolygon, Smoothness, Vec2, Vec3} from './manifold-global-types';
+import {Box, ErrorStatus, FillRule, JoinType, Mat3, Mat4, Polygons, RayHit, Rect, SealedFloat32Array, SealedUint32Array, SimplePolygon, Smoothness, Vec2, Vec3} from './manifold-global-types';
 
 /**
  * Triangulates a set of /epsilon-valid polygons.
@@ -1143,6 +1143,17 @@ export class Manifold {
    * @group Measurement
    */
   minGap(other: Manifold, searchLength: number): number;
+
+  /**
+   * Cast a ray segment, returning all hits sorted by distance.
+   *
+   * @param origin The start point of the ray segment.
+   * @param endpoint The end point of the ray segment.
+   * @returns Array of RayHit sorted by distance, empty on miss.
+   *
+   * @group Spatial Queries
+   */
+  rayCast(origin: Vec3, endpoint: Vec3): RayHit[];
 
   /**
    * Returns the reason for an input Mesh producing an empty Manifold. This

--- a/bindings/wasm/manifold-global-types.d.ts
+++ b/bindings/wasm/manifold-global-types.d.ts
@@ -102,6 +102,13 @@ export type Smoothness = {
   smoothness: number
 };
 
+export type RayHit = {
+  faceID: number,
+  distance: number,
+  position: Vec3,
+  normal: Vec3
+};
+
 export type FillRule = 'EvenOdd'|'NonZero'|'Positive'|'Negative';
 
 export type JoinType = 'Square'|'Round'|'Miter';

--- a/bindings/wasm/test/bindings.test.ts
+++ b/bindings/wasm/test/bindings.test.ts
@@ -39,6 +39,20 @@ suite('Manifold Bindings', () => {
     expect(manifold.volume()).toBeGreaterThan(0);
   });
 
+  test('rayCast returns hits through cube', () => {
+    const cube = manifoldModule.Manifold.cube([1, 1, 1], true);
+    const hits = cube.rayCast([0, 0, -5], [0, 0, 5]);
+    expect(hits).toHaveLength(2);
+    expect(hits[0].position[2]).toEqual(-0.5);
+    expect(hits[1].position[2]).toEqual(0.5);
+  });
+
+  test('rayCast returns empty on miss', () => {
+    const cube = manifoldModule.Manifold.cube([1, 1, 1], true);
+    const hits = cube.rayCast([10, 10, -5], [10, 10, 5]);
+    expect(hits).toHaveLength(0);
+  });
+
   test('refineToTolerance does not throw (issue #1545)', () => {
     // Reproduces the original failing geometry from issue #1545: a flat-faced
     // mesh with normals set via calculateNormals + smoothByNormals. On flat

--- a/bindings/wasm/types/manifoldCAD.d.ts
+++ b/bindings/wasm/types/manifoldCAD.d.ts
@@ -88,7 +88,7 @@ export declare function isManifoldCAD(): boolean
 export type {
   Mat3, Mat4, Vec2, Vec3,
   Polygons, SimplePolygon, FillRule, JoinType,
-  Box, Rect, Smoothness,
+  Box, Rect, Smoothness, RayHit,
   ErrorStatus
 } from '../manifold';
 

--- a/test/manifoldc_test.cpp
+++ b/test/manifoldc_test.cpp
@@ -525,6 +525,34 @@ TEST(CBIND, meshgl64_merge_returns_mem) {
   free(cube);
 }
 
+TEST(CBIND, ray_cast) {
+  ManifoldManifold* cube =
+      manifold_cube(alloc_manifold_buffer(), 1.0, 1.0, 1.0, 1);
+
+  void* mem = malloc(manifold_ray_hit_vec_size());
+  ManifoldRayHitVec* hits =
+      manifold_ray_cast(mem, cube, 0.0, 0.0, -5.0, 0.0, 0.0, 5.0);
+  ASSERT_EQ(manifold_ray_hit_vec_length(hits), 2);
+  ManifoldRayHit h0 = manifold_ray_hit_vec_get(hits, 0);
+  ManifoldRayHit h1 = manifold_ray_hit_vec_get(hits, 1);
+  EXPECT_FLOAT_EQ(h0.position.z, -0.5);
+  EXPECT_FLOAT_EQ(h0.normal.z, -1.0);
+  EXPECT_FLOAT_EQ(h1.position.z, 0.5);
+  EXPECT_FLOAT_EQ(h1.normal.z, 1.0);
+  manifold_destruct_ray_hit_vec(hits);
+  free(mem);
+
+  void* mem2 = malloc(manifold_ray_hit_vec_size());
+  ManifoldRayHitVec* miss =
+      manifold_ray_cast(mem2, cube, 10.0, 10.0, -5.0, 10.0, 10.0, 5.0);
+  EXPECT_EQ(manifold_ray_hit_vec_length(miss), 0);
+  manifold_destruct_ray_hit_vec(miss);
+  free(mem2);
+
+  manifold_destruct_manifold(cube);
+  free(cube);
+}
+
 TEST(CBIND, tolerance) {
   ManifoldManifold* sphere = manifold_sphere(alloc_manifold_buffer(), 1.0, 100);
 


### PR DESCRIPTION
## Summary
- Add `RayCast` bindings to all in-tree languages (C, Python, WASM/JS) matching the core API from #1645

Builds on #1645. Fixes #1640.

## C API design
Uses the same opaque-vec pattern as `ManifoldManifoldVec` and `ManifoldCrossSectionVec`:
- `ManifoldRayHitVec*` opaque handle wrapping `std::vector<RayHit>`
- `manifold_ray_cast(mem, m, ...)` → returns vec
- `manifold_ray_hit_vec_length(v)` / `manifold_ray_hit_vec_get(v, idx)` → access
- Standard `_size` / `_alloc` / `_destruct` / `_delete` lifecycle

Empty vec = miss (no separate `hit` flag needed).

We considered a sized-buffer approach (`manifold_ray_cast(m, out, max_hits, ...)` returning count) but rejected it — when the returned count equals `max_hits`, there's no way for the caller to know whether that's all the hits or a truncation. The opaque vec avoids this ambiguity.

## Test plan
- [ ] C API: `CBIND.ray_cast` (hit, miss, normals, lifecycle)
- [ ] WASM: `rayCast returns hits through cube` and `rayCast returns empty on miss`
- [ ] Python/WASM: can't be tested locally (no emscripten/nanobind in local build), relies on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)