### PR TITLE
Thread ExecutionContext into Boolean3 for mid-boolean cancel

### DIFF
--- a/src/boolean3.cpp
+++ b/src/boolean3.cpp
@@ -479,8 +479,8 @@ Vec<int> Winding03(const Manifold::Impl& inP, const Manifold::Impl& inQ,
 
 namespace manifold {
 Boolean3::Boolean3(const Manifold::Impl& inP, const Manifold::Impl& inQ,
-                   OpType op)
-    : inP_(inP), inQ_(inQ), expandP_(op == OpType::Add) {
+                   OpType op, ExecutionContext::Impl* ctx)
+    : inP_(inP), inQ_(inQ), expandP_(op == OpType::Add), ctx_(ctx) {
   ZoneScoped;
   // Symbolic perturbation:
   // Union -> expand inP, expand inQ
@@ -498,6 +498,10 @@ Boolean3::Boolean3(const Manifold::Impl& inP, const Manifold::Impl& inQ,
     return;
   }
 
+  auto cancelled = [&] {
+    return ctx_ && ctx_->cancel.load(std::memory_order_relaxed);
+  };
+
 #if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
   Timer intersections;
   intersections.Start();
@@ -509,11 +513,13 @@ Boolean3::Boolean3(const Manifold::Impl& inP, const Manifold::Impl& inQ,
   // Build up the intersection of the edges and triangles, keeping only those
   // that intersect, and record the direction the edge is passing through the
   // triangle.
+  if (cancelled()) return;
   xv12_ = Intersect12<true>(inP, inQ, expandP_);
 #if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
   intersect12P.Stop();
   intersect12Q.Start();
 #endif
+  if (cancelled()) return;
   xv21_ = Intersect12<false>(inP, inQ, expandP_);
 #if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
   intersect12Q.Stop();
@@ -529,11 +535,13 @@ Boolean3::Boolean3(const Manifold::Impl& inP, const Manifold::Impl& inQ,
 #if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
   winding03P.Start();
 #endif
+  if (cancelled()) return;
   w03_ = Winding03<true>(inP, inQ, xv12_.p1q2, expandP_);
 #if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
   winding03P.Stop();
   winding03Q.Start();
 #endif
+  if (cancelled()) return;
   w30_ = Winding03<false>(inP, inQ, xv21_.p1q2, expandP_);
 
 #if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)

--- a/src/boolean3.h
+++ b/src/boolean3.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include "execution_impl.h"
 #include "impl.h"
 
 #ifdef MANIFOLD_DEBUG
@@ -56,7 +57,8 @@ struct Intersections {
 
 class Boolean3 {
  public:
-  Boolean3(const Manifold::Impl& inP, const Manifold::Impl& inQ, OpType op);
+  Boolean3(const Manifold::Impl& inP, const Manifold::Impl& inQ, OpType op,
+           ExecutionContext::Impl* ctx = nullptr);
   Manifold::Impl Result(OpType op) const;
 
  private:
@@ -65,5 +67,6 @@ class Boolean3 {
   Intersections xv12_, xv21_;
   Vec<int> w03_, w30_;
   bool valid = true;
+  ExecutionContext::Impl* ctx_ = nullptr;
 };
 }  // namespace manifold

--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <array>
 #include <map>
+#include <optional>
 
 #include "boolean3.h"
 #include "parallel.h"
@@ -685,6 +686,21 @@ Manifold::Impl Boolean3::Result(OpType op) const {
     return inP_;
   }
 
+  auto cancelled = [&]() -> std::optional<Manifold::Impl> {
+    if (ctx_ && ctx_->cancel.load(std::memory_order_relaxed)) {
+      auto impl = Manifold::Impl();
+      impl.status_ = Manifold::Error::Cancelled;
+      return impl;
+    }
+    return std::nullopt;
+  };
+
+  // Catches both ctor-detected cancel (ctx->cancel is sticky) and cancel
+  // fired between ctor and Result. The assemble phase (through
+  // AppendWholeEdges) is O(N) in intersection count and has no internal
+  // cancel checkpoint until Face2Tri.
+  if (auto c = cancelled()) return *c;
+
   if (!valid) {
     auto impl = Manifold::Impl();
     impl.status_ = Manifold::Error::ResultTooLarge;
@@ -831,6 +847,8 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   triangulate.Start();
 #endif
 
+  if (auto c = cancelled()) return *c;
+
   // Level 6
   outR.Face2Tri(faceEdge, halfedgeRef);
   halfedgeRef.clear();
@@ -843,6 +861,8 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   Timer simplify;
   simplify.Start();
 #endif
+
+  if (auto c = cancelled()) return *c;
 
   if (ManifoldParams().intermediateChecks)
     DEBUG_ASSERT(outR.IsManifold(), logicErr,
@@ -864,6 +884,8 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   Timer sort;
   sort.Start();
 #endif
+
+  if (auto c = cancelled()) return *c;
 
   outR.CalculateBBox();
   outR.SortGeometry();

--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -180,7 +180,7 @@ std::shared_ptr<CsgLeafNode> SimpleBoolean(const Manifold::Impl& a,
     dump_lock.unlock();
   };
   try {
-    Boolean3 boolean(a, b, op);
+    Boolean3 boolean(a, b, op, ctx);
     auto impl = boolean.Result(op);
     if (ManifoldParams().selfIntersectionChecks && impl.IsSelfIntersecting()) {
       dump_lock.lock();
@@ -198,7 +198,7 @@ std::shared_ptr<CsgLeafNode> SimpleBoolean(const Manifold::Impl& a,
     throw err;
   }
 #else
-  auto leaf = ImplToLeaf(Boolean3(a, b, op).Result(op));
+  auto leaf = ImplToLeaf(Boolean3(a, b, op, ctx).Result(op));
   if (ctx) ctx->doneBooleans.fetch_add(1, std::memory_order_relaxed);
   return leaf;
 #endif

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -1496,6 +1496,37 @@ TEST(Manifold, ExecutionContextCancelConcurrent) {
 }
 #endif  // MANIFOLD_PAR == 1
 
+// Cancel mid-evaluation of a *single* Boolean3 call (as opposed to the outer
+// CSG tree loop). Before per-phase cancel checks inside Boolean3, this would
+// only return Cancelled if the flag fired before the boolean started; a large
+// single boolean would run to completion. With phase-boundary checks, cancel
+// requested mid-way is honored.
+#if MANIFOLD_PAR == 1
+TEST(Manifold, ExecutionContextCancelMidBoolean) {
+  // One big boolean — N-1 = 1 op, so outer-loop cancel only has a single
+  // checkpoint. The work itself (two large spheres overlapping) takes long
+  // enough that cancel fires reliably while Boolean3 is running.
+  Manifold a = Manifold::Sphere(1.0, 256);
+  Manifold b = Manifold::Sphere(1.0, 256).Translate(vec3(0.5, 0, 0));
+  Manifold u = a + b;
+
+  ExecutionContext ctx;
+  std::atomic<Manifold::Error> result{Manifold::Error::NoError};
+  std::thread evalThread([&] { result.store(u.Status(ctx)); });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  ctx.Cancel();
+  evalThread.join();
+
+  // Either outcome is acceptable. NoError: eval raced past the 1ms sleep
+  // before cancel fired. Cancelled: caught by an inner Boolean3 phase
+  // check or by the outer CsgOpNode::ToLeafNode check after a fast
+  // SimpleBoolean — we can't cheaply distinguish those paths.
+  EXPECT_TRUE(result.load() == Manifold::Error::Cancelled ||
+              result.load() == Manifold::Error::NoError);
+}
+#endif  // MANIFOLD_PAR == 1
+
 // Status() and Status(ctx) should return identical results when no cancel.
 TEST(Manifold, ExecutionContextMatchesPlainStatus) {
   Manifold u = (Manifold::Cube(vec3(1), true) + Manifold::Sphere(1.0, 32)) -


### PR DESCRIPTION
Follow-up to #1663. Progress towards #971.

After #1663, a single boolean between large meshes couldn't be cancelled — `ctx->cancel` was only checked at the CSG tree loop heads (`SimpleBoolean`/`BatchBoolean`/`BatchUnion`), not inside `Boolean3` itself. This threads `ExecutionContext::Impl*` into `Boolean3` and checks at 8 phase boundaries (4 in the ctor — before each `Intersect12` and `Winding03`; 4 in `Result` — assembly entry, `Face2Tri`, `CreateProperties`, `CalculateBBox`), bounding mid-boolean cancel latency to at most one phase.

Cost: 8 relaxed atomic loads per boolean, negligible relative to the work each phase does. Within-phase cancellation (checks inside hot parallel lambdas) is a separate follow-up.

Default ctx is `nullptr` so non-CSG callers (`Manifold::Split`, etc.) don't need to thread it. Those remain uncancellable and are tracked in #971.

## Test

`ExecutionContextCancelMidBoolean` spawns eval on a worker thread and cancels after 1ms. Probabilistic — `Cancelled` may come from an inner `Boolean3` check or from the outer `CsgOpNode::ToLeafNode` check after a fast `SimpleBoolean`, and `NoError` is valid if eval races past the sleep. `MANIFOLD_PAR == 1` guarded like `CancelConcurrent`.