### PR TITLE
add non-blocking PR benchmark guard in manifold.yml (base vs head perfTest)

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -637,7 +637,17 @@ jobs:
           --json-out ./bench/result.json
         cat ./bench/summary.md >> "$GITHUB_STEP_SUMMARY"
     - name: Upload benchmark artifacts
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: pr-benchmark-guard
         path: bench/
+    - name: Cleanup benchmark worktrees
+      if: always()
+      shell: bash
+      run: |
+        for wt in wt-base wt-head; do
+          if [ -d "$wt" ]; then
+            git worktree remove "$wt" --force
+          fi
+        done

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -591,3 +591,53 @@ jobs:
     - name: Compare meshes across platforms
       run: |
         bash ./scripts/compare_artifact.sh meshes
+
+  benchmark_guard:
+    name: perfTest base-vs-head guard
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 45
+    runs-on: ubuntu-24.04
+    env:
+      PERF_REPEATS: 3
+      REGRESSION_WARN_PCT: 20
+      REGRESSION_WARN_ABS_MS: 10
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: Install apt packages
+      uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+      with:
+        packages: libgtest-dev libtbb-dev cmake
+        version: 1
+    - *clone-clipper2
+    - name: Prepare base and head worktrees
+      shell: bash
+      run: |
+        set -euo pipefail
+        BASE_SHA="${{ github.event.pull_request.base.sha }}"
+        HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+        git worktree add wt-base "$BASE_SHA"
+        git worktree add wt-head "$HEAD_SHA"
+    - name: Benchmark base and head
+      shell: bash
+      run: |
+        for variant in base head; do
+          bash ./scripts/run_pr_perf_guard.sh "./wt-${variant}" ./clipper2 "./bench/${variant}" "${PERF_REPEATS}"
+        done
+    - name: Compare benchmark results
+      shell: bash
+      run: |
+        python3 ./scripts/compare_pr_perf_guard.py \
+          --base-dir ./bench/base \
+          --head-dir ./bench/head \
+          --warn-pct "${REGRESSION_WARN_PCT}" \
+          --warn-abs-ms "${REGRESSION_WARN_ABS_MS}" \
+          --markdown-out ./bench/summary.md \
+          --json-out ./bench/result.json
+        cat ./bench/summary.md >> "$GITHUB_STEP_SUMMARY"
+    - name: Upload benchmark artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: pr-benchmark-guard
+        path: bench/

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -656,3 +656,4 @@ jobs:
         cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
 ###Inspect Raw Benchmark Logs
 Open the `Compare benchmark results` step in this workflow run.
+        EOF

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -614,44 +614,11 @@ jobs:
     - name: Prepare base and head worktrees
       continue-on-error: true
       shell: bash
-      run: |
-        set -euo pipefail
-        BASE_SHA="${{ github.event.pull_request.base.sha }}"
-        HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-        git worktree add wt-base "$BASE_SHA"
-        git worktree add wt-head "$HEAD_SHA"
+      run: bash ./scripts/prepare_pr_perf_guard_worktrees.sh "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"
     - name: Benchmark base and head
       continue-on-error: true
       shell: bash
-      run: |
-        for variant in base head; do
-          bash ./scripts/run_pr_perf_guard.sh "./wt-${variant}" ./clipper2 "./bench/${variant}" "${PERF_REPEATS}"
-        done
+      run: bash ./scripts/benchmark_pr_perf_guard.sh ./clipper2 "${PERF_REPEATS}"
     - name: Compare benchmark results
       shell: bash
-      run: |
-        python3 ./scripts/compare_pr_perf_guard.py \
-          --base-dir ./bench/base \
-          --head-dir ./bench/head \
-          --warn-pct "${REGRESSION_WARN_PCT}" \
-          --warn-abs-ms "${REGRESSION_WARN_ABS_MS}" \
-          --markdown-out ./bench/summary.md \
-          --json-out ./bench/result.json
-        echo "::group::PR benchmark summary"
-        cat ./bench/summary.md
-        echo "::endgroup::"
-        echo "::group::PR benchmark result.json"
-        cat ./bench/result.json
-        echo "::endgroup::"
-        echo "::group::PR benchmark raw outputs"
-        for variant in base head; do
-          for run_file in ./bench/${variant}/run*.txt; do
-            [ -f "${run_file}" ] || continue
-            echo "--- ${run_file} ---"
-            cat "${run_file}"
-          done
-        done
-        echo "::endgroup::"
-        cat ./bench/summary.md >> "$GITHUB_STEP_SUMMARY"
-        echo "" >> "$GITHUB_STEP_SUMMARY"
-        echo "Raw logs: open this step and expand \`PR benchmark result.json\` and \`PR benchmark raw outputs\` groups." >> "$GITHUB_STEP_SUMMARY"
+      run: bash ./scripts/report_pr_perf_guard.sh ./bench/base ./bench/head "${REGRESSION_WARN_PCT}" "${REGRESSION_WARN_ABS_MS}"

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -653,7 +653,5 @@ jobs:
         done
         echo "::endgroup::"
         cat ./bench/summary.md >> "$GITHUB_STEP_SUMMARY"
