### PR TITLE
Thread ExecutionContext into Hull and Minkowski

### DIFF
--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -1169,11 +1169,12 @@ export class Manifold {
 
   /**
    * Returns a copy of this Manifold with the given ExecutionContext attached.
-   * The attachment is consumed by the next eager op invoked on the result —
-   * status() for a deferred CSG tree, or refine() / refineToLength() /
-   * refineToTolerance() for those eager ops. Deferred ops (Boolean
-   * operators, transforms, batch ops) ignore any attached ctx and produce
-   * a result with no attached ctx. See ExecutionContext for the full model.
+   * The attachment is consumed by the next eager op invoked on the result:
+   * status() for a deferred CSG tree, refine() / refineToLength() /
+   * refineToTolerance(), hull(), or minkowskiSum() / minkowskiDifference().
+   * Deferred ops (Boolean operators, transforms, batch ops) ignore any
+   * attached ctx and produce a result with no attached ctx. See
+   * ExecutionContext for the full model.
    *
    * @group Information
    */

--- a/bindings/wasm/manifold-global-types.d.ts
+++ b/bindings/wasm/manifold-global-types.d.ts
@@ -125,10 +125,10 @@ export type ErrorStatus = 'NoError'|'NonFiniteVertex'|'NotManifold'|
 /**
  * Observe and control a long-running Manifold evaluation. Attach to a
  * Manifold via Manifold.withContext(); the next eager op invoked on the
- * result (status(), or one of the refine* family) snapshots the ctx and
- * reports progress / observes cancellation through it. Deferred ops
- * (Boolean, transforms, batch ops) ignore any attached ctx. Safe to
- * read/write from any thread/worker.
+ * result (status(), one of the refine* family, hull(), or minkowskiSum() /
+ * minkowskiDifference()) snapshots the ctx and reports progress / observes
+ * cancellation through it. Deferred ops (Boolean, transforms, batch ops)
+ * ignore any attached ctx. Safe to read/write from any thread/worker.
  *
  * Cancellation is permanent for a Manifold: once cancelled and detected,
  * the Manifold's status becomes 'Cancelled' and stays 'Cancelled'.

--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -176,9 +176,10 @@ struct RayHit {
  * @brief Observe and control a long-running Manifold evaluation.
  *
  * Attach to a Manifold via Manifold::WithContext(ctx); the next *eager* op
- * invoked on the result (Status, Refine / RefineToLength / RefineToTolerance)
- * snapshots the ctx and reports progress and observes cancellation through
- * it. Safe to read/write from any thread.
+ * invoked on the result (Status, Refine / RefineToLength / RefineToTolerance,
+ * Hull, MinkowskiSum / MinkowskiDifference) snapshots the ctx and reports
+ * progress and observes cancellation through it. Safe to read/write from any
+ * thread.
  *
  * Copyable and movable: copies share the same underlying state via a
  * shared_ptr, so one thread can evaluate while another holds a copy and
@@ -196,11 +197,13 @@ struct RayHit {
  * short-circuit to Error::Cancelled. Construct a fresh context to make a
  * new evaluation cancellable independently.
  *
- * Cancellation granularity is currently per-boolean-operation; a single
- * large boolean may run to completion before the flag is checked again.
- * This may improve in future versions.
+ * Cancellation granularity varies by op: Boolean trees check per
+ * sub-boolean (so a single very large boolean may run to completion
+ * before the next check); Hull checks at the boundaries of its main
+ * phases (post-buildMesh and post-SortGeometry); Minkowski checks per
+ * face of the first input and per internal BatchBoolean batch.
  *
- * Example: cancel from an observer thread.
+ * Example: cancel a long-running BatchBoolean from an observer thread.
  * @code
  * ExecutionContext ctx;
  * Manifold big = Manifold::BatchBoolean(items, OpType::Add).WithContext(ctx);
@@ -210,6 +213,19 @@ struct RayHit {
  *   }
  * });
  * // ...later, from the UI thread:
+ * ctx.Cancel();
+ * eval.join();
+ * @endcode
+ *
+ * Example: cancel a Minkowski sum mid-evaluation.
+ * @code
+ * ExecutionContext ctx;
+ * std::thread eval([&] {
+ *   if (a.WithContext(ctx).MinkowskiSum(b).Status() ==
+ *       Manifold::Error::Cancelled) {
+ *     // evaluation was cancelled
+ *   }
+ * });
  * ctx.Cancel();
  * eval.join();
  * @endcode

--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -384,10 +384,11 @@ class Manifold {
 
   /// Returns a copy of this Manifold with the given ExecutionContext attached.
   /// The attachment is consumed only by `Status()` (for deferred CSG trees)
-  /// and the `Refine()` / `RefineToLength()` / `RefineToTolerance()` family
-  /// (eager ops); those snapshot the ctx and report progress / observe
-  /// cancellation through it. Other queries that force evaluation (`Volume`,
-  /// `GetMeshGL`, `BoundingBox`, etc.) do not currently observe attached ctx.
+  /// and the eager ops (`Refine` / `RefineToLength` / `RefineToTolerance`,
+  /// `Hull`, `MinkowskiSum` / `MinkowskiDifference`); those snapshot the ctx
+  /// and report progress / observe cancellation through it. Other queries
+  /// that force evaluation (`Volume`, `GetMeshGL`, `BoundingBox`, etc.) do
+  /// not currently observe attached ctx.
   ///
   /// Deferred ops (Boolean operators, Translate / Rotate / Scale / Transform
   /// / Mirror / Warp / SetTolerance / Simplify, BatchBoolean, the
@@ -400,6 +401,7 @@ class Manifold {
   /// while the idiom for observing an eager op is:
   ///
   ///   m.WithContext(ctx).Refine(n);
+  ///   m.WithContext(ctx).MinkowskiSum(other);
   ///
   /// Raw copy / assignment preserves the attachment (it's the same logical
   /// Manifold). Only ops that derive a *new* Manifold drop the attachment.

--- a/src/impl.h
+++ b/src/impl.h
@@ -196,10 +196,11 @@ struct Manifold::Impl {
               ExecutionContext::Impl* ctx = nullptr);
 
   // quickhull.cpp
-  void Hull(VecView<const vec3> vertPos);
+  void Hull(VecView<const vec3> vertPos, ExecutionContext::Impl* ctx = nullptr);
 
   // minkowski.cpp
-  Manifold Minkowski(const Impl& other, bool inset) const;
+  Manifold Minkowski(const Impl& other, bool inset,
+                     ExecutionContext::Impl* ctx = nullptr) const;
 };
 
 extern std::mutex dump_lock;

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -975,11 +975,12 @@ Manifold Manifold::TrimByPlane(vec3 normal, double originOffset) const {
  * @param other The other manifold to minkowski sum to this one.
  */
 Manifold Manifold::MinkowskiSum(const Manifold& other) const {
-  auto aImpl = GetCsgLeafNode().GetImpl();
+  auto ctx = std::atomic_load(&ctx_);
+  auto aImpl = GetCsgLeafNode(ctx.get()).GetImpl();
   if (aImpl->status_ != Error::NoError) return PropagateStatus(aImpl->status_);
-  auto bImpl = other.GetCsgLeafNode().GetImpl();
+  auto bImpl = other.GetCsgLeafNode(ctx.get()).GetImpl();
   if (bImpl->status_ != Error::NoError) return PropagateStatus(bImpl->status_);
-  return aImpl->Minkowski(*bImpl, false);
+  return aImpl->Minkowski(*bImpl, false, ctx.get());
 }
 
 /**
@@ -992,11 +993,12 @@ Manifold Manifold::MinkowskiSum(const Manifold& other) const {
  * @param other The other manifold to minkowski subtract from this one.
  */
 Manifold Manifold::MinkowskiDifference(const Manifold& other) const {
-  auto aImpl = GetCsgLeafNode().GetImpl();
+  auto ctx = std::atomic_load(&ctx_);
+  auto aImpl = GetCsgLeafNode(ctx.get()).GetImpl();
   if (aImpl->status_ != Error::NoError) return PropagateStatus(aImpl->status_);
-  auto bImpl = other.GetCsgLeafNode().GetImpl();
+  auto bImpl = other.GetCsgLeafNode(ctx.get()).GetImpl();
   if (bImpl->status_ != Error::NoError) return PropagateStatus(bImpl->status_);
-  return aImpl->Minkowski(*bImpl, true);
+  return aImpl->Minkowski(*bImpl, true, ctx.get());
 }
 
 /**
@@ -1038,11 +1040,12 @@ Manifold Manifold::Hull(const std::vector<vec3>& pts) {
  * Compute the convex hull of this manifold.
  */
 Manifold Manifold::Hull() const {
-  auto srcImpl = GetCsgLeafNode().GetImpl();
+  auto ctx = std::atomic_load(&ctx_);
+  auto srcImpl = GetCsgLeafNode(ctx.get()).GetImpl();
   if (srcImpl->status_ != Error::NoError)
     return PropagateStatus(srcImpl->status_);
   std::shared_ptr<Impl> impl = std::make_shared<Impl>();
-  impl->Hull(srcImpl->vertPos_);
+  impl->Hull(srcImpl->vertPos_, ctx.get());
   return Manifold(std::make_shared<CsgLeafNode>(impl));
 }
 

--- a/src/minkowski.cpp
+++ b/src/minkowski.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "execution_impl.h"
 #include "impl.h"
 #include "parallel.h"
 
@@ -23,7 +24,33 @@ namespace manifold {
  * @param other The other Impl to minkowski sum/diff with this one.
  * @param inset Whether it should subtract (erode) rather than add (dilate).
  */
-Manifold Manifold::Impl::Minkowski(const Impl& other, bool inset) const {
+Manifold Manifold::Impl::Minkowski(const Impl& other, bool inset,
+                                   ExecutionContext::Impl* ctx) const {
+  // Helper to short-circuit on cancel. Cancellation is observed both at
+  // the boundaries between hull/Boolean phases and inside each
+  // BatchBoolean (via the same ctx threaded into GetCsgLeafNode, which
+  // routes into Boolean3's existing cancel checks). The per-hull work
+  // itself is currently not interrupted -- granularity inside a batch
+  // is "one Manifold::Hull(simpleHull) call."
+  auto cancelled = [] {
+    auto impl = std::make_shared<Impl>();
+    impl->status_ = Error::Cancelled;
+    return Manifold(impl);
+  };
+  // Build a BatchBoolean and force ctx-observed evaluation so an
+  // attached cancel fires inside Boolean3 rather than after the whole
+  // batch completes.
+  auto evalBatch = [ctx](std::vector<Manifold>&& items, OpType op) {
+    Manifold tree = Manifold::BatchBoolean(items, op);
+    // Trigger lazy eval with ctx. The returned leaf may have
+    // status_=Cancelled if cancel fired mid-Boolean; the caller still
+    // pushes it into composedHulls and the outer cancel check catches
+    // it.
+    tree.GetCsgLeafNode(ctx);
+    return tree;
+  };
+  if (IsCancelled(ctx)) return cancelled();
+
   const Impl* aImpl = this;
   const Impl* bImpl = &other;
 
@@ -74,6 +101,7 @@ Manifold Manifold::Impl::Minkowski(const Impl& other, bool inset) const {
 
     // do it in batches of 1000 meshes
     for (size_t offset = 0; offset < numTri; offset += BATCH_SIZE) {
+      if (IsCancelled(ctx)) return cancelled();
       size_t numIter = std::min(numTri - offset, BATCH_SIZE);
       std::vector<Manifold> newHulls(numIter);
       for_each_n(autoPolicy(numIter, 100), countAt(0), numIter,
@@ -90,7 +118,7 @@ Manifold Manifold::Impl::Minkowski(const Impl& other, bool inset) const {
                    }
                    newHulls[iter] = Manifold::Hull(simpleHull);
                  });
-      composedHulls.push_back(Manifold::BatchBoolean(newHulls, OpType::Add));
+      composedHulls.push_back(evalBatch(std::move(newHulls), OpType::Add));
     }
     // Non-Convex - Non-Convex Minkowski: Very Slow
     // Process A faces sequentially with periodic batch reduction to balance
@@ -108,6 +136,7 @@ Manifold Manifold::Impl::Minkowski(const Impl& other, bool inset) const {
 
     // Process each A face sequentially
     for (size_t aFace = 0; aFace < numTriA; ++aFace) {
+      if (IsCancelled(ctx)) return cancelled();
       vec3 a1 = aImpl->vertPos_[aImpl->halfedge_.Start((aFace * 3) + 0)];
       vec3 a2 = aImpl->vertPos_[aImpl->halfedge_.Start((aFace * 3) + 1)];
       vec3 a3 = aImpl->vertPos_[aImpl->halfedge_.Start((aFace * 3) + 2)];
@@ -146,12 +175,12 @@ Manifold Manifold::Impl::Minkowski(const Impl& other, bool inset) const {
 
       if (!validFaceHulls.empty()) {
         accumulated.push_back(
-            Manifold::BatchBoolean(validFaceHulls, OpType::Add));
+            evalBatch(std::move(validFaceHulls), OpType::Add));
       }
 
       // Periodically reduce to limit memory usage
       if (accumulated.size() >= REDUCE_THRESHOLD) {
-        Manifold reduced = Manifold::BatchBoolean(accumulated, OpType::Add);
+        Manifold reduced = evalBatch(std::move(accumulated), OpType::Add);
         accumulated.clear();
         accumulated.push_back(std::move(reduced));
       }
@@ -159,12 +188,12 @@ Manifold Manifold::Impl::Minkowski(const Impl& other, bool inset) const {
 
     // Final merge of remaining accumulated results
     if (!accumulated.empty()) {
-      composedHulls.push_back(Manifold::BatchBoolean(accumulated, OpType::Add));
+      composedHulls.push_back(evalBatch(std::move(accumulated), OpType::Add));
     }
   }
-  return Manifold::BatchBoolean(composedHulls, inset
-                                                   ? manifold::OpType::Subtract
-                                                   : manifold::OpType::Add)
+  if (IsCancelled(ctx)) return cancelled();
+  return evalBatch(std::move(composedHulls),
+                   inset ? manifold::OpType::Subtract : manifold::OpType::Add)
       .AsOriginal();
 }
 

--- a/src/quickhull.cpp
+++ b/src/quickhull.cpp
@@ -852,6 +852,13 @@ void Manifold::Impl::Hull(VecView<const vec3> vertPos,
   SetEpsilon();
   InitializeOriginal();
   SortGeometry(ctx);
+  // SortGeometry returns silently on cancel, leaving the Impl in a
+  // partial state; catch that here so SetNormalsAndCoplanar doesn't
+  // run on broken geometry and the caller sees a Cancelled result.
+  if (IsCancelled(ctx)) {
+    MakeEmpty(Error::Cancelled);
+    return;
+  }
   SetNormalsAndCoplanar();
 }
 

--- a/src/quickhull.cpp
+++ b/src/quickhull.cpp
@@ -22,6 +22,7 @@
 #include <limits>
 #include <unordered_map>
 
+#include "execution_impl.h"
 #include "impl.h"
 
 namespace manifold {
@@ -825,19 +826,32 @@ bool QuickHull::addPointToFace(typename MeshBuilder::Face& f,
 }
 
 // Wrapper to call the QuickHull algorithm with the given vertex data to build
-// the Impl
-void Manifold::Impl::Hull(VecView<const vec3> vertPos) {
+// the Impl. Cancellation is observed between QuickHull's hot kernel and the
+// SortGeometry post-pass, plus during SortGeometry itself (which is
+// ctx-aware). QuickHull's own loop is cancel-blind for now -- the
+// granularity is "after buildMesh returns", matching how Refine handles
+// Subdivide.
+void Manifold::Impl::Hull(VecView<const vec3> vertPos,
+                          ExecutionContext::Impl* ctx) {
   size_t numVert = vertPos.size();
   // empty hull
   if (vertPos.empty()) return;
+  if (IsCancelled(ctx)) {
+    MakeEmpty(Error::Cancelled);
+    return;
+  }
   QuickHull qh(vertPos);
   Vec<Halfedge> Halfedge;
   std::tie(Halfedge, vertPos_) = qh.buildMesh();
   halfedge_ = Halfedges(std::move(Halfedge));
+  if (IsCancelled(ctx)) {
+    MakeEmpty(Error::Cancelled);
+    return;
+  }
   CalculateBBox();
   SetEpsilon();
   InitializeOriginal();
-  SortGeometry();
+  SortGeometry(ctx);
   SetNormalsAndCoplanar();
 }
 

--- a/test/context_test.cpp
+++ b/test/context_test.cpp
@@ -739,7 +739,13 @@ TEST(Manifold, ManifoldContextCancelConcurrentHull) {
 // std::thread.
 #if MANIFOLD_PAR == 1
 TEST(Manifold, ManifoldContextCancelConcurrentMinkowski) {
-  // Two non-convex inputs to force the slow path.
+  // Two non-convex inputs to force the slow path. The tet-difference here
+  // produces near-degenerate geometry that fails the MANIFOLD_DEBUG
+  // triangulation CCW check on macOS without processOverlaps -- matches
+  // the workaround in Boolean.NonConvexNonConvexMinkowski{Sum,Difference}.
+  ManifoldParamGuard guard;
+  ManifoldParams().processOverlaps = true;
+
   Manifold tet = Manifold::Tetrahedron();
   Manifold nonConvex = tet - tet.Rotate(0, 0, 90).Translate(vec3(1));
   Manifold other = nonConvex.Scale(vec3(0.5));

--- a/test/context_test.cpp
+++ b/test/context_test.cpp
@@ -700,6 +700,34 @@ TEST(Manifold, ManifoldContextCancelMidMinkowski) {
   EXPECT_EQ(sum.Status(), Manifold::Error::Cancelled);
 }
 
+// Concurrent cancel mid-Hull: spawn a thread that fires cancel a short
+// delay after the main thread launches a Hull on a non-trivial input.
+// Cancel can fire at either the post-buildMesh checkpoint or inside
+// SortGeometry's per-phase checks; either way the result is Cancelled.
+//
+// MANIFOLD_PAR guard: same as the other concurrent tests -- requires
+// std::thread.
+#if MANIFOLD_PAR == 1
+TEST(Manifold, ManifoldContextCancelConcurrentHull) {
+  // High-resolution sphere so QuickHull + SortGeometry have measurable
+  // work to do.
+  Manifold sphere = Manifold::Sphere(1.0, 256);
+
+  ExecutionContext ctx;
+  std::atomic<Manifold::Error> result{Manifold::Error::NoError};
+  std::thread evalThread(
+      [&] { result.store(sphere.WithContext(ctx).Hull().Status()); });
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  ctx.Cancel();
+  evalThread.join();
+
+  // Either NoError (eval raced past the 1ms sleep) or Cancelled
+  // (caught at one of the Hull cancel checkpoints).
+  EXPECT_TRUE(result.load() == Manifold::Error::Cancelled ||
+              result.load() == Manifold::Error::NoError);
+}
+#endif  // MANIFOLD_PAR == 1
+
 // Concurrent cancel mid-Minkowski: spawn a thread that fires cancel a
 // short delay after the main thread launches a non-convex Minkowski
 // (the slow path). The internal BatchBoolean calls observe ctx (via

--- a/test/context_test.cpp
+++ b/test/context_test.cpp
@@ -674,6 +674,64 @@ TEST(Manifold, ManifoldContextRefineDropsAttachmentFromResult) {
   EXPECT_EQ(other.impl_->totalBooleans.load(), kSentinel);
 }
 
+// Eager Hull observes attached ctx -- a pre-cancelled ctx aborts the
+// post-pass that runs after QuickHull's buildMesh, returning a Cancelled
+// result rather than a finished hull.
+TEST(Manifold, ManifoldContextCancelMidHull) {
+  ExecutionContext ctx;
+  ctx.Cancel();
+  // Non-trivial input so the post-buildMesh path is reached.
+  Manifold sphere = Manifold::Sphere(1.0, 64).WithContext(ctx);
+  Manifold hull = sphere.Hull();
+  EXPECT_EQ(hull.Status(), Manifold::Error::Cancelled);
+}
+
+// Eager Minkowski observes attached ctx -- a pre-cancelled ctx aborts
+// between the hull/Boolean phases. Cancel granularity is "one batch" of
+// per-face hulls.
+TEST(Manifold, ManifoldContextCancelMidMinkowski) {
+  ExecutionContext ctx;
+  ctx.Cancel();
+  // Two convex inputs hit the fast path; that's enough to exercise the
+  // up-front cancel check.
+  Manifold a = Manifold::Cube(vec3(1), true).WithContext(ctx);
+  Manifold b = Manifold::Cube(vec3(0.5), true);
+  Manifold sum = a.MinkowskiSum(b);
+  EXPECT_EQ(sum.Status(), Manifold::Error::Cancelled);
+}
+
+// Concurrent cancel mid-Minkowski: spawn a thread that fires cancel a
+// short delay after the main thread launches a non-convex Minkowski
+// (the slow path). The internal BatchBoolean calls observe ctx (via
+// the tree.GetCsgLeafNode(ctx) trigger in Impl::Minkowski), so cancel
+// fires inside Boolean3's per-phase checks rather than waiting for the
+// whole batch.
+//
+// MANIFOLD_PAR guard: same as the other concurrent tests -- requires
+// std::thread.
+#if MANIFOLD_PAR == 1
+TEST(Manifold, ManifoldContextCancelConcurrentMinkowski) {
+  // Two non-convex inputs to force the slow path.
+  Manifold tet = Manifold::Tetrahedron();
+  Manifold nonConvex = tet - tet.Rotate(0, 0, 90).Translate(vec3(1));
+  Manifold other = nonConvex.Scale(vec3(0.5));
+
+  ExecutionContext ctx;
+  std::atomic<Manifold::Error> result{Manifold::Error::NoError};
+  std::thread evalThread([&] {
+    result.store(nonConvex.WithContext(ctx).MinkowskiSum(other).Status());
+  });
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  ctx.Cancel();
+  evalThread.join();
+
+  // Either NoError (eval raced past the 1ms sleep) or Cancelled
+  // (caught mid-Boolean inside Minkowski) is acceptable.
+  EXPECT_TRUE(result.load() == Manifold::Error::Cancelled ||
+              result.load() == Manifold::Error::NoError);
+}
+#endif  // MANIFOLD_PAR == 1
+
 // Cancellation requested on the attached ctx after Status() begins (or
 // before, in the deferred-tree-root idiom) aborts evaluation.
 TEST(Manifold, ManifoldContextCancelMidEval) {


### PR DESCRIPTION
Picks up the remaining non-static eager ops from the #971 eager-ops backlog (`Refine` landed in #1704, `Face2Tri` in #1699). After this, every eager op the data-attached model can naturally observe is wired up. Static factories (`Hull(vector<vec3>)`, `Hull(vector<Manifold>)`, `LevelSet`, `MeshGL` constructors) are intentionally out of scope: they have no input `Manifold` to source ctx from, and picking the static-factory convention is a separate design conversation.

#### Hull

`Impl::Hull` gains an optional `ctx` parameter. Cancel checks fire at entry, after `QuickHull::buildMesh`, after `SortGeometry`, plus inside `SortGeometry` itself (already ctx-aware via #1697 / #1699). `QuickHull`'s own loop stays cancel-blind -- granularity is "after `buildMesh` returns," matching how `Refine` handles `Subdivide`. Public `Manifold::Hull()` snapshots `this->ctx_` and threads it through `GetCsgLeafNode` and `Impl::Hull`.

#### Minkowski

`Impl::Minkowski` gains an optional `ctx` parameter. Cancel checks fire at function entry, per batch in the convex/non-convex path, per A-face in the non-convex/non-convex path, and before the final `BatchBoolean`. Internal `BatchBoolean` calls are evaluated with ctx via a local `evalBatch` helper that forces lazy eval through `tree.GetCsgLeafNode(ctx)`, routing into Boolean3's existing per-phase cancel machinery -- so mid-Boolean cancel fires inside Minkowski, not just between batches. Per-hull `Manifold::Hull(simpleHull)` calls (the static factory) remain ctx-blind; granularity inside a batch is "one hull."

#### Tests

Pre-cancel tests for the up-front checks (`ManifoldContextCancelMidHull`, `ManifoldContextCancelMidMinkowski`) and concurrent-cancel tests under `MANIFOLD_PAR == 1` that fire cancel from an observer thread mid-evaluation (`ManifoldContextCancelConcurrentHull`, `ManifoldContextCancelConcurrentMinkowski`).

## Test plan

- [x] 397/397 tests pass under `MANIFOLD_PAR=OFF`.
- [ ] Confirm 397/397 under `MANIFOLD_PAR=ON` (concurrent tests will compile in and run).
- [x] clang-format-20 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)