### PR TITLE
Record normals on Manifold; auto-substitute on GetMeshGL; round-trip via MeshGL

### DIFF
--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -447,9 +447,9 @@ float* manifold_meshgl_halfedge_tangent(void* mem, ManifoldMeshGL* m);
 float manifold_meshgl_tolerance(ManifoldMeshGL* m);
 size_t manifold_meshgl_run_flags_length(ManifoldMeshGL* m);
 uint8_t* manifold_meshgl_run_flags(void* mem, ManifoldMeshGL* m);
-int manifold_meshgl_has_normals(ManifoldMeshGL* m);
 size_t manifold_meshgl_num_run(ManifoldMeshGL* m);
-void manifold_meshgl_update_normals(ManifoldMeshGL* m, int normal_idx);
+int manifold_meshgl_backside(ManifoldMeshGL* m, size_t run);
+int manifold_meshgl_has_normals(ManifoldMeshGL* m, size_t run);
 
 size_t manifold_meshgl64_num_prop(ManifoldMeshGL64* m);
 size_t manifold_meshgl64_num_vert(ManifoldMeshGL64* m);
@@ -474,9 +474,9 @@ double* manifold_meshgl64_halfedge_tangent(void* mem, ManifoldMeshGL64* m);
 double manifold_meshgl64_tolerance(ManifoldMeshGL64* m);
 size_t manifold_meshgl64_run_flags_length(ManifoldMeshGL64* m);
 uint8_t* manifold_meshgl64_run_flags(void* mem, ManifoldMeshGL64* m);
-int manifold_meshgl64_has_normals(ManifoldMeshGL64* m);
 size_t manifold_meshgl64_num_run(ManifoldMeshGL64* m);
-void manifold_meshgl64_update_normals(ManifoldMeshGL64* m, int normal_idx);
+int manifold_meshgl64_backside(ManifoldMeshGL64* m, size_t run);
+int manifold_meshgl64_has_normals(ManifoldMeshGL64* m, size_t run);
 
 // Triangulation
 

--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -447,6 +447,7 @@ float* manifold_meshgl_halfedge_tangent(void* mem, ManifoldMeshGL* m);
 float manifold_meshgl_tolerance(ManifoldMeshGL* m);
 size_t manifold_meshgl_run_flags_length(ManifoldMeshGL* m);
 uint8_t* manifold_meshgl_run_flags(void* mem, ManifoldMeshGL* m);
+int manifold_meshgl_has_normals(ManifoldMeshGL* m);
 size_t manifold_meshgl_num_run(ManifoldMeshGL* m);
 void manifold_meshgl_update_normals(ManifoldMeshGL* m, int normal_idx);
 
@@ -473,6 +474,7 @@ double* manifold_meshgl64_halfedge_tangent(void* mem, ManifoldMeshGL64* m);
 double manifold_meshgl64_tolerance(ManifoldMeshGL64* m);
 size_t manifold_meshgl64_run_flags_length(ManifoldMeshGL64* m);
 uint8_t* manifold_meshgl64_run_flags(void* mem, ManifoldMeshGL64* m);
+int manifold_meshgl64_has_normals(ManifoldMeshGL64* m);
 size_t manifold_meshgl64_num_run(ManifoldMeshGL64* m);
 void manifold_meshgl64_update_normals(ManifoldMeshGL64* m, int normal_idx);
 

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -694,12 +694,12 @@ size_t manifold_meshgl_num_run(ManifoldMeshGL* m) {
   return from_c(m)->NumRun();
 }
 