-        cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
-###Inspect Raw Benchmark Logs
-Open the `Compare benchmark results` step in this workflow run.
-        EOF
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "Raw logs: open this step and expand \`PR benchmark result.json\` and \`PR benchmark raw outputs\` groups." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -637,19 +637,22 @@ jobs:
           --warn-abs-ms "${REGRESSION_WARN_ABS_MS}" \
           --markdown-out ./bench/summary.md \
           --json-out ./bench/result.json
-        cat ./bench/summary.md >> "$GITHUB_STEP_SUMMARY"
-    - name: Upload benchmark artifacts
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: pr-benchmark-guard
-        path: bench/
-    - name: Cleanup benchmark worktrees
-      if: always()
-      shell: bash
-      run: |
-        for wt in wt-base wt-head; do
-          if [ -d "$wt" ]; then
-            git worktree remove "$wt" --force
-          fi
+        echo "::group::PR benchmark summary"
+        cat ./bench/summary.md
+        echo "::endgroup::"
+        echo "::group::PR benchmark result.json"
+        cat ./bench/result.json
+        echo "::endgroup::"
+        echo "::group::PR benchmark raw outputs"
+        for variant in base head; do
+          for run_file in ./bench/${variant}/run*.txt; do
+            [ -f "${run_file}" ] || continue
+            echo "--- ${run_file} ---"
+            cat "${run_file}"
+          done
         done
+        echo "::endgroup::"
+        cat ./bench/summary.md >> "$GITHUB_STEP_SUMMARY"
+        cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+###Inspect Raw Benchmark Logs
+Open the `Compare benchmark results` step in this workflow run.

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -612,6 +612,7 @@ jobs:
         version: 1
     - *clone-clipper2
     - name: Prepare base and head worktrees
+      continue-on-error: true
       shell: bash
       run: |
         set -euo pipefail
@@ -620,12 +621,15 @@ jobs:
         git worktree add wt-base "$BASE_SHA"
         git worktree add wt-head "$HEAD_SHA"
     - name: Benchmark base and head
+      if: always()
+      continue-on-error: true
       shell: bash
       run: |
         for variant in base head; do
           bash ./scripts/run_pr_perf_guard.sh "./wt-${variant}" ./clipper2 "./bench/${variant}" "${PERF_REPEATS}"
         done
     - name: Compare benchmark results
+      if: always()
       shell: bash
       run: |
         python3 ./scripts/compare_pr_perf_guard.py \

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -621,7 +621,6 @@ jobs:
         git worktree add wt-base "$BASE_SHA"
         git worktree add wt-head "$HEAD_SHA"
     - name: Benchmark base and head
-      if: always()
       continue-on-error: true
       shell: bash
       run: |
@@ -629,7 +628,6 @@ jobs:
           bash ./scripts/run_pr_perf_guard.sh "./wt-${variant}" ./clipper2 "./bench/${variant}" "${PERF_REPEATS}"
         done
     - name: Compare benchmark results
-      if: always()
       shell: bash
       run: |
         python3 ./scripts/compare_pr_perf_guard.py \

--- a/scripts/benchmark_pr_perf_guard.sh
+++ b/scripts/benchmark_pr_perf_guard.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <clipper2-dir> <repeats>"
+  exit 2
+fi
+
+CLIPPER2_DIR="$1"
+REPEATS="$2"
+
+for variant in base head; do
+  bash ./scripts/run_pr_perf_guard.sh "./wt-${variant}" "$CLIPPER2_DIR" "./bench/${variant}" "$REPEATS"
+done

--- a/scripts/compare_pr_perf_guard.py
+++ b/scripts/compare_pr_perf_guard.py
@@ -8,6 +8,10 @@ from pathlib import Path
 TIME_PATTERN = re.compile(r"time\s*=\s*([0-9]*\.?[0-9]+)\s*sec")
 
 
+def mean(values: list[float]) -> float:
+    return statistics.fmean(values)
+
+
 def parse_run(run_path: Path) -> dict:
     times = []
     for line in run_path.read_text(encoding="utf-8").splitlines():
@@ -19,7 +23,7 @@ def parse_run(run_path: Path) -> dict:
     return {
         "path": str(run_path),
         "samples_sec": times,
-        "mean_sec": sum(times) / len(times),
+        "mean_sec": mean(times),
         "max_sec": max(times),
     }
 
@@ -34,7 +38,7 @@ def parse_suite(suite_dir: Path) -> dict:
         "runs": runs,
         "run_means_sec": run_means,
         "median_run_mean_sec": statistics.median(run_means),
-        "mean_of_run_means_sec": sum(run_means) / len(run_means),
+        "mean_of_run_means_sec": mean(run_means),
     }
 
 
