### PR TITLE
Snapshot meshIDCounter_ once in CsgLeafNode::Compose

### DIFF
--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -273,11 +273,15 @@ std::shared_ptr<CsgLeafNode> CsgLeafNode::Compose(
   if (nodes.size() > 1 && policy == ExecutionPolicy::Par)
     policy = ExecutionPolicy::Seq;
 
+  // Snapshot once and reuse for both shifts; two reads can disagree under
+  // cross-thread CSG and leave triRef.meshID values not in meshIDtransform.
+  const uint32_t meshIDCounterSnapshot = Manifold::Impl::meshIDCounter_;
+
   for_each_n(
       nodes.size() > 1 ? ExecutionPolicy::Par : ExecutionPolicy::Seq,
       countAt(0), nodes.size(),
       [&nodes, &vertIndices, &edgeIndices, &triIndices, &propVertIndices,
-       numPropOut, &combined, policy](int i) {
+       numPropOut, &combined, policy, meshIDCounterSnapshot](int i) {
         auto& node = nodes[i];
         copy(node->pImpl_->halfedgeTangent_.begin(),
              node->pImpl_->halfedgeTangent_.end(),
@@ -357,7 +361,7 @@ std::shared_ptr<CsgLeafNode> CsgLeafNode::Compose(
         // Since the nodes may be copies containing the same meshIDs, it is
         // important to add an offset so that each node instance gets
         // unique meshIDs.
-        const int offset = i * Manifold::Impl::meshIDCounter_;
+        const int offset = i * meshIDCounterSnapshot;
         transform(node->pImpl_->meshRelation_.triRef.begin(),
                   node->pImpl_->meshRelation_.triRef.end(),
                   combined.meshRelation_.triRef.begin() + triIndices[i],
@@ -369,7 +373,7 @@ std::shared_ptr<CsgLeafNode> CsgLeafNode::Compose(
 
   for (size_t i = 0; i < nodes.size(); i++) {
     auto& node = nodes[i];
-    const int offset = i * Manifold::Impl::meshIDCounter_;
+    const int offset = i * meshIDCounterSnapshot;
 
     for (const auto& pair : node->pImpl_->meshRelation_.meshIDtransform) {
       Manifold::Impl::Relation rel = pair.second;

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
+#include <limits>
+#include <thread>
+
 #include "../src/utils.h"
 #include "manifold/common.h"
 #include "manifold/manifold.h"
@@ -799,6 +803,52 @@ TEST(Boolean, SimpleCubeRegression) {
       Manifold::Cube().Rotate(-0.10000000000000001, -0.10000000000066571, -1.);
   EXPECT_EQ(result.Status(), Manifold::Error::NoError);
 }
+
+// Regression: Compose() in csg_tree.cpp used to read the global atomic
+// Manifold::Impl::meshIDCounter_ twice — once when shifting `triRef.meshID`
+// values and once when shifting `meshIDtransform` keys. If another thread
+// advanced the counter between the two reads, the offsets disagreed and
+// the resulting Impl had `triRef.meshID` values not present in
+// `meshIDtransform`. After IncrementMeshIDs's HashTable lookup, those
+// orphan meshIDs collapsed to 0, and GetMeshGL64 emitted runs with the
+// default Relation's `originalID = -1` (UINT32_MAX as uint32).
+//
+// MANIFOLD_PAR guard: emscripten/WASM builds without pthreads can't
+// construct std::thread and abort at runtime; the bug also can't manifest
+// without concurrent CSG, so skipping there is fine.
+#if MANIFOLD_PAR == 1
+TEST(Boolean, BatchBooleanComposeMeshIDStable) {
+  // Three pairwise-disjoint cubes — forces the Compose path inside
+  // BatchBoolean(Add).
+  auto build = []() {
+    Manifold a = Manifold::Cube(vec3(1, 1, 1));
+    Manifold b = Manifold::Cube(vec3(1, 1, 1)).Translate({3, 0, 0});
+    Manifold c = Manifold::Cube(vec3(1, 1, 1)).Translate({0, 3, 0});
+    return Manifold::BatchBoolean({a, b, c}, OpType::Add);
+  };
+
+  // Several worker threads each running the same pipeline. The internal
+  // ReserveIDs calls during their CSG ops provide the cross-thread counter
+  // contention the bug needs.
+  std::atomic<int> orphans{0};
+  auto worker = [&]() {
+    for (int i = 0; i < 200; ++i) {
+      MeshGL64 m = build().GetMeshGL64();
+      for (uint32_t orig : m.runOriginalID) {
+        if (orig == std::numeric_limits<uint32_t>::max()) ++orphans;
+      }
+    }
+  };
+
+  std::vector<std::thread> ts;
+  for (int t = 0; t < 8; ++t) ts.emplace_back(worker);
+  for (auto& t : ts) t.join();
+
+  EXPECT_EQ(orphans.load(), 0)
+      << "Compose produced runs with originalID = -1; indicates a "
+         "non-atomic meshIDCounter_ snapshot.";
+}
+#endif  // MANIFOLD_PAR == 1
 
 TEST(Boolean, BatchBoolean) {
   Manifold cube = Manifold::Cube({100, 100, 1});


### PR DESCRIPTION
## Summary

`CsgLeafNode::Compose` read `Manifold::Impl::meshIDCounter_` twice to compute the per-component offset — once when shifting `triRef.meshID` inside the parallel `for_each_n`, and again in the sequential loop that shifts `meshIDtransform` keys. Under cross-thread CSG, another thread can advance the atomic between the reads, so the two offsets disagree: `triRef` holds meshIDs not present in `meshIDtransform`, `IncrementMeshIDs`'s `HashTable` lookup misses, the meshIDs collapse to 0, and `GetMeshGL64` emits runs with the default `Relation`'s `originalID = -1`. Downstream this can also produce different topology after `SetTolerance` because `SimplifyTopology`'s collapse decisions use `SameFace` on the corrupted refs.

The fix snapshots the counter once and reuses it in both shifts. The other read of `meshIDCounter_` in the codebase (`UpdateReference` in `boolean_result.cpp`) already snapshots once and reuses, so it's unaffected.

## Test

`Boolean.BatchBooleanComposeMeshIDStable`: 8 worker threads each repeatedly run `BatchBoolean(Add)` over three pairwise-disjoint cubes (which forces the `Compose` path). Their internal `ReserveIDs` calls during the CSG ops provide the cross-thread counter contention. Without the fix the test sees runs with `originalID = UINT32_MAX` (the default `Relation`); with the fix none. Verified TDD: red on parent, green after.

## Test plan

- [ ] CI matrix (\`MANIFOLD_PAR ∈ {ON, OFF}\`, TSAN, determinism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)