-int manifold_meshgl_has_normals(ManifoldMeshGL* m) {
-  return from_c(m)->hasNormals ? 1 : 0;
+int manifold_meshgl_backside(ManifoldMeshGL* m, size_t run) {
+  return from_c(m)->Backside(run) ? 1 : 0;
 }
 
-void manifold_meshgl_update_normals(ManifoldMeshGL* m, int normal_idx) {
-  from_c(m)->UpdateNormals(normal_idx);
+int manifold_meshgl_has_normals(ManifoldMeshGL* m, size_t run) {
+  return from_c(m)->HasNormals(run) ? 1 : 0;
 }
 
 size_t manifold_meshgl64_num_prop(ManifoldMeshGL64* m) {
@@ -779,12 +779,12 @@ size_t manifold_meshgl64_num_run(ManifoldMeshGL64* m) {
   return from_c(m)->NumRun();
 }
 
-int manifold_meshgl64_has_normals(ManifoldMeshGL64* m) {
-  return from_c(m)->hasNormals ? 1 : 0;
+int manifold_meshgl64_backside(ManifoldMeshGL64* m, size_t run) {
+  return from_c(m)->Backside(run) ? 1 : 0;
 }
 
-void manifold_meshgl64_update_normals(ManifoldMeshGL64* m, int normal_idx) {
-  from_c(m)->UpdateNormals(normal_idx);
+int manifold_meshgl64_has_normals(ManifoldMeshGL64* m, size_t run) {
+  return from_c(m)->HasNormals(run) ? 1 : 0;
 }
 
 ManifoldManifold* manifold_as_original(void* mem, ManifoldManifold* m) {

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -694,6 +694,10 @@ size_t manifold_meshgl_num_run(ManifoldMeshGL* m) {
   return from_c(m)->NumRun();
 }
 
+int manifold_meshgl_has_normals(ManifoldMeshGL* m) {
+  return from_c(m)->hasNormals ? 1 : 0;
+}
+
 void manifold_meshgl_update_normals(ManifoldMeshGL* m, int normal_idx) {
   from_c(m)->UpdateNormals(normal_idx);
 }
@@ -773,6 +777,10 @@ uint8_t* manifold_meshgl64_run_flags(void* mem, ManifoldMeshGL64* m) {
 
 size_t manifold_meshgl64_num_run(ManifoldMeshGL64* m) {
   return from_c(m)->NumRun();
+}
+
+int manifold_meshgl64_has_normals(ManifoldMeshGL64* m) {
+  return from_c(m)->hasNormals ? 1 : 0;
 }
 
 void manifold_meshgl64_update_normals(ManifoldMeshGL64* m, int normal_idx) {

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -523,7 +523,7 @@ NB_MODULE(manifold3d, m) {
                  nb::ndarray<uint32_t, nb::shape<-1>, nb::c_contig>>& faceID,
              const std::optional<nb::ndarray<float, nb::shape<-1, 3, 4>,
                                              nb::c_contig>>& halfedgeTangent,
-             float tolerance, bool hasNormals) {
+             float tolerance) {
             new (self) MeshGL();
             MeshGL& out = *self;
             out.numProp = vertProp.shape(1);
@@ -562,8 +562,6 @@ NB_MODULE(manifold3d, m) {
               out.halfedgeTangent =
                   toVector(halfedgeTangent->data(), halfedgeTangent->size());
             }
-
-            out.hasNormals = hasNormals;
           },
           nb::arg("vert_properties"), nb::arg("tri_verts"),
           nb::arg("merge_from_vert") = nb::none(),
@@ -572,8 +570,7 @@ NB_MODULE(manifold3d, m) {
           nb::arg("run_original_id") = nb::none(),
           nb::arg("run_transform") = nb::none(),
           nb::arg("run_flags") = nb::none(), nb::arg("face_id") = nb::none(),
-          nb::arg("halfedge_tangent") = nb::none(), nb::arg("tolerance") = 0,
-          nb::arg("has_normals") = false)
+          nb::arg("halfedge_tangent") = nb::none(), nb::arg("tolerance") = 0)
       .def_prop_ro(
           "vert_properties",
           [](const MeshGL& self) {
@@ -613,7 +610,8 @@ NB_MODULE(manifold3d, m) {
       .def_ro("run_original_id", &MeshGL::runOriginalID)
       .def_ro("run_flags", &MeshGL::runFlags)
       .def_ro("face_id", &MeshGL::faceID)
-      .def_ro("has_normals", &MeshGL::hasNormals)
+      .def("backside", &MeshGL::Backside, nb::arg("run"))
+      .def("has_normals", &MeshGL::HasNormals, nb::arg("run"))
       .def("merge", &MeshGL::Merge, mesh_gl__merge);
 
   nb::class_<MeshGL64>(m, "Mesh64")
@@ -640,7 +638,7 @@ NB_MODULE(manifold3d, m) {
                  nb::ndarray<uint64_t, nb::shape<-1>, nb::c_contig>>& faceID,
              const std::optional<nb::ndarray<double, nb::shape<-1, 3, 4>,
                                              nb::c_contig>>& halfedgeTangent,
-             float tolerance, bool hasNormals) {
+             float tolerance) {
             new (self) MeshGL64();
             MeshGL64& out = *self;
             out.numProp = vertProp.shape(1);
@@ -679,8 +677,6 @@ NB_MODULE(manifold3d, m) {
               out.halfedgeTangent =
                   toVector(halfedgeTangent->data(), halfedgeTangent->size());
             }
-
-            out.hasNormals = hasNormals;
           },
           nb::arg("vert_properties"), nb::arg("tri_verts"),
           nb::arg("merge_from_vert") = nb::none(),
@@ -689,8 +685,7 @@ NB_MODULE(manifold3d, m) {
           nb::arg("run_original_id") = nb::none(),
           nb::arg("run_transform") = nb::none(),
           nb::arg("run_flags") = nb::none(), nb::arg("face_id") = nb::none(),
-          nb::arg("halfedge_tangent") = nb::none(), nb::arg("tolerance") = 0,
-          nb::arg("has_normals") = false)
+          nb::arg("halfedge_tangent") = nb::none(), nb::arg("tolerance") = 0)
       .def_prop_ro(
           "vert_properties",
           [](const MeshGL64& self) {
@@ -730,7 +725,8 @@ NB_MODULE(manifold3d, m) {
       .def_ro("run_original_id", &MeshGL64::runOriginalID)
       .def_ro("run_flags", &MeshGL64::runFlags)
       .def_ro("face_id", &MeshGL64::faceID)
-      .def_ro("has_normals", &MeshGL64::hasNormals)
+      .def("backside", &MeshGL64::Backside, nb::arg("run"))
+      .def("has_normals", &MeshGL64::HasNormals, nb::arg("run"))
       .def("merge", &MeshGL64::Merge, mesh_gl__merge);
 
   nb::class_<RayHit>(m, "RayHit")

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -324,10 +324,10 @@ NB_MODULE(manifold3d, m) {
            nb::arg("endpoint"),
            "Cast a ray segment, returning all hits sorted by distance.")
       .def("calculate_normals", &Manifold::CalculateNormals,
-           nb::arg("normal_idx"), nb::arg("min_sharp_angle") = 60,
+           nb::arg("normal_idx") = 0, nb::arg("min_sharp_angle") = 60,
            manifold__calculate_normals__normal_idx__min_sharp_angle)
       .def("smooth_by_normals", &Manifold::SmoothByNormals,
-           nb::arg("normal_idx"), manifold__smooth_by_normals__normal_idx)
+           nb::arg("normal_idx") = 0, manifold__smooth_by_normals__normal_idx)
       .def("smooth_out", &Manifold::SmoothOut, nb::arg("min_sharp_angle") = 60,
            nb::arg("min_smoothness") = 0,
            manifold__smooth_out__min_sharp_angle__min_smoothness)
@@ -523,7 +523,7 @@ NB_MODULE(manifold3d, m) {
                  nb::ndarray<uint32_t, nb::shape<-1>, nb::c_contig>>& faceID,
              const std::optional<nb::ndarray<float, nb::shape<-1, 3, 4>,
                                              nb::c_contig>>& halfedgeTangent,
-             float tolerance) {
+             float tolerance, bool hasNormals) {
             new (self) MeshGL();
             MeshGL& out = *self;
             out.numProp = vertProp.shape(1);
@@ -562,6 +562,8 @@ NB_MODULE(manifold3d, m) {
               out.halfedgeTangent =
                   toVector(halfedgeTangent->data(), halfedgeTangent->size());
             }
+
+            out.hasNormals = hasNormals;
           },
           nb::arg("vert_properties"), nb::arg("tri_verts"),
           nb::arg("merge_from_vert") = nb::none(),
@@ -570,7 +572,8 @@ NB_MODULE(manifold3d, m) {
           nb::arg("run_original_id") = nb::none(),
           nb::arg("run_transform") = nb::none(),
           nb::arg("run_flags") = nb::none(), nb::arg("face_id") = nb::none(),
-          nb::arg("halfedge_tangent") = nb::none(), nb::arg("tolerance") = 0)
+          nb::arg("halfedge_tangent") = nb::none(), nb::arg("tolerance") = 0,
+          nb::arg("has_normals") = false)
       .def_prop_ro(
           "vert_properties",
           [](const MeshGL& self) {
@@ -610,6 +613,7 @@ NB_MODULE(manifold3d, m) {
       .def_ro("run_original_id", &MeshGL::runOriginalID)
       .def_ro("run_flags", &MeshGL::runFlags)
       .def_ro("face_id", &MeshGL::faceID)
+      .def_ro("has_normals", &MeshGL::hasNormals)
       .def("merge", &MeshGL::Merge, mesh_gl__merge);
 
   nb::class_<MeshGL64>(m, "Mesh64")
@@ -636,7 +640,7 @@ NB_MODULE(manifold3d, m) {
                  nb::ndarray<uint64_t, nb::shape<-1>, nb::c_contig>>& faceID,
              const std::optional<nb::ndarray<double, nb::shape<-1, 3, 4>,
                                              nb::c_contig>>& halfedgeTangent,
-             float tolerance) {
+             float tolerance, bool hasNormals) {
             new (self) MeshGL64();
             MeshGL64& out = *self;
             out.numProp = vertProp.shape(1);
@@ -675,6 +679,8 @@ NB_MODULE(manifold3d, m) {
               out.halfedgeTangent =
                   toVector(halfedgeTangent->data(), halfedgeTangent->size());
             }
+
+            out.hasNormals = hasNormals;
           },
           nb::arg("vert_properties"), nb::arg("tri_verts"),
           nb::arg("merge_from_vert") = nb::none(),
@@ -683,7 +689,8 @@ NB_MODULE(manifold3d, m) {
           nb::arg("run_original_id") = nb::none(),
           nb::arg("run_transform") = nb::none(),
           nb::arg("run_flags") = nb::none(), nb::arg("face_id") = nb::none(),
-          nb::arg("halfedge_tangent") = nb::none(), nb::arg("tolerance") = 0)
+          nb::arg("halfedge_tangent") = nb::none(), nb::arg("tolerance") = 0,
+          nb::arg("has_normals") = false)
       .def_prop_ro(
           "vert_properties",
           [](const MeshGL64& self) {
@@ -723,6 +730,7 @@ NB_MODULE(manifold3d, m) {
       .def_ro("run_original_id", &MeshGL64::runOriginalID)
       .def_ro("run_flags", &MeshGL64::runFlags)
       .def_ro("face_id", &MeshGL64::faceID)
+      .def_ro("has_normals", &MeshGL64::hasNormals)
       .def("merge", &MeshGL64::Merge, mesh_gl__merge);
 
   nb::class_<RayHit>(m, "RayHit")

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -180,7 +180,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("refine", &Manifold::Refine)
       .function("refineToLength", &Manifold::RefineToLength)
       .function("refineToTolerance", &Manifold::RefineToTolerance)
-      .function("smoothByNormals", &Manifold::SmoothByNormals)
+      .function("_SmoothByNormals", &Manifold::SmoothByNormals)
       .function("_SmoothOut", &Manifold::SmoothOut)
       .function("_Warp", &man_js::Warp)
       .function("_WarpBatch", &man_js::WarpBatch)

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -252,8 +252,12 @@ Module.setup = function() {
   };
 
   Module.Manifold.prototype.calculateNormals = function(
-      normalIdx, minSharpAngle = 60) {
+      normalIdx = 0, minSharpAngle = 60) {
     return this._CalculateNormals(normalIdx, minSharpAngle);
+  };
+
+  Module.Manifold.prototype.smoothByNormals = function(normalIdx = 0) {
+    return this._SmoothByNormals(normalIdx);
   };
 
   Module.Manifold.prototype.setProperties = function(numProp, func) {

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -451,6 +451,16 @@ Module.setup = function() {
       mat4[15] = 1;
       return mat4;
     }
+
+    backside(run) {
+      return this.runFlags != null && run < this.runFlags.length &&
+          (this.runFlags[run] & 1) !== 0;
+    }
+
+    hasNormals(run) {
+      return this.runFlags != null && run < this.runFlags.length &&
+          (this.runFlags[run] & 2) !== 0;
+    }
   }
 
   Module.Mesh = Mesh;

--- a/bindings/wasm/helpers.cpp
+++ b/bindings/wasm/helpers.cpp
@@ -48,6 +48,7 @@ val MeshGL2JS(const MeshGL& mesh) {
              val(typed_memory_view(mesh.runFlags.size(), mesh.runFlags.data()))
                  .call<val>("slice"));
   meshJS.set("tolerance", mesh.tolerance);
+  meshJS.set("hasNormals", mesh.hasNormals);
 
   return meshJS;
 }
@@ -89,6 +90,9 @@ MeshGL MeshJS2GL(const val& mesh) {
   }
   if (mesh["tolerance"] != val::undefined()) {
     out.tolerance = mesh["tolerance"].as<float>();
+  }
+  if (mesh["hasNormals"] != val::undefined()) {
+    out.hasNormals = mesh["hasNormals"].as<bool>();
   }
   return out;
 }

--- a/bindings/wasm/helpers.cpp
+++ b/bindings/wasm/helpers.cpp
@@ -48,7 +48,6 @@ val MeshGL2JS(const MeshGL& mesh) {
              val(typed_memory_view(mesh.runFlags.size(), mesh.runFlags.data()))
                  .call<val>("slice"));
   meshJS.set("tolerance", mesh.tolerance);
-  meshJS.set("hasNormals", mesh.hasNormals);
 
   return meshJS;
 }
@@ -90,9 +89,6 @@ MeshGL MeshJS2GL(const val& mesh) {
   }
   if (mesh["tolerance"] != val::undefined()) {
     out.tolerance = mesh["tolerance"].as<float>();
-  }
-  if (mesh["hasNormals"] != val::undefined()) {
-    out.hasNormals = mesh["hasNormals"].as<bool>();
   }
   return out;
 }

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -739,10 +739,12 @@ export class Manifold {
    *
    * @param normalIdx The first property channel of the normals. NumProp must be
    * at least normalIdx + 3. Any vertex where multiple normals exist and don't
-   * agree will result in a sharp edge.
+   * agree will result in a sharp edge. Default is 0, the standard slot.
+   * Non-zero values are retained for compatibility and will not be supported
+   * in a future release.
    * @group Smoothing
    */
-  smoothByNormals(normalIdx: number): Manifold;
+  smoothByNormals(normalIdx?: number): Manifold;
 
   /**
    * Smooths out the Manifold by filling in the halfedgeTangent vectors. The
@@ -846,10 +848,13 @@ export class Manifold {
    * Fills in vertex properties for normal vectors, calculated from the mesh
    * geometry. Flat faces composed of three or more triangles will remain flat.
    *
-   * @param normalIdx The property channel in which to store the X
-   * values of the normals. The X, Y, and Z channels will be sequential. The
-   * property set will be automatically expanded to include up through normalIdx
-   * + 2.
+   * @param normalIdx The property channel in which to store the X values of the
+   * normals. The X, Y, and Z channels will be sequential. The property set will
+   * be automatically expanded to include up through normalIdx + 2. Default is
+   * 0, the standard slot; in that case the Manifold's hasNormals flag is set,
+   * so a subsequent getMesh() without an explicit normalIdx returns solid-frame
+   * normals. Non-zero values are retained for compatibility and will not be
+   * supported in a future release.
    *
    * @param minSharpAngle Any edges with angles greater than this value will
    * remain sharp, getting different normal vector properties on each side of
@@ -859,7 +864,7 @@ export class Manifold {
    * all.
    * @group Properties
    */
-  calculateNormals(normalIdx: number, minSharpAngle?: number): Manifold;
+  calculateNormals(normalIdx?: number, minSharpAngle?: number): Manifold;
 
   // Boolean Operations
 
@@ -1262,6 +1267,13 @@ export interface MeshOptions {
   faceID?: Uint32Array;
   halfedgeTangent?: Float32Array;
   tolerance?: number;
+  /**
+   * True if the first three extra-property channels (slots 3, 4, 5) hold
+   * vertex normals. Set on output by getMesh() when normals were recorded on
+   * the Manifold (via calculateNormals); read on input by ofMesh() so the
+   * recording survives a round-trip.
+   */
+  hasNormals?: boolean;
 }
 
 /**
@@ -1360,6 +1372,14 @@ export class Mesh {
    * Tolerance may be enlarged when floating point error accumulates.
    */
   tolerance: number;
+
+  /**
+   * True if the first three extra-property channels (slots 3, 4, 5) hold
+   * vertex normals. Set on output by getMesh() when normals were recorded on
+   * the Manifold (via calculateNormals); read on input by ofMesh() so the
+   * recording survives a round-trip.
+   */
+  hasNormals: boolean;
 
   /**
    * Number of triangles

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -1459,6 +1459,13 @@ export class Mesh {
    * round-tripped via `runFlags` bit 1). Consumers should treat the slot
    * as normals and skip re-applying `runTransform` to it.
    *
+   * hasNormals is per-run, so different runs may set it differently.
+   * Behavior is undefined when a single propVert is shared by triangles
+   * from runs that disagree - the slot has one interpretation, and a
+   * transform rotates it for hasNormals=true and clobbers any
+   * hasNormals=false sharer. Standard `calculateNormals` / boolean /
+   * compose outputs never produce that shape.
+   *
    * @param run triangle run index.
    */
   hasNormals(run: number): boolean;

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -851,8 +851,8 @@ export class Manifold {
    * @param normalIdx The property channel in which to store the X values of the
    * normals. The X, Y, and Z channels will be sequential. The property set will
    * be automatically expanded to include up through normalIdx + 2. Default is
-   * 0, the standard slot; in that case the Manifold's hasNormals flag is set,
-   * so a subsequent getMesh() without an explicit normalIdx returns solid-frame
+   * 0, the standard slot; in that case the Manifold records the recording so
+   * a subsequent getMesh() without an explicit normalIdx returns solid-frame
    * normals. Non-zero values are retained for compatibility and will not be
    * supported in a future release.
    *
@@ -1267,13 +1267,6 @@ export interface MeshOptions {
   faceID?: Uint32Array;
   halfedgeTangent?: Float32Array;
   tolerance?: number;
-  /**
-   * True if the first three extra-property channels (slots 3, 4, 5) hold
-   * vertex normals. Set on output by getMesh() when normals were recorded on
-   * the Manifold (via calculateNormals); read on input by ofMesh() so the
-   * recording survives a round-trip.
-   */
-  hasNormals?: boolean;
 }
 
 /**
@@ -1372,14 +1365,6 @@ export class Mesh {
    * Tolerance may be enlarged when floating point error accumulates.
    */
   tolerance: number;
-
-  /**
-   * True if the first three extra-property channels (slots 3, 4, 5) hold
-   * vertex normals. Set on output by getMesh() when normals were recorded on
-   * the Manifold (via calculateNormals); read on input by ofMesh() so the
-   * recording survives a round-trip.
-   */
-  hasNormals: boolean;
 
   /**
    * Number of triangles

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -1459,11 +1459,6 @@ export class Mesh {
    * round-tripped via `runFlags` bit 1). Consumers should treat the slot
    * as normals and skip re-applying `runTransform` to it.
    *
-   * Mixed hasNormals across runs is supported: when ingesting a hand-built
-   * Mesh with shared propVerts spanning differing-flag runs, the
-   * `Manifold(Mesh)` ctor duplicates them so each camp's slot 0..2
-   * transforms independently.
-   *
    * @param run triangle run index.
    */
   hasNormals(run: number): boolean;

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -1342,6 +1342,14 @@ export class Mesh {
   runTransform: Float32Array;
 
   /**
+   * Optional: For each run, a bitmask of flags. Bit 0 = backside (this run
+   * is on the backside of its original mesh, e.g. from a subtraction).
+   * Bit 1 = hasNormals (the first three extra-property channels of this run
+   * hold world-frame vertex normals). See `backside(run)` / `hasNormals(run)`.
+   */
+  runFlags: Uint8Array;
+
+  /**
    * Optional: Length NumTri, contains the source face ID this triangle comes
    * from. Simplification will maintain all edges between triangles with
    * different faceIDs. Input faceIDs will be maintained to the outputs, but if
@@ -1434,4 +1442,24 @@ export class Mesh {
    * @param run triangle run index.
    */
   transform(run: number): Mat4;
+
+  /**
+   * Returns true if this triangle run is on the backside compared to the
+   * original mesh, e.g. from a subtraction. Informational only - the
+   * framework already orients stored normals so the standard `getMesh()`
+   * flow returns world-frame values regardless of this bit.
+   *
+   * @param run triangle run index.
+   */
+  backside(run: number): boolean;
+
+  /**
+   * Returns true if the first three extra-property channels of this run
+   * carry world-frame vertex normals (set by `calculateNormals(0)` and
+   * round-tripped via `runFlags` bit 1). Consumers should treat the slot
+   * as normals and skip re-applying `runTransform` to it.
+   *
+   * @param run triangle run index.
+   */
+  hasNormals(run: number): boolean;
 }

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -1459,6 +1459,11 @@ export class Mesh {
    * round-tripped via `runFlags` bit 1). Consumers should treat the slot
    * as normals and skip re-applying `runTransform` to it.
    *
+   * Mixed hasNormals across runs is supported: when ingesting a hand-built
+   * Mesh with shared propVerts spanning differing-flag runs, the
+   * `Manifold(Mesh)` ctor duplicates them so each camp's slot 0..2
+   * transforms independently.
+   *
    * @param run triangle run index.
    */
   hasNormals(run: number): boolean;

--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -245,7 +245,7 @@ class Manifold {
       int numProp,
       std::function<void(double*, vec3, const double*)> propFunc) const;
   Manifold CalculateCurvature(int gaussianIdx, int meanIdx) const;
-  Manifold CalculateNormals(int normalIdx, double minSharpAngle = 60) const;
+  Manifold CalculateNormals(int normalIdx = 0, double minSharpAngle = 60) const;
   ///@}
 
   /** @name Smoothing
@@ -256,7 +256,7 @@ class Manifold {
   Manifold Refine(int) const;
   Manifold RefineToLength(double) const;
   Manifold RefineToTolerance(double) const;
-  Manifold SmoothByNormals(int normalIdx) const;
+  Manifold SmoothByNormals(int normalIdx = 0) const;
   Manifold SmoothOut(double minSharpAngle = 60, double minSmoothness = 0) const;
   static Manifold Smooth(const MeshGL&,
                          const std::vector<Smoothness>& sharpenedEdges = {});

--- a/include/manifold/mesh.h
+++ b/include/manifold/mesh.h
@@ -154,6 +154,11 @@ struct MeshGLP {
   /// the bounding box. Any edge shorter than tolerance may be collapsed.
   /// Tolerance may be enlarged when floating point error accumulates.
   Precision tolerance = 0;
+  /// True if the first three extra-property channels (slots 3, 4, 5) hold
+  /// vertex normals. Set on output by GetMeshGL/GetMeshGL64 when normals were
+  /// recorded on the Manifold (via CalculateNormals); read on input by the
+  /// MeshGL Manifold constructor so the recording survives a round-trip.
+  bool hasNormals = false;
 
   MeshGLP() = default;
 
@@ -164,9 +169,12 @@ struct MeshGLP {
    *
    * @param normalIdx Specifies the first of the three consecutive property
    * channels forming the (x, y, z) normals to update. NumProp must be at least
-   * normalIdx + 3 and normalIdx must be >= 3.
+   * normalIdx + 3. Default is -1, meaning "use the standard slot (3, 4, 5) if
+   * `hasNormals` is set; otherwise no-op." Pass a value >= 3 explicitly to
+   * update normals at a non-standard channel; that path is retained for
+   * compatibility and will not be supported in a future release.
    */
-  void UpdateNormals(int normalIdx);
+  void UpdateNormals(int normalIdx = -1);
 
   /**
    * Updates the mergeFromVert and mergeToVert vectors in order to create a

--- a/include/manifold/mesh.h
+++ b/include/manifold/mesh.h
@@ -154,27 +154,8 @@ struct MeshGLP {
   /// the bounding box. Any edge shorter than tolerance may be collapsed.
   /// Tolerance may be enlarged when floating point error accumulates.
   Precision tolerance = 0;
-  /// True if the first three extra-property channels (slots 3, 4, 5) hold
-  /// vertex normals. Set on output by GetMeshGL/GetMeshGL64 when normals were
-  /// recorded on the Manifold (via CalculateNormals); read on input by the
-  /// MeshGL Manifold constructor so the recording survives a round-trip.
-  bool hasNormals = false;
 
   MeshGLP() = default;
-
-  /**
-   * Updates the normals of the mesh based on the runTransform matrices and
-   * backside flags, which are then cleared to avoid double-applying them when
-   * round-tripping.
-   *
-   * @param normalIdx Specifies the first of the three consecutive property
-   * channels forming the (x, y, z) normals to update. NumProp must be at least
-   * normalIdx + 3. Default is -1, meaning "use the standard slot (3, 4, 5) if
-   * `hasNormals` is set; otherwise no-op." Pass a value >= 3 explicitly to
-   * update normals at a non-standard channel; that path is retained for
-   * compatibility and will not be supported in a future release.
-   */
-  void UpdateNormals(int normalIdx = -1);
 
   /**
    * Updates the mergeFromVert and mergeToVert vectors in order to create a
@@ -243,13 +224,34 @@ struct MeshGLP {
 
   /**
    * Returns true if this triangle run is on the backside compared to the
-   * original mesh, e.g. from a subtraction. In this case vertex normals will
-   * need to be flipped. UpdateNormals() will take care of this.
+   * original mesh, e.g. from a subtraction. In this case vertex normals stored
+   * for the run point opposite to the result surface and consumers reading
+   * them via `runTransform` should multiply by -1.
    *
    * @param run The index of the triangle run (0 <= run < runFlags.size()).
    */
   bool Backside(size_t run) const {
-    return run < runFlags.size() && runFlags[run] == 1;
+    return run < runFlags.size() && (runFlags[run] & 1) != 0;
+  }
+
+  /**
+   * Returns true if the first three extra-property channels (slots 3, 4, 5)
+   * of this run carry world-frame vertex normals (set by
+   * `Manifold::CalculateNormals(0)` and round-tripped via `runFlags` bit 1).
+   * Consumers should treat the slot as normals and skip re-applying
+   * `runTransform` to it.
+   *
+   * For hand-built MeshGL inputs: if multiple runs share propVerts (same
+   * vertex index used by triangles from different runs), all sharing runs
+   * must agree on what slot 3..5 represents. Mixing hasNormals=true and
+   * hasNormals=false across shared propVerts is undefined - the stored
+   * value can only have one interpretation. Outputs from CalculateNormals
+   * / Boolean / Compose never share propVerts across differing-flag runs.
+   *
+   * @param run The index of the triangle run (0 <= run < runFlags.size()).
+   */
+  bool HasNormals(size_t run) const {
+    return run < runFlags.size() && (runFlags[run] & 2) != 0;
   }
 };
 

--- a/include/manifold/mesh.h
+++ b/include/manifold/mesh.h
@@ -241,6 +241,13 @@ struct MeshGLP {
    * Consumers should treat the slot as normals and skip re-applying
    * `runTransform` to it.
    *
+   * hasNormals is per-run, so different runs may set it differently.
+   * Behavior is undefined when a single propVert is shared by triangles
+   * from runs that disagree - the slot has one interpretation, and a
+   * Transform rotates it for hasNormals=true and clobbers any
+   * hasNormals=false sharer. Standard `CalculateNormals` / Boolean /
+   * Compose outputs never produce that shape.
+   *
    * @param run The index of the triangle run (0 <= run < runFlags.size()).
    */
   bool HasNormals(size_t run) const {

--- a/include/manifold/mesh.h
+++ b/include/manifold/mesh.h
@@ -241,6 +241,12 @@ struct MeshGLP {
    * Consumers should treat the slot as normals and skip re-applying
    * `runTransform` to it.
    *
+   * Mixed hasNormals values across runs are supported. If a propVert is
+   * shared between a hasNormals=true run and a hasNormals=false run (e.g. a
+   * hand-built MeshGL stitches a normals-bearing run to a color-only run at
+   * common vertices), the `Manifold(MeshGL)` ctor duplicates the propVert
+   * so each camp's slot 0..2 transforms independently.
+   *
    * @param run The index of the triangle run (0 <= run < runFlags.size()).
    */
   bool HasNormals(size_t run) const {

--- a/include/manifold/mesh.h
+++ b/include/manifold/mesh.h
@@ -241,12 +241,6 @@ struct MeshGLP {
    * Consumers should treat the slot as normals and skip re-applying
    * `runTransform` to it.
    *
-   * Mixed hasNormals values across runs are supported. If a propVert is
-   * shared between a hasNormals=true run and a hasNormals=false run (e.g. a
-   * hand-built MeshGL stitches a normals-bearing run to a color-only run at
-   * common vertices), the `Manifold(MeshGL)` ctor duplicates the propVert
-   * so each camp's slot 0..2 transforms independently.
-   *
    * @param run The index of the triangle run (0 <= run < runFlags.size()).
    */
   bool HasNormals(size_t run) const {

--- a/include/manifold/mesh.h
+++ b/include/manifold/mesh.h
@@ -224,9 +224,9 @@ struct MeshGLP {
 
   /**
    * Returns true if this triangle run is on the backside compared to the
-   * original mesh, e.g. from a subtraction. In this case vertex normals stored
-   * for the run point opposite to the result surface and consumers reading
-   * them via `runTransform` should multiply by -1.
+   * original mesh, e.g. from a subtraction. Informational only - the framework
+   * already orients stored normals so the standard `getMesh()` flow returns
+   * world-frame values regardless of this bit.
    *
    * @param run The index of the triangle run (0 <= run < runFlags.size()).
    */
@@ -240,13 +240,6 @@ struct MeshGLP {
    * `Manifold::CalculateNormals(0)` and round-tripped via `runFlags` bit 1).
    * Consumers should treat the slot as normals and skip re-applying
    * `runTransform` to it.
-   *
-   * For hand-built MeshGL inputs: if multiple runs share propVerts (same
-   * vertex index used by triangles from different runs), all sharing runs
-   * must agree on what slot 3..5 represents. Mixing hasNormals=true and
-   * hasNormals=false across shared propVerts is undefined - the stored
-   * value can only have one interpretation. Outputs from CalculateNormals
-   * / Boolean / Compose never share propVerts across differing-flag runs.
    *
    * @param run The index of the triangle run (0 <= run < runFlags.size()).
    */

--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -569,7 +569,8 @@ struct Barycentric {
 };
 
 void CreateProperties(Manifold::Impl& outR, const Manifold::Impl& inP,
-                      const Manifold::Impl& inQ, ExecutionContext::Impl* ctx) {
+                      const Manifold::Impl& inQ, bool invertQ,
+                      ExecutionContext::Impl* ctx) {
   ZoneScoped;
   // Invariant: every ctx-passing parallel op is followed by IsCancelled to
   // keep partial output from feeding unconditional downstream consumers.
@@ -607,6 +608,15 @@ void CreateProperties(Manifold::Impl& outR, const Manifold::Impl& inP,
     const int oldNumProp = PQ ? numPropP : numPropQ;
     const auto& properties = PQ ? inP.properties_ : inQ.properties_;
     const auto& halfedge = PQ ? inP.halfedge_ : inQ.halfedge_;
+
+    // For Subtract, Q's triangles are flipped in the result, so Q's
+    // world-frame vertex normals (slot 0..2 when hasNormals) need a sign
+    // flip to point outward from the result's solid (into the cavity).
+    // Check is per-source-triangle, not whole input - inQ may be a mixed
+    // Boolean result.
+    const bool negateNormals =
+        !PQ && invertQ && oldNumProp >= 3 &&
+        Manifold::Impl::TriHasNormals(inQ.meshRelation_, ref.faceID);
 
     for (const int i : {0, 1, 2}) {
       const int vert = outR.halfedge_.Start(3 * tri + i);
@@ -665,7 +675,9 @@ void CreateProperties(Manifold::Impl& outR, const Manifold::Impl& inP,
           for (const int j : {0, 1, 2})
             oldProps[j] =
                 properties[oldNumProp * halfedge.Prop(3 * ref.faceID + j) + p];
-          outR.properties_.push_back(la::dot(uvw, oldProps));
+          double val = la::dot(uvw, oldProps);
+          if (negateNormals && p < 3) val = -val;
+          outR.properties_.push_back(val);
         } else {
           outR.properties_.push_back(0);
         }
@@ -936,7 +948,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
     DEBUG_ASSERT(outR.IsManifold(), logicErr,
                  "triangulated mesh is not manifold!");
 
-  CreateProperties(outR, inP_, inQ_, ctx_);
+  CreateProperties(outR, inP_, inQ_, invertQ, ctx_);
   if (auto c = phase()) return *c;
 
   UpdateReference(outR, inP_, inQ_, invertQ, ctx_);

--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -314,6 +314,18 @@ std::shared_ptr<CsgLeafNode> CsgLeafNode::Compose(
                 newProp.end(), numPropOut);
             copy(oldRange.begin(), oldRange.end(), newRange.begin());
           }
+          // Properties copy above doesn't go through the on-the-fly transform
+          // applied to vertPos_/faceNormal_ below; eager-transform slot 0..2
+          // per-meshID so world-frame normals stay in sync. Covers mixed
+          // input nodes (some meshIDs with hasNormals, some without).
+          if (numProp >= 3 && node->transform_ != mat3x4(la::identity)) {
+            const mat3 normalTransform =
+                la::inverse(la::transpose(mat3(node->transform_)));
+            Manifold::Impl::EagerTransformPropNormals(
+                node->pImpl_->halfedge_, node->pImpl_->meshRelation_,
+                normalTransform, newProp, oldProp.size() / numProp, numPropOut,
+                propVertIndices[i]);
+          }
         }
 
         if (node->transform_ == mat3x4(la::identity)) {

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -167,6 +167,36 @@ void Manifold::Impl::RemoveUnreferencedVerts() {
   });
 }
 
+void Manifold::Impl::EagerTransformPropNormals(
+    const Halfedges& halfedge, const MeshRelationD& meshRelation,
+    const mat3& normalTransform, Vec<double>& properties, int numPropVert,
+    int stride, int offset) {
+  // Short-circuit when no meshID carries normals. Note this is OR semantics
+  // (any has it), not AND like Impl::HasNormals() - mixed inputs still need
+  // the per-meshID iteration below to rotate the with-normals subset.
+  bool anyHasNormals = false;
+  for (const auto& m : meshRelation.meshIDtransform) {
+    if (m.second.hasNormals) {
+      anyHasNormals = true;
+      break;
+    }
+  }
+  if (!anyHasNormals) return;
+  Vec<bool> propVisited(numPropVert, false);
+  for (size_t e = 0; e < halfedge.size(); ++e) {
+    if (!TriHasNormals(meshRelation, e / 3)) continue;
+    const int prop = halfedge.Prop(e);
+    if (prop < 0 || propVisited[prop]) continue;
+    propVisited[prop] = true;
+    vec3 n;
+    for (const int i : {0, 1, 2})
+      n[i] = properties[(offset + prop) * stride + i];
+    n = normalTransform * n;
+    for (const int i : {0, 1, 2})
+      properties[(offset + prop) * stride + i] = n[i];
+  }
+}
+
 void Manifold::Impl::InitializeOriginal() {
   const int meshID = ReserveIDs(1);
   meshRelation_.originalID = meshID;
@@ -176,8 +206,13 @@ void Manifold::Impl::InitializeOriginal() {
              [meshID, &triRef](const int tri) {
                triRef[tri] = {meshID, meshID, -1, triRef[tri].coplanarID};
              });
+  // Preserve the AND-across-old-Relations state so AsOriginal keeps the
+  // recording when it builds a fresh Relation. Primitives start with an
+  // empty map, which HasNormals() returns false for.
+  const bool wasHasNormals = HasNormals();
   meshRelation_.meshIDtransform.clear();
-  meshRelation_.meshIDtransform[meshID] = {meshID};
+  meshRelation_.meshIDtransform[meshID] = {meshID, la::identity, false,
+                                           wasHasNormals};
 }
 
 void Manifold::Impl::SetNormalsAndCoplanar() {
@@ -584,7 +619,6 @@ Manifold::Impl Manifold::Impl::Transform(const mat3x4& transform_) const {
   result.epsilon_ = epsilon_;
   result.tolerance_ = tolerance_;
   result.numProp_ = numProp_;
-  result.hasNormals_ = hasNormals_;
   result.properties_ = properties_;
   result.bBox_ = bBox_;
   result.halfedge_ = halfedge_;
@@ -606,6 +640,14 @@ Manifold::Impl Manifold::Impl::Transform(const mat3x4& transform_) const {
             TransformNormals({normalTransform}));
   transform(vertNormal_.begin(), vertNormal_.end(), result.vertNormal_.begin(),
             TransformNormals({normalTransform}));
+
+  // Eager-transform property normals per-meshID. Mixed Boolean/Compose
+  // outputs leave HasNormals() false overall but still have hasNormals=true
+  // meshIDs whose stored world-frame values would otherwise go stale.
+  if (numProp_ >= 3) {
+    EagerTransformPropNormals(halfedge_, meshRelation_, normalTransform,
+                              result.properties_, NumPropVert(), numProp_);
+  }
 
   const bool invert = la::determinant(mat3(transform_)) < 0;
 

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -171,9 +171,9 @@ void Manifold::Impl::EagerTransformPropNormals(
     const Halfedges& halfedge, const MeshRelationD& meshRelation,
     const mat3& normalTransform, Vec<double>& properties, int numPropVert,
     int stride, int offset) {
-  // Short-circuit when no meshID carries normals. Note this is OR semantics
-  // (any has it), not AND like Impl::HasNormals() - mixed inputs still need
-  // the per-meshID iteration below to rotate the with-normals subset.
+  // Short-circuit when no meshID carries normals. OR semantics (any has
+  // it), unlike AllHaveNormals() - mixed inputs still need the per-meshID
+  // iteration below to rotate the with-normals subset.
   bool anyHasNormals = false;
   for (const auto& m : meshRelation.meshIDtransform) {
     if (m.second.hasNormals) {
@@ -191,7 +191,10 @@ void Manifold::Impl::EagerTransformPropNormals(
     vec3 n;
     for (const int i : {0, 1, 2})
       n[i] = properties[(offset + prop) * stride + i];
-    n = normalTransform * n;
+    // Re-normalize as we transform: non-orthogonal transforms (scale) and
+    // barycentric interpolation upstream both leave non-unit values that
+    // would otherwise compound and break downstream lighting / smoothing.
+    n = SafeNormalize(normalTransform * n);
     for (const int i : {0, 1, 2})
       properties[(offset + prop) * stride + i] = n[i];
   }
@@ -208,11 +211,11 @@ void Manifold::Impl::InitializeOriginal() {
              });
   // Preserve the AND-across-old-Relations state so AsOriginal keeps the
   // recording when it builds a fresh Relation. Primitives start with an
-  // empty map, which HasNormals() returns false for.
-  const bool wasHasNormals = HasNormals();
+  // empty map, which AllHaveNormals() returns false for.
+  const bool hadNormals = AllHaveNormals();
   meshRelation_.meshIDtransform.clear();
   meshRelation_.meshIDtransform[meshID] = {meshID, la::identity, false,
-                                           wasHasNormals};
+                                           hadNormals};
 }
 
 void Manifold::Impl::SetNormalsAndCoplanar() {
@@ -641,9 +644,6 @@ Manifold::Impl Manifold::Impl::Transform(const mat3x4& transform_) const {
   transform(vertNormal_.begin(), vertNormal_.end(), result.vertNormal_.begin(),
             TransformNormals({normalTransform}));
 
-  // Eager-transform property normals per-meshID. Mixed Boolean/Compose
-  // outputs leave HasNormals() false overall but still have hasNormals=true
-  // meshIDs whose stored world-frame values would otherwise go stale.
   if (numProp_ >= 3) {
     EagerTransformPropNormals(halfedge_, meshRelation_, normalTransform,
                               result.properties_, NumPropVert(), numProp_);

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -584,6 +584,7 @@ Manifold::Impl Manifold::Impl::Transform(const mat3x4& transform_) const {
   result.epsilon_ = epsilon_;
   result.tolerance_ = tolerance_;
   result.numProp_ = numProp_;
+  result.hasNormals_ = hasNormals_;
   result.properties_ = properties_;
   result.bBox_ = bBox_;
   result.halfedge_ = halfedge_;

--- a/src/impl.h
+++ b/src/impl.h
@@ -52,6 +52,10 @@ struct Manifold::Impl {
   double epsilon_ = -1;
   double tolerance_ = -1;
   int numProp_ = 0;
+  // True when normals live at the first three extra-property channels
+  // (MeshGL slots 3, 4, 5). Set by CalculateNormals at idx 0; survives
+  // transforms. Boolean output clears it.
+  bool hasNormals_ = false;
   Error status_ = Error::NoError;
   Vec<vec3> vertPos_;
   Halfedges halfedge_;
@@ -313,6 +317,10 @@ Manifold::Impl::Impl(const MeshGLP<Precision, I>& meshGL) {
 
   const auto numProp = meshGL.numProp - 3;
   numProp_ = numProp;
+  // Restore the recorded normals slot only if the input actually has room
+  // for it; defensive against callers who set the flag but didn't pack
+  // normals at slots 3-5.
+  hasNormals_ = meshGL.hasNormals && numProp >= 3;
   properties_.resize_nofill(meshGL.NumVert() * numProp);
   tolerance_ = meshGL.tolerance;
   // This will have unreferenced duplicate positions that will be removed by
@@ -450,6 +458,10 @@ inline MeshGLP<Precision, I> GetMeshGLImpl(const manifold::Manifold::Impl& impl,
 
   MeshGLP<Precision, I> out;
   out.numProp = 3 + numProp;
+  // Mirror the recorded slot to the output so an ofMesh+getMesh round-trip
+  // preserves the convention. Only meaningful when the standard slot is in use
+  // (which is also what GetMeshGL(-1) auto-substitutes for).
+  out.hasNormals = impl.hasNormals_ && normalIdx == 0;
   out.tolerance = impl.tolerance_;
   if (std::is_same<Precision, float>::value)
     out.tolerance =

--- a/src/impl.h
+++ b/src/impl.h
@@ -424,19 +424,67 @@ Manifold::Impl::Impl(const MeshGLP<Precision, I>& meshGL) {
   Vec<ivec3> triProp;
   triProp.reserve(numTri);
   Vec<ivec3> triVert;
-  const bool needsPropMap = numProp > 0 && !prop2vert.empty();
+  // When there are properties, triProp indexes propVert space and triVert
+  // indexes (possibly merged) position space; CreateHalfedges needs both.
+  // When numProp == 0 there is no distinct prop space and the legacy single-
+  // array form (triProp only) is preserved.
+  const bool needsPropMap = numProp > 0;
   if (needsPropMap) triVert.reserve(numTri);
   if (triRef.size() > 0) meshRelation_.triRef.reserve(numTri);
+
+  // Per-propVert claim tracking. When a single input vertProperty is
+  // referenced by triangles from runs with differing hasNormals flags, the
+  // eager-transform contract can't track both interpretations through a
+  // single storage slot. Duplicate the propVert at ctor time so each
+  // hasNormals camp gets its own slot 0..2 to mutate independently.
+  // Triangles from the first-seen camp keep the original index; triangles
+  // from the opposite camp point at the appended alt copy.
+  struct PropClaim {
+    bool primaryHasN = false;
+    int altCopy = -1;
+    bool initialized = false;
+  };
+  // Vec's size-only ctor leaves elements uninitialized; use value-init.
+  Vec<PropClaim> propClaim(needsPropMap ? numVert : 0, PropClaim{});
+
   for (size_t i = 0; i < numTri; ++i) {
     ivec3 triP, triV;
+    bool myHasN = false;
+    if (triRef.size() > 0) {
+      auto it = meshRelation_.meshIDtransform.find(triRef[i].meshID);
+      myHasN = it != meshRelation_.meshIDtransform.end() &&
+               it->second.hasNormals;
+    }
     for (const size_t j : {0, 1, 2}) {
       uint32_t vert = (uint32_t)meshGL.triVerts[3 * i + j];
       if (vert >= numVert) {
         MakeEmpty(Error::VertexOutOfBounds);
         return;
       }
-      triP[j] = vert;
-      triV[j] = prop2vert.empty() ? vert : prop2vert[vert];
+      int propIdx = static_cast<int>(vert);
+      if (needsPropMap) {
+        auto& claim = propClaim[vert];
+        if (!claim.initialized) {
+          claim.primaryHasN = myHasN;
+          claim.initialized = true;
+        } else if (claim.primaryHasN != myHasN) {
+          if (claim.altCopy < 0) {
+            // Snapshot source values first - push_back may reallocate
+            // properties_ and invalidate the indexed reference.
+            std::vector<double> snapshot(numProp);
+            for (size_t k = 0; k < numProp; ++k) {
+              snapshot[k] = properties_[vert * numProp + k];
+            }
+            claim.altCopy = static_cast<int>(properties_.size() / numProp);
+            for (size_t k = 0; k < numProp; ++k) {
+              properties_.push_back(snapshot[k]);
+            }
+          }
+          propIdx = claim.altCopy;
+        }
+      }
+      triP[j] = propIdx;
+      triV[j] = prop2vert.empty() ? static_cast<int>(vert) : prop2vert[vert];
     }
     if (triV[0] != triV[1] && triV[1] != triV[2] && triV[2] != triV[0]) {
       if (needsPropMap) {

--- a/src/impl.h
+++ b/src/impl.h
@@ -29,6 +29,10 @@ struct Manifold::Impl {
     int originalID = -1;
     mat3x4 transform = la::identity;
     bool backSide = false;
+    // True when this meshID's contribution to properties_ slots 0..2 holds
+    // world-frame vertex normals (set by CalculateNormals at slot 0). Carries
+    // through Transforms and Booleans. Exported as runFlags bit 1.
+    bool hasNormals = false;
 
     mat3 GetNormalTransform() const {
       return NormalTransform(transform) * (backSide ? -1.0 : 1.0);
@@ -52,11 +56,27 @@ struct Manifold::Impl {
   double epsilon_ = -1;
   double tolerance_ = -1;
   int numProp_ = 0;
-  // True when normals live at the first three extra-property channels
-  // (MeshGL slots 3, 4, 5). Set by CalculateNormals at idx 0; survives
-  // transforms. Boolean output clears it.
-  bool hasNormals_ = false;
   Error status_ = Error::NoError;
+
+  // True iff every meshID in meshRelation_.meshIDtransform has hasNormals
+  // set (i.e., slot 0..2 of properties_ holds world-frame normals across the
+  // whole impl). Set by CalculateNormals at idx 0; AND'd across inputs by
+  // Boolean and Compose; preserved by Transform/Refine.
+  bool HasNormals() const {
+    if (meshRelation_.meshIDtransform.empty()) return false;
+    for (const auto& m : meshRelation_.meshIDtransform) {
+      if (!m.second.hasNormals) return false;
+    }
+    return true;
+  }
+
+  // True iff the meshID owning `tri` has hasNormals set. Returns false when
+  // the meshID isn't in meshRelation_.meshIDtransform (treat as no-normals).
+  static bool TriHasNormals(const MeshRelationD& meshRelation, int tri) {
+    const int meshID = meshRelation.triRef[tri].meshID;
+    auto it = meshRelation.meshIDtransform.find(meshID);
+    return it != meshRelation.meshIDtransform.end() && it->second.hasNormals;
+  }
   Vec<vec3> vertPos_;
   Halfedges halfedge_;
   Vec<double> properties_;
@@ -92,6 +112,19 @@ struct Manifold::Impl {
                        const Vec<ivec3>& triVert = {});
   void CalculateVertNormals();
   void IncrementMeshIDs();
+
+  // Eager-transform slot 0..2 of properties_ for propVerts whose meshID
+  // carries hasNormals. Used by both Impl::Transform and Compose. The buffer
+  // is laid out as `properties[(offset + propVert) * stride + i]` so the
+  // helper can target either an in-place properties_ vector (offset=0) or
+  // a per-node slice of a combined properties array (offset=propVertIndices,
+  // stride=numPropOut).
+  static void EagerTransformPropNormals(const Halfedges& halfedge,
+                                        const MeshRelationD& meshRelation,
+                                        const mat3& normalTransform,
+                                        Vec<double>& properties,
+                                        int numPropVert, int stride,
+                                        int offset = 0);
 
   void MakeEmpty(Error status);
   void Warp(std::function<void(vec3&)> warpFunc);
@@ -317,10 +350,6 @@ Manifold::Impl::Impl(const MeshGLP<Precision, I>& meshGL) {
 
   const auto numProp = meshGL.numProp - 3;
   numProp_ = numProp;
-  // Restore the recorded normals slot only if the input actually has room
-  // for it; defensive against callers who set the flag but didn't pack
-  // normals at slots 3-5.
-  hasNormals_ = meshGL.hasNormals && numProp >= 3;
   properties_.resize_nofill(meshGL.NumVert() * numProp);
   tolerance_ = meshGL.tolerance;
   // This will have unreferenced duplicate positions that will be removed by
@@ -364,6 +393,10 @@ Manifold::Impl::Impl(const MeshGLP<Precision, I>& meshGL) {
     const int meshID = startID + i;
     const int originalID = runOriginalID[i];
     const bool backside = meshGL.Backside(i);
+    // Per-run hasNormals (runFlags bit 1). Defensively require numProp >= 3
+    // so a caller setting the bit on a too-small MeshGL doesn't make us read
+    // past the property bounds.
+    const bool runHasN = meshGL.HasNormals(i) && numProp >= 3;
     for (size_t tri = runIndex[i] / 3; tri < runIndex[i + 1] / 3; ++tri) {
       TriRef& ref = triRef[tri];
       ref.meshID = meshID;
@@ -373,7 +406,8 @@ Manifold::Impl::Impl(const MeshGLP<Precision, I>& meshGL) {
     }
 
     if (meshGL.runTransform.empty()) {
-      meshRelation_.meshIDtransform[meshID] = {originalID};
+      meshRelation_.meshIDtransform[meshID] = {originalID, la::identity, false,
+                                               runHasN};
     } else {
       const Precision* m = meshGL.runTransform.data() + 12 * i;
       meshRelation_.meshIDtransform[meshID] = {originalID,
@@ -381,7 +415,8 @@ Manifold::Impl::Impl(const MeshGLP<Precision, I>& meshGL) {
                                                 {m[3], m[4], m[5]},
                                                 {m[6], m[7], m[8]},
                                                 {m[9], m[10], m[11]}},
-                                               backside};
+                                               backside,
+                                               runHasN};
     }
   }
 
@@ -458,10 +493,6 @@ inline MeshGLP<Precision, I> GetMeshGLImpl(const manifold::Manifold::Impl& impl,
 
   MeshGLP<Precision, I> out;
   out.numProp = 3 + numProp;
-  // Mirror the recorded slot to the output so an ofMesh+getMesh round-trip
-  // preserves the convention. Only meaningful when the standard slot is in use
-  // (which is also what GetMeshGL(-1) auto-substitutes for).
-  out.hasNormals = impl.hasNormals_ && normalIdx == 0;
   out.tolerance = impl.tolerance_;
   if (std::is_same<Precision, float>::value)
     out.tolerance =
@@ -494,19 +525,19 @@ inline MeshGLP<Precision, I> GetMeshGLImpl(const manifold::Manifold::Impl& impl,
                      });
   }
 
-  std::vector<mat3> runNormalTransform;
-  auto addRun = [updateNormals, isOriginal](
-                    MeshGLP<Precision, I>& out,
-                    std::vector<mat3>& runNormalTransform, int tri,
-                    const manifold::Manifold::Impl::Relation& rel) {
+  // runFlags layout: bit 0 = backSide, bit 1 = hasNormals (slot 0..2 of the
+  // extra properties is world-frame vertex normals; consumers should skip
+  // re-applying runTransform to those channels).
+  auto addRun = [isOriginal](MeshGLP<Precision, I>& out, int tri,
+                             const manifold::Manifold::Impl::Relation& rel) {
     out.runIndex.push_back(3 * tri);
     out.runOriginalID.push_back(rel.originalID);
-    if (updateNormals) {
-      runNormalTransform.push_back(rel.GetNormalTransform());
-    }
-    // clear transforms if applying them to normals
-    if (!isOriginal && !updateNormals) {
-      out.runFlags.push_back(rel.backSide ? 1 : 0);
+    // runFlags carries hasNormals (bit 1) which we want on originals too;
+    // runTransform is just metadata so skip it for originals where it would
+    // always be identity.
+    const uint8_t flags = (rel.backSide ? 1u : 0u) | (rel.hasNormals ? 2u : 0u);
+    out.runFlags.push_back(flags);
+    if (!isOriginal) {
       for (const int col : {0, 1, 2, 3}) {
         for (const int row : {0, 1, 2}) {
           out.runTransform.push_back(rel.transform[col][row]);
@@ -530,14 +561,14 @@ inline MeshGLP<Precision, I> GetMeshGLImpl(const manifold::Manifold::Impl& impl,
       manifold::Manifold::Impl::Relation rel;
       auto it = meshIDtransform.find(meshID);
       if (it != meshIDtransform.end()) rel = it->second;
-      addRun(out, runNormalTransform, tri, rel);
+      addRun(out, tri, rel);
       meshIDtransform.erase(meshID);
       lastID = meshID;
     }
   }
   // Add runs for originals that did not contribute any faces to the output
   for (const auto& pair : meshIDtransform) {
-    addRun(out, runNormalTransform, numTri, pair.second);
+    addRun(out, numTri, pair.second);
   }
   out.runIndex.push_back(3 * numTri);
 
@@ -585,13 +616,25 @@ inline MeshGLP<Precision, I> GetMeshGLImpl(const manifold::Manifold::Impl& impl,
           out.vertProperties.push_back(impl.properties_[prop * numProp + p]);
         }
 
+        // Normalize the requested normal slot. For runs that already carry
+        // world-frame normals (hasNormals bit), just normalize; for legacy
+        // callers asking to interpret a slot as normals on a run without
+        // hasNormals, apply the per-run inverse-frame transform first.
         if (updateNormals) {
           vec3 normal;
           const int start = out.vertProperties.size() - out.numProp;
           for (int i : {0, 1, 2}) {
             normal[i] = out.vertProperties[start + 3 + normalIdx + i];
           }
-          normal = SafeNormalize(runNormalTransform[run] * normal);
+          const bool runHasN = !isOriginal && (out.runFlags[run] & 2) != 0;
+          if (!isOriginal && !runHasN) {
+            const Precision* m = out.runTransform.data() + 12 * run;
+            const mat3x4 t({m[0], m[1], m[2]}, {m[3], m[4], m[5]},
+                           {m[6], m[7], m[8]}, {m[9], m[10], m[11]});
+            normal = NormalTransform(t) *
+                     ((out.runFlags[run] & 1) ? -1.0 : 1.0) * normal;
+          }
+          normal = SafeNormalize(normal);
           for (int i : {0, 1, 2}) {
             out.vertProperties[start + 3 + normalIdx + i] = normal[i];
           }

--- a/src/impl.h
+++ b/src/impl.h
@@ -452,8 +452,8 @@ Manifold::Impl::Impl(const MeshGLP<Precision, I>& meshGL) {
     bool myHasN = false;
     if (triRef.size() > 0) {
       auto it = meshRelation_.meshIDtransform.find(triRef[i].meshID);
-      myHasN = it != meshRelation_.meshIDtransform.end() &&
-               it->second.hasNormals;
+      myHasN =
+          it != meshRelation_.meshIDtransform.end() && it->second.hasNormals;
     }
     for (const size_t j : {0, 1, 2}) {
       uint32_t vert = (uint32_t)meshGL.triVerts[3 * i + j];

--- a/src/impl.h
+++ b/src/impl.h
@@ -58,11 +58,12 @@ struct Manifold::Impl {
   int numProp_ = 0;
   Error status_ = Error::NoError;
 
-  // True iff every meshID in meshRelation_.meshIDtransform has hasNormals
-  // set (i.e., slot 0..2 of properties_ holds world-frame normals across the
-  // whole impl). Set by CalculateNormals at idx 0; AND'd across inputs by
-  // Boolean and Compose; preserved by Transform/Refine.
-  bool HasNormals() const {
+  // True only when every meshID carries normals at slot 0..2 - the
+  // condition under which GetMeshGL(-1) can safely auto-substitute that
+  // slot. A mixed Boolean output (some meshIDs with normals, some
+  // without) returns false; the output MeshGL's per-run bit 1 still
+  // marks the with-normals runs individually.
+  bool AllHaveNormals() const {
     if (meshRelation_.meshIDtransform.empty()) return false;
     for (const auto& m : meshRelation_.meshIDtransform) {
       if (!m.second.hasNormals) return false;
@@ -620,6 +621,9 @@ inline MeshGLP<Precision, I> GetMeshGLImpl(const manifold::Manifold::Impl& impl,
         // world-frame normals (hasNormals bit), just normalize; for legacy
         // callers asking to interpret a slot as normals on a run without
         // hasNormals, apply the per-run inverse-frame transform first.
+        // TODO: collapse the !runHasN branch into a no-op once the explicit-
+        // normalIdx parameter on GetMeshGL is removed and `updateNormals`
+        // becomes implied by the hasNormals bit.
         if (updateNormals) {
           vec3 normal;
           const int start = out.vertProperties.size() - out.numProp;

--- a/src/impl.h
+++ b/src/impl.h
@@ -424,67 +424,19 @@ Manifold::Impl::Impl(const MeshGLP<Precision, I>& meshGL) {
   Vec<ivec3> triProp;
   triProp.reserve(numTri);
   Vec<ivec3> triVert;
-  // When there are properties, triProp indexes propVert space and triVert
-  // indexes (possibly merged) position space; CreateHalfedges needs both.
-  // When numProp == 0 there is no distinct prop space and the legacy single-
-  // array form (triProp only) is preserved.
-  const bool needsPropMap = numProp > 0;
+  const bool needsPropMap = numProp > 0 && !prop2vert.empty();
   if (needsPropMap) triVert.reserve(numTri);
   if (triRef.size() > 0) meshRelation_.triRef.reserve(numTri);
-
-  // Per-propVert claim tracking. When a single input vertProperty is
-  // referenced by triangles from runs with differing hasNormals flags, the
-  // eager-transform contract can't track both interpretations through a
-  // single storage slot. Duplicate the propVert at ctor time so each
-  // hasNormals camp gets its own slot 0..2 to mutate independently.
-  // Triangles from the first-seen camp keep the original index; triangles
-  // from the opposite camp point at the appended alt copy.
-  struct PropClaim {
-    bool primaryHasN = false;
-    int altCopy = -1;
-    bool initialized = false;
-  };
-  // Vec's size-only ctor leaves elements uninitialized; use value-init.
-  Vec<PropClaim> propClaim(needsPropMap ? numVert : 0, PropClaim{});
-
   for (size_t i = 0; i < numTri; ++i) {
     ivec3 triP, triV;
-    bool myHasN = false;
-    if (triRef.size() > 0) {
-      auto it = meshRelation_.meshIDtransform.find(triRef[i].meshID);
-      myHasN =
-          it != meshRelation_.meshIDtransform.end() && it->second.hasNormals;
-    }
     for (const size_t j : {0, 1, 2}) {
       uint32_t vert = (uint32_t)meshGL.triVerts[3 * i + j];
       if (vert >= numVert) {
         MakeEmpty(Error::VertexOutOfBounds);
         return;
       }
-      int propIdx = static_cast<int>(vert);
-      if (needsPropMap) {
-        auto& claim = propClaim[vert];
-        if (!claim.initialized) {
-          claim.primaryHasN = myHasN;
-          claim.initialized = true;
-        } else if (claim.primaryHasN != myHasN) {
-          if (claim.altCopy < 0) {
-            // Snapshot source values first - push_back may reallocate
-            // properties_ and invalidate the indexed reference.
-            std::vector<double> snapshot(numProp);
-            for (size_t k = 0; k < numProp; ++k) {
-              snapshot[k] = properties_[vert * numProp + k];
-            }
-            claim.altCopy = static_cast<int>(properties_.size() / numProp);
-            for (size_t k = 0; k < numProp; ++k) {
-              properties_.push_back(snapshot[k]);
-            }
-          }
-          propIdx = claim.altCopy;
-        }
-      }
-      triP[j] = propIdx;
-      triV[j] = prop2vert.empty() ? static_cast<int>(vert) : prop2vert[vert];
+      triP[j] = vert;
+      triV[j] = prop2vert.empty() ? vert : prop2vert[vert];
     }
     if (triV[0] != triV[1] && triV[1] != triV[2] && triV[2] != triV[0]) {
       if (needsPropMap) {

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -247,10 +247,14 @@ Manifold::Manifold(const MeshGL64& meshGL64)
  * used automatically; otherwise no normals are applied. If normals are
  * selected, the runTransform matrices will be removed from the output, to
  * avoid them being double-applied when round-tripped.
+ * Passing a non-negative `normalIdx` is the legacy interface from before
+ * `CalculateNormals` recorded the slot on the Manifold itself; prefer the
+ * no-arg form after `CalculateNormals(0)`. The explicit-idx path will be
+ * removed in a future release.
  */
 MeshGL Manifold::GetMeshGL(int normalIdx) const {
   const Impl& impl = *GetCsgLeafNode().GetImpl();
-  if (normalIdx < 0 && impl.HasNormals()) normalIdx = 0;
+  if (normalIdx < 0 && impl.AllHaveNormals()) normalIdx = 0;
   return GetMeshGLImpl<float, uint32_t>(impl, normalIdx);
 }
 
@@ -270,10 +274,12 @@ MeshGL Manifold::GetMeshGL(int normalIdx) const {
  * used automatically; otherwise no normals are applied. If normals are
  * selected, the runTransform matrices will be removed from the output, to
  * avoid them being double-applied when round-tripped.
+ * Same deprecation note as `GetMeshGL`: prefer the no-arg form after
+ * `CalculateNormals(0)`.
  */
 MeshGL64 Manifold::GetMeshGL64(int normalIdx) const {
   const Impl& impl = *GetCsgLeafNode().GetImpl();
-  if (normalIdx < 0 && impl.HasNormals()) normalIdx = 0;
+  if (normalIdx < 0 && impl.AllHaveNormals()) normalIdx = 0;
   return GetMeshGLImpl<double, uint64_t>(impl, normalIdx);
 }
 

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -250,7 +250,7 @@ Manifold::Manifold(const MeshGL64& meshGL64)
  */
 MeshGL Manifold::GetMeshGL(int normalIdx) const {
   const Impl& impl = *GetCsgLeafNode().GetImpl();
-  if (normalIdx < 0 && impl.hasNormals_) normalIdx = 0;
+  if (normalIdx < 0 && impl.HasNormals()) normalIdx = 0;
   return GetMeshGLImpl<float, uint32_t>(impl, normalIdx);
 }
 
@@ -273,7 +273,7 @@ MeshGL Manifold::GetMeshGL(int normalIdx) const {
  */
 MeshGL64 Manifold::GetMeshGL64(int normalIdx) const {
   const Impl& impl = *GetCsgLeafNode().GetImpl();
-  if (normalIdx < 0 && impl.hasNormals_) normalIdx = 0;
+  if (normalIdx < 0 && impl.HasNormals()) normalIdx = 0;
   return GetMeshGLImpl<double, uint64_t>(impl, normalIdx);
 }
 
@@ -555,6 +555,11 @@ Manifold Manifold::Mirror(vec3 normal) const {
  * that is not checked here, so it is up to the user to choose their function
  * with discretion.
  *
+ * Any normals recording set by `CalculateNormals()` is preserved across the
+ * Warp, but the stored values reflect the pre-warp surface and may no longer
+ * match the new geometry. Re-call `CalculateNormals()` if accurate normals
+ * matter after a non-rigid warp.
+ *
  * @param warpFunc A function that modifies a given vertex position.
  */
 Manifold Manifold::Warp(std::function<void(vec3&)> warpFunc) const {
@@ -569,7 +574,10 @@ Manifold Manifold::Warp(std::function<void(vec3&)> warpFunc) const {
 /**
  * Same as Manifold::Warp but calls warpFunc with
  * a VecView which is roughly equivalent to std::span
- * pointing to all vec3 elements to be modified in-place
+ * pointing to all vec3 elements to be modified in-place. Like Warp, this
+ * preserves any normals recording without updating the stored values;
+ * re-call `CalculateNormals()` if accurate normals matter after a non-rigid
+ * warp.
  *
  * @param warpFunc A function that modifies multiple vertex positions.
  */
@@ -592,6 +600,11 @@ Manifold Manifold::WarpBatch(
  *
  * If propFunc is a nullptr, this function will just set the channel to zeroes.
  *
+ * Any normals recording set by `CalculateNormals()` is preserved. If the new
+ * properties overwrite slot 0..2 with non-normal data, the recording becomes
+ * stale; re-call `CalculateNormals()` (or use a numProp < 3 call followed by
+ * CalculateNormals) to reset.
+ *
  * @param numProp The new number of properties per vertex.
  * @param propFunc A function that modifies the properties of a given vertex.
  */
@@ -605,10 +618,6 @@ Manifold Manifold::SetProperties(
   auto pImpl = std::make_shared<Impl>(*leafImpl);
   const int oldNumProp = NumProp();
   const Vec<double> oldProperties = pImpl->properties_;
-  // TODO: hasNormals_ is preserved across SetProperties, which is wrong if
-  // the user overwrote channels 0-2. Detecting this by comparing old vs new
-  // slot values is straightforward but deferred to a follow-up. For now,
-  // callers who rewrite normals should re-call CalculateNormals.
 
   if (numProp == 0) {
     pImpl->properties_.clear();
@@ -670,10 +679,10 @@ Manifold Manifold::CalculateCurvature(int gaussianIdx, int meanIdx) const {
  * @param normalIdx The property channel in which to store the X values of the
  * normals. The X, Y, and Z channels will be sequential. The property set will
  * be automatically expanded such that NumProp will be at least normalIdx + 3.
- * Default is 0, the standard slot (MeshGL channels 3, 4, 5); the Manifold's
- * hasNormals flag is set in that case so subsequent `GetMeshGL()` /
- * `GetMeshGL64()` without an explicit normalIdx will return solid-frame
- * normals (applying the runNormalTransform on export). Non-zero values are
+ * Default is 0, the standard slot (MeshGL channels 3, 4, 5); the Manifold
+ * records the recording per-meshID in that case so subsequent `GetMeshGL()` /
+ * `GetMeshGL64()` without an explicit normalIdx will return world-frame
+ * normals and mark each output run via runFlags bit 1. Non-zero values are
  * retained for compatibility and will not be supported in a future release.
  *
  * @param minSharpAngle Any edges with angles greater than this value will
@@ -688,9 +697,14 @@ Manifold Manifold::CalculateNormals(int normalIdx, double minSharpAngle) const {
     return PropagateStatus(leafImpl->status_);
   auto pImpl = std::make_shared<Impl>(*leafImpl);
   pImpl->SetNormals(normalIdx, minSharpAngle);
-  // Only mark hasNormals when normals landed at the standard slot, so
-  // GetMeshGL(-1) can safely auto-substitute slot 0 on export.
-  if (normalIdx == 0) pImpl->hasNormals_ = true;
+  // Mark per-meshID hasNormals so GetMeshGL(-1) can auto-substitute slot 0 on
+  // export. Restricted to the standard slot since a non-zero slot would be
+  // ambiguous when round-tripping through MeshGL.
+  if (normalIdx == 0) {
+    for (auto& m : pImpl->meshRelation_.meshIDtransform) {
+      m.second.hasNormals = true;
+    }
+  }
   return Manifold(std::make_shared<CsgLeafNode>(pImpl));
 }
 
@@ -769,9 +783,9 @@ Manifold Manifold::SmoothOut(double minSharpAngle, double minSmoothness) const {
  * will not be immediately collapsed) unless the Mesh/Manifold has
  * halfedgeTangents specified (e.g. from the Smooth() constructor), in which
  * case the new vertices will be moved to the interpolated surface according to
- * their barycentric coordinates. If a normals recording was set by
- * `CalculateNormals()`, it is cleared, since subdivision linearly interpolates
- * the stored normals - re-call `CalculateNormals()` after refining if needed.
+ * their barycentric coordinates. Any normals recording set by
+ * `CalculateNormals()` is preserved; the new verts get linearly-interpolated
+ * normals, which are less precise than recomputed ones but still meaningful.
  *
  * @param n The number of pieces to split every edge into. Must be > 1.
  */
@@ -783,10 +797,6 @@ Manifold Manifold::Refine(int n) const {
   auto pImpl = std::make_shared<Impl>(*leafImpl);
   if (n > 1) {
     pImpl->Refine([n](vec3, vec4, vec4) { return n - 1; }, false, ctx.get());
-    // Subdivided verts get linearly interpolated property values, so any
-    // recorded normals at the standard slot no longer point at the surface.
-    // Caller should re-call CalculateNormals().
-    pImpl->hasNormals_ = false;
   }
   return Manifold(std::make_shared<CsgLeafNode>(pImpl));
 }
@@ -797,8 +807,9 @@ Manifold Manifold::Refine(int n) const {
  * triangulation edges also of roughly the same length. If halfedgeTangents are
  * present (e.g. from the Smooth() constructor), the new vertices will be moved
  * to the interpolated surface according to their barycentric coordinates. Quads
- * will ignore their interior triangle bisector. If a normals recording was set
- * by `CalculateNormals()`, it is cleared.
+ * will ignore their interior triangle bisector. Any normals recording set by
+ * `CalculateNormals()` is preserved; the new verts get linearly-interpolated
+ * normals, which are less precise than recomputed ones but still meaningful.
  *
  * @param length The length that edges will be broken down to.
  */
@@ -814,7 +825,6 @@ Manifold Manifold::RefineToLength(double length) const {
         return static_cast<int>(la::length(edge) / length);
       },
       false, ctx.get());
-  pImpl->hasNormals_ = false;
   return Manifold(std::make_shared<CsgLeafNode>(pImpl));
 }
 
@@ -824,9 +834,9 @@ Manifold Manifold::RefineToLength(double length) const {
  * smoothly curved surface defined by the tangent vectors. This means tightly
  * curving regions will be divided more finely than smoother regions. If
  * halfedgeTangents are not present, the result will simply be a copy of the
- * original. Quads will ignore their interior triangle bisector. If a normals
- * recording was set by `CalculateNormals()` and refinement actually occurs,
- * it is cleared.
+ * original. Quads will ignore their interior triangle bisector. Any normals
+ * recording set by `CalculateNormals()` is preserved; the new verts get
+ * linearly-interpolated normals.
  *
  * @param tolerance The desired maximum distance between the faceted mesh
  * produced and the exact smoothly curving surface. All vertices are exactly on
@@ -855,7 +865,6 @@ Manifold Manifold::RefineToTolerance(double tolerance) const {
           return static_cast<int>(std::sqrt(3 * d / (4 * tolerance)));
         },
         true, ctx.get());
-    pImpl->hasNormals_ = false;
   }
   return Manifold(std::make_shared<CsgLeafNode>(pImpl));
 }

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -242,17 +242,20 @@ Manifold::Manifold(const MeshGL64& meshGL64)
  * forming the (x, y, z) normals, which will cause this output MeshGL to
  * automatically update these normals according to the applied transforms and
  * front/back side. normalIdx + 3 must be <= numProp, and all original meshes
- * must use the same channels for their normals. Default is -1, meaning no
- * normals. If normals are selected, the runTransform matrices will be removed
- * from the output, to avoid them being double-applied when round-tripped.
+ * must use the same channels for their normals. Default is -1: if
+ * `CalculateNormals()` recorded normals at the standard slot, that slot is
+ * used automatically; otherwise no normals are applied. If normals are
+ * selected, the runTransform matrices will be removed from the output, to
+ * avoid them being double-applied when round-tripped.
  */
 MeshGL Manifold::GetMeshGL(int normalIdx) const {
   const Impl& impl = *GetCsgLeafNode().GetImpl();
+  if (normalIdx < 0 && impl.hasNormals_) normalIdx = 0;
   return GetMeshGLImpl<float, uint32_t>(impl, normalIdx);
 }
 
 /**
- * Returns a MeshGL that is designed
+ * Returns a MeshGL64 that is designed
  * to easily push into a renderer, including all interleaved vertex properties
  * that may have been input. It also includes relations to all the input meshes
  * that form a part of this result and the transforms applied to each.
@@ -262,13 +265,15 @@ MeshGL Manifold::GetMeshGL(int normalIdx) const {
  * forming the (x, y, z) normals, which will cause this output MeshGL to
  * automatically update these normals according to the applied transforms and
  * front/back side. normalIdx + 3 must be <= numProp, and all original meshes
- * must use the same channels for their normals. Default is -1, meaning no
- * normals. If normals are selected, the runTransform matrices will be removed
- * from the output, to avoid them being double-applied when round-tripped.
-
+ * must use the same channels for their normals. Default is -1: if
+ * `CalculateNormals()` recorded normals at the standard slot, that slot is
+ * used automatically; otherwise no normals are applied. If normals are
+ * selected, the runTransform matrices will be removed from the output, to
+ * avoid them being double-applied when round-tripped.
  */
 MeshGL64 Manifold::GetMeshGL64(int normalIdx) const {
   const Impl& impl = *GetCsgLeafNode().GetImpl();
+  if (normalIdx < 0 && impl.hasNormals_) normalIdx = 0;
   return GetMeshGLImpl<double, uint64_t>(impl, normalIdx);
 }
 
@@ -600,6 +605,10 @@ Manifold Manifold::SetProperties(
   auto pImpl = std::make_shared<Impl>(*leafImpl);
   const int oldNumProp = NumProp();
   const Vec<double> oldProperties = pImpl->properties_;
+  // TODO: hasNormals_ is preserved across SetProperties, which is wrong if
+  // the user overwrote channels 0-2. Detecting this by comparing old vs new
+  // slot values is straightforward but deferred to a follow-up. For now,
+  // callers who rewrite normals should re-call CalculateNormals.
 
   if (numProp == 0) {
     pImpl->properties_.clear();
@@ -658,10 +667,14 @@ Manifold Manifold::CalculateCurvature(int gaussianIdx, int meanIdx) const {
  * Fills in vertex properties for normal vectors, calculated from the mesh
  * geometry. Flat faces composed of three or more triangles will remain flat.
  *
- * @param normalIdx The property channel in which to store the X
- * values of the normals. The X, Y, and Z channels will be sequential. The
- * property set will be automatically expanded such that NumProp will be at
- * least normalIdx + 3.
+ * @param normalIdx The property channel in which to store the X values of the
+ * normals. The X, Y, and Z channels will be sequential. The property set will
+ * be automatically expanded such that NumProp will be at least normalIdx + 3.
+ * Default is 0, the standard slot (MeshGL channels 3, 4, 5); the Manifold's
+ * hasNormals flag is set in that case so subsequent `GetMeshGL()` /
+ * `GetMeshGL64()` without an explicit normalIdx will return solid-frame
+ * normals (applying the runNormalTransform on export). Non-zero values are
+ * retained for compatibility and will not be supported in a future release.
  *
  * @param minSharpAngle Any edges with angles greater than this value will
  * remain sharp, getting different normal vector properties on each side of the
@@ -675,6 +688,9 @@ Manifold Manifold::CalculateNormals(int normalIdx, double minSharpAngle) const {
     return PropagateStatus(leafImpl->status_);
   auto pImpl = std::make_shared<Impl>(*leafImpl);
   pImpl->SetNormals(normalIdx, minSharpAngle);
+  // Only mark hasNormals when normals landed at the standard slot, so
+  // GetMeshGL(-1) can safely auto-substitute slot 0 on export.
+  if (normalIdx == 0) pImpl->hasNormals_ = true;
   return Manifold(std::make_shared<CsgLeafNode>(pImpl));
 }
 
@@ -690,7 +706,9 @@ Manifold Manifold::CalculateNormals(int normalIdx, double minSharpAngle) const {
  *
  * @param normalIdx The first property channel of the normals. NumProp must be
  * at least normalIdx + 3. Any vertex where multiple normals exist and don't
- * agree will result in a sharp edge.
+ * agree will result in a sharp edge. Default is 0, the standard slot.
+ * Non-zero values are retained for compatibility and will not be supported in
+ * a future release.
  */
 Manifold Manifold::SmoothByNormals(int normalIdx) const {
   auto leafImpl = GetCsgLeafNode().GetImpl();
@@ -751,7 +769,9 @@ Manifold Manifold::SmoothOut(double minSharpAngle, double minSmoothness) const {
  * will not be immediately collapsed) unless the Mesh/Manifold has
  * halfedgeTangents specified (e.g. from the Smooth() constructor), in which
  * case the new vertices will be moved to the interpolated surface according to
- * their barycentric coordinates.
+ * their barycentric coordinates. If a normals recording was set by
+ * `CalculateNormals()`, it is cleared, since subdivision linearly interpolates
+ * the stored normals - re-call `CalculateNormals()` after refining if needed.
  *
  * @param n The number of pieces to split every edge into. Must be > 1.
  */
@@ -763,6 +783,10 @@ Manifold Manifold::Refine(int n) const {
   auto pImpl = std::make_shared<Impl>(*leafImpl);
   if (n > 1) {
     pImpl->Refine([n](vec3, vec4, vec4) { return n - 1; }, false, ctx.get());
+    // Subdivided verts get linearly interpolated property values, so any
+    // recorded normals at the standard slot no longer point at the surface.
+    // Caller should re-call CalculateNormals().
+    pImpl->hasNormals_ = false;
   }
   return Manifold(std::make_shared<CsgLeafNode>(pImpl));
 }
@@ -773,7 +797,8 @@ Manifold Manifold::Refine(int n) const {
  * triangulation edges also of roughly the same length. If halfedgeTangents are
  * present (e.g. from the Smooth() constructor), the new vertices will be moved
  * to the interpolated surface according to their barycentric coordinates. Quads
- * will ignore their interior triangle bisector.
+ * will ignore their interior triangle bisector. If a normals recording was set
+ * by `CalculateNormals()`, it is cleared.
  *
  * @param length The length that edges will be broken down to.
  */
@@ -789,6 +814,7 @@ Manifold Manifold::RefineToLength(double length) const {
         return static_cast<int>(la::length(edge) / length);
       },
       false, ctx.get());
+  pImpl->hasNormals_ = false;
   return Manifold(std::make_shared<CsgLeafNode>(pImpl));
 }
 
@@ -798,7 +824,9 @@ Manifold Manifold::RefineToLength(double length) const {
  * smoothly curved surface defined by the tangent vectors. This means tightly
  * curving regions will be divided more finely than smoother regions. If
  * halfedgeTangents are not present, the result will simply be a copy of the
- * original. Quads will ignore their interior triangle bisector.
+ * original. Quads will ignore their interior triangle bisector. If a normals
+ * recording was set by `CalculateNormals()` and refinement actually occurs,
+ * it is cleared.
  *
  * @param tolerance The desired maximum distance between the faceted mesh
  * produced and the exact smoothly curving surface. All vertices are exactly on
@@ -827,6 +855,7 @@ Manifold Manifold::RefineToTolerance(double tolerance) const {
           return static_cast<int>(std::sqrt(3 * d / (4 * tolerance)));
         },
         true, ctx.get());
+    pImpl->hasNormals_ = false;
   }
   return Manifold(std::make_shared<CsgLeafNode>(pImpl));
 }

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -508,6 +508,8 @@ void Manifold::Impl::SetNormals(int normalIdx, double minSharpAngle) {
   // Cached per-meshID inverse-normal-transform for the legacy non-zero
   // normalIdx path. Lazily populated on first lookup; reused across all
   // verts in the loop below.
+  // TODO: drop this and its only caller below when the non-zero normalIdx
+  // parameter on CalculateNormals is removed.
   std::map<int, mat3> meshIDtoNormalTransform;
   auto getTransform = [&](int meshID) {
     if (meshIDtoNormalTransform.find(meshID) == meshIDtoNormalTransform.end()) {

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -268,17 +268,21 @@ namespace manifold {
  * normalIdx shows the beginning of where normals are stored in the properties.
  */
 vec3 Manifold::Impl::GetNormal(int halfedge, int normalIdx) const {
-  const int meshID = meshRelation_.triRef[halfedge / 3].meshID;
-
-  const mat3 transform =
-      meshRelation_.meshIDtransform.find(meshID)->second.GetNormalTransform();
-
   const int prop = halfedge_.Prop(halfedge);
   vec3 normal;
   for (const int i : {0, 1, 2}) {
     normal[i] = properties_[prop * numProp_ + normalIdx + i];
   }
-  return transform * normal;
+  // hasNormals=true means CalculateNormals (or a flagged round-trip) wrote
+  // world-frame values, kept world-frame through Transform/Compose. Without
+  // the flag, treat the slot as per-mesh frame and re-rotate to world like
+  // pre-#1718 callers expected.
+  const int meshID = meshRelation_.triRef[halfedge / 3].meshID;
+  auto it = meshRelation_.meshIDtransform.find(meshID);
+  if (it != meshRelation_.meshIDtransform.end() && !it->second.hasNormals) {
+    normal = it->second.GetNormalTransform() * normal;
+  }
+  return normal;
 }
 
 /**
@@ -501,27 +505,41 @@ void Manifold::Impl::SetNormals(int normalIdx, double minSharpAngle) {
                halfedge_.SetProp(i, -1);
              });
 
+  // Cached per-meshID inverse-normal-transform for the legacy non-zero
+  // normalIdx path. Lazily populated on first lookup; reused across all
+  // verts in the loop below.
   std::map<int, mat3> meshIDtoNormalTransform;
+  auto getTransform = [&](int meshID) {
+    if (meshIDtoNormalTransform.find(meshID) == meshIDtoNormalTransform.end()) {
+      meshIDtoNormalTransform[meshID] =
+          meshRelation_.meshIDtransform[meshID].GetInverseNormalTransform();
+    }
+    return meshIDtoNormalTransform[meshID];
+  };
 
   const int numEdge = halfedge_.size();
   for (int startEdge = 0; startEdge < numEdge; ++startEdge) {
     if (halfedge_.Prop(startEdge) >= 0) continue;
     const int vert = halfedge_.Start(startEdge);
 
-    auto getTransform = [&](int meshID) {
-      if (meshIDtoNormalTransform.find(meshID) ==
-          meshIDtoNormalTransform.end()) {
-        meshIDtoNormalTransform[meshID] =
-            meshRelation_.meshIDtransform[meshID].GetInverseNormalTransform();
-      }
-      return meshIDtoNormalTransform[meshID];
-    };
-
     if (vertNumSharp[vert] < 2) {  // vertex has single normal
+      const vec3 worldNormal = vertFlatFace[vert] >= 0
+                                   ? faceNormal_[vertFlatFace[vert]]
+                                   : vertNormal_[vert];
+      // Non-zero normalIdx is the legacy deferred-transform path: store in
+      // per-mesh frame so GetMeshGL's runTransform application on export
+      // recovers world frame even after later transforms. Standard slot 0
+      // uses the eager-transform contract: store world-frame directly.
+      // Caveat: for legacy idx!=0, if a single propVert is shared between
+      // triangles of different meshIDs, we pick startEdge's meshID for the
+      // per-mesh-frame mapping. Other meshIDs reading the same propVert
+      // through a different runTransform on export will get a wrong
+      // rotation. Same shape as master; out of scope here.
       const vec3 normal =
-          getTransform(meshRelation_.triRef[startEdge / 3].meshID) *
-          (vertFlatFace[vert] >= 0 ? faceNormal_[vertFlatFace[vert]]
-                                   : vertNormal_[vert]);
+          normalIdx == 0
+              ? worldNormal
+              : getTransform(meshRelation_.triRef[startEdge / 3].meshID) *
+                    worldNormal;
       int lastProp = -1;
       ForVert(startEdge, [&](int current) {
         const int prop = oldHalfedgeProp[current];
@@ -607,17 +625,25 @@ void Manifold::Impl::SetNormals(int normalIdx, double minSharpAngle) {
           }
           groups.push_back(normals.size() - 1);
           if (std::isfinite(next.normalizedEdge.x)) {
+            // Boolean subtractee triangles keep their original winding but
+            // have faceNormal_ negated, so the edge-cross points opposite to
+            // faceNormal_ there - flip to keep the accumulation outward-from-
+            // result.
+            vec3 dir = SafeNormalize(
+                la::cross(next.normalizedEdge, here.normalizedEdge));
+            if (la::dot(dir, faceNormal_[next.face]) < 0) dir = -dir;
             normals.back() +=
-                SafeNormalize(
-                    la::cross(next.normalizedEdge, here.normalizedEdge)) *
-                AngleBetween(here.normalizedEdge, next.normalizedEdge);
+                dir * AngleBetween(here.normalizedEdge, next.normalizedEdge);
           } else {
             next.normalizedEdge = here.normalizedEdge;
           }
         });
 
     for (int i = 0; i < normals.size(); ++i) {
-      normals[i] = getTransform(meshIds[i]) * SafeNormalize(normals[i]);
+      vec3 n = SafeNormalize(normals[i]);
+      // Same frame-storage rule as the single-normal path above.
+      if (normalIdx != 0) n = getTransform(meshIds[i]) * n;
+      normals[i] = n;
     }
 
     int lastGroup = 0;

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -612,11 +612,19 @@ bool MeshGL64::Merge() {
 
 template <>
 void MeshGL::UpdateNormals(int normalIdx) {
+  if (normalIdx < 0) {
+    if (hasNormals) UpdateNormalsMeshGLP(*this, 3);
+    return;
+  }
   UpdateNormalsMeshGLP(*this, normalIdx);
 }
 
 template <>
 void MeshGL64::UpdateNormals(int normalIdx) {
+  if (normalIdx < 0) {
+    if (hasNormals) UpdateNormalsMeshGLP(*this, 3);
+    return;
+  }
   UpdateNormalsMeshGLP(*this, normalIdx);
 }
 }  // namespace manifold

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -179,35 +179,6 @@ bool MergeMeshGLP(MeshGLP<Precision, I>& mesh) {
   return true;
 }
 
-template <typename Precision, typename I>
-void UpdateNormalsMeshGLP(MeshGLP<Precision, I>& mesh, int normalIdx) {
-  ZoneScoped;
-  if (normalIdx < 3 || normalIdx + 3 > mesh.numProp) {
-    return;
-  }
-  std::vector<bool> vertUpdated(mesh.NumVert(), false);
-  for (size_t run = 0; run < mesh.NumRun(); ++run) {
-    const mat3 transform = NormalTransform(mesh.GetRunTransform(run)) *
-                           (mesh.Backside(run) ? -1.0 : 1.0);
-    for (I* itr = &mesh.triVerts[mesh.runIndex[run]];
-         itr < &mesh.triVerts[mesh.runIndex[run + 1]]; ++itr) {
-      const I vert = *itr;
-      if (vertUpdated[vert]) continue;
-      vertUpdated[vert] = true;
-      vec3 normal;
-      const int start = vert * mesh.numProp + normalIdx;
-      for (int i : {0, 1, 2}) {
-        normal[i] = mesh.vertProperties[start + i];
-      }
-      normal = SafeNormalize(transform * normal);
-      for (int i : {0, 1, 2}) {
-        mesh.vertProperties[start + i] = normal[i];
-      }
-    }
-  }
-  mesh.runTransform.clear();
-  mesh.runFlags.clear();
-}
 }  // namespace
 
 namespace manifold {
@@ -610,21 +581,4 @@ bool MeshGL64::Merge() {
   return MergeMeshGLP(*this);
 }
 
-template <>
-void MeshGL::UpdateNormals(int normalIdx) {
-  if (normalIdx < 0) {
-    if (hasNormals) UpdateNormalsMeshGLP(*this, 3);
-    return;
-  }
-  UpdateNormalsMeshGLP(*this, normalIdx);
-}
-
-template <>
-void MeshGL64::UpdateNormals(int normalIdx) {
-  if (normalIdx < 0) {
-    if (hasNormals) UpdateNormalsMeshGLP(*this, 3);
-    return;
-  }
-  UpdateNormalsMeshGLP(*this, normalIdx);
-}
 }  // namespace manifold

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -352,17 +352,12 @@ TEST(Manifold, NormalsNonStandardSlotNotRecorded) {
 }
 
 TEST(Manifold, NormalsSharedPropVertMixedFlags) {
-  // Per-run hasNormals is intended to let runs interpret slot 0..2
-  // independently. The eager-transform contract stores ONE value per
-  // propVert, so a propVert shared between a hasNormals=true run (treats
-  // slot as normals) and a hasNormals=false run (treats slot as color)
-  // can only carry one interpretation through a subsequent Transform.
-  //
-  // Currently this test FAILS by design: Impl::Transform applies the
-  // rotation when it sees the hasNormals run, corrupting Run 1's color.
-  // Fixing requires splitting propVerts whose runs disagree on the flag,
-  // either during ctor or during Transform. Leaving as a discussion-driver
-  // for now (see PR #1718 review thread).
+  // Per-run hasNormals lets runs interpret slot 0..2 independently. The
+  // eager-transform contract stores ONE value per propVert, so a propVert
+  // shared between a hasNormals=true run (treats slot as normals) and a
+  // hasNormals=false run (treats slot as color) would otherwise be unable
+  // to carry both interpretations through a Transform. The MeshGL ctor
+  // therefore duplicates such propVerts so each camp gets its own slot.
   MeshGL gl;
   gl.numProp = 6;
   const float pts[4][3] = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {0, 0, 1}};

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -227,6 +227,144 @@ TEST(Manifold, ErrorPropagationCalculateNormals) {
             Manifold::Error::NonFiniteVertex);
 }
 
+// CalculateNormals(idx) followed by GetMeshGL() (no idx) used to drop
+// the transform-on-export step, returning input-frame data.
+TEST(Manifold, CalculateNormalsRoundTripsThroughGetMeshGL) {
+  // Cavity from a Boolean difference: inner-sphere normals should point
+  // toward the origin (outward from the surrounding solid).
+  Manifold cavity = (Manifold::Sphere(10.0, 32) - Manifold::Sphere(3.0, 32))
+                        .CalculateNormals(0);
+  MeshGL cavityMesh = cavity.GetMeshGL();
+  ASSERT_GE(cavityMesh.numProp, 6);
+  int innerGood = 0, innerBad = 0;
+  for (size_t v = 0; v < cavityMesh.NumVert(); ++v) {
+    vec3 pos(cavityMesh.vertProperties[cavityMesh.numProp * v + 0],
+             cavityMesh.vertProperties[cavityMesh.numProp * v + 1],
+             cavityMesh.vertProperties[cavityMesh.numProp * v + 2]);
+    vec3 n(cavityMesh.vertProperties[cavityMesh.numProp * v + 3],
+           cavityMesh.vertProperties[cavityMesh.numProp * v + 4],
+           cavityMesh.vertProperties[cavityMesh.numProp * v + 5]);
+    if (std::abs(la::length(pos) - 3.0) < 0.05) {
+      if (la::dot(n, la::normalize(-pos)) > 0.9)
+        ++innerGood;
+      else
+        ++innerBad;
+    }
+  }
+  // Pre-fix all inner verts came out inverted; post-fix all align with the
+  // expected outward-from-solid direction.
+  EXPECT_GT(innerGood, 0);
+  EXPECT_EQ(innerBad, 0);
+
+  // Rotation before CalculateNormals: SetNormals stores input-frame
+  // (pre-rotation) normals; GetMeshGL must apply the forward transform
+  // on export to recover solid-frame.
+  Manifold rotated =
+      Manifold::Sphere(10.0, 32).Rotate(45, 0, 0).CalculateNormals(0);
+  MeshGL rotMesh = rotated.GetMeshGL();
+  int rotGood = 0, rotBad = 0;
+  for (size_t v = 0; v < rotMesh.NumVert(); ++v) {
+    vec3 pos(rotMesh.vertProperties[rotMesh.numProp * v + 0],
+             rotMesh.vertProperties[rotMesh.numProp * v + 1],
+             rotMesh.vertProperties[rotMesh.numProp * v + 2]);
+    vec3 n(rotMesh.vertProperties[rotMesh.numProp * v + 3],
+           rotMesh.vertProperties[rotMesh.numProp * v + 4],
+           rotMesh.vertProperties[rotMesh.numProp * v + 5]);
+    if (la::dot(n, la::normalize(pos)) > 0.9)
+      ++rotGood;
+    else
+      ++rotBad;
+  }
+  EXPECT_EQ(rotBad, 0);
+
+  // Rotation *after* CalculateNormals: exercises hasNormals_ propagation
+  // through Impl::Transform.
+  Manifold transformedAfter =
+      Manifold::Sphere(10.0, 32).CalculateNormals(0).Rotate(45, 0, 0);
+  MeshGL afterMesh = transformedAfter.GetMeshGL();
+  int afterGood = 0, afterBad = 0;
+  for (size_t v = 0; v < afterMesh.NumVert(); ++v) {
+    vec3 pos(afterMesh.vertProperties[afterMesh.numProp * v + 0],
+             afterMesh.vertProperties[afterMesh.numProp * v + 1],
+             afterMesh.vertProperties[afterMesh.numProp * v + 2]);
+    vec3 n(afterMesh.vertProperties[afterMesh.numProp * v + 3],
+           afterMesh.vertProperties[afterMesh.numProp * v + 4],
+           afterMesh.vertProperties[afterMesh.numProp * v + 5]);
+    if (la::dot(n, la::normalize(pos)) > 0.9)
+      ++afterGood;
+    else
+      ++afterBad;
+  }
+  EXPECT_EQ(afterBad, 0);
+
+  // No-arg invocation: defaults to slot 0 and sets hasNormals.
+  MeshGL noIdxMesh = Manifold::Sphere(10.0, 32).CalculateNormals().GetMeshGL();
+  EXPECT_TRUE(noIdxMesh.hasNormals);
+  ASSERT_GE(noIdxMesh.numProp, 6);
+
+  // Roundtrip: getMesh -> ofMesh -> getMesh should preserve hasNormals,
+  // so the second getMesh still applies the transform on export.
+  Manifold round = (Manifold::Sphere(10.0, 32) - Manifold::Sphere(3.0, 32))
+                       .CalculateNormals();
+  MeshGL roundOut1 = round.GetMeshGL();
+  EXPECT_TRUE(roundOut1.hasNormals);
+  Manifold round2(roundOut1);
+  MeshGL roundOut2 = round2.GetMeshGL();
+  EXPECT_TRUE(roundOut2.hasNormals);
+  int rtGood = 0, rtBad = 0;
+  for (size_t v = 0; v < roundOut2.NumVert(); ++v) {
+    vec3 pos(roundOut2.vertProperties[roundOut2.numProp * v + 0],
+             roundOut2.vertProperties[roundOut2.numProp * v + 1],
+             roundOut2.vertProperties[roundOut2.numProp * v + 2]);
+    vec3 n(roundOut2.vertProperties[roundOut2.numProp * v + 3],
+           roundOut2.vertProperties[roundOut2.numProp * v + 4],
+           roundOut2.vertProperties[roundOut2.numProp * v + 5]);
+    if (std::abs(la::length(pos) - 3.0) < 0.05) {
+      if (la::dot(n, la::normalize(-pos)) > 0.9)
+        ++rtGood;
+      else
+        ++rtBad;
+    }
+  }
+  EXPECT_GT(rtGood, 0);
+  EXPECT_EQ(rtBad, 0);
+
+  // Refine clears hasNormals: linearly-interpolated normals at the new
+  // verts wouldn't be unit-length or follow the surface, so the auto-
+  // substitute path shouldn't return them.
+  MeshGL refinedMesh =
+      Manifold::Sphere(10.0, 32).CalculateNormals().Refine(2).GetMeshGL();
+  EXPECT_FALSE(refinedMesh.hasNormals);
+
+  // MeshGL::UpdateNormals() no-arg: callable on a mesh whose hasNormals
+  // flag is set. The path that actually has work to do (a MeshGL with
+  // runTransform intact and hasNormals true) doesn't arise from any
+  // in-repo flow today, so just exercise the no-op path.
+  roundOut1.UpdateNormals();
+
+  // SmoothByNormals() no-arg: smoke test that the new default-arg path is
+  // callable and produces a manifold (tangents at the standard slot).
+  Manifold smoothed =
+      Manifold::Sphere(10.0, 32).CalculateNormals().SmoothByNormals();
+  EXPECT_EQ(smoothed.Status(), Manifold::Error::NoError);
+
+  // CalculateNormals(non-zero) does NOT set hasNormals_: the asymmetry
+  // is intentional, since non-standard-slot recordings can't be safely
+  // auto-substituted on GetMeshGL(-1).
+  MeshGL nonStd = Manifold::Sphere(10.0, 32).CalculateNormals(3).GetMeshGL();
+  EXPECT_FALSE(nonStd.hasNormals);
+
+  // Malformed MeshGL input: hasNormals=true with numProp < 6 (no room
+  // for 3 normal channels after position). The Manifold(MeshGL) ctor
+  // should defensively clear the flag rather than honor it and let
+  // downstream code read past the property bounds.
+  MeshGL malformed = Manifold::Cube().GetMeshGL();
+  ASSERT_EQ(malformed.numProp, 3);
+  malformed.hasNormals = true;
+  Manifold cube(malformed);
+  EXPECT_FALSE(cube.GetMeshGL().hasNormals);
+}
+
 TEST(Manifold, ErrorPropagationSmoothByNormals) {
   MeshGL in = TetGL();
   in.vertProperties[2 * 3 + 1] = NAN;

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -297,20 +297,22 @@ TEST(Manifold, CalculateNormalsRoundTripsThroughGetMeshGL) {
   }
   EXPECT_EQ(afterBad, 0);
 
-  // No-arg invocation: defaults to slot 0 and sets hasNormals.
+  // No-arg invocation: defaults to slot 0 and sets the per-run hasNormals
+  // bit on every output run.
   MeshGL noIdxMesh = Manifold::Sphere(10.0, 32).CalculateNormals().GetMeshGL();
-  EXPECT_TRUE(noIdxMesh.hasNormals);
   ASSERT_GE(noIdxMesh.numProp, 6);
+  ASSERT_GT(noIdxMesh.NumRun(), 0u);
+  EXPECT_TRUE(noIdxMesh.HasNormals(0));
 
-  // Roundtrip: getMesh -> ofMesh -> getMesh should preserve hasNormals,
-  // so the second getMesh still applies the transform on export.
+  // Roundtrip: getMesh -> ofMesh -> getMesh should preserve the per-run flag,
+  // so the second getMesh still emits world-frame normals.
   Manifold round = (Manifold::Sphere(10.0, 32) - Manifold::Sphere(3.0, 32))
                        .CalculateNormals();
   MeshGL roundOut1 = round.GetMeshGL();
-  EXPECT_TRUE(roundOut1.hasNormals);
+  EXPECT_TRUE(roundOut1.HasNormals(0));
   Manifold round2(roundOut1);
   MeshGL roundOut2 = round2.GetMeshGL();
-  EXPECT_TRUE(roundOut2.hasNormals);
+  EXPECT_TRUE(roundOut2.HasNormals(0));
   int rtGood = 0, rtBad = 0;
   for (size_t v = 0; v < roundOut2.NumVert(); ++v) {
     vec3 pos(roundOut2.vertProperties[roundOut2.numProp * v + 0],
@@ -329,18 +331,12 @@ TEST(Manifold, CalculateNormalsRoundTripsThroughGetMeshGL) {
   EXPECT_GT(rtGood, 0);
   EXPECT_EQ(rtBad, 0);
 
-  // Refine clears hasNormals: linearly-interpolated normals at the new
-  // verts wouldn't be unit-length or follow the surface, so the auto-
-  // substitute path shouldn't return them.
+  // Refine preserves the recording: linearly-interpolated normals at the
+  // new verts are less precise than recomputed ones but still meaningful.
   MeshGL refinedMesh =
       Manifold::Sphere(10.0, 32).CalculateNormals().Refine(2).GetMeshGL();
-  EXPECT_FALSE(refinedMesh.hasNormals);
-
-  // MeshGL::UpdateNormals() no-arg: callable on a mesh whose hasNormals
-  // flag is set. The path that actually has work to do (a MeshGL with
-  // runTransform intact and hasNormals true) doesn't arise from any
-  // in-repo flow today, so just exercise the no-op path.
-  roundOut1.UpdateNormals();
+  ASSERT_GT(refinedMesh.NumRun(), 0u);
+  EXPECT_TRUE(refinedMesh.HasNormals(0));
 
   // SmoothByNormals() no-arg: smoke test that the new default-arg path is
   // callable and produces a manifold (tangents at the standard slot).
@@ -348,21 +344,163 @@ TEST(Manifold, CalculateNormalsRoundTripsThroughGetMeshGL) {
       Manifold::Sphere(10.0, 32).CalculateNormals().SmoothByNormals();
   EXPECT_EQ(smoothed.Status(), Manifold::Error::NoError);
 
-  // CalculateNormals(non-zero) does NOT set hasNormals_: the asymmetry
-  // is intentional, since non-standard-slot recordings can't be safely
-  // auto-substituted on GetMeshGL(-1).
+  // CalculateNormals(non-zero) does NOT set the recording: non-standard-slot
+  // recordings can't be safely auto-substituted on GetMeshGL(-1).
   MeshGL nonStd = Manifold::Sphere(10.0, 32).CalculateNormals(3).GetMeshGL();
-  EXPECT_FALSE(nonStd.hasNormals);
+  ASSERT_GT(nonStd.NumRun(), 0u);
+  EXPECT_FALSE(nonStd.HasNormals(0));
+}
 
-  // Malformed MeshGL input: hasNormals=true with numProp < 6 (no room
-  // for 3 normal channels after position). The Manifold(MeshGL) ctor
-  // should defensively clear the flag rather than honor it and let
-  // downstream code read past the property bounds.
-  MeshGL malformed = Manifold::Cube().GetMeshGL();
-  ASSERT_EQ(malformed.numProp, 3);
-  malformed.hasNormals = true;
-  Manifold cube(malformed);
-  EXPECT_FALSE(cube.GetMeshGL().hasNormals);
+TEST(Manifold, GetNormalLegacyContract) {
+  // Pre-#1718, slot N normals were stored in per-mesh frame and runTransform
+  // had to be applied on read - there was no runFlags bit 1 to mark
+  // world-frame storage. GetNormal must still honour that contract when
+  // reading a MeshGL without the bit set, or SmoothByNormals on legacy data
+  // produces wrong tangents.
+  //
+  // Build twins: take a CalculateNormals'd rotated cube, emit both as a
+  // modern MeshGL (world-frame + bit 1 set) and as a legacy MeshGL (the same
+  // normals inverse-rotated into per-mesh frame, bit 1 cleared). Both should
+  // produce the same SmoothByNormals.Refine output if GetNormal recomposes
+  // correctly.
+  const Manifold rotated =
+      Manifold::Cube({1, 1, 1}, true).Rotate(30, 45, 0).CalculateNormals(0);
+  MeshGL gl_modern = rotated.GetMeshGL();
+  ASSERT_GT(gl_modern.NumRun(), 0u);
+  ASSERT_TRUE(gl_modern.HasNormals(0));
+
+  MeshGL gl_legacy = gl_modern;
+  std::vector<bool> visited(gl_legacy.NumVert(), false);
+  for (size_t run = 0; run < gl_legacy.NumRun(); ++run) {
+    // Invert the per-run normal transform that the legacy GetNormal will
+    // apply on read, so the stored values look "per-mesh frame" again.
+    const mat3 fwd =
+        la::inverse(la::transpose(mat3(gl_legacy.GetRunTransform(run)))) *
+        (gl_legacy.Backside(run) ? -1.0 : 1.0);
+    const mat3 inv = la::inverse(fwd);
+    for (uint32_t* itr = &gl_legacy.triVerts[gl_legacy.runIndex[run]];
+         itr < &gl_legacy.triVerts[gl_legacy.runIndex[run + 1]]; ++itr) {
+      const uint32_t v = *itr;
+      if (visited[v]) continue;
+      visited[v] = true;
+      vec3 n(gl_legacy.vertProperties[v * gl_legacy.numProp + 3],
+             gl_legacy.vertProperties[v * gl_legacy.numProp + 4],
+             gl_legacy.vertProperties[v * gl_legacy.numProp + 5]);
+      n = inv * n;
+      gl_legacy.vertProperties[v * gl_legacy.numProp + 3] = n.x;
+      gl_legacy.vertProperties[v * gl_legacy.numProp + 4] = n.y;
+      gl_legacy.vertProperties[v * gl_legacy.numProp + 5] = n.z;
+    }
+    gl_legacy.runFlags[run] &= ~uint8_t(2);
+  }
+  ASSERT_FALSE(gl_legacy.HasNormals(0));
+
+  Manifold m_modern(gl_modern);
+  Manifold m_legacy(gl_legacy);
+
+  Manifold sm_modern = m_modern.SmoothByNormals(0).Refine(4);
+  Manifold sm_legacy = m_legacy.SmoothByNormals(0).Refine(4);
+  EXPECT_NEAR(sm_modern.Volume(), sm_legacy.Volume(), 1e-4);
+  EXPECT_NEAR(sm_modern.SurfaceArea(), sm_legacy.SurfaceArea(), 1e-4);
+}
+
+namespace {
+// A disjoint Union of a CubeSTL (no hasNormals) and a Sphere with
+// CalculateNormals. The result has mixed meshIDs - some with hasNormals,
+// some without - which is the exact shape the per-meshID handling in
+// Impl::Transform / Compose / CreateProperties was added to support.
+Manifold MixedNormalsCubePlusSphere(double sphereRadius = 5.0) {
+  MeshGL cubeGL = CubeSTL();
+  cubeGL.Merge();
+  return Manifold(cubeGL).Translate({20, 0, 0}) +
+         Manifold::Sphere(sphereRadius, 32).CalculateNormals(0);
+}
+
+// Count verts on the sphere surface (|pos| ~ sphereRadius) whose stored
+// normal at slot 3..5+offset aligns with `expected(pos)` (dot > 0.9).
+// Returns (good, bad).
+template <typename ExpectedFn>
+std::pair<int, int> CountSphereNormalAlignment(const MeshGL& gl,
+                                               double sphereRadius,
+                                               int normalSlotOffset,
+                                               ExpectedFn expected) {
+  int good = 0, bad = 0;
+  for (size_t v = 0; v < gl.NumVert(); ++v) {
+    const vec3 pos(gl.vertProperties[v * gl.numProp + 0],
+                   gl.vertProperties[v * gl.numProp + 1],
+                   gl.vertProperties[v * gl.numProp + 2]);
+    if (std::abs(la::length(pos) - sphereRadius) > 0.1) continue;
+    const vec3 n(gl.vertProperties[v * gl.numProp + normalSlotOffset + 0],
+                 gl.vertProperties[v * gl.numProp + normalSlotOffset + 1],
+                 gl.vertProperties[v * gl.numProp + normalSlotOffset + 2]);
+    if (la::dot(n, expected(pos)) > 0.9)
+      ++good;
+    else
+      ++bad;
+  }
+  return {good, bad};
+}
+}  // namespace
+
+TEST(Manifold, TransformMixedNormalsPerMeshID) {
+  // Mixed Boolean output (no-normals + with-normals): the result's
+  // HasNormals() is false (AND across meshIDs), but the with-normals
+  // meshIDs still hold world-frame normals at slot 0..2 that must rotate
+  // with a subsequent Transform. Impl::Transform must per-meshID iterate,
+  // not skip on the whole-impl flag.
+  MeshGL gl = MixedNormalsCubePlusSphere().Rotate(90, 0, 0).GetMeshGL();
+  auto [good, bad] = CountSphereNormalAlignment(
+      gl, 5.0, 3, [](vec3 pos) { return la::normalize(pos); });
+  EXPECT_GT(good, 0);
+  EXPECT_EQ(bad, 0);
+}
+
+TEST(Manifold, ComposeMixedNormalsPerMeshID) {
+  // Compose's per-node eager-transform check is per-Relation, not whole-node.
+  // Pass a mixed Manifold with a pending Rotate into a 3-input BatchBoolean,
+  // forcing the disjoint Compose path where node->transform_ is non-identity
+  // and node->pImpl_->HasNormals() is false (mixed). Sphere's normals within
+  // the mixed input must still rotate.
+  const Manifold mixed_rot = MixedNormalsCubePlusSphere().Rotate(90, 0, 0);
+  const Manifold t1 = Manifold::Tetrahedron().Translate({-50, 0, 0});
+  const Manifold t2 = Manifold::Tetrahedron().Translate({-100, 0, 0});
+  MeshGL gl =
+      Manifold::BatchBoolean({mixed_rot, t1, t2}, OpType::Add).GetMeshGL();
+  auto [good, bad] = CountSphereNormalAlignment(
+      gl, 5.0, 3, [](vec3 pos) { return la::normalize(pos); });
+  EXPECT_GT(good, 0);
+  EXPECT_EQ(bad, 0);
+}
+
+TEST(Manifold, BooleanSubtractMixedQPerMeshIDNegation) {
+  // CreateProperties' cavity sign-flip must be per-source-meshID. Subtract a
+  // mixed Q (some meshIDs with hasNormals, some without). Cavity verts from
+  // the hasNormals meshIDs need their slot 0..2 flipped to point outward
+  // from the result solid (into the cavity = toward sphere center).
+  const Manifold A = Manifold::Cube({100, 100, 100}, true);
+  MeshGL gl = (A - MixedNormalsCubePlusSphere()).GetMeshGL();
+  auto [good, bad] = CountSphereNormalAlignment(
+      gl, 5.0, 3, [](vec3 pos) { return la::normalize(-pos); });
+  EXPECT_GT(good, 0);
+  EXPECT_EQ(bad, 0);
+}
+
+TEST(Manifold, CalculateNormalsNonZeroIdxSurvivesTransform) {
+  // Non-zero normalIdx is the legacy deferred-transform path: SetNormals
+  // stores slot N in per-mesh frame, and GetMeshGL(N)'s legacy export
+  // applies the per-run runTransform to recover world-frame. This must
+  // survive transforms applied between CalculateNormals and GetMeshGL.
+  const int idx = 3;
+  MeshGL gl = Manifold::Sphere(5.0, 32)
+                  .Rotate(30)
+                  .CalculateNormals(idx)
+                  .Rotate(60)
+                  .GetMeshGL(idx);
+  ASSERT_GE(gl.numProp, 3 + idx + 3);
+  auto [good, bad] = CountSphereNormalAlignment(
+      gl, 5.0, 3 + idx, [](vec3 pos) { return la::normalize(pos); });
+  EXPECT_GT(good, 0);
+  EXPECT_EQ(bad, 0);
 }
 
 TEST(Manifold, ErrorPropagationSmoothByNormals) {

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -35,6 +35,42 @@ int NumUnique(const std::vector<T>& in) {
   return unique.size();
 }
 
+// A disjoint Union of a CubeSTL (no hasNormals) and a Sphere with
+// CalculateNormals. The result has mixed meshIDs - some with hasNormals,
+// some without - the exact shape the per-meshID handling in
+// Impl::Transform / Compose / CreateProperties was added to support.
+Manifold MixedNormalsCubePlusSphere(double sphereRadius = 5.0) {
+  MeshGL cubeGL = CubeSTL();
+  cubeGL.Merge();
+  return Manifold(cubeGL).Translate({20, 0, 0}) +
+         Manifold::Sphere(sphereRadius, 32).CalculateNormals(0);
+}
+
+// Count verts on the sphere surface (|pos| ~ sphereRadius) whose stored
+// normal at slot 3..5+offset aligns with `expected(pos)` (dot > 0.9).
+// Returns (good, bad).
+template <typename ExpectedFn>
+std::pair<int, int> CountSphereNormalAlignment(const MeshGL& gl,
+                                               double sphereRadius,
+                                               int normalSlotOffset,
+                                               ExpectedFn expected) {
+  int good = 0, bad = 0;
+  for (size_t v = 0; v < gl.NumVert(); ++v) {
+    const vec3 pos(gl.vertProperties[v * gl.numProp + 0],
+                   gl.vertProperties[v * gl.numProp + 1],
+                   gl.vertProperties[v * gl.numProp + 2]);
+    if (std::abs(la::length(pos) - sphereRadius) > 0.1) continue;
+    const vec3 n(gl.vertProperties[v * gl.numProp + normalSlotOffset + 0],
+                 gl.vertProperties[v * gl.numProp + normalSlotOffset + 1],
+                 gl.vertProperties[v * gl.numProp + normalSlotOffset + 2]);
+    if (la::dot(n, expected(pos)) > 0.9)
+      ++good;
+    else
+      ++bad;
+  }
+  return {good, bad};
+}
+
 }  // namespace
 
 /**
@@ -229,126 +265,145 @@ TEST(Manifold, ErrorPropagationCalculateNormals) {
 
 // CalculateNormals(idx) followed by GetMeshGL() (no idx) used to drop
 // the transform-on-export step, returning input-frame data.
-TEST(Manifold, CalculateNormalsRoundTripsThroughGetMeshGL) {
-  // Cavity from a Boolean difference: inner-sphere normals should point
+TEST(Manifold, NormalsCavity) {
+  // The #1712 repro: inner-sphere normals from a Boolean diff should point
   // toward the origin (outward from the surrounding solid).
-  Manifold cavity = (Manifold::Sphere(10.0, 32) - Manifold::Sphere(3.0, 32))
-                        .CalculateNormals(0);
-  MeshGL cavityMesh = cavity.GetMeshGL();
-  ASSERT_GE(cavityMesh.numProp, 6);
-  int innerGood = 0, innerBad = 0;
-  for (size_t v = 0; v < cavityMesh.NumVert(); ++v) {
-    vec3 pos(cavityMesh.vertProperties[cavityMesh.numProp * v + 0],
-             cavityMesh.vertProperties[cavityMesh.numProp * v + 1],
-             cavityMesh.vertProperties[cavityMesh.numProp * v + 2]);
-    vec3 n(cavityMesh.vertProperties[cavityMesh.numProp * v + 3],
-           cavityMesh.vertProperties[cavityMesh.numProp * v + 4],
-           cavityMesh.vertProperties[cavityMesh.numProp * v + 5]);
-    if (std::abs(la::length(pos) - 3.0) < 0.05) {
-      if (la::dot(n, la::normalize(-pos)) > 0.9)
-        ++innerGood;
-      else
-        ++innerBad;
-    }
-  }
-  // Pre-fix all inner verts came out inverted; post-fix all align with the
-  // expected outward-from-solid direction.
-  EXPECT_GT(innerGood, 0);
-  EXPECT_EQ(innerBad, 0);
+  MeshGL mesh = (Manifold::Sphere(10.0, 32) - Manifold::Sphere(3.0, 32))
+                    .CalculateNormals(0)
+                    .GetMeshGL();
+  ASSERT_GE(mesh.numProp, 6);
+  auto [good, bad] = CountSphereNormalAlignment(
+      mesh, 3.0, 3, [](vec3 pos) { return la::normalize(-pos); });
+  EXPECT_GT(good, 0);
+  EXPECT_EQ(bad, 0);
+}
 
-  // Rotation before CalculateNormals: SetNormals stores input-frame
-  // (pre-rotation) normals; GetMeshGL must apply the forward transform
-  // on export to recover solid-frame.
-  Manifold rotated =
-      Manifold::Sphere(10.0, 32).Rotate(45, 0, 0).CalculateNormals(0);
-  MeshGL rotMesh = rotated.GetMeshGL();
-  int rotGood = 0, rotBad = 0;
-  for (size_t v = 0; v < rotMesh.NumVert(); ++v) {
-    vec3 pos(rotMesh.vertProperties[rotMesh.numProp * v + 0],
-             rotMesh.vertProperties[rotMesh.numProp * v + 1],
-             rotMesh.vertProperties[rotMesh.numProp * v + 2]);
-    vec3 n(rotMesh.vertProperties[rotMesh.numProp * v + 3],
-           rotMesh.vertProperties[rotMesh.numProp * v + 4],
-           rotMesh.vertProperties[rotMesh.numProp * v + 5]);
-    if (la::dot(n, la::normalize(pos)) > 0.9)
-      ++rotGood;
-    else
-      ++rotBad;
-  }
-  EXPECT_EQ(rotBad, 0);
+TEST(Manifold, NormalsRotateBeforeCalc) {
+  // Rotation before CalculateNormals: SetNormals computes from already-
+  // rotated faceNormal_ and stores world-frame at slot 0.
+  MeshGL mesh = Manifold::Sphere(10.0, 32)
+                    .Rotate(45, 0, 0)
+                    .CalculateNormals(0)
+                    .GetMeshGL();
+  auto [_, bad] = CountSphereNormalAlignment(
+      mesh, 10.0, 3, [](vec3 pos) { return la::normalize(pos); });
+  EXPECT_EQ(bad, 0);
+}
 
-  // Rotation *after* CalculateNormals: exercises hasNormals_ propagation
-  // through Impl::Transform.
-  Manifold transformedAfter =
-      Manifold::Sphere(10.0, 32).CalculateNormals(0).Rotate(45, 0, 0);
-  MeshGL afterMesh = transformedAfter.GetMeshGL();
-  int afterGood = 0, afterBad = 0;
-  for (size_t v = 0; v < afterMesh.NumVert(); ++v) {
-    vec3 pos(afterMesh.vertProperties[afterMesh.numProp * v + 0],
-             afterMesh.vertProperties[afterMesh.numProp * v + 1],
-             afterMesh.vertProperties[afterMesh.numProp * v + 2]);
-    vec3 n(afterMesh.vertProperties[afterMesh.numProp * v + 3],
-           afterMesh.vertProperties[afterMesh.numProp * v + 4],
-           afterMesh.vertProperties[afterMesh.numProp * v + 5]);
-    if (la::dot(n, la::normalize(pos)) > 0.9)
-      ++afterGood;
-    else
-      ++afterBad;
-  }
-  EXPECT_EQ(afterBad, 0);
+TEST(Manifold, NormalsRotateAfterCalc) {
+  // Rotation *after* CalculateNormals: Impl::Transform eager-transforms the
+  // stored slot 0..2 so it tracks the new orientation.
+  MeshGL mesh = Manifold::Sphere(10.0, 32)
+                    .CalculateNormals(0)
+                    .Rotate(45, 0, 0)
+                    .GetMeshGL();
+  auto [_, bad] = CountSphereNormalAlignment(
+      mesh, 10.0, 3, [](vec3 pos) { return la::normalize(pos); });
+  EXPECT_EQ(bad, 0);
+}
 
+TEST(Manifold, NormalsAutoSubstitute) {
   // No-arg invocation: defaults to slot 0 and sets the per-run hasNormals
   // bit on every output run.
-  MeshGL noIdxMesh = Manifold::Sphere(10.0, 32).CalculateNormals().GetMeshGL();
-  ASSERT_GE(noIdxMesh.numProp, 6);
-  ASSERT_GT(noIdxMesh.NumRun(), 0u);
-  EXPECT_TRUE(noIdxMesh.HasNormals(0));
+  MeshGL mesh = Manifold::Sphere(10.0, 32).CalculateNormals().GetMeshGL();
+  ASSERT_GE(mesh.numProp, 6);
+  ASSERT_GT(mesh.NumRun(), 0u);
+  EXPECT_TRUE(mesh.HasNormals(0));
+}
 
-  // Roundtrip: getMesh -> ofMesh -> getMesh should preserve the per-run flag,
-  // so the second getMesh still emits world-frame normals.
+TEST(Manifold, NormalsRoundTrip) {
+  // getMesh -> ofMesh -> getMesh preserves the per-run flag, so the second
+  // getMesh still emits world-frame normals.
   Manifold round = (Manifold::Sphere(10.0, 32) - Manifold::Sphere(3.0, 32))
                        .CalculateNormals();
-  MeshGL roundOut1 = round.GetMeshGL();
-  EXPECT_TRUE(roundOut1.HasNormals(0));
-  Manifold round2(roundOut1);
-  MeshGL roundOut2 = round2.GetMeshGL();
-  EXPECT_TRUE(roundOut2.HasNormals(0));
-  int rtGood = 0, rtBad = 0;
-  for (size_t v = 0; v < roundOut2.NumVert(); ++v) {
-    vec3 pos(roundOut2.vertProperties[roundOut2.numProp * v + 0],
-             roundOut2.vertProperties[roundOut2.numProp * v + 1],
-             roundOut2.vertProperties[roundOut2.numProp * v + 2]);
-    vec3 n(roundOut2.vertProperties[roundOut2.numProp * v + 3],
-           roundOut2.vertProperties[roundOut2.numProp * v + 4],
-           roundOut2.vertProperties[roundOut2.numProp * v + 5]);
-    if (std::abs(la::length(pos) - 3.0) < 0.05) {
-      if (la::dot(n, la::normalize(-pos)) > 0.9)
-        ++rtGood;
-      else
-        ++rtBad;
-    }
-  }
-  EXPECT_GT(rtGood, 0);
-  EXPECT_EQ(rtBad, 0);
+  MeshGL out1 = round.GetMeshGL();
+  EXPECT_TRUE(out1.HasNormals(0));
+  MeshGL out2 = Manifold(out1).GetMeshGL();
+  EXPECT_TRUE(out2.HasNormals(0));
+  auto [good, bad] = CountSphereNormalAlignment(
+      out2, 3.0, 3, [](vec3 pos) { return la::normalize(-pos); });
+  EXPECT_GT(good, 0);
+  EXPECT_EQ(bad, 0);
+}
 
-  // Refine preserves the recording: linearly-interpolated normals at the
-  // new verts are less precise than recomputed ones but still meaningful.
-  MeshGL refinedMesh =
+TEST(Manifold, NormalsRefinePreserved) {
+  // Refine keeps the recording: linearly-interpolated normals at the new
+  // verts are less precise than recomputed ones but still meaningful.
+  MeshGL mesh =
       Manifold::Sphere(10.0, 32).CalculateNormals().Refine(2).GetMeshGL();
-  ASSERT_GT(refinedMesh.NumRun(), 0u);
-  EXPECT_TRUE(refinedMesh.HasNormals(0));
+  ASSERT_GT(mesh.NumRun(), 0u);
+  EXPECT_TRUE(mesh.HasNormals(0));
+}
 
-  // SmoothByNormals() no-arg: smoke test that the new default-arg path is
-  // callable and produces a manifold (tangents at the standard slot).
+TEST(Manifold, NormalsSmoothByNormalsNoArg) {
+  // Smoke test that the no-arg SmoothByNormals reads from the recorded
+  // slot 0 and produces a valid manifold.
   Manifold smoothed =
       Manifold::Sphere(10.0, 32).CalculateNormals().SmoothByNormals();
   EXPECT_EQ(smoothed.Status(), Manifold::Error::NoError);
+}
 
-  // CalculateNormals(non-zero) does NOT set the recording: non-standard-slot
-  // recordings can't be safely auto-substituted on GetMeshGL(-1).
-  MeshGL nonStd = Manifold::Sphere(10.0, 32).CalculateNormals(3).GetMeshGL();
-  ASSERT_GT(nonStd.NumRun(), 0u);
-  EXPECT_FALSE(nonStd.HasNormals(0));
+TEST(Manifold, NormalsNonStandardSlotNotRecorded) {
+  // CalculateNormals(non-zero) does NOT set the per-run recording, since a
+  // non-standard slot can't be safely auto-substituted on GetMeshGL(-1).
+  MeshGL mesh = Manifold::Sphere(10.0, 32).CalculateNormals(3).GetMeshGL();
+  ASSERT_GT(mesh.NumRun(), 0u);
+  EXPECT_FALSE(mesh.HasNormals(0));
+}
+
+TEST(Manifold, NormalsSharedPropVertMixedFlags) {
+  // Per-run hasNormals is intended to let runs interpret slot 0..2
+  // independently. The eager-transform contract stores ONE value per
+  // propVert, so a propVert shared between a hasNormals=true run (treats
+  // slot as normals) and a hasNormals=false run (treats slot as color)
+  // can only carry one interpretation through a subsequent Transform.
+  //
+  // Currently this test FAILS by design: Impl::Transform applies the
+  // rotation when it sees the hasNormals run, corrupting Run 1's color.
+  // Fixing requires splitting propVerts whose runs disagree on the flag,
+  // either during ctor or during Transform. Leaving as a discussion-driver
+  // for now (see PR #1718 review thread).
+  MeshGL gl;
+  gl.numProp = 6;
+  const float pts[4][3] = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
+  for (int v = 0; v < 4; ++v) {
+    for (int j : {0, 1, 2}) gl.vertProperties.push_back(pts[v][j]);
+    // Slot 0..2: +Z. Run 0 treats as normal, Run 1 treats as color.
+    gl.vertProperties.push_back(0);
+    gl.vertProperties.push_back(0);
+    gl.vertProperties.push_back(1);
+  }
+  gl.triVerts = {0, 1, 3, 0, 2, 1, 0, 3, 2, 1, 2, 3};
+  gl.runOriginalID = {Manifold::ReserveIDs(1), Manifold::ReserveIDs(1)};
+  gl.runIndex = {0, 6, 12};
+  gl.runFlags = {0x02, 0x00};  // run 0 hasNormals, run 1 plain color
+
+  Manifold m(gl);
+  ASSERT_EQ(m.Status(), Manifold::Error::NoError);
+
+  MeshGL out = m.Rotate(90, 0, 0).GetMeshGL();
+
+  // Walk triangles per-run; verify each run's interpretation survived.
+  int run0Bad = 0;  // Run 0's normal should rotate to (0, -1, 0).
+  int run1Bad = 0;  // Run 1's color should stay (0, 0, 1).
+  for (size_t run = 0; run < out.NumRun(); ++run) {
+    const bool isNormalsRun = out.HasNormals(run);
+    for (uint32_t i = out.runIndex[run]; i < out.runIndex[run + 1]; ++i) {
+      const uint32_t v = out.triVerts[i];
+      const vec3 val(out.vertProperties[v * out.numProp + 3],
+                     out.vertProperties[v * out.numProp + 4],
+                     out.vertProperties[v * out.numProp + 5]);
+      if (isNormalsRun) {
+        const vec3 expected(0, -1, 0);
+        if (la::length(val - expected) > 0.01) ++run0Bad;
+      } else {
+        const vec3 expected(0, 0, 1);
+        if (la::length(val - expected) > 0.01) ++run1Bad;
+      }
+    }
+  }
+  EXPECT_EQ(run0Bad, 0);
+  EXPECT_EQ(run1Bad, 0);
 }
 
 TEST(Manifold, GetNormalLegacyContract) {
@@ -404,47 +459,9 @@ TEST(Manifold, GetNormalLegacyContract) {
   EXPECT_NEAR(sm_modern.SurfaceArea(), sm_legacy.SurfaceArea(), 1e-4);
 }
 
-namespace {
-// A disjoint Union of a CubeSTL (no hasNormals) and a Sphere with
-// CalculateNormals. The result has mixed meshIDs - some with hasNormals,
-// some without - which is the exact shape the per-meshID handling in
-// Impl::Transform / Compose / CreateProperties was added to support.
-Manifold MixedNormalsCubePlusSphere(double sphereRadius = 5.0) {
-  MeshGL cubeGL = CubeSTL();
-  cubeGL.Merge();
-  return Manifold(cubeGL).Translate({20, 0, 0}) +
-         Manifold::Sphere(sphereRadius, 32).CalculateNormals(0);
-}
-
-// Count verts on the sphere surface (|pos| ~ sphereRadius) whose stored
-// normal at slot 3..5+offset aligns with `expected(pos)` (dot > 0.9).
-// Returns (good, bad).
-template <typename ExpectedFn>
-std::pair<int, int> CountSphereNormalAlignment(const MeshGL& gl,
-                                               double sphereRadius,
-                                               int normalSlotOffset,
-                                               ExpectedFn expected) {
-  int good = 0, bad = 0;
-  for (size_t v = 0; v < gl.NumVert(); ++v) {
-    const vec3 pos(gl.vertProperties[v * gl.numProp + 0],
-                   gl.vertProperties[v * gl.numProp + 1],
-                   gl.vertProperties[v * gl.numProp + 2]);
-    if (std::abs(la::length(pos) - sphereRadius) > 0.1) continue;
-    const vec3 n(gl.vertProperties[v * gl.numProp + normalSlotOffset + 0],
-                 gl.vertProperties[v * gl.numProp + normalSlotOffset + 1],
-                 gl.vertProperties[v * gl.numProp + normalSlotOffset + 2]);
-    if (la::dot(n, expected(pos)) > 0.9)
-      ++good;
-    else
-      ++bad;
-  }
-  return {good, bad};
-}
-}  // namespace
-
 TEST(Manifold, TransformMixedNormalsPerMeshID) {
   // Mixed Boolean output (no-normals + with-normals): the result's
-  // HasNormals() is false (AND across meshIDs), but the with-normals
+  // AllHaveNormals() is false (AND across meshIDs), but the with-normals
   // meshIDs still hold world-frame normals at slot 0..2 that must rotate
   // with a subsequent Transform. Impl::Transform must per-meshID iterate,
   // not skip on the whole-impl flag.
@@ -459,8 +476,8 @@ TEST(Manifold, ComposeMixedNormalsPerMeshID) {
   // Compose's per-node eager-transform check is per-Relation, not whole-node.
   // Pass a mixed Manifold with a pending Rotate into a 3-input BatchBoolean,
   // forcing the disjoint Compose path where node->transform_ is non-identity
-  // and node->pImpl_->HasNormals() is false (mixed). Sphere's normals within
-  // the mixed input must still rotate.
+  // and node->pImpl_->AllHaveNormals() is false (mixed). Sphere's normals
+  // within the mixed input must still rotate.
   const Manifold mixed_rot = MixedNormalsCubePlusSphere().Rotate(90, 0, 0);
   const Manifold t1 = Manifold::Tetrahedron().Translate({-50, 0, 0});
   const Manifold t2 = Manifold::Tetrahedron().Translate({-100, 0, 0});

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -351,18 +351,15 @@ TEST(Manifold, NormalsNonStandardSlotNotRecorded) {
   EXPECT_FALSE(mesh.HasNormals(0));
 }
 
-TEST(Manifold, NormalsSharedPropVertMixedFlags) {
-  // Per-run hasNormals is intended to let runs interpret slot 0..2
-  // independently. The eager-transform contract stores ONE value per
-  // propVert, so a propVert shared between a hasNormals=true run (treats
-  // slot as normals) and a hasNormals=false run (treats slot as color)
-  // can only carry one interpretation through a subsequent Transform.
-  //
-  // Currently this test FAILS by design: Impl::Transform applies the
-  // rotation when it sees the hasNormals run, corrupting Run 1's color.
-  // Fixing requires splitting propVerts whose runs disagree on the flag,
-  // either during ctor or during Transform. Leaving as a discussion-driver
-  // for now (see PR #1718 review thread).
+TEST(Manifold, NormalsSharedPropVertMixedFlagsUndefined) {
+  // hasNormals is per-run, but a single propVert holds one slot 0..2
+  // value. If a hand-built MeshGL shares a propVert between a
+  // hasNormals=true run and a hasNormals=false run, a Transform rotates
+  // the slot on behalf of the hasNormals=true camp; the other camp's
+  // interpretation (e.g. color) is collateral damage. Standard
+  // CalculateNormals / Boolean / Compose outputs never share propVerts
+  // this way - this test pins the documented behaviour for the only
+  // input shape that can produce it.
   MeshGL gl;
   gl.numProp = 6;
   const float pts[4][3] = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
@@ -383,9 +380,8 @@ TEST(Manifold, NormalsSharedPropVertMixedFlags) {
 
   MeshGL out = m.Rotate(90, 0, 0).GetMeshGL();
 
-  // Walk triangles per-run; verify each run's interpretation survived.
-  int run0Bad = 0;  // Run 0's normal should rotate to (0, -1, 0).
-  int run1Bad = 0;  // Run 1's color should stay (0, 0, 1).
+  int run0Bad = 0;  // hasNormals camp: slot rotates as expected.
+  int run1Bad = 0;  // no-normals camp: collateral, slot is now rotated.
   for (size_t run = 0; run < out.NumRun(); ++run) {
     const bool isNormalsRun = out.HasNormals(run);
     for (uint32_t i = out.runIndex[run]; i < out.runIndex[run + 1]; ++i) {
@@ -403,7 +399,7 @@ TEST(Manifold, NormalsSharedPropVertMixedFlags) {
     }
   }
   EXPECT_EQ(run0Bad, 0);
-  EXPECT_EQ(run1Bad, 0);
+  EXPECT_GT(run1Bad, 0);
 }
 
 TEST(Manifold, GetNormalLegacyContract) {

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -352,12 +352,17 @@ TEST(Manifold, NormalsNonStandardSlotNotRecorded) {
 }
 
 TEST(Manifold, NormalsSharedPropVertMixedFlags) {
-  // Per-run hasNormals lets runs interpret slot 0..2 independently. The
-  // eager-transform contract stores ONE value per propVert, so a propVert
-  // shared between a hasNormals=true run (treats slot as normals) and a
-  // hasNormals=false run (treats slot as color) would otherwise be unable
-  // to carry both interpretations through a Transform. The MeshGL ctor
-  // therefore duplicates such propVerts so each camp gets its own slot.
+  // Per-run hasNormals is intended to let runs interpret slot 0..2
+  // independently. The eager-transform contract stores ONE value per
+  // propVert, so a propVert shared between a hasNormals=true run (treats
+  // slot as normals) and a hasNormals=false run (treats slot as color)
+  // can only carry one interpretation through a subsequent Transform.
+  //
+  // Currently this test FAILS by design: Impl::Transform applies the
+  // rotation when it sees the hasNormals run, corrupting Run 1's color.
+  // Fixing requires splitting propVerts whose runs disagree on the flag,
+  // either during ctor or during Transform. Leaving as a discussion-driver
+  // for now (see PR #1718 review thread).
   MeshGL gl;
   gl.numProp = 6;
   const float pts[4][3] = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {0, 0, 1}};

--- a/test/manifoldc_test.cpp
+++ b/test/manifoldc_test.cpp
@@ -659,44 +659,44 @@ TEST(CBIND, meshgl_run_accessors) {
   free(cube_tmp);
 }
 
-TEST(CBIND, meshgl_update_normals) {
-  // Get a mesh with normals, then verify UpdateNormals doesn't corrupt it.
+TEST(CBIND, run_flag_accessors) {
+  // CalculateNormals sets the per-run hasNormals bit; a subtractee cavity
+  // gets backside set. Exercise the C accessors for both bits.
   ManifoldManifold* cube =
-      manifold_cube(alloc_manifold_buffer(), 1.0, 1.0, 1.0, 0);
+      manifold_cube(alloc_manifold_buffer(), 2.0, 2.0, 2.0, 1);
+  ManifoldManifold* sphere = manifold_sphere(alloc_manifold_buffer(), 1.0, 32);
+  ManifoldManifold* cut =
+      manifold_difference(alloc_manifold_buffer(), cube, sphere);
   ManifoldManifold* with_normals =
-      manifold_calculate_normals(alloc_manifold_buffer(), cube, 3, 60.0);
-  EXPECT_EQ(manifold_status(with_normals), MANIFOLD_NO_ERROR);
-
-  // MeshGL with normals at channel 3
+      manifold_calculate_normals(alloc_manifold_buffer(), cut, 0, 60.0);
   ManifoldMeshGL* mesh =
-      manifold_get_meshgl_w_normals(alloc_meshgl_buffer(), with_normals, 3);
-  size_t tri_before = manifold_meshgl_num_tri(mesh);
-  manifold_meshgl_update_normals(mesh, 3);
-  EXPECT_EQ(manifold_meshgl_num_tri(mesh), tri_before);
+      manifold_get_meshgl(alloc_meshgl_buffer(), with_normals);
 
-  // Verify the mesh is still valid by constructing a Manifold from it.
-  ManifoldManifold* rebuilt = manifold_of_meshgl(alloc_manifold_buffer(), mesh);
-  EXPECT_EQ(manifold_status(rebuilt), MANIFOLD_NO_ERROR);
+  const size_t runs = manifold_meshgl_num_run(mesh);
+  ASSERT_GE(runs, 2u);
 
-  // MeshGL64 same test
-  ManifoldMeshGL64* mesh64 =
-      manifold_get_meshgl64_w_normals(alloc_meshgl64_buffer(), with_normals, 3);
-  manifold_meshgl64_update_normals(mesh64, 3);
-  ManifoldManifold* rebuilt64 =
-      manifold_of_meshgl64(alloc_manifold_buffer(), mesh64);
-  EXPECT_EQ(manifold_status(rebuilt64), MANIFOLD_NO_ERROR);
+  int backside_count = 0;
+  int has_normals_count = 0;
+  for (size_t r = 0; r < runs; ++r) {
+    if (manifold_meshgl_backside(mesh, r)) ++backside_count;
+    if (manifold_meshgl_has_normals(mesh, r)) ++has_normals_count;
+  }
+  EXPECT_EQ(backside_count, 1);
+  EXPECT_EQ(has_normals_count, static_cast<int>(runs));
 
-  manifold_destruct_manifold(rebuilt64);
-  manifold_destruct_meshgl64(mesh64);
-  manifold_destruct_manifold(rebuilt);
+  // Out-of-range returns false.
+  EXPECT_EQ(manifold_meshgl_backside(mesh, runs + 10), 0);
+  EXPECT_EQ(manifold_meshgl_has_normals(mesh, runs + 10), 0);
+
   manifold_destruct_meshgl(mesh);
   manifold_destruct_manifold(with_normals);
+  manifold_destruct_manifold(cut);
+  manifold_destruct_manifold(sphere);
   manifold_destruct_manifold(cube);
-  free(rebuilt64);
-  free(mesh64);
-  free(rebuilt);
   free(mesh);
   free(with_normals);
+  free(cut);
+  free(sphere);
   free(cube);
 }
 

--- a/test/properties_test.cpp
+++ b/test/properties_test.cpp
@@ -144,9 +144,8 @@ TEST(Properties, CalculateNormals) {
       norm2[j] = out2.vertProperties[np * v + 3 + j];
       ASSERT_FLOAT_EQ(pos[j], pos2[j]);
     }
-    // FIXME
-    // ASSERT_GT(dot(pos2, norm2), 0);
-    // ASSERT_GT(dot(pos, norm), 0);
+    if (dot(pos, norm) <= 0) ++numBad;
+    if (dot(pos2, norm2) <= 0) ++numBad2;
   }
   EXPECT_EQ(numBad, 0);
   EXPECT_EQ(numBad2, 0);

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -338,7 +338,31 @@ void RelatedGL(const Manifold& out, const std::vector<MeshGL>& originals,
     runTransforms[run] = output.GetRunTransform(run);
   }
   if (updateNormals) {
-    output.UpdateNormals(3);
+    // Bring slot 3..5 into world frame on every run and normalize. Runs with
+    // hasNormals (runFlags bit 1) are already in world frame but may be off
+    // unit-length from barycentric interpolation at seam verts; the others
+    // need the inverse-transpose of the per-run linear transform applied
+    // (and a sign flip for backside).
+    std::vector<bool> vertUpdated(output.NumVert(), false);
+    for (size_t run = 0; run < output.NumRun(); ++run) {
+      const bool runHasN = output.HasNormals(run);
+      const mat3 t =
+          runHasN ? mat3(la::identity)
+                  : la::inverse(la::transpose(mat3(runTransforms[run]))) *
+                        (output.Backside(run) ? -1.0 : 1.0);
+      for (uint32_t* itr = &output.triVerts[output.runIndex[run]];
+           itr < &output.triVerts[output.runIndex[run + 1]]; ++itr) {
+        const uint32_t v = *itr;
+        if (vertUpdated[v]) continue;
+        vertUpdated[v] = true;
+        vec3 n;
+        for (int k : {0, 1, 2})
+          n[k] = output.vertProperties[v * output.numProp + 3 + k];
+        n = la::normalize(t * n);
+        for (int k : {0, 1, 2})
+          output.vertProperties[v * output.numProp + 3 + k] = n[k];
+      }
+    }
   }
 
   for (size_t run = 0; run < output.NumRun(); ++run) {


### PR DESCRIPTION
Fixes #1712, fixes #1719.

## Summary

Make "where are my normals?" a property of the `Manifold` rather than something the caller threads through every call. After `CalculateNormals()`, `GetMeshGL()` returns world-frame normals without an explicit `normalIdx`, and a `MeshGL` <-> `Manifold` round-trip preserves the recording per-run even across mixed-input Booleans (e.g., a cube without normals composed with a sphere that has them).

The #1712 repro from `(sphere - sphere.Translate(10)).CalculateNormals().GetMeshGL()` now returns the expected outward-from-cavity normals. The underlying cross-mesh seam-vert sign issue (#1719) is fixed in `SetNormals`.

## Mechanism

- `runFlags` becomes a bitmask: bit 0 = backside (existing), bit 1 = hasNormals (new). New `MeshGLP::HasNormals(run)` accessor mirrors `Backside(run)`. Fixed `Backside` from `runFlags[run] == 1` to `& 1` so it survives the addition of a second bit.
- `CalculateNormals(0)` marks the per-meshID `Relation.hasNormals` flag, which `Impl::HasNormals()` ANDs across to give the impl-wide answer. `GetMeshGL(-1)` auto-substitutes slot 0 on output when `HasNormals()` is true.
- Normals at the standard slot are stored world-frame on the Impl. `Impl::Transform` and `csg_tree.cpp::Compose` eager-transform `properties_[0..2]` per-meshID so the slot stays in sync with `vertPos_` and `faceNormal_` across any sequence of transforms, including mixed-input Boolean/Compose outputs where some meshIDs carry normals and others don't.
- `SetNormals` multi-normal walk sign-flips `cross(next, here)` when it disagrees with `faceNormal_[next.face]`. This handles Boolean subtractee triangles (winding unchanged, faceNormal_ negated by the Boolean post-pass) without losing the existing "flair" curving for smooth surfaces. This is what fixes #1719.
- `CreateProperties` negates Q's slot 0..2 per source-meshID for subtractee cavity inversion.
- `GetNormal` returns `properties_[0..2]` directly when the meshID's `Relation.hasNormals` is true (world-frame already); applies the per-meshID inverse-normal-transform when false, preserving the pre-PR contract for hand-built MeshGL inputs that don't set the bit.
- Non-zero `normalIdx` to `CalculateNormals` uses the legacy deferred-transform path: stores per-mesh-frame, recovered to world-frame by `GetMeshGL`'s per-run transform on export. Docstring notes this path will be removed in a future release.

## API additions

- `MeshGLP::HasNormals(run)` C++ accessor plus C and Python bindings.
- `MeshGLP::Backside(run)` C and Python bindings (previously C++-only).

## Tests

- `Properties.CalculateNormals`: previously-FIXME'd `dot(pos, norm) > 0` asserts enabled (#1719 regression).
- `Manifold.CalculateNormalsRoundTripsThroughGetMeshGL`: ofMesh+getMesh preserving the per-run flag, Rotate before and after CalculateNormals, no-arg invocation, non-zero idx.
- `Manifold.GetNormalLegacyContract`: per-mesh-frame fallback in `GetNormal` for MeshGLs without bit 1.
- `Manifold.TransformMixedNormalsPerMeshID`, `Manifold.ComposeMixedNormalsPerMeshID`, `Manifold.BooleanSubtractMixedQPerMeshIDNegation`: per-meshID iteration in `Impl::Transform` / `Compose` / `CreateProperties` for mixed-input Boolean outputs.
- `Manifold.CalculateNormalsNonZeroIdxSurvivesTransform`: legacy non-zero `normalIdx` path across post-calc transforms.
- `CBIND.run_flag_accessors`: exercises the new C accessors.

## Known limitations

- Hand-built MeshGL inputs that share propVerts across runs with differing hasNormals settings produce one-interpretation-wins behavior at the shared propVerts (the stored value can only have one semantic). Standard `CalculateNormals` / Boolean / Compose outputs never produce this shape. Documented on `MeshGLP::HasNormals(run)`.
- `Warp` / `WarpBatch` / `SetProperties` keep the recording set; if the user replaces slot 0..2 or warps non-rigidly, the stored normals are stale until they call `CalculateNormals()` again. Documented on each method.
