### PR TITLE
Fix MSVC strict conversion warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,9 @@ endif()
 
 if(MSVC)
   list(APPEND MANIFOLD_FLAGS /DNOMINMAX /bigobj /fp:precise)
+  if(MANIFOLD_STRICT)
+    list(APPEND MANIFOLD_FLAGS /WX)
+  endif()
 else()
   list(
     APPEND

--- a/extras/minimize_testcase.cpp
+++ b/extras/minimize_testcase.cpp
@@ -89,7 +89,7 @@ bool safeToRemove(const Polygons& polys, size_t i, size_t j, double precision) {
 std::pair<int, int> findIndex(const Polygons& polys, size_t i) {
   size_t outer = 0;
   while (i >= polys[outer].size()) i -= polys[outer++].size();
-  return std::make_pair(outer, i);
+  return std::make_pair(static_cast<int>(outer), static_cast<int>(i));
 }
 
 void Dump(const Polygons& polys, const double epsilon) {

--- a/extras/minimize_testcase.cpp
+++ b/extras/minimize_testcase.cpp
@@ -86,10 +86,10 @@ bool safeToRemove(const Polygons& polys, size_t i, size_t j, double precision) {
   return true;
 }
 
-std::pair<int, int> findIndex(const Polygons& polys, size_t i) {
+std::pair<size_t, size_t> findIndex(const Polygons& polys, size_t i) {
   size_t outer = 0;
   while (i >= polys[outer].size()) i -= polys[outer++].size();
-  return std::make_pair(static_cast<int>(outer), static_cast<int>(i));
+  return std::make_pair(outer, i);
 }
 
 void Dump(const Polygons& polys, const double epsilon) {
@@ -117,9 +117,9 @@ void DumpTriangulation(const Polygons& polys, double precision) {
   std::vector<ivec3> result = Triangulate(polys);
   ManifoldParams() = oldParams;
   for (const ivec3& tri : result) {
-    std::pair<int, int> xid = findIndex(polys, tri.x);
-    std::pair<int, int> yid = findIndex(polys, tri.y);
-    std::pair<int, int> zid = findIndex(polys, tri.z);
+    std::pair<size_t, size_t> xid = findIndex(polys, tri.x);
+    std::pair<size_t, size_t> yid = findIndex(polys, tri.y);
+    std::pair<size_t, size_t> zid = findIndex(polys, tri.z);
     vec2 x = polys[xid.first][xid.second];
     vec2 y = polys[yid.first][yid.second];
     vec2 z = polys[zid.first][zid.second];

--- a/src/boolean3.cpp
+++ b/src/boolean3.cpp
@@ -387,7 +387,7 @@ Intersections Intersect12_(const Manifold::Impl& inP, const Manifold::Impl& inQ,
   sequence(i12.begin(), i12.end());
 
   int index = forward ? 0 : 1;
-  stable_sort(i12.begin(), i12.end(), [&](size_t a, size_t b) {
+  stable_sort(i12.begin(), i12.end(), [&](auto a, auto b) {
     return p1q2[a][index] < p1q2[b][index] ||
            (p1q2[a][index] == p1q2[b][index] &&
             p1q2[a][1 - index] < p1q2[b][1 - index]);
@@ -420,7 +420,7 @@ Vec<int> Winding03_(const Manifold::Impl& inP, const Manifold::Impl& inQ,
 
   // Invariant: every ctx-passing parallel op is followed by IsCancelled to
   // keep partial output from feeding unconditional downstream consumers.
-  DisjointSets uA(static_cast<uint32_t>(a.vertPos_.size()));
+  DisjointSets uA(a.vertPos_.size());
   for_each(autoPolicy(a.halfedge_.size()), countAt(0),
            countAt(static_cast<int>(a.halfedge_.size())), ctx, [&](int edge) {
              const int start = a.halfedge_.Start(edge);
@@ -437,26 +437,26 @@ Vec<int> Winding03_(const Manifold::Impl& inP, const Manifold::Impl& inQ,
   if (IsCancelled(ctx)) return Vec<int>{};
 
   // find components, the hope is the number of components should be small
-  std::unordered_set<int> components;
+  std::unordered_set<size_t> components;
 #if (MANIFOLD_PAR == 1)
   if (a.vertPos_.size() > 1e5) {
-    tbb::combinable<std::unordered_set<int>> componentsShared;
-    for_each(autoPolicy(a.vertPos_.size()), countAt(0),
-             countAt(static_cast<int>(a.vertPos_.size())), ctx,
-             [&](int v) { componentsShared.local().insert(uA.find(v)); });
-    componentsShared.combine_each([&](const std::unordered_set<int>& data) {
+    tbb::combinable<std::unordered_set<size_t>> componentsShared;
+    for_each(autoPolicy(a.vertPos_.size()), countAt(0_uz),
+             countAt(a.vertPos_.size()), ctx,
+             [&](size_t v) { componentsShared.local().insert(uA.find(v)); });
+    componentsShared.combine_each([&](const std::unordered_set<size_t>& data) {
       components.insert(data.begin(), data.end());
     });
   } else
 #endif
   {
     for (size_t v = 0; v < a.vertPos_.size(); v++)
-      components.insert(uA.find(static_cast<uint32_t>(v)));
+      components.insert(uA.find(v));
   }
   if (IsCancelled(ctx)) return Vec<int>{};
   Vec<int> verts;
   verts.reserve(components.size());
-  for (int c : components) verts.push_back(c);
+  for (size_t c : components) verts.push_back(static_cast<int>(c));
 
   Vec<int> w03(a.NumVert(), 0);
   Kernel02<expandP, forward> k02{a, b};
@@ -473,8 +473,8 @@ Vec<int> Winding03_(const Manifold::Impl& inP, const Manifold::Impl& inQ,
   // flood fill
   for_each(autoPolicy(w03.size()), countAt(0_uz), countAt(w03.size()), ctx,
            [&](size_t i) {
-             uint32_t root = uA.find(static_cast<uint32_t>(i));
-             if (root == static_cast<uint32_t>(i)) return;
+             size_t root = uA.find(i);
+             if (root == i) return;
              w03[i] = w03[root];
            });
   if (IsCancelled(ctx)) return Vec<int>{};

--- a/src/boolean3.cpp
+++ b/src/boolean3.cpp
@@ -387,7 +387,7 @@ Intersections Intersect12_(const Manifold::Impl& inP, const Manifold::Impl& inQ,
   sequence(i12.begin(), i12.end());
 
   int index = forward ? 0 : 1;
-  stable_sort(i12.begin(), i12.end(), [&](int a, int b) {
+  stable_sort(i12.begin(), i12.end(), [&](size_t a, size_t b) {
     return p1q2[a][index] < p1q2[b][index] ||
            (p1q2[a][index] == p1q2[b][index] &&
             p1q2[a][1 - index] < p1q2[b][1 - index]);
@@ -420,9 +420,9 @@ Vec<int> Winding03_(const Manifold::Impl& inP, const Manifold::Impl& inQ,
 
   // Invariant: every ctx-passing parallel op is followed by IsCancelled to
   // keep partial output from feeding unconditional downstream consumers.
-  DisjointSets uA(a.vertPos_.size());
+  DisjointSets uA(static_cast<uint32_t>(a.vertPos_.size()));
   for_each(autoPolicy(a.halfedge_.size()), countAt(0),
-           countAt(a.halfedge_.size()), ctx, [&](int edge) {
+           countAt(static_cast<int>(a.halfedge_.size())), ctx, [&](int edge) {
              const int start = a.halfedge_.Start(edge);
              const int end = a.halfedge_.End(edge);
              if (start >= end) return;
@@ -442,7 +442,7 @@ Vec<int> Winding03_(const Manifold::Impl& inP, const Manifold::Impl& inQ,
   if (a.vertPos_.size() > 1e5) {
     tbb::combinable<std::unordered_set<int>> componentsShared;
     for_each(autoPolicy(a.vertPos_.size()), countAt(0),
-             countAt(a.vertPos_.size()), ctx,
+             countAt(static_cast<int>(a.vertPos_.size())), ctx,
              [&](int v) { componentsShared.local().insert(uA.find(v)); });
     componentsShared.combine_each([&](const std::unordered_set<int>& data) {
       components.insert(data.begin(), data.end());
@@ -451,7 +451,7 @@ Vec<int> Winding03_(const Manifold::Impl& inP, const Manifold::Impl& inQ,
 #endif
   {
     for (size_t v = 0; v < a.vertPos_.size(); v++)
-      components.insert(uA.find(v));
+      components.insert(uA.find(static_cast<uint32_t>(v)));
   }
   if (IsCancelled(ctx)) return Vec<int>{};
   Vec<int> verts;
@@ -471,10 +471,10 @@ Vec<int> Winding03_(const Manifold::Impl& inP, const Manifold::Impl& inQ,
   b.collider_.Collisions<false>(recorder, f, verts.size(), true, ctx);
   if (IsCancelled(ctx)) return Vec<int>{};
   // flood fill
-  for_each(autoPolicy(w03.size()), countAt(0), countAt(w03.size()), ctx,
+  for_each(autoPolicy(w03.size()), countAt(0_uz), countAt(w03.size()), ctx,
            [&](size_t i) {
-             size_t root = uA.find(i);
-             if (root == i) return;
+             uint32_t root = uA.find(static_cast<uint32_t>(i));
+             if (root == static_cast<uint32_t>(i)) return;
              w03[i] = w03[root];
            });
   if (IsCancelled(ctx)) return Vec<int>{};

--- a/src/collider.h
+++ b/src/collider.h
@@ -306,7 +306,7 @@ class Collider {
     ZoneScoped;
     DEBUG_ASSERT(IsAxisAligned(transform), userErr,
                  "transform must be axis-aligned");
-    for_each(autoPolicy(nodeBBox_.size()), countAt(0),
+    for_each(autoPolicy(nodeBBox_.size()), countAt(0_uz),
              countAt(nodeBBox_.size()), [&transform, this](size_t i) {
                nodeBBox_[i] = nodeBBox_[i].Transform(transform);
              });

--- a/src/constructors.cpp
+++ b/src/constructors.cpp
@@ -490,7 +490,7 @@ std::vector<Manifold> Manifold::Decompose() const {
   if (pImpl_->status_ != Error::NoError) {
     return {PropagateStatus(pImpl_->status_)};
   }
-  DisjointSets uf(static_cast<uint32_t>(NumVert()));
+  DisjointSets uf(NumVert());
   for (size_t edge = 0; edge < pImpl_->halfedge_.size(); ++edge) {
     if (pImpl_->halfedge_.IsForward(edge)) {
       uf.unite(pImpl_->halfedge_.Start(edge), pImpl_->halfedge_.End(edge));
@@ -527,17 +527,16 @@ std::vector<Manifold> Manifold::Decompose() const {
     gather(vertNew2Old.begin(), vertNew2Old.end(), pImpl_->vertNormal_.begin(),
            impl->vertNormal_.begin());
 
-    Vec<int> faceNew2Old(NumTri());
+    Vec<int> faceNew2Old;
+    faceNew2Old.reserve(NumTri());
     const auto& halfedge = pImpl_->halfedge_;
-    const int nFace = copy_if(countAt(0), countAt(static_cast<int>(NumTri())),
-                              faceNew2Old.begin(),
-                              [i, &vertLabel, &halfedge](int face) {
-                                return vertLabel[halfedge.Start(3 * face)] == i;
-                              }) -
-                      faceNew2Old.begin();
+    for (size_t face = 0; face < NumTri(); ++face) {
+      if (vertLabel[halfedge.Start(static_cast<int>(3 * face))] == i) {
+        faceNew2Old.push_back(static_cast<int>(face));
+      }
+    }
 
-    if (nFace == 0) continue;
-    faceNew2Old.resize(nFace);
+    if (faceNew2Old.empty()) continue;
 
     impl->GatherFaces(*pImpl_, faceNew2Old);
     impl->ReindexVerts(vertNew2Old, pImpl_->NumVert());

--- a/src/constructors.cpp
+++ b/src/constructors.cpp
@@ -490,7 +490,7 @@ std::vector<Manifold> Manifold::Decompose() const {
   if (pImpl_->status_ != Error::NoError) {
     return {PropagateStatus(pImpl_->status_)};
   }
-  DisjointSets uf(NumVert());
+  DisjointSets uf(static_cast<uint32_t>(NumVert()));
   for (size_t edge = 0; edge < pImpl_->halfedge_.size(); ++edge) {
     if (pImpl_->halfedge_.IsForward(edge)) {
       uf.unite(pImpl_->halfedge_.Start(edge), pImpl_->halfedge_.End(edge));
@@ -529,12 +529,12 @@ std::vector<Manifold> Manifold::Decompose() const {
 
     Vec<int> faceNew2Old(NumTri());
     const auto& halfedge = pImpl_->halfedge_;
-    const int nFace =
-        copy_if(countAt(0_uz), countAt(NumTri()), faceNew2Old.begin(),
-                [i, &vertLabel, &halfedge](int face) {
-                  return vertLabel[halfedge.Start(3 * face)] == i;
-                }) -
-        faceNew2Old.begin();
+    const int nFace = copy_if(countAt(0), countAt(static_cast<int>(NumTri())),
+                              faceNew2Old.begin(),
+                              [i, &vertLabel, &halfedge](int face) {
+                                return vertLabel[halfedge.Start(3 * face)] == i;
+                              }) -
+                      faceNew2Old.begin();
 
     if (nFace == 0) continue;
     faceNew2Old.resize(nFace);

--- a/src/disjoint_sets.h
+++ b/src/disjoint_sets.h
@@ -21,8 +21,10 @@
 //
 #pragma once
 #include <atomic>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <unordered_map>
 #include <vector>
 
@@ -30,37 +32,32 @@
 
 class DisjointSets {
  public:
-  DisjointSets(uint32_t size) : mData(size) {
-    for (uint32_t i = 0; i < size; ++i) {
-      mData[i] = i;
-    }
+  DisjointSets(size_t size) : mData(size) {
+    assert(size <= std::numeric_limits<uint32_t>::max());
+    using namespace manifold;
+    for_each(autoPolicy(size), countAt(0_uz), countAt(size),
+             [this](size_t i) { mData[i] = static_cast<uint32_t>(i); });
   }
 
-  uint32_t find(uint32_t id) const {
-    while (id != parent(id)) {
-      uint64_t value = mData[id];
-      uint32_t new_parent = parent((uint32_t)value);
-      uint64_t new_value = (value & 0xFFFFFFFF00000000ULL) | new_parent;
-      /* Try to update parent (may fail, that's ok) */
-      if (value != new_value) mData[id].compare_exchange_weak(value, new_value);
-      id = new_parent;
-    }
-    return id;
-  }
+  size_t find(size_t id) const { return findImpl(ToIndex(id)); }
 
-  bool same(uint32_t id1, uint32_t id2) const {
+  bool same(size_t id1In, size_t id2In) const {
+    uint32_t id1 = ToIndex(id1In);
+    uint32_t id2 = ToIndex(id2In);
     for (;;) {
-      id1 = find(id1);
-      id2 = find(id2);
+      id1 = findImpl(id1);
+      id2 = findImpl(id2);
       if (id1 == id2) return true;
       if (parent(id1) == id1) return false;
     }
   }
 
-  uint32_t unite(uint32_t id1, uint32_t id2) {
+  size_t unite(size_t id1In, size_t id2In) {
+    uint32_t id1 = ToIndex(id1In);
+    uint32_t id2 = ToIndex(id2In);
     for (;;) {
-      id1 = find(id1);
-      id2 = find(id2);
+      id1 = findImpl(id1);
+      id2 = findImpl(id2);
 
       if (id1 == id2) return id1;
 
@@ -89,7 +86,7 @@ class DisjointSets {
     return id2;
   }
 
-  uint32_t size() const { return (uint32_t)mData.size(); }
+  size_t size() const { return mData.size(); }
 
   uint32_t rank(uint32_t id) const {
     return ((uint32_t)(mData[id] >> 32)) & 0x7FFFFFFFu;
@@ -104,7 +101,7 @@ class DisjointSets {
     for (size_t i = 0; i < mData.size(); ++i) {
       // we optimize for connected component of size 1
       // no need to put them into the hashmap
-      auto iParent = find(i);
+      uint32_t iParent = findImpl(ToIndex(i));
       if (rank(iParent) == 0) {
         components[i] = static_cast<int>(toLabel.size()) + lonelyNodes++;
         continue;
@@ -122,4 +119,22 @@ class DisjointSets {
   }
 
   mutable std::vector<std::atomic<uint64_t>> mData;
+
+ private:
+  static uint32_t ToIndex(size_t id) {
+    assert(id <= std::numeric_limits<uint32_t>::max());
+    return static_cast<uint32_t>(id);
+  }
+
+  uint32_t findImpl(uint32_t id) const {
+    while (id != parent(id)) {
+      uint64_t value = mData[id];
+      uint32_t new_parent = parent((uint32_t)value);
+      uint64_t new_value = (value & 0xFFFFFFFF00000000ULL) | new_parent;
+      /* Try to update parent (may fail, that's ok) */
+      if (value != new_value) mData[id].compare_exchange_weak(value, new_value);
+      id = new_parent;
+    }
+    return id;
+  }
 };

--- a/src/disjoint_sets.h
+++ b/src/disjoint_sets.h
@@ -31,9 +31,9 @@
 class DisjointSets {
  public:
   DisjointSets(uint32_t size) : mData(size) {
-    using namespace manifold;
-    for_each(autoPolicy(size), countAt(0), countAt(size),
-             [this](uint32_t i) { mData[i] = i; });
+    for (uint32_t i = 0; i < size; ++i) {
+      mData[i] = i;
+    }
   }
 
   uint32_t find(uint32_t id) const {

--- a/src/edge_op.cpp
+++ b/src/edge_op.cpp
@@ -739,7 +739,7 @@ void Manifold::Impl::SplitPinchedVerts() {
     // halfedges because it is thread local. This is why we need a vector to
     // deduplicate the probematic halfedges we found.
     std::vector<std::atomic<size_t>> largestEdge(NumVert());
-    for_each(ExecutionPolicy::Par, countAt(0), countAt(NumVert()),
+    for_each(ExecutionPolicy::Par, countAt(0_uz), countAt(NumVert()),
              [&largestEdge](size_t i) {
                largestEdge[i].store(std::numeric_limits<size_t>::max());
              });

--- a/src/face_op.cpp
+++ b/src/face_op.cpp
@@ -309,7 +309,7 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
   if (IsCancelled(ctx)) return;
 #else
   std::unordered_map<int, HalfedgeTriangulation> results;
-  for (size_t face = 0; face < faceEdge.size() - 1; ++face) {
+  for (int face = 0; face < static_cast<int>(faceEdge.size()) - 1; ++face) {
     if (IsCancelled(ctx)) return;
     const int numEdge = faceEdge[face + 1] - faceEdge[face];
     if (numEdge == 0) {

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -15,6 +15,7 @@
 #include "impl.h"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cstdio>
 #include <cstdlib>
@@ -821,15 +822,14 @@ static std::ostream& WriteOBJWithEpsilon(std::ostream& stream,
     }
     stream << std::endl;
   }
-  std::vector<ivec3> triangles;
+  std::vector<std::array<uint64_t, 3>> triangles;
   triangles.reserve(mesh.NumTri());
   for (size_t i = 0; i < mesh.NumTri(); i++)
-    triangles.emplace_back(static_cast<int>(mesh.triVerts[3 * i] + 1),
-                           static_cast<int>(mesh.triVerts[3 * i + 1] + 1),
-                           static_cast<int>(mesh.triVerts[3 * i + 2] + 1));
+    triangles.push_back({mesh.triVerts[3 * i] + 1, mesh.triVerts[3 * i + 1] + 1,
+                         mesh.triVerts[3 * i + 2] + 1});
   sort(triangles.begin(), triangles.end());
   for (const auto& tri : triangles)
-    stream << "f " << tri.x << " " << tri.y << " " << tri.z << std::endl;
+    stream << "f " << tri[0] << " " << tri[1] << " " << tri[2] << std::endl;
   stream << "# ======== end mesh =======" << std::endl;
   return stream;
 }

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -824,9 +824,9 @@ static std::ostream& WriteOBJWithEpsilon(std::ostream& stream,
   std::vector<ivec3> triangles;
   triangles.reserve(mesh.NumTri());
   for (size_t i = 0; i < mesh.NumTri(); i++)
-    triangles.emplace_back(mesh.triVerts[3 * i] + 1,
-                           mesh.triVerts[3 * i + 1] + 1,
-                           mesh.triVerts[3 * i + 2] + 1);
+    triangles.emplace_back(static_cast<int>(mesh.triVerts[3 * i] + 1),
+                           static_cast<int>(mesh.triVerts[3 * i + 1] + 1),
+                           static_cast<int>(mesh.triVerts[3 * i + 2] + 1));
   sort(triangles.begin(), triangles.end());
   for (const auto& tri : triangles)
     stream << "f " << tri.x << " " << tri.y << " " << tri.z << std::endl;

--- a/src/iters.h
+++ b/src/iters.h
@@ -208,6 +208,8 @@ struct CountingIterator {
   }
 };
 
+constexpr CountingIterator<int> countAt(int i) { return CountingIterator(i); }
+
 constexpr CountingIterator<size_t> countAt(size_t i) {
   return CountingIterator(i);
 }

--- a/src/iters.h
+++ b/src/iters.h
@@ -13,11 +13,20 @@
 // limitations under the License.
 #pragma once
 
+#include <cstddef>
 #include <iterator>
 #include <optional>
 #include <type_traits>
 
 namespace manifold {
+
+/**
+ * Stand-in for C++23's operator""uz (P0330R8)[https://wg21.link/P0330R8].
+ */
+[[nodiscard]] constexpr std::size_t operator""_uz(
+    unsigned long long n) noexcept {
+  return n;
+}
 
 template <typename F, typename Iter>
 struct TransformIterator {
@@ -208,9 +217,8 @@ struct CountingIterator {
   }
 };
 
-constexpr CountingIterator<int> countAt(int i) { return CountingIterator(i); }
-
-constexpr CountingIterator<size_t> countAt(size_t i) {
+template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
+constexpr CountingIterator<T> countAt(T i) {
   return CountingIterator(i);
 }
 

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -1151,7 +1151,7 @@ template <typename InputIterator1, typename InputIterator2,
           typename OutputIterator>
 void scatter(ExecutionPolicy policy, InputIterator1 first, InputIterator1 last,
              InputIterator2 mapFirst, OutputIterator outputFirst) {
-  for_each(policy, countAt(size_t{0}),
+  for_each(policy, countAt(0_uz),
            countAt(static_cast<size_t>(std::distance(first, last))),
            [first, mapFirst, outputFirst](size_t i) {
              outputFirst[mapFirst[i]] = first[i];
@@ -1183,7 +1183,7 @@ template <typename InputIterator, typename RandomAccessIterator,
 void gather(ExecutionPolicy policy, InputIterator mapFirst,
             InputIterator mapLast, RandomAccessIterator inputFirst,
             OutputIterator outputFirst) {
-  for_each(policy, countAt(size_t{0}),
+  for_each(policy, countAt(0_uz),
            countAt(static_cast<size_t>(std::distance(mapFirst, mapLast))),
            [mapFirst, inputFirst, outputFirst](size_t i) {
              outputFirst[i] = inputFirst[mapFirst[i]];
@@ -1207,7 +1207,7 @@ void gather(InputIterator mapFirst, InputIterator mapLast,
 // Write `[0, last - first)` to the range `[first, last)`.
 template <typename Iterator>
 void sequence(ExecutionPolicy policy, Iterator first, Iterator last) {
-  for_each(policy, countAt(size_t{0}),
+  for_each(policy, countAt(0_uz),
            countAt(static_cast<size_t>(std::distance(first, last))),
            [first](size_t i) { first[i] = i; });
 }

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -451,7 +451,8 @@ void for_each_n(ExecutionPolicy policy, Iter first, size_t n,
                     typename std::iterator_traits<Iter>::iterator_category,
                     std::random_access_iterator_tag>,
                 "You can only parallelize RandomAccessIterator.");
-  for_each(policy, first, first + n, ctx, f);
+  using Difference = typename std::iterator_traits<Iter>::difference_type;
+  for_each(policy, first, first + static_cast<Difference>(n), ctx, f);
 }
 
 // Non-cancellable shim.
@@ -811,7 +812,8 @@ size_t count_if(ExecutionPolicy policy, InputIter first, InputIter last,
 #if (MANIFOLD_PAR == 1)
   if (policy == ExecutionPolicy::Par) {
     return reduce(policy, TransformIterator(first, pred),
-                  TransformIterator(last, pred), 0, std::plus<size_t>());
+                  TransformIterator(last, pred), size_t{0},
+                  std::plus<size_t>());
   }
 #endif
   return std::count_if(first, last, pred);
@@ -1149,7 +1151,7 @@ template <typename InputIterator1, typename InputIterator2,
           typename OutputIterator>
 void scatter(ExecutionPolicy policy, InputIterator1 first, InputIterator1 last,
              InputIterator2 mapFirst, OutputIterator outputFirst) {
-  for_each(policy, countAt(0),
+  for_each(policy, countAt(size_t{0}),
            countAt(static_cast<size_t>(std::distance(first, last))),
            [first, mapFirst, outputFirst](size_t i) {
              outputFirst[mapFirst[i]] = first[i];
@@ -1181,7 +1183,7 @@ template <typename InputIterator, typename RandomAccessIterator,
 void gather(ExecutionPolicy policy, InputIterator mapFirst,
             InputIterator mapLast, RandomAccessIterator inputFirst,
             OutputIterator outputFirst) {
-  for_each(policy, countAt(0),
+  for_each(policy, countAt(size_t{0}),
            countAt(static_cast<size_t>(std::distance(mapFirst, mapLast))),
            [mapFirst, inputFirst, outputFirst](size_t i) {
              outputFirst[i] = inputFirst[mapFirst[i]];
@@ -1205,7 +1207,7 @@ void gather(InputIterator mapFirst, InputIterator mapLast,
 // Write `[0, last - first)` to the range `[first, last)`.
 template <typename Iterator>
 void sequence(ExecutionPolicy policy, Iterator first, Iterator last) {
-  for_each(policy, countAt(0),
+  for_each(policy, countAt(size_t{0}),
            countAt(static_cast<size_t>(std::distance(first, last))),
            [first](size_t i) { first[i] = i; });
 }

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -153,7 +153,7 @@ bool MergeMeshGLP(MeshGLP<Precision, I>& mesh) {
   Permute(openVerts, vertNew2Old);
 
   Collider collider(vertBox, vertMorton);
-  DisjointSets uf(static_cast<uint32_t>(numVert));
+  DisjointSets uf(numVert);
 
   auto f = [&uf, &openVerts](int a, int b) {
     return uf.unite(openVerts[a], openVerts[b]);
@@ -169,7 +169,7 @@ bool MergeMeshGLP(MeshGLP<Precision, I>& mesh) {
   mesh.mergeToVert.clear();
   mesh.mergeFromVert.clear();
   for (size_t v = 0; v < numVert; ++v) {
-    const size_t mergeTo = uf.find(static_cast<uint32_t>(v));
+    const size_t mergeTo = uf.find(v);
     if (mergeTo != v) {
       mesh.mergeFromVert.push_back(v);
       mesh.mergeToVert.push_back(mergeTo);

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -153,7 +153,7 @@ bool MergeMeshGLP(MeshGLP<Precision, I>& mesh) {
   Permute(openVerts, vertNew2Old);
 
   Collider collider(vertBox, vertMorton);
-  DisjointSets uf(numVert);
+  DisjointSets uf(static_cast<uint32_t>(numVert));
 
   auto f = [&uf, &openVerts](int a, int b) {
     return uf.unite(openVerts[a], openVerts[b]);
@@ -169,7 +169,7 @@ bool MergeMeshGLP(MeshGLP<Precision, I>& mesh) {
   mesh.mergeToVert.clear();
   mesh.mergeFromVert.clear();
   for (size_t v = 0; v < numVert; ++v) {
-    const size_t mergeTo = uf.find(v);
+    const size_t mergeTo = uf.find(static_cast<uint32_t>(v));
     if (mergeTo != v) {
       mesh.mergeFromVert.push_back(v);
       mesh.mergeToVert.push_back(mergeTo);
@@ -523,7 +523,7 @@ void Manifold::Impl::ReorderHalfedges(ExecutionContext::Impl* ctx) {
 
   // step 1: reorder within the same face, such that the halfedge with the
   // smallest starting vertex is placed first
-  for_each(autoPolicy(halfedge_.size() / 3), countAt(0),
+  for_each(autoPolicy(halfedge_.size() / 3), countAt(0_uz),
            countAt(halfedge_.size() / 3), ctx, [this](size_t tri) {
              std::array<Halfedge, 3> face = {halfedge_.Get(tri * 3),
                                              halfedge_.Get(tri * 3 + 1),
@@ -540,7 +540,7 @@ void Manifold::Impl::ReorderHalfedges(ExecutionContext::Impl* ctx) {
            });
   if (IsCancelled(ctx)) return;
   // step 2: fix paired halfedge
-  for_each(autoPolicy(halfedge_.size() / 3), countAt(0),
+  for_each(autoPolicy(halfedge_.size() / 3), countAt(0_uz),
            countAt(halfedge_.size() / 3), ctx, [this](size_t tri) {
              for (int i : {0, 1, 2}) {
                const int currIdx = tri * 3 + i;

--- a/src/subdivision.cpp
+++ b/src/subdivision.cpp
@@ -116,7 +116,7 @@ class Partition {
     const int offset = interiorOffset - newVerts.size();
     size_t old = newVerts.size();
     newVerts.resize_nofill(vertBary.size());
-    std::iota(newVerts.begin() + old, newVerts.end(), old + offset);
+    std::iota(newVerts.begin() + old, newVerts.end(), interiorOffset);
 
     const int numTri = triVert.size();
     Vec<ivec3> newTriVert(numTri);

--- a/src/utils.h
+++ b/src/utils.h
@@ -36,14 +36,6 @@
 
 namespace manifold {
 
-/**
- * Stand-in for C++23's operator""uz (P0330R8)[https://wg21.link/P0330R8].
- */
-[[nodiscard]] constexpr std::size_t operator""_uz(
-    unsigned long long n) noexcept {
-  return n;
-}
-
 constexpr double kPrecision = 1e-12;
 
 inline int Next3(int i) {


### PR DESCRIPTION
Fixes #1189

## Summary

This enables MSVC warnings-as-errors for strict builds and fixes the C4267 size/sign conversion warnings reported when building with MSVC.

The main change is to make `countAt()` preserve the integral type it is given. This keeps existing int-indexed loops as `int` ranges when they use `countAt(0)`, while allowing genuinely size-indexed loops to opt into `size_t` with `countAt(size_t{0})` / `countAt(0_uz)`.

## Details

- Add `/WX` for MSVC when `MANIFOLD_STRICT` is enabled.
- Make `countAt(T)` return `CountingIterator<T>` instead of always producing a `size_t` iterator.
- Fix call sites to choose the intended index type explicitly.
- Avoid adding a mixed `CountingIterator<T>, CountingIterator<U>` `for_each` overload, so mixed begin/end types do not silently create extra template instantiations.
- Add explicit casts where the surrounding data structures are already int-indexed.

## Testing

- `cmake --build build --target manifold_test -j2`
- Fork CI Windows matrix passed: https://github.com/zmerlynn/manifold/actions/runs/26119491509