@@ -104,4 +108,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/scripts/compare_pr_perf_guard.py
+++ b/scripts/compare_pr_perf_guard.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+import statistics
+from pathlib import Path
+
+TIME_PATTERN = re.compile(r"time\s*=\s*([0-9]*\.?[0-9]+)\s*sec")
+
+
+def parse_run(run_path: Path) -> dict:
+    times = []
+    for line in run_path.read_text(encoding="utf-8").splitlines():
+        match = TIME_PATTERN.search(line)
+        if match:
+            times.append(float(match.group(1)))
+    if not times:
+        raise RuntimeError(f"No perf timing lines found in {run_path}")
+    return {
+        "path": str(run_path),
+        "samples_sec": times,
+        "mean_sec": sum(times) / len(times),
+        "max_sec": max(times),
+    }
+
+
+def parse_suite(suite_dir: Path) -> dict:
+    run_files = sorted(suite_dir.glob("run*.txt"))
+    if not run_files:
+        raise RuntimeError(f"No run*.txt files found in {suite_dir}")
+    runs = [parse_run(run_file) for run_file in run_files]
+    run_means = [run["mean_sec"] for run in runs]
+    return {
+        "runs": runs,
+        "run_means_sec": run_means,
+        "median_run_mean_sec": statistics.median(run_means),
+        "mean_of_run_means_sec": sum(run_means) / len(run_means),
+    }
+
+
+def build_summary(base: dict, head: dict, warn_pct: float, warn_abs_ms: float) -> tuple[str, bool, dict]:
+    base_mean = base["median_run_mean_sec"]
+    head_mean = head["median_run_mean_sec"]
+    delta_sec = head_mean - base_mean
+    delta_ms = delta_sec * 1000.0
+    pct = (delta_sec / base_mean * 100.0) if base_mean > 0 else 0.0
+    regressed = (pct >= warn_pct) and (delta_ms >= warn_abs_ms)
+
+    lines = []
+    lines.append("### PR Benchmark Guard (perfTest)")
+    lines.append("")
+    lines.append("| Metric | Base | Head | Delta |")
+    lines.append("|---|---:|---:|---:|")
+    lines.append(
+        f"| Median of run means (sec) | {base_mean:.6f} | {head_mean:.6f} | {delta_sec:+.6f} ({pct:+.2f}%) |"
+    )
+    lines.append(
+        f"| Mean of run means (sec) | {base['mean_of_run_means_sec']:.6f} | {head['mean_of_run_means_sec']:.6f} | "
+        f"{(head['mean_of_run_means_sec'] - base['mean_of_run_means_sec']):+.6f} |"
+    )
+    lines.append("")
+    lines.append(f"Thresholds: warn if regression >= {warn_pct:.1f}% and >= {warn_abs_ms:.1f} ms.")
+    lines.append(f"Result: {'WARNING (regression detected)' if regressed else 'OK (no threshold breach)'}")
+    lines.append("")
+
+    payload = {
+        "base": base,
+        "head": head,
+        "delta_sec": delta_sec,
+        "delta_ms": delta_ms,
+        "delta_pct": pct,
+        "warn_pct": warn_pct,
+        "warn_abs_ms": warn_abs_ms,
+        "regressed": regressed,
+    }
+    return "\n".join(lines), regressed, payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compare perfTest runs for PR benchmark guard.")
+    parser.add_argument("--base-dir", required=True, type=Path)
+    parser.add_argument("--head-dir", required=True, type=Path)
+    parser.add_argument("--warn-pct", type=float, default=20.0)
+    parser.add_argument("--warn-abs-ms", type=float, default=10.0)
+    parser.add_argument("--markdown-out", required=True, type=Path)
+    parser.add_argument("--json-out", required=True, type=Path)
+    args = parser.parse_args()
+
+    base = parse_suite(args.base_dir)
+    head = parse_suite(args.head_dir)
+    markdown, regressed, payload = build_summary(base, head, args.warn_pct, args.warn_abs_ms)
+
+    args.markdown_out.write_text(markdown + "\n", encoding="utf-8")
+    args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    if regressed:
+        print(
+            f"::warning::PR benchmark regression detected: {payload['delta_pct']:.2f}% ({payload['delta_ms']:.2f} ms) slower than base."
+        )
+    else:
+        print("No benchmark regression above warning thresholds.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/scripts/compare_pr_perf_guard.py
+++ b/scripts/compare_pr_perf_guard.py
@@ -5,76 +5,138 @@ import re
 import statistics
 from pathlib import Path
 
-TIME_PATTERN = re.compile(r"time\s*=\s*([0-9]*\.?[0-9]+)\s*sec")
+TIME_PATTERN = re.compile(r"time\s*=\s*([0-9]*\.?[0-9]+)\s*sec") #only extracts time values(for fallback)
+TRI_TIME_PATTERN = re.compile(
+    r"nTri\s*=\s*([0-9]+)\s*,\s*time\s*=\s*([0-9]*\.?[0-9]+)\s*sec"#extracts nTri and time values
+)
 
 
 def mean(values: list[float]) -> float:
     return statistics.fmean(values)
 
 
-def parse_run(run_path: Path) -> dict:
-    times = []
+def parse_run(run_path: Path) -> dict:#parses run*.txt files to extract benchmark timings
+    benchmarks = []
     for line in run_path.read_text(encoding="utf-8").splitlines():
-        match = TIME_PATTERN.search(line)
-        if match:
-            times.append(float(match.group(1)))
-    if not times:
+        tri_match = TRI_TIME_PATTERN.search(line)
+        if tri_match:
+            benchmark_key = f"nTri={tri_match.group(1)}"
+            benchmarks.append({"benchmark": benchmark_key, "time_sec": float(tri_match.group(2))})
+            continue
+            
+        time_match = TIME_PATTERN.search(line)
+        if time_match:
+            benchmark_key = f"benchmark_{len(benchmarks) + 1}"
+            benchmarks.append({"benchmark": benchmark_key, "time_sec": float(time_match.group(1))})
+
+    if not benchmarks:
         raise RuntimeError(f"No perf timing lines found in {run_path}")
+
+    benchmark_names = [entry["benchmark"] for entry in benchmarks]
+    if len(set(benchmark_names)) != len(benchmark_names):
+        raise RuntimeError(f"Duplicate benchmark keys found in {run_path}")
+
     return {
         "path": str(run_path),
-        "samples_sec": times,
-        "mean_sec": mean(times),
-        "max_sec": max(times),
+        "benchmarks": benchmarks,
     }
 
 
-def parse_suite(suite_dir: Path) -> dict:
+def parse_suite(suite_dir: Path) -> dict:#calls parse_run for each run*.txt file in the given directory and arranges the data for head and base runs
     run_files = sorted(suite_dir.glob("run*.txt"))
     if not run_files:
         raise RuntimeError(f"No run*.txt files found in {suite_dir}")
+
     runs = [parse_run(run_file) for run_file in run_files]
-    run_means = [run["mean_sec"] for run in runs]
+    benchmark_order = [entry["benchmark"] for entry in runs[0]["benchmarks"]]
+
+    for run in runs[1:]:
+        run_order = [entry["benchmark"] for entry in run["benchmarks"]]
+        if run_order != benchmark_order:
+            raise RuntimeError(
+                f"Benchmark layout mismatch in {run['path']}: expected {benchmark_order}, got {run_order}"
+            )
+
+    benchmark_samples = {benchmark: [] for benchmark in benchmark_order}
+    for run in runs:
+        for entry in run["benchmarks"]:
+            benchmark_samples[entry["benchmark"]].append(entry["time_sec"])
+
+    benchmarks = {}
+    for benchmark in benchmark_order:
+        samples = benchmark_samples[benchmark]
+        benchmarks[benchmark] = {
+            "samples_sec": samples,
+            "mean_sec": mean(samples),
+            "median_sec": statistics.median(samples),
+            "max_sec": max(samples),
+        }
+
     return {
         "runs": runs,
-        "run_means_sec": run_means,
-        "median_run_mean_sec": statistics.median(run_means),
-        "mean_of_run_means_sec": mean(run_means),
+        "benchmarks": benchmarks,
+        "benchmark_order": benchmark_order,
     }
 
 
-def build_summary(base: dict, head: dict, warn_pct: float, warn_abs_ms: float) -> tuple[str, bool, dict]:
-    # Primary comparison metric: mean of run means.
-    base_mean = base["mean_of_run_means_sec"]
-    head_mean = head["mean_of_run_means_sec"]
-    delta_sec = head_mean - base_mean
-    delta_ms = delta_sec * 1000.0
-    pct = (delta_sec / base_mean * 100.0) if base_mean > 0 else 0.0
-    regressed = (pct >= warn_pct) and (delta_ms >= warn_abs_ms)
+def build_summary(base: dict, head: dict, warn_pct: float, warn_abs_ms: float) -> tuple[str, bool, dict]:#arranges everything
+    if base["benchmark_order"] != head["benchmark_order"]:
+        raise RuntimeError(
+            "Benchmark set/order mismatch between base and head: "
+            f"{base['benchmark_order']} vs {head['benchmark_order']}"
+        )
 
     lines = []
     lines.append("### PR Benchmark Guard (perfTest)")
     lines.append("")
-    lines.append("| Metric | Base | Head | Delta |")
+    lines.append("| Benchmark | Base mean (sec) | Head mean (sec) | Delta | Status |")
     lines.append("|---|---:|---:|---:|")
-    lines.append(
-        f"| Mean of run means (sec) [primary] | {base_mean:.6f} | {head_mean:.6f} | {delta_sec:+.6f} ({pct:+.2f}%) |"
-    )
-    lines.append(
-        f"| Median of run means (sec) | {base['median_run_mean_sec']:.6f} | {head['median_run_mean_sec']:.6f} | "
-        f"{(head['median_run_mean_sec'] - base['median_run_mean_sec']):+.6f} |"
-    )
+
+    per_benchmark = []
+    regressed = False
+    for benchmark in base["benchmark_order"]:
+        base_mean = base["benchmarks"][benchmark]["mean_sec"]
+        head_mean = head["benchmarks"][benchmark]["mean_sec"]
+        delta_sec = head_mean - base_mean
+        delta_ms = delta_sec * 1000.0
+        pct = (delta_sec / base_mean * 100.0) if base_mean > 0 else 0.0
+        this_regressed = (pct >= warn_pct) and (delta_ms >= warn_abs_ms)
+        regressed = regressed or this_regressed
+        status = "WARNING" if this_regressed else "OK"
+
+        lines.append(
+            f"| {benchmark} | {base_mean:.6f} | {head_mean:.6f} | {delta_sec:+.6f} ({pct:+.2f}%) | {status} |"
+        )
+
+        per_benchmark.append(
+            {
+                "benchmark": benchmark,
+                "base_mean_sec": base_mean,
+                "head_mean_sec": head_mean,
+                "delta_sec": delta_sec,
+                "delta_ms": delta_ms,
+                "delta_pct": pct,
+                "regressed": this_regressed,
+            }
+        )
+
     lines.append("")
     lines.append(f"Thresholds: warn if regression >= {warn_pct:.1f}% and >= {warn_abs_ms:.1f} ms.")
-    lines.append(f"Result: {'WARNING (regression detected)' if regressed else 'OK (no threshold breach)'}")
+    lines.append(
+        f"Result: {'WARNING (one or more benchmark regressions detected)' if regressed else 'OK (no threshold breach)'}"
+    )
     lines.append("")
 
+    regressed_rows = [row for row in per_benchmark if row["regressed"]]
+    worst_regression = max(regressed_rows, key=lambda row: row["delta_ms"]) if regressed_rows else None
+
     payload = {
-        "primary_metric": "mean_of_run_means_sec",
+        "primary_metric": "per_benchmark_mean_sec",
         "base": base,
         "head": head,
-        "delta_sec": delta_sec,
-        "delta_ms": delta_ms,
-        "delta_pct": pct,
+        "per_benchmark": per_benchmark,
+        "regressed_count": len(regressed_rows),
+        "worst_regression": worst_regression,
         "warn_pct": warn_pct,
         "warn_abs_ms": warn_abs_ms,
         "regressed": regressed,
@@ -94,9 +156,9 @@ def build_invalid_summary(reason: str) -> tuple[str, dict]:
     payload = {
         "base": None,
         "head": None,
-        "delta_sec": None,
-        "delta_ms": None,
-        "delta_pct": None,
+        "per_benchmark": [],
+        "regressed_count": 0,
+        "worst_regression": None,
         "warn_pct": None,
         "warn_abs_ms": None,
         "regressed": False,
@@ -134,9 +196,15 @@ def main() -> int:
     args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
     if regressed:
-        print(
-            f"::warning::PR benchmark regression detected: {payload['delta_pct']:.2f}% ({payload['delta_ms']:.2f} ms) slower than base."
-        )
+        worst = payload.get("worst_regression")
+        if worst:
+            print(
+                "::warning::PR benchmark regression detected: "
+                f"{payload['regressed_count']} benchmark(s) exceeded thresholds. "
+                f"Worst: {worst['benchmark']} {worst['delta_pct']:.2f}% ({worst['delta_ms']:.2f} ms) slower."
+            )
+        else:
+            print("::warning::PR benchmark regression detected.")
     elif payload.get("data_valid", False):
         print("No benchmark regression above warning thresholds.")
     return 0

--- a/scripts/compare_pr_perf_guard.py
+++ b/scripts/compare_pr_perf_guard.py
@@ -80,6 +80,30 @@ def build_summary(base: dict, head: dict, warn_pct: float, warn_abs_ms: float) -
     return "\n".join(lines), regressed, payload
 
 
+def build_invalid_summary(reason: str) -> tuple[str, dict]:
+    lines = []
+    lines.append("### PR Benchmark Guard (perfTest)")
+    lines.append("")
+    lines.append("Result: WARNING (benchmark data invalid/skipped)")
+    lines.append("")
+    lines.append(f"Reason: {reason}")
+    lines.append("")
+
+    payload = {
+        "base": None,
+        "head": None,
+        "delta_sec": None,
+        "delta_ms": None,
+        "delta_pct": None,
+        "warn_pct": None,
+        "warn_abs_ms": None,
+        "regressed": False,
+        "data_valid": False,
+        "reason": reason,
+    }
+    return "\n".join(lines), payload
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Compare perfTest runs for PR benchmark guard.")
     parser.add_argument("--base-dir", required=True, type=Path)
@@ -90,9 +114,19 @@ def main() -> int:
     parser.add_argument("--json-out", required=True, type=Path)
     args = parser.parse_args()
 
-    base = parse_suite(args.base_dir)
-    head = parse_suite(args.head_dir)
-    markdown, regressed, payload = build_summary(base, head, args.warn_pct, args.warn_abs_ms)
+    try:
+        base = parse_suite(args.base_dir)
+        head = parse_suite(args.head_dir)
+        if len(base["runs"]) != len(head["runs"]):
+            raise RuntimeError(
+                f"Run count mismatch: base has {len(base['runs'])}, head has {len(head['runs'])}."
+            )
+        markdown, regressed, payload = build_summary(base, head, args.warn_pct, args.warn_abs_ms)
+        payload["data_valid"] = True
+    except Exception as exc:
+        markdown, payload = build_invalid_summary(str(exc))
+        regressed = False
+        print(f"::warning::PR benchmark guard data invalid: {exc}")
 
     args.markdown_out.write_text(markdown + "\n", encoding="utf-8")
     args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
@@ -101,7 +135,7 @@ def main() -> int:
         print(
             f"::warning::PR benchmark regression detected: {payload['delta_pct']:.2f}% ({payload['delta_ms']:.2f} ms) slower than base."
         )
-    else:
+    elif payload.get("data_valid", False):
         print("No benchmark regression above warning thresholds.")
     return 0
 

--- a/scripts/compare_pr_perf_guard.py
+++ b/scripts/compare_pr_perf_guard.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 import argparse
+import datetime
 import json
+import os
 import re
 import statistics
+import subprocess
 from pathlib import Path
 
-TIME_PATTERN = re.compile(r"time\s*=\s*([0-9]*\.?[0-9]+)\s*sec") #only extracts time values(for fallback)
+SCHEMA_VERSION = "1.0.0"
+# fallback: extract only time value when nTri label is not present
+TIME_PATTERN = re.compile(r"time\s*=\s*([0-9]*\.?[0-9]+)\s*sec")
+# primary: extract both nTri bucket and timing from perfTest output
 TRI_TIME_PATTERN = re.compile(
-    r"nTri\s*=\s*([0-9]+)\s*,\s*time\s*=\s*([0-9]*\.?[0-9]+)\s*sec"#extracts nTri and time values
+    r"nTri\s*=\s*([0-9]+)\s*,\s*time\s*=\s*([0-9]*\.?[0-9]+)\s*sec"
 )
 
 
@@ -15,19 +21,31 @@ def mean(values: list[float]) -> float:
     return statistics.fmean(values)
 
 
-def parse_run(run_path: Path) -> dict:#parses run*.txt files to extract benchmark timings
+def stdev(values: list[float]) -> float:
+    # keep stdev defined even for single-sample cases
+    if len(values) <= 1:
+        return 0.0
+    return statistics.stdev(values)
+
+
+def parse_run(run_path: Path, run_index: int) -> dict:
+    # parse one run*.txt into ordered benchmark samples
     benchmarks = []
     for line in run_path.read_text(encoding="utf-8").splitlines():
         tri_match = TRI_TIME_PATTERN.search(line)
         if tri_match:
             benchmark_key = f"nTri={tri_match.group(1)}"
-            benchmarks.append({"benchmark": benchmark_key, "time_sec": float(tri_match.group(2))})
+            benchmarks.append(
+                {"benchmark": benchmark_key, "time_sec": float(tri_match.group(2))}
+            )
             continue
-            
+
         time_match = TIME_PATTERN.search(line)
         if time_match:
             benchmark_key = f"benchmark_{len(benchmarks) + 1}"
-            benchmarks.append({"benchmark": benchmark_key, "time_sec": float(time_match.group(1))})
+            benchmarks.append(
+                {"benchmark": benchmark_key, "time_sec": float(time_match.group(1))}
+            )
 
     if not benchmarks:
         raise RuntimeError(f"No perf timing lines found in {run_path}")
@@ -38,16 +56,18 @@ def parse_run(run_path: Path) -> dict:#parses run*.txt files to extract benchmar
 
     return {
         "path": str(run_path),
+        "run_index": run_index,
         "benchmarks": benchmarks,
     }
 
 
-def parse_suite(suite_dir: Path) -> dict:#calls parse_run for each run*.txt file in the given directory and arranges the data for head and base runs
+def parse_suite(suite_dir: Path) -> dict:
+    # parse all run*.txt and build per-benchmark aggregates across repeats
     run_files = sorted(suite_dir.glob("run*.txt"))
     if not run_files:
         raise RuntimeError(f"No run*.txt files found in {suite_dir}")
 
-    runs = [parse_run(run_file) for run_file in run_files]
+    runs = [parse_run(run_file, i + 1) for i, run_file in enumerate(run_files)]
     benchmark_order = [entry["benchmark"] for entry in runs[0]["benchmarks"]]
 
     for run in runs[1:]:
@@ -69,7 +89,9 @@ def parse_suite(suite_dir: Path) -> dict:#calls parse_run for each run*.txt file
             "samples_sec": samples,
             "mean_sec": mean(samples),
             "median_sec": statistics.median(samples),
+            "stdev_sec": stdev(samples),
             "max_sec": max(samples),
+            "n_runs": len(samples),
         }
 
     return {
@@ -79,7 +101,10 @@ def parse_suite(suite_dir: Path) -> dict:#calls parse_run for each run*.txt file
     }
 
 
-def build_summary(base: dict, head: dict, warn_pct: float, warn_abs_ms: float) -> tuple[str, bool, dict]:#arranges everything
+def build_summary(
+    base: dict, head: dict, warn_pct: float, warn_abs_ms: float
+) -> tuple[str, bool, dict]:
+    # compare benchmark means between base and head with dual-threshold warnings
     if base["benchmark_order"] != head["benchmark_order"]:
         raise RuntimeError(
             "Benchmark set/order mismatch between base and head: "
@@ -145,6 +170,7 @@ def build_summary(base: dict, head: dict, warn_pct: float, warn_abs_ms: float) -
 
 
 def build_invalid_summary(reason: str) -> tuple[str, dict]:
+    # non-blocking fallback payload when data is missing/invalid
     lines = []
     lines.append("### PR Benchmark Guard (perfTest)")
     lines.append("")
@@ -168,6 +194,37 @@ def build_invalid_summary(reason: str) -> tuple[str, dict]:
     return "\n".join(lines), payload
 
 
+def detect_compiler() -> str | None:
+    # best compiler fingerprint for metadata (first available binary wins)
+    for binary in ("c++", "g++", "clang++"):
+        try:
+            result = subprocess.run(
+                [binary, "--version"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except (subprocess.CalledProcessError, OSError):
+            continue
+        first_line = result.stdout.splitlines()[0].strip() if result.stdout else ""
+        if first_line:
+            return first_line
+    return None
+
+
+def resolve_metadata(args: argparse.Namespace) -> dict:
+    # resolve metadata from explicit args first, then GitHub env vars
+    timestamp = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
+    return {
+        "commit_sha": args.commit_sha or os.getenv("GITHUB_SHA"),
+        "workflow": args.workflow or os.getenv("GITHUB_WORKFLOW"),
+        "runner": args.runner or os.getenv("RUNNER_NAME"),
+        "os": args.os_name or os.getenv("RUNNER_OS"),
+        "compiler": args.compiler or detect_compiler(),
+        "timestamp": timestamp.isoformat().replace("+00:00", "Z"),
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Compare perfTest runs for PR benchmark guard.")
     parser.add_argument("--base-dir", required=True, type=Path)
@@ -176,7 +233,13 @@ def main() -> int:
     parser.add_argument("--warn-abs-ms", type=float, default=10.0)
     parser.add_argument("--markdown-out", required=True, type=Path)
     parser.add_argument("--json-out", required=True, type=Path)
+    parser.add_argument("--commit-sha")
+    parser.add_argument("--workflow")
+    parser.add_argument("--runner")
+    parser.add_argument("--os-name")
+    parser.add_argument("--compiler")
     args = parser.parse_args()
+    metadata = resolve_metadata(args)
 
     try:
         base = parse_suite(args.base_dir)
@@ -192,6 +255,8 @@ def main() -> int:
         regressed = False
         print(f"::warning::PR benchmark guard data invalid: {exc}")
 
+    payload["schema_version"] = SCHEMA_VERSION
+    payload["metadata"] = metadata
     args.markdown_out.write_text(markdown + "\n", encoding="utf-8")
     args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 

--- a/scripts/compare_pr_perf_guard.py
+++ b/scripts/compare_pr_perf_guard.py
@@ -43,8 +43,9 @@ def parse_suite(suite_dir: Path) -> dict:
 
 
 def build_summary(base: dict, head: dict, warn_pct: float, warn_abs_ms: float) -> tuple[str, bool, dict]:
-    base_mean = base["median_run_mean_sec"]
-    head_mean = head["median_run_mean_sec"]
+    # Primary comparison metric: mean of run means.
+    base_mean = base["mean_of_run_means_sec"]
+    head_mean = head["mean_of_run_means_sec"]
     delta_sec = head_mean - base_mean
     delta_ms = delta_sec * 1000.0
     pct = (delta_sec / base_mean * 100.0) if base_mean > 0 else 0.0
@@ -56,11 +57,11 @@ def build_summary(base: dict, head: dict, warn_pct: float, warn_abs_ms: float) -
     lines.append("| Metric | Base | Head | Delta |")
     lines.append("|---|---:|---:|---:|")
     lines.append(
-        f"| Median of run means (sec) | {base_mean:.6f} | {head_mean:.6f} | {delta_sec:+.6f} ({pct:+.2f}%) |"
+        f"| Mean of run means (sec) [primary] | {base_mean:.6f} | {head_mean:.6f} | {delta_sec:+.6f} ({pct:+.2f}%) |"
     )
     lines.append(
-        f"| Mean of run means (sec) | {base['mean_of_run_means_sec']:.6f} | {head['mean_of_run_means_sec']:.6f} | "
-        f"{(head['mean_of_run_means_sec'] - base['mean_of_run_means_sec']):+.6f} |"
+        f"| Median of run means (sec) | {base['median_run_mean_sec']:.6f} | {head['median_run_mean_sec']:.6f} | "
+        f"{(head['median_run_mean_sec'] - base['median_run_mean_sec']):+.6f} |"
     )
     lines.append("")
     lines.append(f"Thresholds: warn if regression >= {warn_pct:.1f}% and >= {warn_abs_ms:.1f} ms.")
@@ -68,6 +69,7 @@ def build_summary(base: dict, head: dict, warn_pct: float, warn_abs_ms: float) -
     lines.append("")
 
     payload = {
+        "primary_metric": "mean_of_run_means_sec",
         "base": base,
         "head": head,
         "delta_sec": delta_sec,

--- a/scripts/compare_pr_perf_guard.py
+++ b/scripts/compare_pr_perf_guard.py
@@ -216,6 +216,7 @@ def resolve_metadata(args: argparse.Namespace) -> dict:
     # resolve metadata from explicit args first, then GitHub env vars
     timestamp = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
     return {
+        "schema_version": SCHEMA_VERSION,
         "commit_sha": args.commit_sha or os.getenv("GITHUB_SHA"),
         "workflow": args.workflow or os.getenv("GITHUB_WORKFLOW"),
         "runner": args.runner or os.getenv("RUNNER_NAME"),
@@ -255,7 +256,6 @@ def main() -> int:
         regressed = False
         print(f"::warning::PR benchmark guard data invalid: {exc}")
 
-    payload["schema_version"] = SCHEMA_VERSION
     payload["metadata"] = metadata
     args.markdown_out.write_text(markdown + "\n", encoding="utf-8")
     args.json_out.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")

--- a/scripts/prepare_pr_perf_guard_worktrees.sh
+++ b/scripts/prepare_pr_perf_guard_worktrees.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <base-sha> <head-sha>"
+  exit 2
+fi
+
+BASE_SHA="$1"
+HEAD_SHA="$2"
+
+git worktree add wt-base "$BASE_SHA"
+git worktree add wt-head "$HEAD_SHA"

--- a/scripts/report_pr_perf_guard.sh
+++ b/scripts/report_pr_perf_guard.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "Usage: $0 <base-dir> <head-dir> <warn-pct> <warn-abs-ms>"
+  exit 2
+fi
+
+BASE_DIR="$1"
+HEAD_DIR="$2"
+WARN_PCT="$3"
+WARN_ABS_MS="$4"
+
+python3 ./scripts/compare_pr_perf_guard.py \
+  --base-dir "$BASE_DIR" \
+  --head-dir "$HEAD_DIR" \
+  --warn-pct "$WARN_PCT" \
+  --warn-abs-ms "$WARN_ABS_MS" \
+  --markdown-out ./bench/summary.md \
+  --json-out ./bench/result.json
+
+echo "::group::PR benchmark summary"
+cat ./bench/summary.md
+echo "::endgroup::"
+
+echo "::group::PR benchmark result.json"
+cat ./bench/result.json
+echo "::endgroup::"
+
+echo "::group::PR benchmark raw outputs"
+for variant in base head; do
+  for run_file in "./bench/${variant}"/run*.txt; do
+    [ -f "${run_file}" ] || continue
+    echo "--- ${run_file} ---"
+    cat "${run_file}"
+  done
+done
+echo "::endgroup::"
+
+cat ./bench/summary.md >> "$GITHUB_STEP_SUMMARY"
+echo "" >> "$GITHUB_STEP_SUMMARY"
+echo "Raw logs: open this step and expand \`PR benchmark result.json\` and \`PR benchmark raw outputs\` groups." >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/run_pr_perf_guard.sh
+++ b/scripts/run_pr_perf_guard.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 4 ]; then
+  echo "Usage: $0 <source-dir> <clipper2-dir> <output-dir> <repeats>"
+  exit 2
+fi
+
+SRC_DIR="$1"
+CLIPPER2_DIR="$2"
+OUT_DIR="$3"
+REPEATS="$4"
+BUILD_DIR="${OUT_DIR}/build"
+
+cmake \
+  -S "$SRC_DIR" \
+  -B "$BUILD_DIR" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DMANIFOLD_STRICT=ON \
+  -DMANIFOLD_PYBIND=OFF \
+  -DMANIFOLD_TEST=ON \
+  -DMANIFOLD_PAR=ON \
+  -DMANIFOLD_CROSS_SECTION=OFF \
+  -DFETCHCONTENT_SOURCE_DIR_CLIPPER2="$CLIPPER2_DIR"
+
+cmake --build "$BUILD_DIR" --target perfTest
+
+BIN=""
+for candidate in "${BUILD_DIR}/extras/perfTest" "${BUILD_DIR}/bin/perfTest"; do
+  if [ -x "$candidate" ]; then
+    BIN="$candidate"
+    break
+  fi
+done
+if [ -z "$BIN" ]; then
+  echo "perfTest binary not found in expected paths."
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+for i in $(seq 1 "$REPEATS"); do
+  "$BIN" > "${OUT_DIR}/run${i}.txt"
+done


### PR DESCRIPTION
## Summary

This PR adds an initial PR benchmark guard to CI for performance visibility during review.
It runs a lightweight benchmark comparison between:
- the PR base commit, and
- the PR head commit,
on the same runner to reduce cross-runner noise.

### working
1. Checkout repository with full history.
2. Create two git worktrees:
   - `wt-base` from `github.event.pull_request.base.sha`
   - `wt-head` from `github.event.pull_request.head.sha`
3. Build and run `extras/perfTest` for each variant (`base`, `head`) with the same settings.
benchmark used -> perfTest
4. Repeat runs (`PERF_REPEATS=3`) and save outputs under:
   - `bench/base/run*.txt`
   - `bench/head/run*.txt`

### reporting
- Parse timing lines (`time = ... sec`) from both sides.
Compute per-run means and compare using mean of run means (primary); median of run means is also reported for context.
- Emit a warning when both thresholds are exceeded:
  - `REGRESSION_WARN_PCT=20`
  - `REGRESSION_WARN_ABS_MS=10`
- Append markdown summary to `GITHUB_STEP_SUMMARY`.
- Upload raw outputs and JSON summary as artifact (`pr-benchmark-guard`).

## expected follow-up
Calibrate thresholds and repeats using data.
Improve output accordingly if needed (case-level clarity, summary polish).

ref - https://github.com/opencax/GSoC/issues/114#issuecomment-4044725388