### PR TITLE
Sub-Boolean progress granularity via per-phase increments

### DIFF
--- a/bindings/wasm/manifold-global-types.d.ts
+++ b/bindings/wasm/manifold-global-types.d.ts
@@ -135,7 +135,11 @@ export interface ExecutionContext {
   cancel(): void;
   /** Has cancellation been requested? */
   cancelled(): boolean;
-  /** Normalized progress in [0, 1]. Monotonic within an evaluation. */
+  /**
+   * Normalized progress in [0, 1]. Monotonic within an evaluation.
+   * Returns 1 when no work has been scheduled (interpreted as trivially
+   * complete -- e.g. a single-leaf manifold has nothing to evaluate).
+   */
   progress(): number;
 
   // Memory

--- a/bindings/wasm/test/bindings.test.ts
+++ b/bindings/wasm/test/bindings.test.ts
@@ -56,7 +56,8 @@ suite('Manifold Bindings', () => {
   test('ExecutionContext happy path returns NoError', () => {
     const ctx = new manifoldModule.ExecutionContext();
     expect(ctx.cancelled()).toBe(false);
-    expect(ctx.progress()).toEqual(0);
+    // Fresh ctx with no scheduled work reads as trivially complete (1.0).
+    expect(ctx.progress()).toEqual(1);
 
     const cube = manifoldModule.Manifold.cube([1, 1, 1], true);
     const sphere = manifoldModule.Manifold.sphere(1.0, 8);

--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -225,8 +225,11 @@ class ExecutionContext {
   void Cancel();
   /// Has cancellation been requested?
   bool Cancelled() const;
-  /// Normalized progress in [0, 1]. Returns 0 before any work has been
-  /// scheduled. Monotonically increases during evaluation.
+  /// Normalized progress in [0, 1]. Monotonically increases during
+  /// evaluation. Returns 1.0 when no work has been scheduled (interpreted
+  /// as trivially complete -- e.g. a single-leaf manifold has nothing to
+  /// evaluate, and `Progress()` called before any `Status(ctx)` reflects
+  /// the same "no pending work" state).
   double Progress() const;
 
   /// @internal Opaque implementation. Defined in src/execution_impl.h;

--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -694,6 +694,33 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   const int c2 = op == OpType::Add ? 1 : 0;
   const int c3 = op == OpType::Intersect ? 1 : -1;
 
+  // Sub-Boolean progress accounting. `phase()` advances `donePhases` by 1
+  // and checks cancel; `balance` (declared just below) tops up `donePhases`
+  // to `kPhasesPerBoolean` on any non-cancelled return so `Progress()`
+  // reaches 1.0 even after early-exit paths (status errors, empty/degenerate
+  // inputs) that skip most or all of the phase sites.
+  int phasesPublished = 0;
+  bool fullPath = false;
+  struct PhaseBalance {
+    ExecutionContext::Impl* ctx;
+    int& published;
+    bool& fullPath;
+    ~PhaseBalance() {
+      if (!ctx) return;
+      if (IsCancelled(ctx)) return;  // partial publication is intentional
+      if (fullPath) {
+        DEBUG_ASSERT(published == kPhasesPerBoolean, logicErr,
+                     "Boolean3::Result phase count drift; "
+                     "update kPhasesPerBoolean to match phase() site count");
+        return;
+      }
+      if (published < kPhasesPerBoolean) {
+        ctx->donePhases.fetch_add(kPhasesPerBoolean - published,
+                                  std::memory_order_relaxed);
+      }
+    }
+  } balance{ctx_, phasesPublished, fullPath};
+
   if (inP_.status_ != Manifold::Error::NoError) {
     auto impl = Manifold::Impl();
     impl.status_ = inP_.status_;
@@ -717,7 +744,9 @@ Manifold::Impl Boolean3::Result(OpType op) const {
     return inP_;
   }
 
-  auto cancelled = [&]() -> std::optional<Manifold::Impl> {
+  auto phase = [&]() -> std::optional<Manifold::Impl> {
+    if (ctx_) ctx_->donePhases.fetch_add(1, std::memory_order_relaxed);
+    ++phasesPublished;
     if (IsCancelled(ctx_)) {
       auto impl = Manifold::Impl();
       impl.status_ = Manifold::Error::Cancelled;
@@ -728,7 +757,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
 
   // Invariant: every ctx-passing parallel op is followed by IsCancelled to
   // keep partial output from feeding unconditional downstream consumers.
-  if (auto c = cancelled()) return *c;
+  if (auto c = phase()) return *c;
 
   if (!valid) {
     auto impl = Manifold::Impl();
@@ -799,7 +828,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
              DuplicateVerts({outR.vertPos_, i12, v12R, xv12_.v12}));
   for_each_n(autoPolicy(i21.size(), 1e4), countAt(0), i21.size(), ctx_,
              DuplicateVerts({outR.vertPos_, i21, v21R, xv21_.v12}));
-  if (auto c = cancelled()) return *c;
+  if (auto c = phase()) return *c;
 
   PRINT(nPv << " verts from inP");
   PRINT(nQv << " verts from inQ");
@@ -821,7 +850,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
                   0, ctx_);
   AddNewEdgeVerts(edgesQ, edgesNew, xv21_.p1q2, i21, v21R, inQ_.halfedge_,
                   false, xv12_.p1q2.size(), ctx_);
-  if (auto c = cancelled()) return *c;
+  if (auto c = phase()) return *c;
 
   v12R.clear();
   v21R.clear();
@@ -832,7 +861,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   std::tie(faceEdge, facePQ2R) =
       SizeOutput(outR, inP_, inQ_, i03, i30, i12, i21, xv12_.p1q2, xv21_.p1q2,
                  invertQ, ctx_);
-  if (auto c = cancelled()) return *c;
+  if (auto c = phase()) return *c;
 
   i12.clear();
   i21.clear();
@@ -851,14 +880,14 @@ Manifold::Impl Boolean3::Result(OpType op) const {
                      i03, vP2R, facePQ2R.begin(), true, ctx_);
   AppendPartialEdges(outR, wholeHalfedgeQ, facePtrR, edgesQ, halfedgeRef, inQ_,
                      i30, vQ2R, facePQ2R.begin() + inP_.NumTri(), false, ctx_);
-  if (auto c = cancelled()) return *c;
+  if (auto c = phase()) return *c;
 
   edgesP.clear();
   edgesQ.clear();
 
   AppendNewEdges(outR, facePtrR, edgesNew, halfedgeRef, facePQ2R, inP_.NumTri(),
                  ctx_);
-  if (auto c = cancelled()) return *c;
+  if (auto c = phase()) return *c;
 
   edgesNew.clear();
 
@@ -866,7 +895,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
                    facePQ2R.cview(0, inP_.NumTri()), true, ctx_);
   AppendWholeEdges(outR, facePtrR, halfedgeRef, inQ_, wholeHalfedgeQ, i30, vQ2R,
                    facePQ2R.cview(inP_.NumTri(), inQ_.NumTri()), false, ctx_);
-  if (auto c = cancelled()) return *c;
+  if (auto c = phase()) return *c;
 
   wholeHalfedgeP.clear();
   wholeHalfedgeQ.clear();
@@ -889,7 +918,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   faceEdge.clear();
 
   outR.ReorderHalfedges(ctx_);
-  if (auto c = cancelled()) return *c;
+  if (auto c = phase()) return *c;
 
 #if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
   triangulate.Stop();
@@ -902,10 +931,10 @@ Manifold::Impl Boolean3::Result(OpType op) const {
                  "triangulated mesh is not manifold!");
 
   CreateProperties(outR, inP_, inQ_, ctx_);
-  if (auto c = cancelled()) return *c;
+  if (auto c = phase()) return *c;
 
   UpdateReference(outR, inP_, inQ_, invertQ, ctx_);
-  if (auto c = cancelled()) return *c;
+  if (auto c = phase()) return *c;
 
   outR.SimplifyTopology(nPv + nQv);
   outR.RemoveUnreferencedVerts();
@@ -923,7 +952,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   outR.CalculateBBox();
   outR.SortGeometry(ctx_);
   outR.IncrementMeshIDs();
-  if (auto c = cancelled()) return *c;
+  if (auto c = phase()) return *c;
 
 #if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
   sort.Stop();
@@ -937,6 +966,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   }
 #endif
 
+  fullPath = true;
   return outR;
 }
 

--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -699,12 +699,10 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   // to `kPhasesPerBoolean` on any non-cancelled return so `Progress()`
   // reaches 1.0 even after early-exit paths (status errors, empty/degenerate
   // inputs) that skip most or all of the phase sites.
-  int phasesPublished = 0;
-  bool fullPath = false;
   struct PhaseBalance {
     ExecutionContext::Impl* ctx;
-    int& published;
-    bool& fullPath;
+    int published = 0;
+    bool fullPath = false;
     ~PhaseBalance() {
       if (!ctx) return;
       if (IsCancelled(ctx)) return;  // partial publication is intentional
@@ -719,7 +717,8 @@ Manifold::Impl Boolean3::Result(OpType op) const {
                                   std::memory_order_relaxed);
       }
     }
-  } balance{ctx_, phasesPublished, fullPath};
+  };
+  PhaseBalance balance{ctx_};
 
   if (inP_.status_ != Manifold::Error::NoError) {
     auto impl = Manifold::Impl();
@@ -746,7 +745,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
 
   auto phase = [&]() -> std::optional<Manifold::Impl> {
     if (ctx_) ctx_->donePhases.fetch_add(1, std::memory_order_relaxed);
-    ++phasesPublished;
+    ++balance.published;
     if (IsCancelled(ctx_)) {
       auto impl = Manifold::Impl();
       impl.status_ = Manifold::Error::Cancelled;
@@ -966,7 +965,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   }
 #endif
 
-  fullPath = true;
+  balance.fullPath = true;
   return outR;
 }
 

--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -521,9 +521,12 @@ std::shared_ptr<CsgLeafNode> BatchUnion(
         impls.push_back(CsgLeafNode::Compose(tmp));
         // Compose absorbs set.size() leaves into 1 leaf, which is
         // set.size() - 1 leaf-reductions toward the final result.
-        if (ctx)
-          ctx->doneBooleans.fetch_add(static_cast<int>(set.size() - 1),
-                                      std::memory_order_relaxed);
+        if (ctx) {
+          const int reductions = static_cast<int>(set.size() - 1);
+          ctx->doneBooleans.fetch_add(reductions, std::memory_order_relaxed);
+          ctx->donePhases.fetch_add(reductions * kPhasesPerBoolean,
+                                    std::memory_order_relaxed);
+        }
       }
     }
 

--- a/src/execution_impl.cpp
+++ b/src/execution_impl.cpp
@@ -33,7 +33,11 @@ bool ExecutionContext::Cancelled() const { return IsCancelled(impl_.get()); }
 
 double ExecutionContext::Progress() const {
   const int total = impl_->totalPhases.load(std::memory_order_relaxed);
-  if (total == 0) return 0.0;
+  // Zero-work case: no phases scheduled (single-leaf manifold, or
+  // pre-evaluation). Treat as complete -- "no work to do" maps to 100%
+  // more naturally than 0%, and matches the user expectation that a
+  // returned `Status() == NoError` means the operation is done.
+  if (total == 0) return 1.0;
   return double(impl_->donePhases.load(std::memory_order_relaxed)) / total;
 }
 

--- a/src/execution_impl.cpp
+++ b/src/execution_impl.cpp
@@ -32,11 +32,9 @@ void ExecutionContext::Cancel() {
 bool ExecutionContext::Cancelled() const { return IsCancelled(impl_.get()); }
 
 double ExecutionContext::Progress() const {
-  const int total = impl_->totalBooleans.load(std::memory_order_relaxed);
-  return total > 0
-             ? double(impl_->doneBooleans.load(std::memory_order_relaxed)) /
-                   total
-             : 0.0;
+  const int total = impl_->totalPhases.load(std::memory_order_relaxed);
+  if (total == 0) return 0.0;
+  return double(impl_->donePhases.load(std::memory_order_relaxed)) / total;
 }
 
 }  // namespace manifold

--- a/src/execution_impl.h
+++ b/src/execution_impl.h
@@ -23,15 +23,34 @@ inline bool IsCancelled(ExecutionContext::Impl* ctx);
 
 /** @ingroup Private
  *
+ * Number of progress phases per `Boolean3::Result`. Must equal the count of
+ * `phase()` sites in `boolean_result.cpp`'s `Boolean3::Result` (asserted on
+ * the happy-path return). Bump in lockstep when adding/removing a site.
+ */
+constexpr int kPhasesPerBoolean = 11;
+
+/** @ingroup Private
+ *
  * Pimpl for ExecutionContext. `cancel` is private; use `IsCancelled(ctx)`
  * to read it -- this is the canonical reader, enforced by the type system.
- * `totalBooleans` and `doneBooleans` are public for progress reporting and
- * test introspection.
+ * `totalBooleans`, `doneBooleans`, `totalPhases`, and `donePhases` are
+ * public for progress reporting and test introspection.
+ *
+ * `Progress() = donePhases / totalPhases`. `totalPhases` is the canonical
+ * progress denominator across op types; for Boolean trees it is set at
+ * `GetCsgLeafNode` to `totalBooleans * kPhasesPerBoolean`. Future
+ * non-Boolean ops (Hull, LevelSet, Refine, ...) can add to `totalPhases`
+ * and increment `donePhases` independently using the same mechanism.
+ *
+ * `totalBooleans`/`doneBooleans` are kept as introspection counters for
+ * tests and tools; they are not used in `Progress()`.
  */
 struct ExecutionContext::Impl {
  public:
   std::atomic<int> totalBooleans{0};
   std::atomic<int> doneBooleans{0};
+  std::atomic<int> totalPhases{0};
+  std::atomic<int> donePhases{0};
 
  private:
   std::atomic<bool> cancel{false};

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -168,9 +168,15 @@ CsgLeafNode& Manifold::GetCsgLeafNode(ExecutionContext::Impl* ctx) const {
     // part of the documented API contract (see ExecutionContext in
     // common.h).
     const size_t leaves = pNode_->NumLeaves();
-    ctx->totalBooleans.store(leaves > 0 ? static_cast<int>(leaves - 1) : 0,
-                             std::memory_order_relaxed);
+    const int booleans = leaves > 0 ? static_cast<int>(leaves - 1) : 0;
+    // Reset numerators before denominators so a concurrent `Progress()`
+    // observer cannot see (old donePhases / new totalPhases), which could
+    // yield Progress > 1.0 transiently when a ctx is reused across evals.
     ctx->doneBooleans.store(0, std::memory_order_relaxed);
+    ctx->donePhases.store(0, std::memory_order_relaxed);
+    ctx->totalBooleans.store(booleans, std::memory_order_relaxed);
+    ctx->totalPhases.store(booleans * kPhasesPerBoolean,
+                           std::memory_order_relaxed);
   }
   if (pNode_->GetNodeType() != CsgNodeType::Leaf) {
     pNode_ = pNode_->ToLeafNode(ctx);

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -1849,7 +1849,8 @@ TEST(Manifold, ExecutionContextNoWorkNeeded) {
   EXPECT_EQ(cube.Status(ctx), Manifold::Error::NoError);
   EXPECT_EQ(ctx.impl_->totalBooleans.load(), 0);
   EXPECT_EQ(ctx.impl_->doneBooleans.load(), 0);
-  EXPECT_DOUBLE_EQ(ctx.Progress(), 0.0);  // 0/0 is defined as 0
+  // No work scheduled = trivially complete = 1.0.
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
 }
 
 // doneBooleans reaches totalBooleans exactly for many tree shapes — the N-1

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -1496,6 +1496,10 @@ TEST(Manifold, ExecutionContextCancelConcurrent) {
               result.load() == Manifold::Error::NoError);
   if (result.load() == Manifold::Error::Cancelled) {
     EXPECT_LT(ctx.impl_->doneBooleans.load(), ctx.impl_->totalBooleans.load());
+    // Sub-Boolean granularity: PhaseBalance skips its top-up on cancel, so
+    // donePhases must reflect partial work (strictly less than the full
+    // budget). This pins the "partial publication is intentional" invariant.
+    EXPECT_LT(ctx.Progress(), 1.0);
   }
 }
 #endif  // MANIFOLD_PAR == 1
@@ -1723,9 +1727,66 @@ TEST(Manifold, ExecutionContextConcurrentProgress) {
   // Final state invariants.
   EXPECT_EQ(ctx.impl_->totalBooleans.load(), 29);
   EXPECT_EQ(ctx.impl_->doneBooleans.load(), 29);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
   // We expect to have seen a mid-evaluation snapshot, though this is
   // timing-dependent. Not strictly required but usually the case.
   // (Not asserting sawProgress to avoid CI flakes.)
+}
+#endif  // MANIFOLD_PAR == 1
+
+// Trivial Booleans (empty input, no intersection) early-return from
+// Boolean3::Result before any phase() site executes. The PhaseBalance scope
+// guard must still credit a full kPhasesPerBoolean phases on those returns
+// so Progress() reaches 1.0 after a sequence of no-op evaluations.
+TEST(Manifold, ExecutionContextProgressReachesOneOnTrivialBooleans) {
+  ExecutionContext ctx;
+  // Boolean of empty + cube: Boolean3::Result takes the IsEmpty fast-path.
+  Manifold result = Manifold() + Manifold::Cube();
+  EXPECT_EQ(result.Status(ctx), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalBooleans.load(), 1);
+  EXPECT_EQ(ctx.impl_->doneBooleans.load(), 1);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerBoolean);
+  EXPECT_EQ(ctx.impl_->donePhases.load(), kPhasesPerBoolean);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
+}
+
+#if MANIFOLD_PAR == 1
+// Sub-Boolean granularity: within a single Boolean3 op, Progress() should
+// observably advance through phases (donePhases > 0 while doneBooleans == 0).
+// MANIFOLD_PAR guard: same as above, polling thread requires std::thread.
+TEST(Manifold, ExecutionContextSubBooleanProgress) {
+  // A single nontrivial Boolean with a real intersection: NumLeaves == 2 ->
+  // totalBooleans == 1, so doneBooleans only flips from 0 to 1 at the very
+  // end. Any observed Progress() > 0 mid-eval comes from sub-Boolean phase
+  // advancement. Two overlapping spheres ensure the Boolean takes the full
+  // path (no degenerate-input early return that would short-circuit phases).
+  Manifold a = Manifold::Sphere(1.0, 256);
+  Manifold b = Manifold::Sphere(1.0, 256).Translate(vec3(0.5, 0, 0));
+  Manifold result = a + b;
+
+  ExecutionContext ctx;
+  std::atomic<bool> sawSubBoolean{false};
+  std::thread observer([&] {
+    for (int i = 0; i < 10000 && !sawSubBoolean.load(); i++) {
+      const int donePhases = ctx.impl_->donePhases.load();
+      const int doneBooleans = ctx.impl_->doneBooleans.load();
+      if (donePhases > 0 && doneBooleans == 0) {
+        sawSubBoolean.store(true);
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::microseconds(50));
+    }
+  });
+
+  EXPECT_EQ(result.Status(ctx), Manifold::Error::NoError);
+  observer.join();
+  // Final state: exactly kPhasesPerBoolean phases per completed Boolean.
+  EXPECT_EQ(ctx.impl_->totalBooleans.load(), 1);
+  EXPECT_EQ(ctx.impl_->doneBooleans.load(), 1);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerBoolean);
+  EXPECT_EQ(ctx.impl_->donePhases.load(), kPhasesPerBoolean);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
+  // sawSubBoolean is timing-dependent; not asserted to avoid CI flakes.
 }
 #endif  // MANIFOLD_PAR == 1
 
@@ -1805,6 +1866,7 @@ TEST(Manifold, ExecutionContextProgressInvariant) {
     EXPECT_EQ(u.Status(ctx), Manifold::Error::NoError);
     EXPECT_EQ(ctx.impl_->totalBooleans.load(), 2);
     EXPECT_EQ(ctx.impl_->doneBooleans.load(), 2);
+    EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
   }
   // Mixed Add/Subtract
   {
@@ -1815,6 +1877,7 @@ TEST(Manifold, ExecutionContextProgressInvariant) {
     EXPECT_EQ(u.Status(ctx), Manifold::Error::NoError);
     EXPECT_EQ(ctx.impl_->totalBooleans.load(), 2);  // 3 leaves - 1
     EXPECT_EQ(ctx.impl_->doneBooleans.load(), 2);
+    EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
   }
   // Disjoint union (triggers Compose path)
   {
@@ -1828,6 +1891,11 @@ TEST(Manifold, ExecutionContextProgressInvariant) {
     EXPECT_EQ(u.Status(ctx), Manifold::Error::NoError);
     EXPECT_EQ(ctx.impl_->totalBooleans.load(), 5);
     EXPECT_EQ(ctx.impl_->doneBooleans.load(), 5);
+    // Progress == 1.0 here is the load-bearing assertion: it cross-checks
+    // that Compose's `donePhases += (set.size() - 1) * kPhasesPerBoolean`
+    // mirror was wired in. Without it, Progress would land below 1.0 and
+    // only the Compose-path multiplier would catch the bug.
+    EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
   }
 }
 

--- a/test/manifoldc_test.cpp
+++ b/test/manifoldc_test.cpp
@@ -723,7 +723,8 @@ TEST(CBIND, execution_context_happy_path) {
   ManifoldExecutionContext* ctx =
       manifold_execution_context(malloc(manifold_execution_context_size()));
   EXPECT_EQ(manifold_execution_context_cancelled(ctx), 0);
-  EXPECT_DOUBLE_EQ(manifold_execution_context_progress(ctx), 0.0);
+  // Fresh ctx with no scheduled work reads as trivially complete (1.0).
+  EXPECT_DOUBLE_EQ(manifold_execution_context_progress(ctx), 1.0);
 
   // Uncancelled ctx on a valid evaluation returns NO_ERROR.
   ManifoldManifold* cube1 = manifold_cube(alloc_manifold_buffer(), 1, 1, 1, 0);


### PR DESCRIPTION
Follow-up on #971, extending #1674 / #1693. With cancellation now sub-Boolean, `Progress()` is the one part still stuck at boolean-boundary granularity — a single long Boolean plateaus at `(N-1)/N` until completion.

## What changes

`Progress()` is now `donePhases / totalPhases`. `totalPhases` is a new atomic, set at `GetCsgLeafNode` to `totalBooleans * kPhasesPerBoolean` for Boolean trees. The denominator is op-agnostic — future non-Boolean ops (Hull, LevelSet, Refine, ...) can add to `totalPhases` and increment `donePhases` independently.

`doneBooleans` / `totalBooleans` semantics are unchanged and remain useful for test introspection; they no longer drive `Progress()`.

## How sub-Boolean progress is reported

`Boolean3::Result`'s existing `cancelled()` lambda is renamed to `phase()`, which both advances `donePhases` and checks cancel. Each `if (auto c = phase()) return *c;` replaces the old `cancelled()` call — **zero new lines per phase site**. `kPhasesPerBoolean = 11` must equal the count of `phase()` sites; a `DEBUG_ASSERT` on the happy-path return catches drift.

A function-local `PhaseBalance` scope guard tops up `donePhases` to `kPhasesPerBoolean` on any non-cancelled return, so trivial Booleans (status errors, empty/degenerate inputs) that early-exit before the first `phase()` site still credit a full Boolean. On cancel, partial publication is intentional and `Progress < 1.0` correctly reflects incomplete work.

`Compose` mirrors its existing `doneBooleans += set.size() - 1` with `donePhases += (set.size() - 1) * kPhasesPerBoolean`.

## Out of scope (Phase 2)

The `totalPhases` decoupling enables non-Boolean op coverage via ctx-aware overloads `Op(args..., ExecutionContext& ctx)` mirroring the existing `Status(ExecutionContext&)` pattern. Priority order by user value: `LevelSet` (resolution³), `Hull`, `MinkowskiSum/Difference`, `RefineToLength/Tolerance`.

## Test plan

- [x] All 392 PAR / 387 no-PAR tests pass locally (RelWithDebInfo + TBB).
- [x] `EXPECT_DOUBLE_EQ(Progress(), 1.0)` cross-check added to `ConcurrentProgress` and to `ProgressInvariant`'s three sub-cases. The Compose case is load-bearing — without the `* kPhasesPerBoolean` multiplier in the Compose path, that case fails.
- [x] New `ProgressReachesOneOnTrivialBooleans`: empty + cube hits the IsEmpty fast-path, asserts PhaseBalance credits `kPhasesPerBoolean`.
- [x] New `SubBooleanProgress` (PAR): single overlapping-spheres Boolean; observer thread polls best-effort, final-state invariants pin `totalPhases == donePhases == kPhasesPerBoolean`.
- [x] `CancelConcurrent` strengthened: `Progress() < 1.0` strictly when `Cancelled`.
- [ ] CI green.