### PR TITLE
Fix mergeRec stability when pivot comes from right half

### DIFF
--- a/src/parallel.h
+++ b/src/parallel.h
@@ -89,13 +89,21 @@ void mergeRec(SrcIter src, DestIter dest, size_t p1, size_t r1, size_t p2,
     std::merge(src + p1, src + r1, src + p2, src + r2, dest + p3, comp);
   } else {
     size_t q1, q2;
+    // For stability: equal-keyed elements from the left half must precede
+    // those from the right in the output. Pivot from the larger half and
+    // use the bound that puts equal-to-pivot from the OPPOSITE half on the
+    // pivot's stable side.
     if (length1 > length2) {
+      // Left pivot: right-side equals belong after pivot. lower_bound on
+      // right places them at q2+ (second sub-merge with pivot).
       q1 = p1 + length1 / 2;
       auto end = std::lower_bound(src + p2, src + r2, src[q1], comp);
       q2 = std::distance(src, end);
     } else {
+      // Right pivot: left-side equals belong before pivot. upper_bound on
+      // left places them strictly before q1 (first sub-merge).
       q2 = p2 + length2 / 2;
-      auto end = std::lower_bound(src + p1, src + r1, src[q2], comp);
+      auto end = std::upper_bound(src + p1, src + r1, src[q2], comp);
       q1 = std::distance(src, end);
     }
     size_t q3 = p3 + (q1 - p1) + (q2 - p2);

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -1785,31 +1785,31 @@ TEST(Manifold, ExecutionContextProgressInvariant) {
 }
 
 // Sweeps equal-key bucket sizes that span the parallel mergeSort's
-// partition boundaries (n > kSeqThreshold under MANIFOLD_PAR=ON).
+// partition boundaries (n > kSeqThreshold under MANIFOLD_PAR=ON). Tags
+// are sequential and unique; keys are scrambled by a multiplicative hash
+// so the input isn't already sorted by key. std::stable_sort is the
+// oracle.
 TEST(Manifold, ParallelStableSortStability) {
   constexpr size_t kN = 50000;  // > kSeqThreshold to hit parallel
   constexpr size_t kBucketSizes[] = {kN, kN / 2, kN / 4, kN / 8, 1000, 100};
   for (size_t bucket : kBucketSizes) {
     struct Item {
-      double key;
+      size_t key;
       int tag;
     };
     std::vector<Item> items;
     items.reserve(kN);
     for (size_t i = 0; i < kN; ++i) {
-      items.push_back({static_cast<double>(i / bucket), static_cast<int>(i)});
+      items.push_back({(i * 2654435761u % kN) / bucket, static_cast<int>(i)});
     }
-    manifold::stable_sort(
-        items.begin(), items.end(),
-        [](const Item& a, const Item& b) { return a.key > b.key; });
-    // Ascending input tags + stable sort: tags must ascend within equal keys.
-    size_t violations = 0;
-    for (size_t i = 1; i < items.size(); ++i) {
-      if (items[i].key == items[i - 1].key && items[i].tag < items[i - 1].tag) {
-        ++violations;
-      }
+    auto expected = items;
+    auto cmp = [](const Item& a, const Item& b) { return a.key > b.key; };
+    std::stable_sort(expected.begin(), expected.end(), cmp);
+    manifold::stable_sort(items.begin(), items.end(), cmp);
+    for (size_t i = 0; i < items.size(); ++i) {
+      ASSERT_EQ(items[i].tag, expected[i].tag)
+          << "bucket=" << bucket << " i=" << i;
     }
-    EXPECT_EQ(violations, 0u) << "bucket=" << bucket;
   }
 }
 

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -20,6 +20,7 @@
 #include <thread>
 
 #include "../src/execution_impl.h"
+#include "../src/parallel.h"
 #ifdef MANIFOLD_CROSS_SECTION
 #include "manifold/cross_section.h"
 #endif
@@ -1780,6 +1781,35 @@ TEST(Manifold, ExecutionContextProgressInvariant) {
     EXPECT_EQ(u.Status(ctx), Manifold::Error::NoError);
     EXPECT_EQ(ctx.impl_->totalBooleans.load(), 5);
     EXPECT_EQ(ctx.impl_->doneBooleans.load(), 5);
+  }
+}
+
+// Sweeps equal-key bucket sizes that span the parallel mergeSort's
+// partition boundaries (n > kSeqThreshold under MANIFOLD_PAR=ON).
+TEST(Manifold, ParallelStableSortStability) {
+  constexpr size_t kN = 50000;  // > kSeqThreshold to hit parallel
+  constexpr size_t kBucketSizes[] = {kN, kN / 2, kN / 4, kN / 8, 1000, 100};
+  for (size_t bucket : kBucketSizes) {
+    struct Item {
+      double key;
+      int tag;
+    };
+    std::vector<Item> items;
+    items.reserve(kN);
+    for (size_t i = 0; i < kN; ++i) {
+      items.push_back({static_cast<double>(i / bucket), static_cast<int>(i)});
+    }
+    manifold::stable_sort(
+        items.begin(), items.end(),
+        [](const Item& a, const Item& b) { return a.key > b.key; });
+    // Ascending input tags + stable sort: tags must ascend within equal keys.
+    size_t violations = 0;
+    for (size_t i = 1; i < items.size(); ++i) {
+      if (items[i].key == items[i - 1].key && items[i].tag < items[i - 1].tag) {
+        ++violations;
+      }
+    }
+    EXPECT_EQ(violations, 0u) << "bucket=" << bucket;
   }
 }
 


### PR DESCRIPTION
## Summary

\`mergeRec\` (parallel merge sort in \`src/parallel.h\`) used \`lower_bound\` on the right-pivot branch, which placed left-side equal-to-pivot elements after the pivot in the merged output — breaking stability. Switching that branch to \`upper_bound\` puts them in the first sub-merge, before the pivot.

The mirror branch (left pivot) was already stable via \`lower_bound\` on the right; #1472's stability fix only handled that case.

## Test

\`ParallelStableSortStability\` sorts 50k items across several equal-key bucket sizes and asserts ascending input tags remain ascending within each group. Verified TDD: red on parent under \`MANIFOLD_PAR=ON\`, green after.

## Test plan

- [ ] CI matrix (\`MANIFOLD_PAR ∈ {ON, OFF}\`, TSAN, determinism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)