### PR TITLE
Thread ExecutionContext into Face2Tri for in-flight cancel

### DIFF
--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -912,7 +912,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
 #endif
 
   // Level 6
-  outR.Face2Tri(faceEdge, halfedgeRef);
+  outR.Face2Tri(faceEdge, halfedgeRef, /*allowConvex=*/false, ctx_);
   halfedgeRef.clear();
   faceEdge.clear();
 

--- a/src/face_op.cpp
+++ b/src/face_op.cpp
@@ -98,9 +98,10 @@ using AddTriangle = std::function<void(int, ivec3, vec3, TriRef)>;
  * faceNormal_ values are retained, repeated as necessary.
  */
 void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
-                              const Vec<TriRef>& halfedgeRef,
-                              bool allowConvex) {
+                              const Vec<TriRef>& halfedgeRef, bool allowConvex,
+                              ExecutionContext::Impl* ctx) {
   ZoneScoped;
+  if (IsCancelled(ctx)) return;
   Vec<ivec3> triVerts;
   Vec<vec3> triNormal;
   Vec<ivec3> triProp;
@@ -190,18 +191,20 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
   // precompute number of triangles per face, and launch async tasks to
   // triangulate complex faces
   for_each(autoPolicy(faceEdge.size(), 1e5), countAt(0_uz),
-           countAt(faceEdge.size() - 1), [&](size_t face) {
+           countAt(faceEdge.size() - 1), ctx, [&](size_t face) {
              triCount[face] = faceEdge[face + 1] - faceEdge[face] - 2;
              DEBUG_ASSERT(triCount[face] >= 1, topologyErr,
                           "face has less than three edges.");
              if (triCount[face] > 2)
                group.run([&, face] {
+                 if (IsCancelled(ctx)) return;
                  std::vector<ivec3> newTris = generalTriangulation(face);
                  triCount[face] = newTris.size();
                  results[face] = std::move(newTris);
                });
            });
   group.wait();
+  if (IsCancelled(ctx)) return;
   // prefix sum computation (assign unique index to each face) and preallocation
   exclusive_scan(triCount.begin(), triCount.end(), triCount.begin(), 0_uz);
   triVerts.resize(triCount.back());
@@ -223,7 +226,7 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
       std::placeholders::_1);
   // set triangles in parallel
   for_each(autoPolicy(faceEdge.size(), 1e4), countAt(0_uz),
-           countAt(faceEdge.size() - 1), processFace2);
+           countAt(faceEdge.size() - 1), ctx, processFace2);
 #else
   triVerts.reserve(faceEdge.size());
   triNormal.reserve(faceEdge.size());
@@ -244,10 +247,12 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
       },
       std::placeholders::_1);
   for (size_t face = 0; face < faceEdge.size() - 1; ++face) {
+    if (IsCancelled(ctx)) return;
     processFace2(face);
   }
 #endif
 
+  if (IsCancelled(ctx)) return;
   faceNormal_ = std::move(triNormal);
   CreateHalfedges(triProp, triVerts);
 }

--- a/src/impl.h
+++ b/src/impl.h
@@ -140,7 +140,8 @@ struct Manifold::Impl {
 
   // face_op.cpp
   void Face2Tri(const Vec<int>& faceEdge, const Vec<TriRef>& halfedgeRef,
-                bool allowConvex = false);
+                bool allowConvex = false,
+                ExecutionContext::Impl* ctx = nullptr);
   Polygons Slice(double height) const;
   Polygons Project() const;
 

--- a/test/context_test.cpp
+++ b/test/context_test.cpp
@@ -145,36 +145,6 @@ TEST(Manifold, ExecutionContextCancelMidBoolean) {
 }
 #endif  // MANIFOLD_PAR == 1
 
