### PR TITLE
Drop early return in CMake on emscripten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,11 +250,6 @@ set_source_files_properties(
   PROPERTIES GENERATED TRUE
 )
 
-# If it's an EMSCRIPTEN build, we're done
-if(EMSCRIPTEN)
-  return()
-endif()
-
 # CMake exports
 configure_file(
   cmake/manifoldConfig.cmake.in


### PR DESCRIPTION
This removes the check and early return in the CMake configuration if emscripten is configured, allowing the installation of the CMake configuration and library headers.

Fixes https://github.com/elalish/manifold/issues/1677