### PR TITLE
Use target_compile_definitions instead of target_compile_options for -D flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,13 +85,13 @@ set(
 )
 foreach(OPT IN LISTS OPTIONS)
   if(${${OPT}})
-    target_compile_options(manifold PUBLIC -D${OPT})
+    target_compile_definitions(manifold PUBLIC ${OPT})
   endif()
 endforeach()
 if(MANIFOLD_PAR)
-  target_compile_options(manifold PUBLIC -DMANIFOLD_PAR=1)
+  target_compile_definitions(manifold PUBLIC MANIFOLD_PAR=1)
 else()
-  target_compile_options(manifold PUBLIC -DMANIFOLD_PAR=-1)
+  target_compile_definitions(manifold PUBLIC MANIFOLD_PAR=-1)
 endif()
 
 target_include_directories(


### PR DESCRIPTION
Preprocessor definitions should be propagated through INTERFACE_COMPILE_DEFINITIONS, not INTERFACE_COMPILE_OPTIONS.  When -DMANIFOLD_DEBUG etc. are placed in compile_options they end up in the installed manifoldTargets.cmake as INTERFACE_COMPILE_OPTIONS.  The consequences for downstream users are:

 1. CMake's de-duplication and filtering logic that strips duplicates only operates on COMPILE_DEFINITIONS; keeping them in COMPILE_OPTIONS means every consumer pays the cost of extra command-line tokens that may interact unexpectedly with other flags.
 2. Makes it impossible to inspect compile-time feature flags through the standard INTERFACE_COMPILE_DEFINITIONS target property.

The fix is a one-line change per usage: replace target_compile_options with target_compile_definitions and drop the -D prefix that the latter adds automatically.