-// Cancel during a workload heavy in Face2Tri. With ctx threaded into
-// Face2Tri the request is honored mid-sweep instead of waiting for the
-// full triangulation to finish. This test exercises the new code path
-// so sanitizer lanes catch UB in the partial-state path; it does not
-// strictly distinguish pre/post-fix outcomes (existing phase-boundary
-// checks already yield Cancelled).
-#if MANIFOLD_PAR == 1
-TEST(Manifold, ExecutionContextCancelDuringFace2Tri) {
-  // High-segment-count spheres bias the boolean's wall time toward
-  // Face2Tri (many sub-edges per face from the intersection curve).
-  Manifold a = Manifold::Sphere(1.0, 384);
-  Manifold b = Manifold::Sphere(1.0, 384).Translate(vec3(0.5, 0, 0));
-  Manifold u = a + b;
-
-  ExecutionContext ctx;
-  std::atomic<Manifold::Error> result{Manifold::Error::NoError};
-  std::thread evalThread([&] { result.store(u.Status(ctx)); });
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  ctx.Cancel();
-  evalThread.join();
-
-  EXPECT_TRUE(result.load() == Manifold::Error::Cancelled ||
-              result.load() == Manifold::Error::NoError);
-  if (result.load() == Manifold::Error::Cancelled) {
-    EXPECT_LT(ctx.Progress(), 1.0);
-  }
-}
-#endif  // MANIFOLD_PAR == 1
-
 // Status() and Status(ctx) should return identical results when no cancel.
 TEST(Manifold, ExecutionContextMatchesPlainStatus) {
   Manifold u = (Manifold::Cube(vec3(1), true) + Manifold::Sphere(1.0, 32)) -

--- a/test/context_test.cpp
+++ b/test/context_test.cpp
@@ -145,6 +145,36 @@ TEST(Manifold, ExecutionContextCancelMidBoolean) {
 }
 #endif  // MANIFOLD_PAR == 1
 
+// Cancel during a workload heavy in Face2Tri. With ctx threaded into
+// Face2Tri the request is honored mid-sweep instead of waiting for the
+// full triangulation to finish. This test exercises the new code path
+// so sanitizer lanes catch UB in the partial-state path; it does not
+// strictly distinguish pre/post-fix outcomes (existing phase-boundary
+// checks already yield Cancelled).
+#if MANIFOLD_PAR == 1
+TEST(Manifold, ExecutionContextCancelDuringFace2Tri) {
+  // High-segment-count spheres bias the boolean's wall time toward
+  // Face2Tri (many sub-edges per face from the intersection curve).
+  Manifold a = Manifold::Sphere(1.0, 384);
+  Manifold b = Manifold::Sphere(1.0, 384).Translate(vec3(0.5, 0, 0));
+  Manifold u = a + b;
+
+  ExecutionContext ctx;
+  std::atomic<Manifold::Error> result{Manifold::Error::NoError};
+  std::thread evalThread([&] { result.store(u.Status(ctx)); });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  ctx.Cancel();
+  evalThread.join();
+
+  EXPECT_TRUE(result.load() == Manifold::Error::Cancelled ||
+              result.load() == Manifold::Error::NoError);
+  if (result.load() == Manifold::Error::Cancelled) {
+    EXPECT_LT(ctx.Progress(), 1.0);
+  }
+}
+#endif  // MANIFOLD_PAR == 1
+
 // Status() and Status(ctx) should return identical results when no cancel.
 TEST(Manifold, ExecutionContextMatchesPlainStatus) {
   Manifold u = (Manifold::Cube(vec3(1), true) + Manifold::Sphere(1.0, 32)) -


### PR DESCRIPTION
## Summary

Thread `ExecutionContext` into `Manifold::Impl::Face2Tri` so cancel during the per-face triangulation phase (level 6 of `Boolean3::Result`) is honored mid-sweep. Without this, cancel requests arriving while triangulation is running wait for the full sweep to finish before the next phase boundary observes them.

Addresses item (2) of [#971](https://github.com/elalish/manifold/issues/971#issuecomment-4396198791), narrowed to `Face2Tri` only per the suggestion in that comment.

## Changes

- `Face2Tri` gains a defaulted `ExecutionContext::Impl* ctx` parameter, mirroring the convention in `sort.cpp` ops.
- `IsCancelled(ctx)` checks at function entry, inside the `tbb::task_group` lambda, after `group.wait()`, before `CreateHalfedges`, and inside the sequential `MANIFOLD_PAR=OFF` loop. Both `for_each` calls use the existing ctx-aware `parallel.h` overload.
- `boolean_result.cpp` forwards `ctx_` to `Face2Tri`.
- New test `ExecutionContextCancelDuringFace2Tri`.

If cancel fires inside `Face2Tri`, the surrounding `phase()` check observes `Cancelled` and discards `outR`; partial state never escapes.

## Phase accounting

No new phase counter. `Face2Tri` stays accounted as part of the existing level-6 phase. `kPhasesPerBoolean` unchanged.

## Verified

- Full test suite passes on `MANIFOLD_PAR=ON` and `MANIFOLD_PAR=OFF`.
- New test passes 10/10 under TSAN-instrumented TBB; no new races.