### PR TITLE
Add vite-bundle-analyzer for bundle size checking

### DIFF
--- a/bindings/wasm/examples/editor/README.md
+++ b/bindings/wasm/examples/editor/README.md
@@ -12,3 +12,15 @@ npm run build
 ```
 See `package.json` for other useful scripts.
 
+## Bundle Analyzer
+
+To generate a bundle analysis report, run:
+
+On Windows PowerShell:
+	$env:ANALYZE=1; npm run build
+
+On Linux/macOS:
+	ANALYZE=1 npm run build
+
+This will include the analyzer in the build and output a report.
+

--- a/bindings/wasm/examples/editor/vite.config.js
+++ b/bindings/wasm/examples/editor/vite.config.js
@@ -36,8 +36,8 @@ export default defineConfig({
         }
       ],
     }),
-    viteBundleAnalyzer()
-  ],
+    process.env.ANALYZE ? viteBundleAnalyzer() : null
+  ].filter(Boolean),
   resolve: {
     alias: {
       path: resolve(

--- a/bindings/wasm/examples/editor/vite.config.js
+++ b/bindings/wasm/examples/editor/vite.config.js
@@ -1,6 +1,7 @@
 // vite.config.js
 import {resolve} from 'path'
 import {defineConfig} from 'vite'
+import viteBundleAnalyzer from 'vite-bundle-analyzer';
 import {viteStaticCopy} from 'vite-plugin-static-copy'
 
 export default defineConfig({
@@ -20,20 +21,23 @@ export default defineConfig({
       'Cross-Origin-Opener-Policy': 'same-origin',
     },
   },
-  plugins: [viteStaticCopy({
-    targets: [
-      // If type declaration files are missing, the web editor can't
-      // load them, and type validation won't work for our core modules.
-      {
-        src: './node_modules/manifold-3d/dist/manifoldCAD.d.ts',
-        dest: './',  // Targets are relative to 'dist'.
-      },
-      {
-        src: './node_modules/manifold-3d/dist/manifoldCADGlobals.d.ts',
-        dest: './',
-      }
-    ],
-  })],
+  plugins: [
+    viteStaticCopy({
+      targets: [
+        // If type declaration files are missing, the web editor can't
+        // load them, and type validation won't work for our core modules.
+        {
+          src: './node_modules/manifold-3d/dist/manifoldCAD.d.ts',
+          dest: './',  // Targets are relative to 'dist'.
+        },
+        {
+          src: './node_modules/manifold-3d/dist/manifoldCADGlobals.d.ts',
+          dest: './',
+        }
+      ],
+    }),
+    viteBundleAnalyzer()
+  ],
   resolve: {
     alias: {
       path: resolve(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "Manifold",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "vite-bundle-analyzer": "^1.3.7"
+      }
+    },
+    "node_modules/vite-bundle-analyzer": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/vite-bundle-analyzer/-/vite-bundle-analyzer-1.3.7.tgz",
+      "integrity": "sha512-dYlW6iM0Gq7+uSEfXytDC+UjruUMgEKhXwQUbw4cJUgHA6FdEhpLgIrL5OZEyabrzVen0mZyfOSESyZ7nGyT8g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "analyze": "dist/bin.js"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "vite-bundle-analyzer": "^1.3.7"
+  }
+}


### PR DESCRIPTION
This PR adds vite-bundle-analyzer as a dev dependency.
It helps us see what makes our bundle big, like which libraries or code parts.
This tool is only for development, It does not affect production builds.
It will help us and other contributors find and fix performance issues more easily.