### PR TITLE
Improve import transformation for complex models

### DIFF
--- a/bindings/wasm/lib/import-model.ts
+++ b/bindings/wasm/lib/import-model.ts
@@ -31,7 +31,7 @@
  * including manifold in another project.
  */
 
-import type * as GLTFTransform from '@gltf-transform/core';
+import * as GLTFTransform from '@gltf-transform/core';
 
 import type {Manifold, Mesh, Vec3} from '../manifold.d.ts';
 
@@ -369,16 +369,27 @@ export async function readFile(filename: string, options: ImportOptions = {}) {
  * ManifoldCAD defines up as '+Z'.
  */
 function importTransform(doc: GLTFTransform.Document): GLTFTransform.Document {
-  // Find top level nodes and correct their scale and orientation.
-  for (const sourceNode of doc.getRoot().listNodes()) {
-    if (sourceNode.getParentNode()) continue;
+  for (const scene of doc.getRoot().listScenes()) {
+    const nodes =
+        scene.listChildren().filter(c => c instanceof GLTFTransform.Node);
+    const rotate = euler2quat([90, 0, 0]);
+    const scale = 1000;
 
-    const scale = sourceNode.getScale();
-    sourceNode.setScale([scale[0] * 1000, scale[1] * 1000, scale[2] * 1000]);
+    if (nodes.length === 1) {
+      // If there's just one node, transform it in place.
+      const [node] = nodes;
+      node.setScale(node.getScale().map(n => n * scale) as GLTFTransform.vec3);
+      node.setRotation(multiplyQuat(node.getRotation(), rotate));
 
-    const original = sourceNode.getRotation();
-    const rotated = multiplyQuat(original, euler2quat([90, 0, 0]));
-    sourceNode.setRotation(rotated);
+    } else {
+      // If there's more than one node, create a parent node and transform that.
+      const parent = doc.createNode();
+      for (const node of nodes) parent.addChild(node);
+
+      parent.setScale([scale, scale, scale]);
+      parent.setRotation(rotate);
+      scene.addChild(parent);
+    }
   }
   return doc;
 }


### PR DESCRIPTION
Some complex glTF models are going to pieces when imported.

For example, here is the LattePanda Mu carrier board model (step file is publicly available) and converted to glTF with opencascade-tools.  Different nodes have different rotations.
<img width="868" height="734" alt="Screenshot 2026-04-30 at 9 43 28 am" src="https://github.com/user-attachments/assets/11879fe6-3161-484d-822b-cccaa7b38760" />

This PR fixes the problem by iterating over glTF scenes rather than nodes.  The end result is more recognizable:

<img width="866" height="678" alt="Screenshot 2026-04-30 at 9 44 02 am" src="https://github.com/user-attachments/assets/6b1a663e-1371-4641-92dc-8e08d4d4d53d" />

(This one isn't actually on the Villianous Task List, I just happened to notice it on the way by)

