### PR TITLE
Fix CsgOpNode destructor corrupting shared subtrees

### DIFF
--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -560,7 +560,10 @@ CsgOpNode::~CsgOpNode() {
     while (!toProcess.empty()) {
       auto child = std::move(toProcess.back());
       toProcess.pop_back();
-      if (impl_.UseCount() == 1) {
+      // Only empty the child's impl if we are its last holder. Otherwise
+      // another live tree still references this CsgOpNode and may later
+      // try to evaluate it, which requires its impl intact.
+      if (child.use_count() == 1 && child->impl_.UseCount() == 1) {
         auto childImpl = child->impl_.GetGuard();
         handleChildren(*childImpl);
       }

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -825,3 +825,28 @@ TEST(Boolean, BatchBoolean) {
   EXPECT_FLOAT_EQ(subtract.Volume(), 7226.043);
   EXPECT_FLOAT_EQ(subtract.SurfaceArea(), 14904.597);
 }
+
+// Regression for #1672: a sub-tree shared between two trees must survive when
+// one of those trees is destroyed without being evaluated. Previously the
+// CsgOpNode destructor emptied descendant impls regardless of whether they
+// were still referenced by other live trees, which then manifested as empty
+// positive_children in Add/Intersect finalize and a crash in BatchUnion.
+TEST(Boolean, SharedSubtreeAfterSiblingDestroyed) {
+  Manifold a = Manifold::Cube(vec3(1));
+  Manifold b = Manifold::Cube(vec3(1)).Translate(vec3(0.5, 0, 0));
+  Manifold c = Manifold::Cube(vec3(1)).Translate(vec3(1.0, 0, 0));
+  Manifold shared = a + b;
+  Manifold tree2 = shared - c;
+  {
+    Manifold tree1 = shared + c;
+    // tree1 goes out of scope here, its destructor runs while its impl
+    // still has original children (never evaluated).
+  }
+  // Build the same tree without sharing so we can compare — a partial
+  // corruption that didn't crash would show up as a tri-count mismatch.
+  Manifold reference = (Manifold::Cube(vec3(1)) +
+                        Manifold::Cube(vec3(1)).Translate(vec3(0.5, 0, 0))) -
+                       Manifold::Cube(vec3(1)).Translate(vec3(1.0, 0, 0));
+  EXPECT_EQ(tree2.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(tree2.NumTri(), reference.NumTri());
+}


### PR DESCRIPTION
Fixes #1672 (confirmed by reporter). Related to #1378 (which fixed a different manifestation of the same "shared tree state gets corrupted" class of bug).

The destructor at `src/csg_tree.cpp:560` guarded the destructive `handleChildren(*childImpl)` with `impl_.UseCount() == 1`. That check referred to the outer (being-destroyed) node's impl — which is tautologically true inside this block, because the enclosing `if (impl_.UseCount() == 1)` already established it and nothing in the loop body changes `impl_`'s refcount. So the guard was effectively unconditional, and the intended check — whether the *child* is still held by other live trees — was never performed. Result: when a tree containing a shared, unevaluated `CsgOpNode` was destroyed, it emptied that shared node's impl, breaking any other tree that still referenced it.

Minimal reproducer, segfaults on master:

```cpp
Manifold shared = a + b;
Manifold tree2 = shared - c;
{
  Manifold tree1 = shared + c;
}  // tree1 destroyed -> shared's impl emptied
tree2.NumTri();  // crash: Add finalize with empty positive_children
```

Fix: check both `child.use_count() == 1` (no other tree holds this `CsgOpNode`) and `child->impl_.UseCount() == 1` (no other `CsgOpNode` shares this impl via `Transform()`).

## Test

New regression `Boolean.SharedSubtreeAfterSiblingDestroyed` in `test/boolean_test.cpp`. Builds `tree2 = shared - c` alongside and after a destroyed `tree1 = shared + c`, then compares against an independently-constructed `(a+b)-c` reference to catch partial corruptions as well as crashes. Full suite (384 tests) passes.