### PR TITLE
Add ctx-aware Refine overloads for progress + cancellation

### DIFF
--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -169,10 +169,21 @@ ManifoldManifold* manifold_smooth_out(void* mem, ManifoldManifold* m,
                                       double minSharpAngle,
                                       double minSmoothness);
 ManifoldManifold* manifold_refine(void* mem, ManifoldManifold* m, int refine);
+// Variants of manifold_refine* that observe progress and allow cancellation
+// via the ExecutionContext. See manifold_execution_context.
+ManifoldManifold* manifold_refine_with_context(void* mem, ManifoldManifold* m,
+                                               int refine,
+                                               ManifoldExecutionContext* ctx);
 ManifoldManifold* manifold_refine_to_length(void* mem, ManifoldManifold* m,
                                             double length);
+ManifoldManifold* manifold_refine_to_length_with_context(
+    void* mem, ManifoldManifold* m, double length,
+    ManifoldExecutionContext* ctx);
 ManifoldManifold* manifold_refine_to_tolerance(void* mem, ManifoldManifold* m,
                                                double tolerance);
+ManifoldManifold* manifold_refine_to_tolerance_with_context(
+    void* mem, ManifoldManifold* m, double tolerance,
+    ManifoldExecutionContext* ctx);
 ManifoldManifold* manifold_set_tolerance(void* mem, ManifoldManifold* m,
                                          double tolerance);
 ManifoldManifold* manifold_simplify(void* mem, ManifoldManifold* m,

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -323,15 +323,36 @@ ManifoldManifold* manifold_refine(void* mem, ManifoldManifold* m, int refine) {
   return to_c(new (mem) Manifold(refined));
 }
 
+ManifoldManifold* manifold_refine_with_context(void* mem, ManifoldManifold* m,
+                                               int refine,
+                                               ManifoldExecutionContext* ctx) {
+  auto refined = from_c(m)->Refine(refine, *from_c(ctx));
+  return to_c(new (mem) Manifold(refined));
+}
+
 ManifoldManifold* manifold_refine_to_length(void* mem, ManifoldManifold* m,
                                             double length) {
   auto refined = from_c(m)->RefineToLength(length);
   return to_c(new (mem) Manifold(refined));
 }
 
+ManifoldManifold* manifold_refine_to_length_with_context(
+    void* mem, ManifoldManifold* m, double length,
+    ManifoldExecutionContext* ctx) {
+  auto refined = from_c(m)->RefineToLength(length, *from_c(ctx));
+  return to_c(new (mem) Manifold(refined));
+}
+
 ManifoldManifold* manifold_refine_to_tolerance(void* mem, ManifoldManifold* m,
                                                double tolerance) {
   auto refined = from_c(m)->RefineToTolerance(tolerance);
+  return to_c(new (mem) Manifold(refined));
+}
+
+ManifoldManifold* manifold_refine_to_tolerance_with_context(
+    void* mem, ManifoldManifold* m, double tolerance,
+    ManifoldExecutionContext* ctx) {
+  auto refined = from_c(m)->RefineToTolerance(tolerance, *from_c(ctx));
   return to_c(new (mem) Manifold(refined));
 }
 

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -331,11 +331,31 @@ NB_MODULE(manifold3d, m) {
       .def("smooth_out", &Manifold::SmoothOut, nb::arg("min_sharp_angle") = 60,
            nb::arg("min_smoothness") = 0,
            manifold__smooth_out__min_sharp_angle__min_smoothness)
-      .def("refine", &Manifold::Refine, nb::arg("n"), manifold__refine__n)
-      .def("refine_to_length", &Manifold::RefineToLength, nb::arg("length"),
-           manifold__refine_to_length__length)
-      .def("refine_to_tolerance", &Manifold::RefineToTolerance,
+      .def("refine",
+           static_cast<Manifold (Manifold::*)(int) const>(&Manifold::Refine),
+           nb::arg("n"), manifold__refine__n)
+      .def("refine",
+           static_cast<Manifold (Manifold::*)(int, ExecutionContext&) const>(
+               &Manifold::Refine),
+           nb::arg("n"), nb::arg("ctx"), manifold__refine__n__ctx)
+      .def("refine_to_length",
+           static_cast<Manifold (Manifold::*)(double) const>(
+               &Manifold::RefineToLength),
+           nb::arg("length"), manifold__refine_to_length__length)
+      .def("refine_to_length",
+           static_cast<Manifold (Manifold::*)(double, ExecutionContext&) const>(
+               &Manifold::RefineToLength),
+           nb::arg("length"), nb::arg("ctx"),
+           manifold__refine_to_length__length__ctx)
+      .def("refine_to_tolerance",
+           static_cast<Manifold (Manifold::*)(double) const>(
+               &Manifold::RefineToTolerance),
            nb::arg("tolerance"), manifold__refine_to_tolerance__tolerance)
+      .def("refine_to_tolerance",
+           static_cast<Manifold (Manifold::*)(double, ExecutionContext&) const>(
+               &Manifold::RefineToTolerance),
+           nb::arg("tolerance"), nb::arg("ctx"),
+           manifold__refine_to_tolerance__tolerance__ctx)
       .def("to_mesh", &Manifold::GetMeshGL, nb::arg("normal_idx") = -1,
            manifold__get_mesh_gl__normal_idx)
       .def("to_mesh64", &Manifold::GetMeshGL64, nb::arg("normal_idx") = -1,

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -177,9 +177,21 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("_Project", &Manifold::Project)
       .function("hull", select_overload<Manifold() const>(&Manifold::Hull))
       .function("_GetMeshJS", &js::GetMeshJS)
-      .function("refine", &Manifold::Refine)
-      .function("refineToLength", &Manifold::RefineToLength)
-      .function("refineToTolerance", &Manifold::RefineToTolerance)
+      .function("refine",
+                select_overload<Manifold(int) const>(&Manifold::Refine))
+      .function("refineWithContext",
+                select_overload<Manifold(int, ExecutionContext&) const>(
+                    &Manifold::Refine))
+      .function("refineToLength", select_overload<Manifold(double) const>(
+                                      &Manifold::RefineToLength))
+      .function("refineToLengthWithContext",
+                select_overload<Manifold(double, ExecutionContext&) const>(
+                    &Manifold::RefineToLength))
+      .function("refineToTolerance", select_overload<Manifold(double) const>(
+                                         &Manifold::RefineToTolerance))
+      .function("refineToToleranceWithContext",
+                select_overload<Manifold(double, ExecutionContext&) const>(
+                    &Manifold::RefineToTolerance))
       .function("smoothByNormals", &Manifold::SmoothByNormals)
       .function("_SmoothOut", &Manifold::SmoothOut)
       .function("_Warp", &man_js::Warp)

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -778,6 +778,15 @@ export class Manifold {
   refine(n: number): Manifold;
 
   /**
+   * Like refine() but observes evaluation progress and allows cancellation
+   * via the provided ExecutionContext. The pending CSG tree is evaluated
+   * first, then the refinement runs as a single additional progress phase.
+   *
+   * @group Smoothing
+   */
+  refineWithContext(n: number, ctx: ExecutionContext): Manifold;
+
+  /**
    * Increase the density of the mesh by splitting each edge into pieces of
    * roughly the input length. Interior verts are added to keep the rest of the
    * triangulation edges also of roughly the same length. If halfedgeTangents
@@ -789,6 +798,14 @@ export class Manifold {
    * @group Smoothing
    */
   refineToLength(length: number): Manifold;
+
+  /**
+   * Like refineToLength() but observes evaluation progress and allows
+   * cancellation via the provided ExecutionContext.
+   *
+   * @group Smoothing
+   */
+  refineToLengthWithContext(length: number, ctx: ExecutionContext): Manifold;
 
   /**
    * Increase the density of the mesh by splitting each edge into pieces such
@@ -804,6 +821,15 @@ export class Manifold {
    * @group Smoothing
    */
   refineToTolerance(tolerance: number): Manifold;
+
+  /**
+   * Like refineToTolerance() but observes evaluation progress and allows
+   * cancellation via the provided ExecutionContext.
+   *
+   * @group Smoothing
+   */
+  refineToToleranceWithContext(tolerance: number, ctx: ExecutionContext):
+      Manifold;
 
   /**
    * Create a new copy of this manifold with updated vertex properties by

--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -466,8 +466,11 @@ class Manifold {
    */
   ///@{
   Manifold Refine(int) const;
+  Manifold Refine(int, ExecutionContext&) const;
   Manifold RefineToLength(double) const;
+  Manifold RefineToLength(double, ExecutionContext&) const;
   Manifold RefineToTolerance(double) const;
+  Manifold RefineToTolerance(double, ExecutionContext&) const;
   Manifold SmoothByNormals(int normalIdx) const;
   Manifold SmoothOut(double minSharpAngle = 60, double minSmoothness = 0) const;
   static Manifold Smooth(const MeshGL&,
@@ -545,7 +548,11 @@ class Manifold {
   mutable std::shared_ptr<CsgNode> pNode_;
 
   std::shared_ptr<CsgNode> LoadPNode() const;
-  CsgLeafNode& GetCsgLeafNode(ExecutionContext::Impl* ctx = nullptr) const;
+  CsgLeafNode& GetCsgLeafNode(ExecutionContext::Impl* ctx = nullptr,
+                              int extraPhases = 0) const;
+  Manifold RefineCommon(std::function<int(vec3, vec4, vec4)> edgeDivisions,
+                        bool keepInterior, bool requireTangents,
+                        ExecutionContext::Impl* ctx) const;
 };
 /** @} */
 

--- a/src/impl.h
+++ b/src/impl.h
@@ -191,7 +191,8 @@ struct Manifold::Impl {
   void DistributeTangents(const Vec<bool>& fixedHalfedges);
   void CreateTangents(int normalIdx);
   void CreateTangents(std::vector<Smoothness>);
-  void Refine(std::function<int(vec3, vec4, vec4)>, bool = false);
+  void Refine(std::function<int(vec3, vec4, vec4)>, bool = false,
+              ExecutionContext::Impl* = nullptr);
 
   // quickhull.cpp
   void Hull(VecView<const vec3> vertPos);

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -158,7 +158,8 @@ std::shared_ptr<CsgNode> Manifold::LoadPNode() const {
   return pNode_;
 }
 
-CsgLeafNode& Manifold::GetCsgLeafNode(ExecutionContext::Impl* ctx) const {
+CsgLeafNode& Manifold::GetCsgLeafNode(ExecutionContext::Impl* ctx,
+                                      int extraPhases) const {
   std::lock_guard<std::mutex> lock(*pNodeMutex_);
   if (ctx != nullptr) {
     // Reset counters to reflect this evaluation. For pre-evaluated leaf
@@ -167,6 +168,11 @@ CsgLeafNode& Manifold::GetCsgLeafNode(ExecutionContext::Impl* ctx) const {
     // ctx. The cancel flag is intentionally NOT reset — sticky cancel is
     // part of the documented API contract (see ExecutionContext in
     // common.h).
+    //
+    // `extraPhases` lets callers (e.g. ctx-aware Refine/Hull/Minkowski)
+    // include their own phase budget in `totalPhases` up front, so that
+    // Progress monotonically rises through the boolean tree eval and the
+    // post-eval work without dipping below 1.0 between them.
     const size_t leaves = pNode_->NumLeaves();
     const int booleans = leaves > 0 ? static_cast<int>(leaves - 1) : 0;
     // Reset numerators before denominators so a concurrent `Progress()`
@@ -175,7 +181,7 @@ CsgLeafNode& Manifold::GetCsgLeafNode(ExecutionContext::Impl* ctx) const {
     ctx->doneBooleans.store(0, std::memory_order_relaxed);
     ctx->donePhases.store(0, std::memory_order_relaxed);
     ctx->totalBooleans.store(booleans, std::memory_order_relaxed);
-    ctx->totalPhases.store(booleans * kPhasesPerBoolean,
+    ctx->totalPhases.store(booleans * kPhasesPerBoolean + extraPhases,
                            std::memory_order_relaxed);
   }
   if (pNode_->GetNodeType() != CsgNodeType::Leaf) {
@@ -737,6 +743,59 @@ Manifold Manifold::SmoothOut(double minSharpAngle, double minSmoothness) const {
   return Manifold(std::make_shared<CsgLeafNode>(pImpl));
 }
 
+// Edge-division callbacks for the three Refine variants. Built once and
+// shared between the non-ctx and ctx-aware overloads of each variant. An
+// empty std::function is the "no refinement" sentinel and tells
+// RefineCommon to skip pImpl->Refine entirely. `static` (file-local
+// linkage) keeps these next to their callers without requiring a second
+// anonymous namespace block in this file.
+static std::function<int(vec3, vec4, vec4)> EdgeDivByN(int n) {
+  if (n <= 1) return {};
+  return [n](vec3, vec4, vec4) { return n - 1; };
+}
+static std::function<int(vec3, vec4, vec4)> EdgeDivByLength(double length) {
+  return [length](vec3 edge, vec4, vec4) {
+    return static_cast<int>(la::length(edge) / length);
+  };
+}
+static std::function<int(vec3, vec4, vec4)> EdgeDivByTolerance(
+    double tolerance) {
+  return [tolerance](vec3 edge, vec4 tangentStart, vec4 tangentEnd) {
+    const vec3 edgeNorm = la::normalize(edge);
+    // Weight heuristic
+    const vec3 tStart = vec3(tangentStart);
+    const vec3 tEnd = vec3(tangentEnd);
+    // Perpendicular to edge
+    const vec3 start = tStart - edgeNorm * la::dot(edgeNorm, tStart);
+    const vec3 end = tEnd - edgeNorm * la::dot(edgeNorm, tEnd);
+    // Circular arc result plus heuristic term for non-circular curves
+    const double d =
+        0.5 * (la::length(start) + la::length(end)) + la::length(start - end);
+    return static_cast<int>(std::sqrt(3 * d / (4 * tolerance)));
+  };
+}
+
+// Shared implementation for all six public Refine variants. `ctx == nullptr`
+// gives the no-progress / no-cancel path used by the existing overloads; a
+// non-null ctx reserves one progress phase up front (via GetCsgLeafNode's
+// extraPhases) so Progress() rises monotonically across the boolean tree
+// eval and the refinement.
+Manifold Manifold::RefineCommon(
+    std::function<int(vec3, vec4, vec4)> edgeDivisions, bool keepInterior,
+    bool requireTangents, ExecutionContext::Impl* ctx) const {
+  auto leafImpl = GetCsgLeafNode(ctx, ctx ? 1 : 0).GetImpl();
+  if (leafImpl->status_ != Error::NoError)
+    return PropagateStatus(leafImpl->status_);
+  if (IsCancelled(ctx)) return PropagateStatus(Error::Cancelled);
+  auto pImpl = std::make_shared<Impl>(*leafImpl);
+  if (edgeDivisions && (!requireTangents || !pImpl->halfedgeTangent_.empty())) {
+    pImpl->Refine(std::move(edgeDivisions), keepInterior, ctx);
+  }
+  if (IsCancelled(ctx)) return PropagateStatus(Error::Cancelled);
+  if (ctx) ctx->donePhases.fetch_add(1, std::memory_order_relaxed);
+  return Manifold(std::make_shared<CsgLeafNode>(pImpl));
+}
+
 /**
  * Increase the density of the mesh by splitting every edge into n pieces. For
  * instance, with n = 2, each triangle will be split into 4 triangles. Quads
@@ -749,14 +808,19 @@ Manifold Manifold::SmoothOut(double minSharpAngle, double minSmoothness) const {
  * @param n The number of pieces to split every edge into. Must be > 1.
  */
 Manifold Manifold::Refine(int n) const {
-  auto leafImpl = GetCsgLeafNode().GetImpl();
-  if (leafImpl->status_ != Error::NoError)
-    return PropagateStatus(leafImpl->status_);
-  auto pImpl = std::make_shared<Impl>(*leafImpl);
-  if (n > 1) {
-    pImpl->Refine([n](vec3, vec4, vec4) { return n - 1; });
-  }
-  return Manifold(std::make_shared<CsgLeafNode>(pImpl));
+  return RefineCommon(EdgeDivByN(n), /*keepInterior=*/false,
+                      /*requireTangents=*/false, /*ctx=*/nullptr);
+}
+
+/**
+ * Like Refine() but observes evaluation progress and allows cancellation
+ * via the provided ExecutionContext. The pending CSG tree is evaluated
+ * first, then the refinement runs as a single additional progress phase.
+ * Refinement honors cancel between major steps.
+ */
+Manifold Manifold::Refine(int n, ExecutionContext& ctx) const {
+  return RefineCommon(EdgeDivByN(n), /*keepInterior=*/false,
+                      /*requireTangents=*/false, ctx.impl_.get());
 }
 
 /**
@@ -770,15 +834,19 @@ Manifold Manifold::Refine(int n) const {
  * @param length The length that edges will be broken down to.
  */
 Manifold Manifold::RefineToLength(double length) const {
-  length = std::abs(length);
-  auto leafImpl = GetCsgLeafNode().GetImpl();
-  if (leafImpl->status_ != Error::NoError)
-    return PropagateStatus(leafImpl->status_);
-  auto pImpl = std::make_shared<Impl>(*leafImpl);
-  pImpl->Refine([length](vec3 edge, vec4, vec4) {
-    return static_cast<int>(la::length(edge) / length);
-  });
-  return Manifold(std::make_shared<CsgLeafNode>(pImpl));
+  return RefineCommon(EdgeDivByLength(std::abs(length)),
+                      /*keepInterior=*/false, /*requireTangents=*/false,
+                      /*ctx=*/nullptr);
+}
+
+/**
+ * Like RefineToLength() but observes evaluation progress and allows
+ * cancellation via the provided ExecutionContext.
+ */
+Manifold Manifold::RefineToLength(double length, ExecutionContext& ctx) const {
+  return RefineCommon(EdgeDivByLength(std::abs(length)),
+                      /*keepInterior=*/false, /*requireTangents=*/false,
+                      ctx.impl_.get());
 }
 
 /**
@@ -794,29 +862,20 @@ Manifold Manifold::RefineToLength(double length) const {
  * the surface, within rounding error.
  */
 Manifold Manifold::RefineToTolerance(double tolerance) const {
-  tolerance = std::abs(tolerance);
-  auto leafImpl = GetCsgLeafNode().GetImpl();
-  if (leafImpl->status_ != Error::NoError)
-    return PropagateStatus(leafImpl->status_);
-  auto pImpl = std::make_shared<Impl>(*leafImpl);
-  if (!pImpl->halfedgeTangent_.empty()) {
-    pImpl->Refine(
-        [tolerance](vec3 edge, vec4 tangentStart, vec4 tangentEnd) {
-          const vec3 edgeNorm = la::normalize(edge);
-          // Weight heuristic
-          const vec3 tStart = vec3(tangentStart);
-          const vec3 tEnd = vec3(tangentEnd);
-          // Perpendicular to edge
-          const vec3 start = tStart - edgeNorm * la::dot(edgeNorm, tStart);
-          const vec3 end = tEnd - edgeNorm * la::dot(edgeNorm, tEnd);
-          // Circular arc result plus heuristic term for non-circular curves
-          const double d = 0.5 * (la::length(start) + la::length(end)) +
-                           la::length(start - end);
-          return static_cast<int>(std::sqrt(3 * d / (4 * tolerance)));
-        },
-        true);
-  }
-  return Manifold(std::make_shared<CsgLeafNode>(pImpl));
+  return RefineCommon(EdgeDivByTolerance(std::abs(tolerance)),
+                      /*keepInterior=*/true, /*requireTangents=*/true,
+                      /*ctx=*/nullptr);
+}
+
+/**
+ * Like RefineToTolerance() but observes evaluation progress and allows
+ * cancellation via the provided ExecutionContext.
+ */
+Manifold Manifold::RefineToTolerance(double tolerance,
+                                     ExecutionContext& ctx) const {
+  return RefineCommon(EdgeDivByTolerance(std::abs(tolerance)),
+                      /*keepInterior=*/true, /*requireTangents=*/true,
+                      ctx.impl_.get());
 }
 
 /**

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -1094,8 +1094,9 @@ bool Manifold::Impl::ValidTangents() const {
 }
 
 void Manifold::Impl::Refine(std::function<int(vec3, vec4, vec4)> edgeDivisions,
-                            bool keepInterior) {
+                            bool keepInterior, ExecutionContext::Impl* ctx) {
   if (IsEmpty()) return;
+  if (IsCancelled(ctx)) return;
 
   if (!ValidTangents()) {
     MakeEmpty(Error::InvalidTangents);
@@ -1106,11 +1107,13 @@ void Manifold::Impl::Refine(std::function<int(vec3, vec4, vec4)> edgeDivisions,
   halfedge_.MakeUnique();
   Vec<Barycentric> vertBary = Subdivide(edgeDivisions, keepInterior);
   if (vertBary.size() == 0) return;
+  if (IsCancelled(ctx)) return;
 
   if (old.halfedgeTangent_.size() == old.halfedge_.size()) {
-    for_each_n(autoPolicy(NumTri(), 1e4), countAt(0), NumVert(),
+    for_each_n(autoPolicy(NumTri(), 1e4), countAt(0), NumVert(), ctx,
                InterpTri({vertPos_, vertBary, &old}));
   }
+  if (IsCancelled(ctx)) return;
 
   halfedgeTangent_.clear();
   if (old.halfedgeTangent_.size() == old.halfedge_.size()) {
@@ -1119,7 +1122,7 @@ void Manifold::Impl::Refine(std::function<int(vec3, vec4, vec4)> edgeDivisions,
   } else {
     CalculateVertNormals();
   }
-  SortGeometry();
+  SortGeometry(ctx);
   meshRelation_.originalID = -1;
 }
 

--- a/test/context_test.cpp
+++ b/test/context_test.cpp
@@ -463,6 +463,48 @@ TEST(Manifold, ExecutionContextProgressInvariant) {
     EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
   }
 }
+
+// Refine(ctx) on an already-evaluated leaf: no boolean work, so the only
+// phase advance comes from Refine itself. donePhases = totalPhases = 1
+// at completion. Cube has 12 tris; Refine(2) splits each into 4 = 48.
+TEST(Manifold, ExecutionContextRefineProgress) {
+  Manifold cube = Manifold::Cube(vec3(1), true);
+  ASSERT_EQ(cube.NumTri(), 12u);
+  ExecutionContext ctx;
+  Manifold refined = cube.Refine(2, ctx);
+  EXPECT_EQ(refined.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(refined.NumTri(), 48u);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), 1);
+  EXPECT_EQ(ctx.impl_->donePhases.load(), 1);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
+}
+
+// Pre-cancelled ctx: Refine(ctx) returns Cancelled without doing the work.
+TEST(Manifold, ExecutionContextRefineCancelled) {
+  Manifold cube = Manifold::Cube(vec3(1), true);
+  ExecutionContext ctx;
+  ctx.Cancel();
+  EXPECT_EQ(cube.Refine(2, ctx).Status(), Manifold::Error::Cancelled);
+  EXPECT_EQ(cube.RefineToLength(0.1, ctx).Status(), Manifold::Error::Cancelled);
+  EXPECT_EQ(cube.RefineToTolerance(0.01, ctx).Status(),
+            Manifold::Error::Cancelled);
+}
+
+// Refine on an unevaluated CSG tree: totalPhases reserves the full eventual
+// budget (boolean phases + 1 for Refine) up front via GetCsgLeafNode's
+// extraPhases parameter. This guarantees Progress() monotonically rises and
+// never dips mid-call, even between the boolean tree finishing and Refine
+// starting. Pre-cancel exposes the post-reset totalPhases value before any
+// donePhases work happens.
+TEST(Manifold, ExecutionContextRefineReservesPhasesUpFront) {
+  Manifold u = Manifold::Cube() + Manifold::Sphere(0.5);  // 1 boolean
+  ExecutionContext ctx;
+  ctx.Cancel();
+  Manifold refined = u.Refine(2, ctx);
+  EXPECT_EQ(refined.Status(), Manifold::Error::Cancelled);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerBoolean + 1);
+}
+
 // Direct test of the ctx-aware `for_each` overload: cancel-already-set
 // must skip the entire range; cancel-unset must run every element. This
 // is the mechanism test; the integration test that cancel works

--- a/test/manifoldc_test.cpp
+++ b/test/manifoldc_test.cpp
@@ -743,6 +743,24 @@ TEST(CBIND, execution_context_happy_path) {
   free(ctx);
 }
 
+TEST(CBIND, refine_with_context) {
+  ManifoldExecutionContext* ctx =
+      manifold_execution_context(malloc(manifold_execution_context_size()));
+  ManifoldManifold* cube = manifold_cube(alloc_manifold_buffer(), 1, 1, 1, 0);
+  ManifoldManifold* refined =
+      manifold_refine_with_context(alloc_manifold_buffer(), cube, 2, ctx);
+  EXPECT_EQ(manifold_status(refined), MANIFOLD_NO_ERROR);
+  EXPECT_GT(manifold_num_tri(refined), manifold_num_tri(cube));
+  EXPECT_DOUBLE_EQ(manifold_execution_context_progress(ctx), 1.0);
+
+  manifold_destruct_manifold(refined);
+  manifold_destruct_manifold(cube);
+  manifold_destruct_execution_context(ctx);
+  free(refined);
+  free(cube);
+  free(ctx);
+}
+
 TEST(CBIND, execution_context_cancel) {
   // alloc + delete pattern (matches the Rust binding's usage of the C API).
   ManifoldExecutionContext* ctx =


### PR DESCRIPTION
## Summary

Adds `Refine`/`RefineToLength`/`RefineToTolerance` overloads taking `ExecutionContext&`, with matching C/Python/WASM bindings. Each runs the eager refinement with mid-flight cancel checks and reports a single progress phase reserved up front so `Progress()` rises monotonically.

Addresses item (1) of [#971](https://github.com/elalish/manifold/issues/971#issuecomment-4396198791). Hull, Minkowski, LevelSet to follow as separate PRs using the same pattern.

## Changes

- `Impl::Refine` gains a defaulted `ctx` with cancel checks at entry, after `Subdivide`, and after the `InterpTri` for_each_n. The for_each_n threads ctx; `SortGeometry` was already ctx-aware.
- `GetCsgLeafNode` gains an `extraPhases` parameter so non-Boolean callers reserve their phase count up front. Refine wrappers pass `extraPhases=1` so Progress rises monotonically through the boolean tree and Refine without dipping.
- Private `RefineCommon` helper plus three static callback factories (`EdgeDivByN`/`ByLength`/`ByTolerance`) consolidate the boilerplate. `ctx == nullptr` keeps existing behavior; existing API surface preserved.
- Bindings: C (`manifold_refine_with_context`, mirroring `manifold_status_with_context`), Python (overload via `static_cast`), WASM (`refineWithContext` with matching `.d.ts`). External bindings (OCaml/Rust/Java) not updated -- out of tree.

## Tests

- Happy path: leaf Refine, `totalPhases = donePhases = 1`, Cube + Refine(2): 12 -> 48 tris.
- Pre-cancelled ctx returns Cancelled for all three variants.
- Pre-cancel a tree refinement: `totalPhases = kPhasesPerBoolean + 1` immediately (validates no-dip end-to-end).
- C-API smoke test for `manifold_refine_with_context`.

## Verified

396 PAR / 390 no-PAR tests pass. Python module builds.