### PR TITLE
Fix leak in `manifold_alloc_*` (C API)

### DIFF
--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -41,6 +41,18 @@ ManifoldManifold* level_set(
   return to_c(new (mem) Manifold(Manifold::LevelSet(
       fun, *from_c(bounds), edge_length, level, tolerance, !seq)));
 }
+
+// Raw uninitialized storage for a T — callers must placement-new into it
+// before any use or before passing to manifold_destruct_* / manifold_delete_*.
+// Pairs with `delete T*`, which uses the plain `::operator delete` for
+// types with default alignment.
+template <typename T>
+T* alloc_raw() {
+  static_assert(alignof(T) <= __STDCPP_DEFAULT_NEW_ALIGNMENT__,
+                "over-aligned types need the aligned operator new/delete "
+                "pair; extend this helper if a binding type ever needs it");
+  return static_cast<T*>(::operator new(sizeof(T)));
+}
 }  // namespace
 
 #ifdef __cplusplus
@@ -914,31 +926,42 @@ size_t manifold_rect_size() { return sizeof(Rect); }
 size_t manifold_triangulation_size() { return sizeof(std::vector<ivec3>); }
 
 // allocation
+//
+// Returns raw uninitialized storage. Callers must placement-new into it
+// via one of the constructor functions (e.g. manifold_cube) before any
+// use or before passing to manifold_destruct_* / manifold_delete_*.
+// Using `new T` here would silently leak the default-constructed object
+// every time a constructor function placement-new'd over it (see
+// Manifold's pNode_ and CrossSection's paths_ shared_ptrs).
 ManifoldManifold* manifold_alloc_manifold() {
-  return to_c(new manifold::Manifold);
+  return to_c(alloc_raw<manifold::Manifold>());
 }
 ManifoldManifoldVec* manifold_alloc_manifold_vec() {
-  return to_c(new std::vector<manifold::Manifold>);
+  return to_c(alloc_raw<std::vector<manifold::Manifold>>());
 }
 ManifoldCrossSection* manifold_alloc_cross_section() {
-  return to_c(new CrossSection);
+  return to_c(alloc_raw<CrossSection>());
 }
 ManifoldCrossSectionVec* manifold_alloc_cross_section_vec() {
-  return to_c(new std::vector<CrossSection>);
+  return to_c(alloc_raw<std::vector<CrossSection>>());
 }
-ManifoldRayHitVec* manifold_alloc_ray_hit_vec() { return to_c(new RayHitVec); }
+ManifoldRayHitVec* manifold_alloc_ray_hit_vec() {
+  return to_c(alloc_raw<RayHitVec>());
+}
 ManifoldSimplePolygon* manifold_alloc_simple_polygon() {
-  return to_c(new SimplePolygon);
+  return to_c(alloc_raw<SimplePolygon>());
 }
 ManifoldPolygons* manifold_alloc_polygons() {
-  return to_c(new std::vector<SimplePolygon>);
+  return to_c(alloc_raw<std::vector<SimplePolygon>>());
 }
-ManifoldMeshGL* manifold_alloc_meshgl() { return to_c(new MeshGL); }
-ManifoldMeshGL64* manifold_alloc_meshgl64() { return to_c(new MeshGL64); }
-ManifoldBox* manifold_alloc_box() { return to_c(new Box); }
-ManifoldRect* manifold_alloc_rect() { return to_c(new Rect); }
+ManifoldMeshGL* manifold_alloc_meshgl() { return to_c(alloc_raw<MeshGL>()); }
+ManifoldMeshGL64* manifold_alloc_meshgl64() {
+  return to_c(alloc_raw<MeshGL64>());
+}
+ManifoldBox* manifold_alloc_box() { return to_c(alloc_raw<Box>()); }
+ManifoldRect* manifold_alloc_rect() { return to_c(alloc_raw<Rect>()); }
 ManifoldTriangulation* manifold_alloc_triangulation() {
-  return to_c(new std::vector<ivec3>);
+  return to_c(alloc_raw<std::vector<ivec3>>());
 }
 
 // pointer free + destruction

--- a/test/manifoldc_test.cpp
+++ b/test/manifoldc_test.cpp
@@ -693,3 +693,21 @@ TEST(CBIND, meshgl_update_normals) {
   free(with_normals);
   free(cube);
 }
+
+// Smoke test for the manifold_alloc_* + manifold_delete_* pattern. The
+// rest of this file covers the malloc + manifold_destruct_* + free
+// pattern; this one fills in the alloc/delete variant (used by
+// language bindings that let the library manage memory).
+TEST(CBIND, alloc_delete_roundtrip) {
+  for (int i = 0; i < 10; ++i) {
+    ManifoldManifold* m = manifold_alloc_manifold();
+    manifold_cube(m, 1.0, 1.0, 1.0, 0);
+    EXPECT_EQ(manifold_status(m), MANIFOLD_NO_ERROR);
+    manifold_delete_manifold(m);
+  }
+  for (int i = 0; i < 10; ++i) {
+    ManifoldCrossSection* cs = manifold_alloc_cross_section();
+    manifold_cross_section_square(cs, 1.0, 1.0, 0);
+    manifold_delete_cross_section(cs);
+  }
+}


### PR DESCRIPTION
`manifold_alloc_X()` was `new T`, which allocates **and** constructs a default `T`. Every subsequent constructor function placement-new's into that memory without calling the old `T`'s destructor, so the default object's heap allocations leak. For `Manifold` it's a `shared_ptr<CsgLeafNode>`; for `CrossSection` it's a `shared_ptr<PathImpl>` (plus a Clipper2 `PathsD`).

Reproducer:

```cpp
for (int i = 0; i < 100; ++i) {
  ManifoldManifold* m = manifold_alloc_manifold();
  manifold_cube(m, 1.0, 1.0, 1.0, 0);
  manifold_delete_manifold(m);
}
// LSan: 100 leaks, scales linearly
```

Surfaced by a downstream Rust binding's LSan CI — [failed run](https://github.com/zmerlynn/manifold-csg/actions/runs/24645851906) (`403452 byte(s) leaked in 2930 allocation(s)`).

Fix: `manifold_alloc_*` returns raw storage via a small `alloc_raw<T>` helper using [`::operator new`](https://en.cppreference.com/w/cpp/memory/new/operator_new), matching what `malloc(manifold_X_size())` already does in the in-tree C test. Callers placement-new into the storage, then `manifold_delete_*` handles dtor + dealloc — the plain `::operator new` pairs with the plain `::operator delete` that [`delete T*`](https://en.cppreference.com/w/cpp/language/delete) picks for default-aligned types. A `static_assert` guards against over-aligned types slipping in later.

0 leaks after the fix. 356 tests pass; ASan run on the full suite + the repro pattern (2000 cycles) clean.

## History

#1018 switched these alloc functions from `malloc` to `new T` to fix a real `malloc`/`delete` pairing UB, and explicitly flagged the leak it traded for: "this causes memory leak for the default-constructed object… should be keep in mind". I copied the pattern forward in #1654 when adding `manifold_alloc_ray_hit_vec`. This change keeps the `new`/`delete` pairing correct and removes the leak by not constructing in alloc.

## Behavior change

`alloc_X()` + `delete_X()` with no intervening constructor call is now UB (calls `~T()` on uninitialized memory). Not a documented pattern; no in-tree test exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)