### PR TITLE
Add ExecutionContext for boolean progress + cancellation

### DIFF
--- a/bindings/c/conv.cpp
+++ b/bindings/c/conv.cpp
@@ -116,6 +116,9 @@ ManifoldError to_c(manifold::Manifold::Error error) {
     case Manifold::Error::InvalidTangents:
       e = MANIFOLD_INVALID_TANGENTS;
       break;
+    case Manifold::Error::Cancelled:
+      e = MANIFOLD_CANCELLED;
+      break;
   };
   return e;
 }

--- a/bindings/c/include/manifold/types.h
+++ b/bindings/c/include/manifold/types.h
@@ -119,6 +119,7 @@ typedef enum ManifoldError {
   MANIFOLD_INVALID_CONSTRUCTION,
   MANIFOLD_RESULT_TOO_LARGE,
   MANIFOLD_INVALID_TANGENTS,
+  MANIFOLD_CANCELLED,
 } ManifoldError;
 
 typedef enum ManifoldFillRule {

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -387,7 +387,10 @@ NB_MODULE(manifold3d, m) {
             return CrossSection(self.Project()).Simplify(self.GetEpsilon());
           },
           manifold__project)
-      .def("status", &Manifold::Status, manifold__status)
+      .def(
+          "status",
+          static_cast<Manifold::Error (Manifold::*)() const>(&Manifold::Status),
+          manifold__status)
       .def(
           "bounding_box",
           [](const Manifold& self) {

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -731,7 +731,8 @@ NB_MODULE(manifold3d, m) {
       .value("FaceIDWrongLength", Manifold::Error::FaceIDWrongLength)
       .value("InvalidConstruction", Manifold::Error::InvalidConstruction)
       .value("ResultTooLarge", Manifold::Error::ResultTooLarge)
-      .value("InvalidTangents", Manifold::Error::InvalidTangents);
+      .value("InvalidTangents", Manifold::Error::InvalidTangents)
+      .value("Cancelled", Manifold::Error::Cancelled);
 
   nb::enum_<CrossSection::FillRule>(m, "FillRule")
       .value("EvenOdd", CrossSection::FillRule::EvenOdd,

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -83,7 +83,8 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .value("FaceIDWrongLength", Manifold::Error::FaceIDWrongLength)
       .value("InvalidConstruction", Manifold::Error::InvalidConstruction)
       .value("ResultTooLarge", Manifold::Error::ResultTooLarge)
-      .value("InvalidTangents", Manifold::Error::InvalidTangents);
+      .value("InvalidTangents", Manifold::Error::InvalidTangents)
+      .value("Cancelled", Manifold::Error::Cancelled);
 
   enum_<CrossSection::FillRule>("fillrule")
       .value("EvenOdd", CrossSection::FillRule::EvenOdd)

--- a/bindings/wasm/manifold-global-types.d.ts
+++ b/bindings/wasm/manifold-global-types.d.ts
@@ -120,4 +120,4 @@ export type ErrorStatus = 'NoError'|'NonFiniteVertex'|'NotManifold'|
     'VertexOutOfBounds'|'PropertiesWrongLength'|'MissingPositionProperties'|
     'MergeVectorsDifferentLengths'|'MergeIndexOutOfBounds'|
     'TransformWrongLength'|'RunIndexWrongLength'|'FaceIDWrongLength'|
-    'InvalidConstruction'|'ResultTooLarge'|'InvalidTangents';
+    'InvalidConstruction'|'ResultTooLarge'|'InvalidTangents'|'Cancelled';

--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -196,6 +196,20 @@ struct RayHit {
  * Cancellation granularity is currently per-boolean-operation; a single
  * large boolean may run to completion before the flag is checked again.
  * This may improve in future versions.
+ *
+ * Example: cancel from an observer thread.
+ * @code
+ * Manifold big = Manifold::BatchBoolean(items, OpType::Add);
+ * ExecutionContext ctx;
+ * std::thread eval([&] {
+ *   if (big.Status(ctx) == Manifold::Error::Cancelled) {
+ *     // evaluation was cancelled
+ *   }
+ * });
+ * // ...later, from the UI thread:
+ * ctx.Cancel();
+ * eval.join();
+ * @endcode
  */
 class ExecutionContext {
  public:

--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -15,6 +15,7 @@
 #pragma once
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <vector>
 
 #ifdef MANIFOLD_DEBUG
@@ -168,6 +169,55 @@ struct RayHit {
   vec3 position = vec3(0.0);
   /// The geometric face normal at the hit.
   vec3 normal = vec3(0.0);
+};
+
+/**
+ * @brief Observe and control a long-running Manifold evaluation.
+ *
+ * Pass to Manifold::Status(ctx) to observe progress and optionally request
+ * cancellation of the evaluation. Safe to read/write from any thread.
+ *
+ * Copyable and movable: copies share the same underlying state via a
+ * shared_ptr, so one thread can evaluate while another holds a copy and
+ * observes Progress() or calls Cancel(). Use a separate context per
+ * evaluation; passing the same context (or a copy of it) to two
+ * concurrent Status(ctx) calls produces meaningless progress values
+ * because both calls reset and mutate the same counters.
+ *
+ * Cancellation is permanent for a Manifold: once requested and detected,
+ * the Manifold's status becomes Error::Cancelled and stays Cancelled. To
+ * retry, construct a new Manifold. A context, however, is reusable: each
+ * Status(ctx) call resets the progress counters, but it does NOT clear
+ * the cancel flag — once Cancel() has been called on a context, every
+ * subsequent evaluation with that context (or any copy of it) will
+ * short-circuit to Error::Cancelled. Construct a fresh context to make a
+ * new evaluation cancellable independently.
+ *
+ * Cancellation granularity is currently per-boolean-operation; a single
+ * large boolean may run to completion before the flag is checked again.
+ * This may improve in future versions.
+ */
+class ExecutionContext {
+ public:
+  ExecutionContext();
+  ~ExecutionContext();
+  ExecutionContext(const ExecutionContext&);
+  ExecutionContext(ExecutionContext&&) noexcept;
+  ExecutionContext& operator=(const ExecutionContext&);
+  ExecutionContext& operator=(ExecutionContext&&) noexcept;
+
+  /// Request cancellation. Can be called from any thread. Idempotent.
+  void Cancel();
+  /// Has cancellation been requested?
+  bool Cancelled() const;
+  /// Normalized progress in [0, 1]. Returns 0 before any work has been
+  /// scheduled. Monotonically increases during evaluation.
+  double Progress() const;
+
+  /// @internal Opaque implementation. Defined in src/execution_impl.h;
+  /// accessible only to internal code that includes that header.
+  struct Impl;
+  std::shared_ptr<Impl> impl_;
 };
 
 /**

--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -371,6 +371,7 @@ class Manifold {
     InvalidConstruction,
     ResultTooLarge,
     InvalidTangents,
+    Cancelled,
   };
 
   /** @name Information
@@ -378,6 +379,7 @@ class Manifold {
    */
   ///@{
   Error Status() const;
+  Error Status(ExecutionContext& ctx) const;
   bool IsEmpty() const;
   size_t NumVert() const;
   size_t NumEdge() const;
@@ -539,7 +541,7 @@ class Manifold {
   mutable std::shared_ptr<CsgNode> pNode_;
 
   std::shared_ptr<CsgNode> LoadPNode() const;
-  CsgLeafNode& GetCsgLeafNode() const;
+  CsgLeafNode& GetCsgLeafNode(ExecutionContext::Impl* ctx = nullptr) const;
 };
 /** @} */
 
@@ -582,6 +584,8 @@ inline std::string ToString(const Manifold::Error& error) {
       return "Result Too Large";
     case Manifold::Error::InvalidTangents:
       return "Invalid Tangents";
+    case Manifold::Error::Cancelled:
+      return "Cancelled";
     default:
       return "Unknown Error";
   };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(
   constructors.cpp
   csg_tree.cpp
   edge_op.cpp
+  execution_impl.cpp
   face_op.cpp
   impl.cpp
   manifold.cpp
@@ -40,6 +41,7 @@ set(
   boolean3.h
   collider.h
   csg_tree.h
+  execution_impl.h
   hashtable.h
   impl.h
   iters.h

--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -21,6 +21,7 @@
 
 #include "boolean3.h"
 #include "csg_tree.h"
+#include "execution_impl.h"
 #include "impl.h"
 #include "mesh_fixes.h"
 #include "parallel.h"
@@ -101,7 +102,8 @@ std::shared_ptr<const Manifold::Impl> CsgLeafNode::GetImpl() const {
   return pImpl_;
 }
 
-std::shared_ptr<CsgLeafNode> CsgLeafNode::ToLeafNode() const {
+std::shared_ptr<CsgLeafNode> CsgLeafNode::ToLeafNode(
+    ExecutionContext::Impl*) const {
   return std::make_shared<CsgLeafNode>(*this);
 }
 
@@ -144,8 +146,19 @@ std::shared_ptr<CsgLeafNode> ImplToLeaf(Manifold::Impl&& impl) {
       std::make_shared<Manifold::Impl>(std::move(impl)));
 }
 
+// Build a leaf with the given error status — used to short-circuit boolean
+// evaluation on cancellation.
+std::shared_ptr<CsgLeafNode> ErrorLeaf(Manifold::Error err) {
+  Manifold::Impl impl;
+  impl.status_ = err;
+  return ImplToLeaf(std::move(impl));
+}
+
 std::shared_ptr<CsgLeafNode> SimpleBoolean(const Manifold::Impl& a,
-                                           const Manifold::Impl& b, OpType op) {
+                                           const Manifold::Impl& b, OpType op,
+                                           ExecutionContext::Impl* ctx) {
+  if (ctx && ctx->cancel.load(std::memory_order_relaxed))
+    return ErrorLeaf(Manifold::Error::Cancelled);
 #ifdef MANIFOLD_DEBUG
   auto dump = [&]() {
     dump_lock.lock();
@@ -175,6 +188,7 @@ std::shared_ptr<CsgLeafNode> SimpleBoolean(const Manifold::Impl& a,
       dump_lock.unlock();
       throw logicErr("self intersection detected");
     }
+    if (ctx) ctx->doneBooleans.fetch_add(1, std::memory_order_relaxed);
     return ImplToLeaf(std::move(impl));
   } catch (logicErr& err) {
     dump();
@@ -184,7 +198,9 @@ std::shared_ptr<CsgLeafNode> SimpleBoolean(const Manifold::Impl& a,
     throw err;
   }
 #else
-  return ImplToLeaf(Boolean3(a, b, op).Result(op));
+  auto leaf = ImplToLeaf(Boolean3(a, b, op).Result(op));
+  if (ctx) ctx->doneBooleans.fetch_add(1, std::memory_order_relaxed);
+  return leaf;
 #endif
 }
 
@@ -379,7 +395,8 @@ std::shared_ptr<CsgLeafNode> CsgLeafNode::Compose(
  * operation. Only supports union and intersection.
  */
 std::shared_ptr<CsgLeafNode> BatchBoolean(
-    OpType operation, std::vector<std::shared_ptr<CsgLeafNode>>& results) {
+    OpType operation, std::vector<std::shared_ptr<CsgLeafNode>>& results,
+    ExecutionContext::Impl* ctx) {
   ZoneScoped;
   DEBUG_ASSERT(operation != OpType::Subtract, logicErr,
                "BatchBoolean doesn't support Difference.");
@@ -388,7 +405,7 @@ std::shared_ptr<CsgLeafNode> BatchBoolean(
   if (results.size() == 1) return results.front();
   if (results.size() == 2)
     return SimpleBoolean(*results[0]->GetImpl(), *results[1]->GetImpl(),
-                         operation);
+                         operation, ctx);
   std::vector<std::pair<std::shared_ptr<CsgLeafNode>, uint64_t>> heapNodes;
   heapNodes.reserve(results.size());
   for (size_t i = 0; i < results.size(); ++i) {
@@ -412,6 +429,8 @@ std::shared_ptr<CsgLeafNode> BatchBoolean(
   for (int i = 0; i < 4; i++) parallelSerial.push_back(0);
 #endif
   while (heapNodes.size() > 1) {
+    if (ctx && ctx->cancel.load(std::memory_order_relaxed))
+      return ErrorLeaf(Manifold::Error::Cancelled);
     for (size_t i = 0; i < 4 && heapNodes.size() > 1; i++) {
       std::pop_heap(heapNodes.begin(), heapNodes.end(), cmpFn);
       auto a = std::move(heapNodes.back());
@@ -422,11 +441,12 @@ std::shared_ptr<CsgLeafNode> BatchBoolean(
 #if MANIFOLD_PAR == 1
       parallelSerial[i] = nextSerial++;
       group.run([&, i, a = std::move(a.first), b = std::move(b.first)]() {
-        parallelTmp[i] = SimpleBoolean(*a->GetImpl(), *b->GetImpl(), operation);
+        parallelTmp[i] =
+            SimpleBoolean(*a->GetImpl(), *b->GetImpl(), operation, ctx);
       });
 #else
-      auto result =
-          SimpleBoolean(*a.first->GetImpl(), *b.first->GetImpl(), operation);
+      auto result = SimpleBoolean(*a.first->GetImpl(), *b.first->GetImpl(),
+                                  operation, ctx);
       tmp.emplace_back(std::move(result), nextSerial++);
 #endif
     }
@@ -449,7 +469,8 @@ std::shared_ptr<CsgLeafNode> BatchBoolean(
  * possible.
  */
 std::shared_ptr<CsgLeafNode> BatchUnion(
-    std::vector<std::shared_ptr<CsgLeafNode>>& children) {
+    std::vector<std::shared_ptr<CsgLeafNode>>& children,
+    ExecutionContext::Impl* ctx) {
   ZoneScoped;
   // INVARIANT: children_ is a vector of leaf nodes
   // this kMaxUnionSize is a heuristic to avoid the pairwise disjoint check
@@ -460,6 +481,8 @@ std::shared_ptr<CsgLeafNode> BatchUnion(
   DEBUG_ASSERT(!children.empty(), logicErr,
                "BatchUnion should not have empty children");
   while (children.size() > 1) {
+    if (ctx && ctx->cancel.load(std::memory_order_relaxed))
+      return ErrorLeaf(Manifold::Error::Cancelled);
     const size_t start = (children.size() > kMaxUnionSize)
                              ? (children.size() - kMaxUnionSize)
                              : 0;
@@ -495,11 +518,16 @@ std::shared_ptr<CsgLeafNode> BatchUnion(
           tmp.push_back(children[start + j]);
         }
         impls.push_back(CsgLeafNode::Compose(tmp));
+        // Compose absorbs set.size() leaves into 1 leaf, which is
+        // set.size() - 1 leaf-reductions toward the final result.
+        if (ctx)
+          ctx->doneBooleans.fetch_add(static_cast<int>(set.size() - 1),
+                                      std::memory_order_relaxed);
       }
     }
 
     children.erase(children.begin() + start, children.end());
-    children.push_back(BatchBoolean(OpType::Add, impls));
+    children.push_back(BatchBoolean(OpType::Add, impls, ctx));
     // move it to the front as we process from the back, and the newly added
     // child should be quite complicated
     std::swap(children.front(), children.back());
@@ -580,7 +608,8 @@ struct CsgStackFrame {
         op_node(op_node) {}
 };
 
-std::shared_ptr<CsgLeafNode> CsgOpNode::ToLeafNode() const {
+std::shared_ptr<CsgLeafNode> CsgOpNode::ToLeafNode(
+    ExecutionContext::Impl* ctx) const {
   ZoneScoped;
   if (cache_ != nullptr) return cache_;
 
@@ -683,16 +712,21 @@ std::shared_ptr<CsgLeafNode> CsgOpNode::ToLeafNode() const {
   //     destination->push_back(node->cache_->Transform(transform));
   // }
   while (!stack.empty()) {
+    if (ctx && ctx->cancel.load(std::memory_order_relaxed)) {
+      cache_ = ErrorLeaf(Manifold::Error::Cancelled);
+      return cache_;
+    }
     std::shared_ptr<CsgStackFrame> frame = stack.back();
     auto impl = frame->op_node->impl_.GetGuard();
     if (frame->finalize) {
       if (!frame->op_node->cache_) {
         switch (frame->op_node->op_) {
           case OpType::Add:
-            *impl = {BatchUnion(frame->positive_children)};
+            *impl = {BatchUnion(frame->positive_children, ctx)};
             break;
           case OpType::Intersect: {
-            *impl = {BatchBoolean(OpType::Intersect, frame->positive_children)};
+            *impl = {
+                BatchBoolean(OpType::Intersect, frame->positive_children, ctx)};
             break;
           };
           case OpType::Subtract:
@@ -700,14 +734,15 @@ std::shared_ptr<CsgLeafNode> CsgOpNode::ToLeafNode() const {
               // nothing to subtract from, so the result is empty.
               *impl = {std::make_shared<CsgLeafNode>()};
             } else {
-              auto positive = BatchUnion(frame->positive_children);
+              auto positive = BatchUnion(frame->positive_children, ctx);
               if (frame->negative_children.empty()) {
                 // nothing to subtract, result equal to the LHS.
                 *impl = {frame->positive_children[0]};
               } else {
-                auto negative = BatchUnion(frame->negative_children);
+                auto negative = BatchUnion(frame->negative_children, ctx);
                 *impl = {SimpleBoolean(*positive->GetImpl(),
-                                       *negative->GetImpl(), OpType::Subtract)};
+                                       *negative->GetImpl(), OpType::Subtract,
+                                       ctx)};
               }
             }
             break;
@@ -776,6 +811,16 @@ CsgNodeType CsgOpNode::GetNodeType() const {
   }
   // unreachable...
   return CsgNodeType::Leaf;
+}
+
+size_t CsgOpNode::NumLeaves() const {
+  // An already-evaluated CsgOpNode counts as a single leaf for the purposes
+  // of estimating remaining boolean work.
+  if (cache_ != nullptr) return 1;
+  auto impl = impl_.GetGuard();
+  size_t total = 0;
+  for (const auto& child : *impl) total += child->NumLeaves();
+  return total;
 }
 
 }  // namespace manifold

--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -713,7 +713,17 @@ std::shared_ptr<CsgLeafNode> CsgOpNode::ToLeafNode(
   // }
   while (!stack.empty()) {
     if (ctx && ctx->cancel.load(std::memory_order_relaxed)) {
-      cache_ = ErrorLeaf(Manifold::Error::Cancelled);
+      // Poison every op_node currently on the stack, not just `this`.
+      // Sub-ops may have had their impl_ partially mutated during finalize
+      // (children replaced with an intermediate result); leaving cache_
+      // unset would let a later evaluation of a shared sub-op run against
+      // a partially-reduced tree. Shared cache ensures any subsequent
+      // eval of any op on the stack returns Cancelled.
+      auto cancelled = ErrorLeaf(Manifold::Error::Cancelled);
+      for (auto& frame : stack) {
+        if (!frame->op_node->cache_) frame->op_node->cache_ = cancelled;
+      }
+      cache_ = cancelled;
       return cache_;
     }
     std::shared_ptr<CsgStackFrame> frame = stack.back();
@@ -815,11 +825,29 @@ CsgNodeType CsgOpNode::GetNodeType() const {
 
 size_t CsgOpNode::NumLeaves() const {
   // An already-evaluated CsgOpNode counts as a single leaf for the purposes
-  // of estimating remaining boolean work.
+  // of estimating remaining boolean work. Iterative walk: `+=` chains can
+  // produce very deep CsgOpNode trees that would blow the call stack if
+  // this were recursive.
   if (cache_ != nullptr) return 1;
-  auto impl = impl_.GetGuard();
   size_t total = 0;
-  for (const auto& child : *impl) total += child->NumLeaves();
+  std::vector<const CsgOpNode*> stack;
+  stack.push_back(this);
+  while (!stack.empty()) {
+    const CsgOpNode* op = stack.back();
+    stack.pop_back();
+    if (op->cache_ != nullptr) {
+      total += 1;
+      continue;
+    }
+    auto impl = op->impl_.GetGuard();
+    for (const auto& child : *impl) {
+      if (child->GetNodeType() == CsgNodeType::Leaf) {
+        total += 1;
+      } else {
+        stack.push_back(static_cast<const CsgOpNode*>(child.get()));
+      }
+    }
+  }
   return total;
 }
 

--- a/src/csg_tree.h
+++ b/src/csg_tree.h
@@ -24,9 +24,14 @@ class CsgLeafNode;
 
 class CsgNode : public std::enable_shared_from_this<CsgNode> {
  public:
-  virtual std::shared_ptr<CsgLeafNode> ToLeafNode() const = 0;
+  virtual std::shared_ptr<CsgLeafNode> ToLeafNode(
+      ExecutionContext::Impl* ctx = nullptr) const = 0;
   virtual std::shared_ptr<CsgNode> Transform(const mat3x4& m) const = 0;
   virtual CsgNodeType GetNodeType() const = 0;
+  /// Count the leaves in the subtree rooted at this node. A CsgOpNode with
+  /// a cached evaluation counts as a single leaf. Used for pre-pass progress
+  /// denominator: a CSG tree with N leaves reduces to 1 result in N-1 ops.
+  virtual size_t NumLeaves() const = 0;
 
   virtual std::shared_ptr<CsgNode> Boolean(
       const std::shared_ptr<CsgNode>& second, OpType op);
@@ -45,11 +50,14 @@ class CsgLeafNode final : public CsgNode {
 
   std::shared_ptr<const Manifold::Impl> GetImpl() const;
 
-  std::shared_ptr<CsgLeafNode> ToLeafNode() const override;
+  std::shared_ptr<CsgLeafNode> ToLeafNode(
+      ExecutionContext::Impl* ctx = nullptr) const override;
 
   std::shared_ptr<CsgNode> Transform(const mat3x4& m) const override;
 
   CsgNodeType GetNodeType() const override;
+
+  size_t NumLeaves() const override { return 1; }
 
   static std::shared_ptr<CsgLeafNode> Compose(
       const std::vector<std::shared_ptr<CsgLeafNode>>& nodes);
@@ -77,9 +85,12 @@ class CsgOpNode final : public CsgNode {
 
   std::shared_ptr<CsgNode> Transform(const mat3x4& m) const override;
 
-  std::shared_ptr<CsgLeafNode> ToLeafNode() const override;
+  std::shared_ptr<CsgLeafNode> ToLeafNode(
+      ExecutionContext::Impl* ctx = nullptr) const override;
 
   CsgNodeType GetNodeType() const override;
+
+  size_t NumLeaves() const override;
 
   ~CsgOpNode();
 

--- a/src/execution_impl.cpp
+++ b/src/execution_impl.cpp
@@ -1,0 +1,44 @@
+// Copyright 2026 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "execution_impl.h"
+
+namespace manifold {
+
+ExecutionContext::ExecutionContext() : impl_(std::make_shared<Impl>()) {}
+ExecutionContext::~ExecutionContext() = default;
+ExecutionContext::ExecutionContext(const ExecutionContext&) = default;
+ExecutionContext::ExecutionContext(ExecutionContext&&) noexcept = default;
+ExecutionContext& ExecutionContext::operator=(const ExecutionContext&) =
+    default;
+ExecutionContext& ExecutionContext::operator=(ExecutionContext&&) noexcept =
+    default;
+
+void ExecutionContext::Cancel() {
+  impl_->cancel.store(true, std::memory_order_relaxed);
+}
+
+bool ExecutionContext::Cancelled() const {
+  return impl_->cancel.load(std::memory_order_relaxed);
+}
+
+double ExecutionContext::Progress() const {
+  const int total = impl_->totalBooleans.load(std::memory_order_relaxed);
+  return total > 0
+             ? double(impl_->doneBooleans.load(std::memory_order_relaxed)) /
+                   total
+             : 0.0;
+}
+
+}  // namespace manifold

--- a/src/execution_impl.h
+++ b/src/execution_impl.h
@@ -1,0 +1,34 @@
+// Copyright 2026 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <atomic>
+
+#include "manifold/common.h"
+
+namespace manifold {
+
+/** @ingroup Private
+ *
+ * Pimpl for ExecutionContext. Holds the atomic state observed/mutated by
+ * the CSG evaluation machinery. Internal code accesses this via
+ * ctx.impl_->field directly.
+ */
+struct ExecutionContext::Impl {
+  std::atomic<int> totalBooleans{0};
+  std::atomic<int> doneBooleans{0};
+  std::atomic<bool> cancel{false};
+};
+
+}  // namespace manifold

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -16,6 +16,7 @@
 
 #include "boolean3.h"
 #include "csg_tree.h"
+#include "execution_impl.h"
 #include "impl.h"
 #include "parallel.h"
 #include "shared.h"
@@ -157,10 +158,22 @@ std::shared_ptr<CsgNode> Manifold::LoadPNode() const {
   return pNode_;
 }
 
-CsgLeafNode& Manifold::GetCsgLeafNode() const {
+CsgLeafNode& Manifold::GetCsgLeafNode(ExecutionContext::Impl* ctx) const {
   std::lock_guard<std::mutex> lock(*pNodeMutex_);
+  if (ctx != nullptr) {
+    // Reset counters to reflect this evaluation. For pre-evaluated leaf
+    // Manifolds, NumLeaves() returns 1 so totalBooleans is 0 — no work.
+    // This also prevents stale counters from a previous use of the same
+    // ctx. The cancel flag is intentionally NOT reset — sticky cancel is
+    // part of the documented API contract (see ExecutionContext in
+    // common.h).
+    const size_t leaves = pNode_->NumLeaves();
+    ctx->totalBooleans.store(leaves > 0 ? static_cast<int>(leaves - 1) : 0,
+                             std::memory_order_relaxed);
+    ctx->doneBooleans.store(0, std::memory_order_relaxed);
+  }
   if (pNode_->GetNodeType() != CsgNodeType::Leaf) {
-    pNode_ = pNode_->ToLeafNode();
+    pNode_ = pNode_->ToLeafNode(ctx);
   }
   return *std::static_pointer_cast<CsgLeafNode>(pNode_);
 }
@@ -250,6 +263,19 @@ bool Manifold::IsEmpty() const { return GetCsgLeafNode().GetImpl()->IsEmpty(); }
  */
 Manifold::Error Manifold::Status() const {
   return GetCsgLeafNode().GetImpl()->status_;
+}
+/**
+ * Like Status() but observes evaluation progress and allows cancellation
+ * via the provided ExecutionContext. If cancel is requested mid-evaluation,
+ * returns Error::Cancelled and the Manifold's status becomes permanent.
+ *
+ * During evaluation, ExecutionContext::Progress() increases monotonically
+ * from 0 to 1 as boolean combinations complete. ExecutionContext::Cancel()
+ * can be called from any thread to request early exit. Cancellation
+ * granularity is per-boolean-operation.
+ */
+Manifold::Error Manifold::Status(ExecutionContext& ctx) const {
+  return GetCsgLeafNode(ctx.impl_.get()).GetImpl()->status_;
 }
 /**
  * The number of vertices in the Manifold.

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -1462,6 +1462,12 @@ TEST(Manifold, ExecutionContextCancelBeforeEval) {
 // Cancel from another thread mid-evaluation. Expensive CSG tree so there's
 // time to set the flag before the full eval finishes. Verify Error::Cancelled
 // is returned and doneBooleans < totalBooleans.
+//
+// MANIFOLD_PAR guard: emscripten/WASM builds without pthreads can't
+// construct std::thread and abort at runtime. Skip on non-parallel builds
+// — cancellation mid-evaluation isn't meaningful there anyway since the
+// eval is synchronous.
+#if MANIFOLD_PAR == 1
 TEST(Manifold, ExecutionContextCancelConcurrent) {
   // Build a large enough tree that evaluation takes measurable time.
   std::vector<Manifold> items;
@@ -1488,6 +1494,7 @@ TEST(Manifold, ExecutionContextCancelConcurrent) {
     EXPECT_LT(ctx.impl_->doneBooleans.load(), ctx.impl_->totalBooleans.load());
   }
 }
+#endif  // MANIFOLD_PAR == 1
 
 // Status() and Status(ctx) should return identical results when no cancel.
 TEST(Manifold, ExecutionContextMatchesPlainStatus) {
@@ -1609,6 +1616,8 @@ TEST(Manifold, ExecutionContextCancelSkippedOnLeaf) {
 }
 
 // Progress is observable from another thread while evaluation runs.
+// MANIFOLD_PAR guard: see note on ExecutionContextCancelConcurrent above.
+#if MANIFOLD_PAR == 1
 TEST(Manifold, ExecutionContextConcurrentProgress) {
   std::vector<Manifold> items;
   for (int i = 0; i < 30; i++) {
@@ -1639,6 +1648,7 @@ TEST(Manifold, ExecutionContextConcurrentProgress) {
   // timing-dependent. Not strictly required but usually the case.
   // (Not asserting sawProgress to avoid CI flakes.)
 }
+#endif  // MANIFOLD_PAR == 1
 
 // Calling Status(ctx) on an already-evaluated Manifold should reset counters,
 // not leave stale values from a previous evaluation on a different Manifold.

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -1562,9 +1562,50 @@ TEST(Manifold, ExecutionContextCancelPermanent) {
   // the cached leaf is the Cancelled one.
   EXPECT_EQ(u.Status(), Manifold::Error::Cancelled);
 
-  // Even reusing the context with cancel cleared.
-  /* cancel remains set; Manifold is already Cancelled */;
+  // Re-querying with the same context (still cancelled) is still Cancelled.
   EXPECT_EQ(u.Status(ctx), Manifold::Error::Cancelled);
+}
+
+// Once a context is cancelled it stays cancelled for any future evaluation
+// through it — not just the Manifold in flight at the time of Cancel().
+TEST(Manifold, ExecutionContextCancelStickyAcrossManifolds) {
+  ExecutionContext ctx;
+  ctx.Cancel();
+
+  // Fresh Manifold that needs evaluation (CsgOpNode, not a leaf) — the
+  // cancelled ctx should short-circuit it to Cancelled.
+  Manifold u = Manifold::Cube() + Manifold::Sphere(0.5);
+  EXPECT_EQ(u.Status(ctx), Manifold::Error::Cancelled);
+
+  // Another unrelated Manifold, same ctx — also Cancelled.
+  Manifold v =
+      Manifold::Tetrahedron() + Manifold::Sphere(0.3).Translate(vec3(2, 0, 0));
+  EXPECT_EQ(v.Status(ctx), Manifold::Error::Cancelled);
+}
+
+// A cancelled ctx does NOT contaminate a fresh context: constructing a new
+// ExecutionContext gives an evaluation that can complete normally.
+TEST(Manifold, ExecutionContextFreshContextEscapesCancel) {
+  ExecutionContext cancelledCtx;
+  cancelledCtx.Cancel();
+  Manifold dead = Manifold::Cube() + Manifold::Sphere(0.5);
+  EXPECT_EQ(dead.Status(cancelledCtx), Manifold::Error::Cancelled);
+
+  ExecutionContext fresh;
+  Manifold live = Manifold::Cube() + Manifold::Sphere(0.5);
+  EXPECT_EQ(live.Status(fresh), Manifold::Error::NoError);
+  EXPECT_FALSE(fresh.Cancelled());
+}
+
+// A cancelled ctx applied to a Manifold that is already a leaf (no
+// evaluation needed) returns the Manifold's real status — cancel only
+// applies when there is actual evaluation work to short-circuit. This
+// matches the docstring phrasing "every subsequent evaluation".
+TEST(Manifold, ExecutionContextCancelSkippedOnLeaf) {
+  Manifold cube = Manifold::Cube();  // CsgLeafNode from the start
+  ExecutionContext ctx;
+  ctx.Cancel();
+  EXPECT_EQ(cube.Status(ctx), Manifold::Error::NoError);
 }
 
 // Progress is observable from another thread while evaluation runs.

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -1689,6 +1689,19 @@ TEST(Manifold, ExecutionContextCopyShareState) {
   EXPECT_EQ(ctx1.impl_->totalBooleans.load(), 42);
 }
 
+// Move construction and move assignment preserve shared state.
+TEST(Manifold, ExecutionContextMoveSemantics) {
+  ExecutionContext ctx1;
+  ctx1.Cancel();
+  ExecutionContext ctx2 = std::move(ctx1);  // move-construct
+  EXPECT_TRUE(ctx2.Cancelled());
+
+  ExecutionContext ctx3;
+  EXPECT_FALSE(ctx3.Cancelled());
+  ctx3 = std::move(ctx2);  // move-assign
+  EXPECT_TRUE(ctx3.Cancelled());
+}
+
 // A Manifold that's already a leaf (no CSG tree) should report no work.
 TEST(Manifold, ExecutionContextNoWorkNeeded) {
   Manifold cube = Manifold::Cube(vec3(1), true);
@@ -1737,4 +1750,23 @@ TEST(Manifold, ExecutionContextProgressInvariant) {
     EXPECT_EQ(ctx.impl_->totalBooleans.load(), 5);
     EXPECT_EQ(ctx.impl_->doneBooleans.load(), 5);
   }
+}
+
+// Deeply-nested CsgOpNode chain (e.g. repeated `+=` in a loop) must not
+// stack-overflow in the leaf-counting pre-pass. Cancel up front so we only
+// exercise NumLeaves, not the full boolean evaluation.
+//
+// 300k depth SIGSEGVs on the recursive NumLeaves (8MB default stack on
+// macOS/Linux); runs in ~1s / ~1.2GB peak RSS on the iterative version.
+TEST(Manifold, DeepChainDoesNotOverflowNumLeaves) {
+  constexpr int kDepth = 300000;
+  Manifold m = Manifold::Cube(vec3(1), true);
+  for (int i = 0; i < kDepth; ++i) {
+    m = m + Manifold::Cube(vec3(1), true).Translate(vec3(i * 2.0, 0, 0));
+  }
+  ExecutionContext ctx;
+  ctx.Cancel();
+  EXPECT_EQ(m.Status(ctx), Manifold::Error::Cancelled);
+  // kDepth + 1 leaves in the chain → kDepth booleans to reduce.
+  EXPECT_EQ(ctx.impl_->totalBooleans.load(), kDepth);
 }

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -15,7 +15,11 @@
 #include "manifold/manifold.h"
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <thread>
 
+#include "../src/execution_impl.h"
 #ifdef MANIFOLD_CROSS_SECTION
 #include "manifold/cross_section.h"
 #endif
@@ -1410,4 +1414,276 @@ TEST(Manifold, RayCastSilhouetteEdge) {
 
   auto hits = cube.RayCast(vec3(0.5, 0, -5), vec3(0.5, 0, 5));
   EXPECT_TRUE(hits.size() == 0 || hits.size() == 2);
+}
+
+// A CSG tree with N leaves reduces to 1 result in N-1 combinations.
+TEST(Manifold, ExecutionContextProgress) {
+  // Build a tree with 5 leaves: a union of 5 cubes.
+  std::vector<Manifold> items;
+  for (int i = 0; i < 5; i++) {
+    items.push_back(Manifold::Cube(vec3(1), true).Translate(vec3(i * 2, 0, 0)));
+  }
+  Manifold u = Manifold::BatchBoolean(items, OpType::Add);
+
+  ExecutionContext ctx;
+  EXPECT_EQ(u.Status(ctx), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalBooleans.load(), 4);  // 5 leaves - 1
+  EXPECT_EQ(ctx.impl_->doneBooleans.load(), 4);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
+}
+
+// Forcing evaluation first, then observing with a fresh context, should
+// report no pending work: the Manifold is already a leaf.
+TEST(Manifold, ExecutionContextAlreadyEvaluated) {
+  Manifold u = Manifold::Cube(vec3(1), true) + Manifold::Cube(vec3(1), true);
+  // Force evaluation.
+  EXPECT_EQ(u.Status(), Manifold::Error::NoError);
+
+  ExecutionContext ctx;
+  EXPECT_EQ(u.Status(ctx), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalBooleans.load(), 0);
+  EXPECT_EQ(ctx.impl_->doneBooleans.load(), 0);
+}
+
+// Setting cancel before calling Status(ctx) should return Cancelled
+// without doing any work.
+TEST(Manifold, ExecutionContextCancelBeforeEval) {
+  std::vector<Manifold> items;
+  for (int i = 0; i < 10; i++) {
+    items.push_back(Manifold::Sphere(1.0, 32).Translate(vec3(i * 0.5, 0, 0)));
+  }
+  Manifold u = Manifold::BatchBoolean(items, OpType::Add);
+
+  ExecutionContext ctx;
+  ctx.Cancel();
+  EXPECT_EQ(u.Status(ctx), Manifold::Error::Cancelled);
+}
+
+// Cancel from another thread mid-evaluation. Expensive CSG tree so there's
+// time to set the flag before the full eval finishes. Verify Error::Cancelled
+// is returned and doneBooleans < totalBooleans.
+TEST(Manifold, ExecutionContextCancelConcurrent) {
+  // Build a large enough tree that evaluation takes measurable time.
+  std::vector<Manifold> items;
+  for (int i = 0; i < 50; i++) {
+    items.push_back(Manifold::Sphere(1.0, 64).Translate(vec3(i * 0.3, 0, 0)));
+  }
+  Manifold u = Manifold::BatchBoolean(items, OpType::Add);
+
+  ExecutionContext ctx;
+  std::atomic<Manifold::Error> result{Manifold::Error::NoError};
+  std::thread evalThread([&] { result.store(u.Status(ctx)); });
+
+  // Yield briefly so evaluation starts, then request cancel.
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  ctx.Cancel();
+  evalThread.join();
+
+  // Cancel may have fired between ops or after the whole eval finished
+  // (depending on timing). Either Cancelled (expected) or NoError (raced
+  // past us) is acceptable.
+  EXPECT_TRUE(result.load() == Manifold::Error::Cancelled ||
+              result.load() == Manifold::Error::NoError);
+  if (result.load() == Manifold::Error::Cancelled) {
+    EXPECT_LT(ctx.impl_->doneBooleans.load(), ctx.impl_->totalBooleans.load());
+  }
+}
+
+// Status() and Status(ctx) should return identical results when no cancel.
+TEST(Manifold, ExecutionContextMatchesPlainStatus) {
+  Manifold u = (Manifold::Cube(vec3(1), true) + Manifold::Sphere(1.0, 32)) -
+               Manifold::Tetrahedron();
+
+  // Build two equivalent manifolds (CsgOpNodes) to avoid caching effects.
+  auto makeTree = [] {
+    return (Manifold::Cube(vec3(1), true) + Manifold::Sphere(1.0, 32)) -
+           Manifold::Tetrahedron();
+  };
+  Manifold a = makeTree();
+  Manifold b = makeTree();
+
+  Manifold::Error aStatus = a.Status();
+  ExecutionContext ctx;
+  Manifold::Error bStatus = b.Status(ctx);
+  EXPECT_EQ(aStatus, bStatus);
+}
+
+// N-1 invariant holds for Subtract trees too.
+TEST(Manifold, ExecutionContextProgressSubtract) {
+  // Tree shape: (cube + sphere) - tet - octahedron
+  Manifold u = (Manifold::Cube(vec3(1), true) + Manifold::Sphere(1.0, 16)) -
+               Manifold::Tetrahedron() - Manifold::Cube(vec3(0.5), true);
+
+  ExecutionContext ctx;
+  EXPECT_EQ(u.Status(ctx), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalBooleans.load(), 3);  // 4 leaves - 1
+  EXPECT_EQ(ctx.impl_->doneBooleans.load(), 3);
+}
+
+// Reusing the same context for two sequential evaluations should reset
+// doneBooleans so Progress is always in [0, 1].
+TEST(Manifold, ExecutionContextReuse) {
+  auto makeTree = [](int n) {
+    std::vector<Manifold> items;
+    for (int i = 0; i < n; i++) {
+      items.push_back(
+          Manifold::Cube(vec3(1), true).Translate(vec3(i * 2, 0, 0)));
+    }
+    return Manifold::BatchBoolean(items, OpType::Add);
+  };
+  Manifold a = makeTree(5);
+  Manifold b = makeTree(3);
+
+  ExecutionContext ctx;
+  EXPECT_EQ(a.Status(ctx), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->doneBooleans.load(), 4);
+
+  // Reuse ctx for b. doneBooleans should reset to 0 at start.
+  EXPECT_EQ(b.Status(ctx), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalBooleans.load(), 2);
+  EXPECT_EQ(ctx.impl_->doneBooleans.load(), 2);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
+}
+
+// Cancel is permanent: once fired, Status on that Manifold stays Cancelled
+// even when called without a context.
+TEST(Manifold, ExecutionContextCancelPermanent) {
+  std::vector<Manifold> items;
+  for (int i = 0; i < 30; i++) {
+    items.push_back(Manifold::Sphere(1.0, 48).Translate(vec3(i * 0.3, 0, 0)));
+  }
+  Manifold u = Manifold::BatchBoolean(items, OpType::Add);
+
+  ExecutionContext ctx;
+  ctx.Cancel();  // cancel before any work
+  EXPECT_EQ(u.Status(ctx), Manifold::Error::Cancelled);
+
+  // Plain Status() on the same Manifold should still report Cancelled —
+  // the cached leaf is the Cancelled one.
+  EXPECT_EQ(u.Status(), Manifold::Error::Cancelled);
+
+  // Even reusing the context with cancel cleared.
+  /* cancel remains set; Manifold is already Cancelled */;
+  EXPECT_EQ(u.Status(ctx), Manifold::Error::Cancelled);
+}
+
+// Progress is observable from another thread while evaluation runs.
+TEST(Manifold, ExecutionContextConcurrentProgress) {
+  std::vector<Manifold> items;
+  for (int i = 0; i < 30; i++) {
+    items.push_back(Manifold::Sphere(1.0, 48).Translate(vec3(i * 0.5, 0, 0)));
+  }
+  Manifold u = Manifold::BatchBoolean(items, OpType::Add);
+
+  ExecutionContext ctx;
+  std::atomic<bool> sawProgress{false};
+  std::thread observer([&] {
+    for (int i = 0; i < 1000 && !sawProgress.load(); i++) {
+      int done = ctx.impl_->doneBooleans.load();
+      int total = ctx.impl_->totalBooleans.load();
+      if (total > 0 && done > 0 && done <= total) {
+        sawProgress.store(true);
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+  });
+
+  EXPECT_EQ(u.Status(ctx), Manifold::Error::NoError);
+  observer.join();
+  // Final state invariants.
+  EXPECT_EQ(ctx.impl_->totalBooleans.load(), 29);
+  EXPECT_EQ(ctx.impl_->doneBooleans.load(), 29);
+  // We expect to have seen a mid-evaluation snapshot, though this is
+  // timing-dependent. Not strictly required but usually the case.
+  // (Not asserting sawProgress to avoid CI flakes.)
+}
+
+// Calling Status(ctx) on an already-evaluated Manifold should reset counters,
+// not leave stale values from a previous evaluation on a different Manifold.
+TEST(Manifold, ExecutionContextNoStaleState) {
+  Manifold complex = Manifold::BatchBoolean(
+      {Manifold::Cube(vec3(1), true),
+       Manifold::Cube(vec3(1), true).Translate(vec3(2, 0, 0)),
+       Manifold::Cube(vec3(1), true).Translate(vec3(4, 0, 0))},
+      OpType::Add);
+  Manifold leaf = Manifold::Cube(vec3(1), true);
+
+  ExecutionContext ctx;
+  EXPECT_EQ(complex.Status(ctx), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->doneBooleans.load(), 2);
+
+  // Now evaluate a leaf Manifold with the same ctx. Counters should
+  // reflect that there's no work to do (0/0), not the stale 2/2.
+  EXPECT_EQ(leaf.Status(ctx), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalBooleans.load(), 0);
+  EXPECT_EQ(ctx.impl_->doneBooleans.load(), 0);
+}
+
+// ExecutionContext copies share state (pimpl semantics): one thread
+// evaluates, another thread holds a copy and observes the same progress.
+TEST(Manifold, ExecutionContextCopyShareState) {
+  ExecutionContext ctx1;
+  ExecutionContext ctx2 = ctx1;  // copy shares impl
+
+  // Cancel on one copy should be observable through the other.
+  EXPECT_FALSE(ctx2.Cancelled());
+  ctx1.Cancel();
+  EXPECT_TRUE(ctx1.Cancelled());
+  EXPECT_TRUE(ctx2.Cancelled());
+
+  // Counters also shared.
+  EXPECT_EQ(ctx1.impl_->totalBooleans.load(), 0);
+  ctx2.impl_->totalBooleans.store(42);
+  EXPECT_EQ(ctx1.impl_->totalBooleans.load(), 42);
+}
+
+// A Manifold that's already a leaf (no CSG tree) should report no work.
+TEST(Manifold, ExecutionContextNoWorkNeeded) {
+  Manifold cube = Manifold::Cube(vec3(1), true);
+  ExecutionContext ctx;
+  EXPECT_EQ(cube.Status(ctx), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalBooleans.load(), 0);
+  EXPECT_EQ(ctx.impl_->doneBooleans.load(), 0);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 0.0);  // 0/0 is defined as 0
+}
+
+// doneBooleans reaches totalBooleans exactly for many tree shapes — the N-1
+// invariant shouldn't depend on op type or tree shape.
+TEST(Manifold, ExecutionContextProgressInvariant) {
+  // Intersect
+  {
+    std::vector<Manifold> items{
+        Manifold::Cube(vec3(2), true),
+        Manifold::Cube(vec3(2), true).Translate(vec3(0.5, 0, 0)),
+        Manifold::Cube(vec3(2), true).Translate(vec3(0, 0.5, 0))};
+    Manifold u = Manifold::BatchBoolean(items, OpType::Intersect);
+    ExecutionContext ctx;
+    EXPECT_EQ(u.Status(ctx), Manifold::Error::NoError);
+    EXPECT_EQ(ctx.impl_->totalBooleans.load(), 2);
+    EXPECT_EQ(ctx.impl_->doneBooleans.load(), 2);
+  }
+  // Mixed Add/Subtract
+  {
+    Manifold u = (Manifold::Cube(vec3(1), true) +
+                  Manifold::Cube(vec3(1), true).Translate(vec3(2, 0, 0))) -
+                 Manifold::Tetrahedron();
+    ExecutionContext ctx;
+    EXPECT_EQ(u.Status(ctx), Manifold::Error::NoError);
+    EXPECT_EQ(ctx.impl_->totalBooleans.load(), 2);  // 3 leaves - 1
+    EXPECT_EQ(ctx.impl_->doneBooleans.load(), 2);
+  }
+  // Disjoint union (triggers Compose path)
+  {
+    std::vector<Manifold> items;
+    for (int i = 0; i < 6; i++) {
+      items.push_back(
+          Manifold::Cube(vec3(0.5), true).Translate(vec3(i * 2, 0, 0)));
+    }
+    Manifold u = Manifold::BatchBoolean(items, OpType::Add);
+    ExecutionContext ctx;
+    EXPECT_EQ(u.Status(ctx), Manifold::Error::NoError);
+    EXPECT_EQ(ctx.impl_->totalBooleans.load(), 5);
+    EXPECT_EQ(ctx.impl_->doneBooleans.load(), 5);
+  }
 }


### PR DESCRIPTION
Progress towards #971 — observe progress and request cancellation of long-running boolean evaluations.

## Public API

```cpp
ExecutionContext ctx;
std::thread eval([&]{ result = m.Status(ctx); });  // triggers evaluation
ctx.Progress();   // [0, 1], monotonic within an evaluation
ctx.Cancel();     // result's Status becomes Error::Cancelled
```

`Status(ctx)` is an overload of the existing `Status()`; no other public API is affected. Copies of `ctx` share state, so a UI thread can hold a copy and call `Cancel()` from a button handler while a worker runs the evaluation.

## Design notes

- **Pimpl with `shared_ptr<Impl>`.** Opaque `Impl` (in `src/execution_impl.h`) keeps the ABI stable and makes copies share state naturally.
- **Sticky cancel.** Once cancelled, a context stays cancelled — same shape as Go's `context.WithCancel`. Typical use is a fresh context per op.
- **Per-boolean granularity as starting state.** Cancel is checked between booleans; a single large boolean runs to completion. Finer granularity (into the boolean kernels themselves) is a follow-up.
- **Progress via leaf pre-pass.** A CSG tree with N leaves reduces in N-1 ops, so `totalBooleans = leaves - 1`; each boolean increments `doneBooleans`. Exact denominator, no estimation.
- **Counters are boolean-scoped.** `totalBooleans`/`doneBooleans` count boolean ops specifically. Future progress dimensions (phases, per-op items) will be added as separate fields rather than reinterpreting these.
- **Relaxed atomics.** The three atomics carry no happens-before for other data; progress readers tolerate staleness; missing cancel by one boolean is within the granularity contract.

## Bindings

`Cancelled` added to the error enum in C/Python/WASM. Full progress/cancel API is a follow-up once the C++ API settles.

## Testing

13 new tests covering progress, cancellation, reuse, copy-share-state, concurrent observation, and the N-1 invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)