### PR TITLE
Topological sort for 3MF export

### DIFF
--- a/bindings/wasm/lib/export-3mf.test.ts
+++ b/bindings/wasm/lib/export-3mf.test.ts
@@ -16,9 +16,10 @@ import * as GLTFTransform from '@gltf-transform/core';
 import {unzipSync} from 'fflate';
 import {afterEach, beforeAll, expect, suite, test} from 'vitest';
 
-import {expectMeshesMatch} from '../test/util.ts';
+import {expectMeshesMatch, permute} from '../test/util.ts';
 
-import {exportFormats as exportFormats3MF, toArrayBuffer as toArrayBuffer3MF} from './export-3mf.ts';
+import type {Component3MF} from './export-3mf.ts';
+import {exportFormats as exportFormats3MF, toArrayBuffer as toArrayBuffer3MF, toposort} from './export-3mf.ts';
 import * as exportModel from './export-model.ts';
 import {importManifold as importManifold3MF} from './import-model.ts';
 import * as wasm from './wasm.ts';
@@ -168,3 +169,54 @@ suite('toArrayBuffer with manifold models', () => {
         expect(model.volume()).toBeCloseTo(16, 1);
       });
 });
+
+suite('Sorts components topologically', () => {
+  // Family 1.
+  // child1 has multiple parents. parent2 has multiple children.
+  const child1: Component3MF = {id: 'child1', children: []};
+  const child2: Component3MF = {id: 'child2', children: []};
+  const parent1:
+      Component3MF = {id: 'parent1', children: [{objectID: 'child1'}]};
+  const parent2: Component3MF = {
+    id: 'parent2',
+    children: [{objectID: 'child1'}, {objectID: 'child2'}]
+  };
+  const grandparent:
+      Component3MF = {id: 'grandparent', children: [{objectID: 'parent1'}]};
+  const family1 = [child1, child2, parent1, parent2, grandparent];
+
+  // Family 2.
+  const child3: Component3MF = {id: 'child3', children: []};
+  const parent3:
+      Component3MF = {id: 'parent3', children: [{objectID: 'child3'}]};
+
+  // External reference, or no children.
+  const mesh: Component3MF = {id: 'mesh', children: [{objectID: 'meshref'}]};
+  const childless: Component3MF = {id: 'childless', children: []};
+
+  test.for(permute(family1))(
+      'Children precede parents (permutation %#)', (permutation) => {
+        const sorted = toposort(permutation);
+        expect(sorted).to.have.deep.members(permutation);
+        expect(sorted.indexOf(child1)).to.be.lessThan(sorted.indexOf(parent1));
+        expect(sorted.indexOf(child1)).to.be.lessThan(sorted.indexOf(parent2));
+        expect(sorted.indexOf(child2)).to.be.lessThan(sorted.indexOf(parent2));
+        expect(sorted.indexOf(parent1))
+            .to.be.lessThan(sorted.indexOf(grandparent));
+      });
+
+  test.for(permute([child1, child3, parent1, parent3]))(
+      'Two trees sort correctly (permutation %#)', (permutation) => {
+        const sorted = toposort(permutation);
+        expect(sorted).to.have.deep.members(permutation);
+        expect(sorted.indexOf(child1)).to.be.lessThan(sorted.indexOf(parent1));
+        expect(sorted.indexOf(child3)).to.be.lessThan(sorted.indexOf(parent3));
+      });
+
+  test.for(permute([child1, parent1, mesh, childless]))(
+      'Childless nodes do not affect sort (permutation %#)', (permutation) => {
+        const sorted = toposort(permutation);
+        expect(sorted).to.have.deep.members(permutation);
+        expect(sorted.indexOf(child1)).to.be.lessThan(sorted.indexOf(parent1));
+      });
+})

