### PR TITLE
Share Boolean symbolic perturbation primitives

### DIFF
--- a/src/boolean3.cpp
+++ b/src/boolean3.cpp
@@ -28,28 +28,8 @@ using namespace manifold;
 
 namespace {
 
-// These two functions (Interpolate and Intersect) are the only places where
-// floating-point operations take place in the whole Boolean function. These
-// are carefully designed to minimize rounding error and to eliminate it at edge
-// cases to ensure consistency.
-
-inline double withSign(bool pos, double v) { return pos ? v : -v; }
-
-inline vec2 Interpolate(vec3 aL, vec3 aR, double x) {
-  const double dxL = x - aL.x;
-  const double dxR = x - aR.x;
-  DEBUG_ASSERT(dxL * dxR <= 0, logicErr,
-               "Boolean manifold error: not in domain");
-  const bool useL = fabs(dxL) < fabs(dxR);
-  const vec3 dLR = aR - aL;
-  const double lambda = (useL ? dxL : dxR) / dLR.x;
-  if (!std::isfinite(lambda) || !std::isfinite(dLR.y) || !std::isfinite(dLR.z))
-    return vec2(aL.y, aL.z);
-  vec2 yz;
-  yz[0] = lambda * dLR.y + (useL ? aL.y : aR.y);
-  yz[1] = lambda * dLR.z + (useL ? aL.z : aR.z);
-  return yz;
-}
+// `Intersect` stays local to the Boolean3 kernel cascade; the lower-level
+// symbolic perturbation primitives it uses live in shared.h.
 
 vec4 Intersect(const vec3& aL, const vec3& aR, const vec3& bL, const vec3& bR) {
   const double dyL = bL.y - aL.y;
@@ -70,10 +50,6 @@ vec4 Intersect(const vec3& aL, const vec3& aR, const vec3& bL, const vec3& bR) {
   xyzz.z = lambda * (aR.z - aL.z) + (useL ? aL.z : aR.z);
   xyzz.w = lambda * (bR.z - bL.z) + (useL ? bL.z : bR.z);
   return xyzz;
-}
-
-inline bool Shadows(double p, double q, double dir) {
-  return p == q ? dir < 0 : p < q;
 }
 
 template <bool expandP, bool forward>

--- a/src/shared.h
+++ b/src/shared.h
@@ -58,6 +58,44 @@ inline mat3 InverseNormalTransform(const mat3x4& transform) {
 }
 
 /**
+ * Symbolic perturbation primitives shared by Boolean3 and Boolean2.
+ * Carefully designed to minimize FP rounding error and eliminate it at edge
+ * cases.
+ */
+
+inline double withSign(bool pos, double v) { return pos ? v : -v; }
+
+/**
+ * Interpolate the (y, z) of segment aL-aR at the given x. The choice of
+ * (x - aL) vs (x - aR) is the smaller in magnitude, which keeps FP error
+ * low near either endpoint. Domain check via DEBUG_ASSERT.
+ */
+inline vec2 Interpolate(vec3 aL, vec3 aR, double x) {
+  const double dxL = x - aL.x;
+  const double dxR = x - aR.x;
+  DEBUG_ASSERT(dxL * dxR <= 0, logicErr,
+               "Boolean manifold error: not in domain");
+  const bool useL = fabs(dxL) < fabs(dxR);
+  const vec3 dLR = aR - aL;
+  const double lambda = (useL ? dxL : dxR) / dLR.x;
+  if (!std::isfinite(lambda) || !std::isfinite(dLR.y) || !std::isfinite(dLR.z))
+    return vec2(aL.y, aL.z);
+  vec2 yz;
+  yz[0] = lambda * dLR.y + (useL ? aL.y : aR.y);
+  yz[1] = lambda * dLR.z + (useL ? aL.z : aR.z);
+  return yz;
+}
+
+/**
+ * `p < q` with symbolic perturbation: when `p == q` exactly, `dir < 0`
+ * acts as the tiebreaker. Used to give consistent strict-ordering answers
+ * regardless of which side of an FP equality we land on.
+ */
+inline bool Shadows(double p, double q, double dir) {
+  return p == q ? dir < 0 : p < q;
+}
+
+/**
  * By using the closest axis-aligned projection to the normal instead of a
  * projection along the normal, we avoid introducing any rounding error.
  */


### PR DESCRIPTION
## Summary

This moves a few low-level symbolic perturbation helpers from `boolean3.cpp` into `shared.h` so they can be reused by other geometry code.

Moved helpers:

- `withSign`
- `Interpolate`
- `Shadows`

`Boolean3` behavior is unchanged; `Intersect` remains local to `boolean3.cpp`.

## Motivation

These helpers are part of the existing Boolean3 robustness machinery and are useful outside the 3D boolean implementation. Pulling them into `shared.h` avoids duplicating the same interpolation and symbolic tie-breaking logic in future code.

This is intentionally small and mechanical: no new backend, no CrossSection behavior changes, and no dependency changes.

Part of the staged work described in:

- #1707

## Testing

- Configured with `MANIFOLD_CROSS_SECTION=OFF`
- Built `manifold`