--- a/bindings/wasm/lib/export-3mf.ts
+++ b/bindings/wasm/lib/export-3mf.ts
@@ -94,7 +94,58 @@ export interface Export3MFOptions extends ExportOptions {
 }
 
 /**
+ * Sort 3MF components topologically.
+ *
+ * Some 3MF parsers (like PrusaSlicer and descendants) expect child nodes to be
+ * defined before their parents.  This function sorts the component list
+ * accordingly.
+ */
+const toposort = (components: Component3MF[]) => {
+  const graph: Record<string, string> = {};
+  for (const parent of components) {
+    for (const {objectID: child} of parent.children) {
+      graph[child] = parent.id;
+    }
+  }
+
+  const children = (id: string) =>
+      Object.entries(graph).filter(([, parent]) => id === parent);
+  const indegree = (id: string) =>
+      Object.entries(graph).filter(([child]) => id === child).length;
+  const removed: Record<string, number> = {};
+  let index = 0;
+
+  const queue = components.map(c => c.id).filter(id => !indegree(id));
+  while (queue.length) {
+    const parent = queue.shift()!;
+    removed[parent] = index++;
+    for (const [child] of children(parent)) {
+      delete graph[child];
+      if (indegree(child) === 0) queue.push(child);
+    }
+  }
+
+  return Object.entries(removed)
+      .sort(([, a], [, b]) => b - a)
+      .map(([id]) => components.find(c => c.id === id))
+      .filter((component) => !!component);
+};
+
+/**
  * Convert a GLTF-Transform document to a 3MF model.
+ *
+ * 3MF files are more sophisticated than STL files; they can encode meshes,
+ * components and build items.
+ *
+ * 3MF components are like a scene graph.  Each component can have multiple
+ * children, and does have its own transformation matrix.
+ * This is flexible enough to allow putting several parts in the same file
+ * (multiple components, each with a mesh) as well as multi-material files (a
+ * tree containing multiple meshes, each for a particular material).
+ *
+ * Finally, build items define what the slicer software actually sees.
+ * ManifoldCAD doesn't have an equivalent comprehension.  We assume that top
+ * level objects -- nodes with no parents -- are build objects.
  *
  * @param doc The GLTF document to convert.
  * @returns A blob containing the converted model.
@@ -167,12 +218,11 @@ export async function toArrayBuffer(
     }
   }
 
-  // Some 3MF parsers (like PrusaSlicer) expect child nodes
-  // to be defined before their parents.
-  const nodes = doc.getRoot().listNodes().reverse()
-  for (const node of nodes) {
+  // Create our components...
+  const components: Component3MF[] = [];
+  for (const node of doc.getRoot().listNodes()) {
     const meshID = node.getMesh() && getMeshID(node.getMesh()!);
-    to3mf.components.push({
+    components.push({
       id: setObjectID(node),
       name: node.getName(),
       children: meshID ? [{objectID: meshID}] : [],
@@ -180,7 +230,7 @@ export async function toArrayBuffer(
     });
   }
 
-  // Now we can work out our node hierarchy.
+  // ...work out our component hierarchy...
   for (const node of doc.getRoot().listNodes()) {
     const objectID = getObjectID(node)
     if (!objectID) {
@@ -200,7 +250,7 @@ export async function toArrayBuffer(
     if (parent) {
       // This is a child node, add it to its parent.
       const parentID = getObjectID(parent);
-      const parent3mf = to3mf.components.find((comp) => comp.id == parentID)!;
+      const parent3mf = components.find((comp) => comp.id == parentID)!;
       parent3mf.children.push(child);
     } else {
       // This is a root node.
@@ -208,6 +258,9 @@ export async function toArrayBuffer(
       to3mf.items.push({objectID})
     }
   }
+
+  // ...and sort it so that parents always follow children.
+  to3mf.components = toposort(components);
 
   const fileForRelThumbnail = new FileForRelThumbnail();
   fileForRelThumbnail.add3dModel('3D/3dmodel.model')

--- a/bindings/wasm/lib/export-3mf.ts
+++ b/bindings/wasm/lib/export-3mf.ts
@@ -50,12 +50,20 @@ interface Mesh3MF {
   name?: string;
 }
 
-interface Child3MF {
+/**
+ * @hidden
+ * Exported for unit tests.
+ */
+export interface Child3MF {
   objectID: string;
   transform?: Mat4|Array<string>;
 }
 
-interface Component3MF {
+/**
+ * @hidden
+ * Exported for unit tests.
+ */
+export interface Component3MF {
   id: string;
   children: Array<Child3MF>;
   name?: string;
@@ -99,8 +107,22 @@ export interface Export3MFOptions extends ExportOptions {
  * Some 3MF parsers (like PrusaSlicer and descendants) expect child nodes to be
  * defined before their parents.  This function sorts the component list
  * accordingly.
+ *
+ * This is a version of Kahn's algorithm -- a stripped down breadth first
+ * search.  It finds root nodes, adds them to the result, then removes them from
+ * the graph.  It moves on to their children, which are now root nodes
+ * themselves.
+ *
+ * Rinse, lather, repeat, and the final result is a list of nodes ordered by
+ * generation.  Order within a generation is not guaranteed, and is not required
+ * in this particular case.
+ *
+ * @hidden
+ * Exported for unit tests.
  */
-const toposort = (unsorted: Component3MF[]): Component3MF[] => {
+export const toposort = (unsorted: Component3MF[]): Component3MF[] => {
+  // Create a local graph.  We will destroy it by removing edges and do not want
+  // to introduce any side effects.
   let graph: Array<[Component3MF, Component3MF]> = [];
   for (const parent of unsorted) {
     for (const {objectID} of parent.children) {
@@ -109,21 +131,22 @@ const toposort = (unsorted: Component3MF[]): Component3MF[] => {
     }
   }
 
-  const orphaned = (child: Component3MF) =>
+  const isRoot = (child: Component3MF): boolean =>
       graph.filter(([, c]) => c.id === child.id).length === 0;
-  const children = (parent: Component3MF) =>
+  const children = (parent: Component3MF): Component3MF[] =>
       graph.filter(([p]) => p.id === parent.id).map(([, c]) => c);
   const disown = (parent: Component3MF, child: Component3MF) => graph =
       graph.filter(([p, c]) => !(p.id === parent.id && c.id === child.id));
 
-  const queue = unsorted.filter(c => orphaned(c));
+  const roots = unsorted.filter(isRoot);
   const sorted = [];
-  while (queue.length) {
-    const parent = queue.shift()!;
-    sorted.unshift(parent);
-    for (const child of children(parent)) {
-      disown(parent, child);
-      if (orphaned(child)) queue.push(child);
+
+  let root;
+  while (root = roots.shift()) {  // For each root node...
+    sorted.unshift(root);         // ...insert before potential ancestors.
+    for (const child of children(root)) {  // For each child....
+      disown(root, child);  // ...remove the parent-child edge from the graph.
+      if (isRoot(child)) roots.push(child);  // Enqueue new root nodes.
     }
   }
 

--- a/bindings/wasm/lib/export-3mf.ts
+++ b/bindings/wasm/lib/export-3mf.ts
@@ -100,35 +100,34 @@ export interface Export3MFOptions extends ExportOptions {
  * defined before their parents.  This function sorts the component list
  * accordingly.
  */
-const toposort = (components: Component3MF[]) => {
-  const graph: Record<string, string> = {};
-  for (const parent of components) {
-    for (const {objectID: child} of parent.children) {
-      graph[child] = parent.id;
+const toposort = (unsorted: Component3MF[]): Component3MF[] => {
+  let graph: Array<[Component3MF, Component3MF]> = [];
+  for (const parent of unsorted) {
+    for (const {objectID} of parent.children) {
+      const child = unsorted.find(c => c.id === objectID);
+      if (child) graph.push([parent, child]);
     }
   }
 
-  const children = (id: string) =>
-      Object.entries(graph).filter(([, parent]) => id === parent);
-  const indegree = (id: string) =>
-      Object.entries(graph).filter(([child]) => id === child).length;
-  const removed: Record<string, number> = {};
-  let index = 0;
+  const orphaned = (child: Component3MF) =>
+      graph.filter(([, c]) => c.id === child.id).length === 0;
+  const children = (parent: Component3MF) =>
+      graph.filter(([p]) => p.id === parent.id).map(([, c]) => c);
+  const disown = (parent: Component3MF, child: Component3MF) => graph =
+      graph.filter(([p, c]) => !(p.id === parent.id && c.id === child.id));
 
-  const queue = components.map(c => c.id).filter(id => !indegree(id));
+  const queue = unsorted.filter(c => orphaned(c));
+  const sorted = [];
   while (queue.length) {
     const parent = queue.shift()!;
-    removed[parent] = index++;
-    for (const [child] of children(parent)) {
-      delete graph[child];
-      if (indegree(child) === 0) queue.push(child);
+    sorted.unshift(parent);
+    for (const child of children(parent)) {
+      disown(parent, child);
+      if (orphaned(child)) queue.push(child);
     }
   }
 
-  return Object.entries(removed)
-      .sort(([, a], [, b]) => b - a)
-      .map(([id]) => components.find(c => c.id === id))
-      .filter((component) => !!component);
+  return sorted;
 };
 
 /**

--- a/bindings/wasm/test/util.ts
+++ b/bindings/wasm/test/util.ts
@@ -64,3 +64,19 @@ export function expectMeshesMatch(
     }
   }
 }
+
+/**
+ * Generate permutations of an array.
+ */
+export function permute<Type>(arr: Array<Type>): Array<Array<Type>> {
+  if (arr.length === 1) return [arr];
+
+  const result = [];
+  for (let i = 0; i < arr.length; i++) {
+    for (const permutation of permute(
+             [...arr.slice(0, i), ...arr.slice(i + 1)])) {
+      result.push([arr.at(i)!, ...permutation])
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
Some 3MF parsers (like PrusaSlicer and descendants) expect child nodes to be defined before their parents.  This has come up before.  The previous approach -- reversing the node list -- is not robust.

This PR topologically sorts components ensuring that children are defined before their parents, independent of their order in the source glTF document.