### PR TITLE
Thread ExecutionContext into Smooth via ExecutionContext::Smooth

### DIFF
--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -268,6 +268,15 @@ class ExecutionContext {
   Manifold FromMeshGL(const MeshGL& mesh);
   Manifold FromMeshGL(const MeshGL64& mesh);
 
+  /// Eager ctx-aware `Manifold::Smooth(MeshGL[64])`. The ingest phases
+  /// plus the tangent-creation phases check cancel and credit
+  /// `Progress()` between phases. Same cancel-vs-validation precedence
+  /// as `FromMeshGL`.
+  Manifold Smooth(const MeshGL& mesh,
+                  const std::vector<Smoothness>& sharpenedEdges = {});
+  Manifold Smooth(const MeshGL64& mesh,
+                  const std::vector<Smoothness>& sharpenedEdges = {});
+
   /// @internal Opaque implementation. Defined in src/execution_impl.h;
   /// accessible only to internal code that includes that header.
   struct Impl;

--- a/src/constructors.cpp
+++ b/src/constructors.cpp
@@ -19,38 +19,6 @@
 #include "manifold/polygon.h"
 #include "parallel.h"
 
-namespace {
-using namespace manifold;
-
-template <typename P, typename I>
-std::shared_ptr<Manifold::Impl> SmoothImpl(
-    const MeshGLP<P, I>& meshGL,
-    const std::vector<Smoothness>& sharpenedEdges) {
-  DEBUG_ASSERT(meshGL.halfedgeTangent.empty(), std::runtime_error,
-               "when supplying tangents, the normal constructor should be used "
-               "rather than Smooth().");
-
-  MeshGLP<P, I> meshTmp = meshGL;
-  meshTmp.faceID.resize(meshGL.NumTri());
-  std::iota(meshTmp.faceID.begin(), meshTmp.faceID.end(), 0);
-
-  std::shared_ptr<Manifold::Impl> impl =
-      std::make_shared<Manifold::Impl>(meshTmp);
-  impl->CreateTangents(impl->UpdateSharpenedEdges(sharpenedEdges));
-  // Restore the original faceID
-  const size_t numTri = impl->NumTri();
-  for (size_t i = 0; i < numTri; ++i) {
-    if (meshGL.faceID.size() == numTri) {
-      impl->meshRelation_.triRef[i].faceID =
-          meshGL.faceID[impl->meshRelation_.triRef[i].faceID];
-    } else {
-      impl->meshRelation_.triRef[i].faceID = -1;
-    }
-  }
-  return impl;
-}
-}  // namespace
-
 namespace manifold {
 /**
  * Constructs a smooth version of the input mesh by creating tangents; this
@@ -82,7 +50,7 @@ namespace manifold {
  */
 Manifold Manifold::Smooth(const MeshGL& meshGL,
                           const std::vector<Smoothness>& sharpenedEdges) {
-  return Manifold(SmoothImpl(meshGL, sharpenedEdges));
+  return Manifold(MakeSmoothImpl(meshGL, sharpenedEdges));
 }
 
 /**
@@ -115,7 +83,7 @@ Manifold Manifold::Smooth(const MeshGL& meshGL,
  */
 Manifold Manifold::Smooth(const MeshGL64& meshGL64,
                           const std::vector<Smoothness>& sharpenedEdges) {
-  return Manifold(SmoothImpl(meshGL64, sharpenedEdges));
+  return Manifold(MakeSmoothImpl(meshGL64, sharpenedEdges));
 }
 
 /**

--- a/src/execution_impl.cpp
+++ b/src/execution_impl.cpp
@@ -72,4 +72,16 @@ Manifold ExecutionContext::FromMeshGL(const MeshGL64& mesh) {
       std::make_shared<Manifold::Impl>(mesh, impl_.get()));
 }
 
+Manifold ExecutionContext::Smooth(
+    const MeshGL& mesh, const std::vector<Smoothness>& sharpenedEdges) {
+  ResetForStaticFactory(impl_.get(), kPhasesPerSmooth);
+  return Manifold::FromImpl(MakeSmoothImpl(mesh, sharpenedEdges, impl_.get()));
+}
+
+Manifold ExecutionContext::Smooth(
+    const MeshGL64& mesh, const std::vector<Smoothness>& sharpenedEdges) {
+  ResetForStaticFactory(impl_.get(), kPhasesPerSmooth);
+  return Manifold::FromImpl(MakeSmoothImpl(mesh, sharpenedEdges, impl_.get()));
+}
+
 }  // namespace manifold

--- a/src/execution_impl.h
+++ b/src/execution_impl.h
@@ -44,9 +44,7 @@ constexpr int kPhasesPerFromMesh = 7;
  * `kPhasesPerFromMesh` ingest phases followed by 7 tangent-creation
  * phases in `Manifold::Impl::CreateTangents(sharpenedEdges, ctx)`.
  * Bump in lockstep with `ADVANCE_PHASE_OR_RETURN(ctx)` sites in that
- * function. Note: Phase 4 of CreateTangents contains two sequential
- * sub-loops (sharpenedEdges then edges) that count as one phase
- * boundary at this granularity.
+ * function.
  */
 constexpr int kPhasesPerSmooth = kPhasesPerFromMesh + 7;
 

--- a/src/execution_impl.h
+++ b/src/execution_impl.h
@@ -40,6 +40,18 @@ constexpr int kPhasesPerFromMesh = 7;
 
 /** @ingroup Private
  *
+ * Heavy phases in `ExecutionContext::Smooth(MeshGL[64])`: the
+ * `kPhasesPerFromMesh` ingest phases followed by 7 tangent-creation
+ * phases in `Manifold::Impl::CreateTangents(sharpenedEdges, ctx)`.
+ * Bump in lockstep with `ADVANCE_PHASE_OR_RETURN(ctx)` sites in that
+ * function. Note: Phase 4 of CreateTangents contains two sequential
+ * sub-loops (sharpenedEdges then edges) that count as one phase
+ * boundary at this granularity.
+ */
+constexpr int kPhasesPerSmooth = kPhasesPerFromMesh + 7;
+
+/** @ingroup Private
+ *
  * Pimpl for ExecutionContext. `cancel` is private; use `IsCancelled(ctx)`
  * to read it -- this is the canonical reader, enforced by the type system.
  * `totalBooleans`, `doneBooleans`, `totalPhases`, and `donePhases` are

--- a/src/impl.h
+++ b/src/impl.h
@@ -679,12 +679,8 @@ inline MeshGLP<Precision, I> GetMeshGLImpl(const manifold::Manifold::Impl& impl,
   return out;
 }
 
-// Shared implementation of Manifold::Smooth(MeshGL[64]) and
-// ExecutionContext::Smooth(MeshGL[64]). Builds the Impl via the ctx-aware
-// MeshGLP ctor, runs CreateTangents with the same ctx, then restores the
-// caller's faceID mapping. Cancel-precedence mirrors the FromMeshGL pattern:
-// entry-time cancel wins; past the entry gate, validation errors from the
-// inner ctor win over a racing cancel.
+// Entry-time cancel wins over empty/malformed input; past this gate,
+// validation errors win over races.
 template <typename P, typename I>
 std::shared_ptr<Manifold::Impl> MakeSmoothImpl(
     const MeshGLP<P, I>& meshGL, const std::vector<Smoothness>& sharpenedEdges,
@@ -705,13 +701,11 @@ std::shared_ptr<Manifold::Impl> MakeSmoothImpl(
 
   std::shared_ptr<Manifold::Impl> impl =
       std::make_shared<Manifold::Impl>(meshTmp, ctx);
-  // Validation errors from the inner ctor (and cancel observed there)
-  // skip tangent creation so phase counters stay honest -- a Cancelled
-  // ingest must not credit smoothing phases that never ran.
+  // Skip tangent creation if ingest failed; phase counters must not
+  // credit smoothing phases that never ran.
   if (impl->status_ != Manifold::Error::NoError) return impl;
   impl->CreateTangents(impl->UpdateSharpenedEdges(sharpenedEdges), ctx);
-  // Restore the original faceID. If CreateTangents was cancelled or the
-  // ingest produced an empty Impl, NumTri() is 0 and this loop is a no-op.
+  // NumTri() is 0 after MakeEmpty, so this loop is a no-op on cancel.
   const size_t numTri = impl->NumTri();
   for (size_t i = 0; i < numTri; ++i) {
     if (meshGL.faceID.size() == numTri) {

--- a/src/impl.h
+++ b/src/impl.h
@@ -231,7 +231,8 @@ struct Manifold::Impl {
   void LinearizeFlatTangents();
   void DistributeTangents(const Vec<bool>& fixedHalfedges);
   void CreateTangents(int normalIdx);
-  void CreateTangents(std::vector<Smoothness>);
+  void CreateTangents(std::vector<Smoothness>,
+                      ExecutionContext::Impl* ctx = nullptr);
   void Refine(std::function<int(vec3, vec4, vec4)>, bool = false,
               ExecutionContext::Impl* ctx = nullptr);
 
@@ -676,5 +677,50 @@ inline MeshGLP<Precision, I> GetMeshGLImpl(const manifold::Manifold::Impl& impl,
     }
   }
   return out;
+}
+
+// Shared implementation of Manifold::Smooth(MeshGL[64]) and
+// ExecutionContext::Smooth(MeshGL[64]). Builds the Impl via the ctx-aware
+// MeshGLP ctor, runs CreateTangents with the same ctx, then restores the
+// caller's faceID mapping. Cancel-precedence mirrors the FromMeshGL pattern:
+// entry-time cancel wins; past the entry gate, validation errors from the
+// inner ctor win over a racing cancel.
+template <typename P, typename I>
+std::shared_ptr<Manifold::Impl> MakeSmoothImpl(
+    const MeshGLP<P, I>& meshGL, const std::vector<Smoothness>& sharpenedEdges,
+    ExecutionContext::Impl* ctx = nullptr) {
+  if (IsCancelled(ctx)) {
+    auto impl = std::make_shared<Manifold::Impl>();
+    impl->MakeEmpty(Manifold::Error::Cancelled);
+    return impl;
+  }
+
+  DEBUG_ASSERT(meshGL.halfedgeTangent.empty(), std::runtime_error,
+               "when supplying tangents, the normal constructor should be used "
+               "rather than Smooth().");
+
+  MeshGLP<P, I> meshTmp = meshGL;
+  meshTmp.faceID.resize(meshGL.NumTri());
+  std::iota(meshTmp.faceID.begin(), meshTmp.faceID.end(), 0);
+
+  std::shared_ptr<Manifold::Impl> impl =
+      std::make_shared<Manifold::Impl>(meshTmp, ctx);
+  // Validation errors from the inner ctor (and cancel observed there)
+  // skip tangent creation so phase counters stay honest -- a Cancelled
+  // ingest must not credit smoothing phases that never ran.
+  if (impl->status_ != Manifold::Error::NoError) return impl;
+  impl->CreateTangents(impl->UpdateSharpenedEdges(sharpenedEdges), ctx);
+  // Restore the original faceID. If CreateTangents was cancelled or the
+  // ingest produced an empty Impl, NumTri() is 0 and this loop is a no-op.
+  const size_t numTri = impl->NumTri();
+  for (size_t i = 0; i < numTri; ++i) {
+    if (meshGL.faceID.size() == numTri) {
+      impl->meshRelation_.triRef[i].faceID =
+          meshGL.faceID[impl->meshRelation_.triRef[i].faceID];
+    } else {
+      impl->meshRelation_.triRef[i].faceID = -1;
+    }
+  }
+  return impl;
 }
 }  // namespace manifold

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -933,7 +933,8 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
  * curvature there, while the tangents of the sharp edges themselves are aligned
  * for continuity.
  */
-void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges) {
+void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges,
+                                    ExecutionContext::Impl* ctx) {
   ZoneScoped;
   const int numHalfedge = halfedge_.size();
   halfedgeTangent_.clear();
@@ -949,8 +950,9 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges) {
       vertNormal[v] = faceNormal_[vertFlatFace[v]];
     }
   }
+  ADVANCE_PHASE_OR_RETURN(ctx);
 
-  for_each_n(autoPolicy(numHalfedge, 1e4), countAt(0), numHalfedge,
+  for_each_n(autoPolicy(numHalfedge, 1e4), countAt(0), numHalfedge, ctx,
              [&tangent, &vertNormal, this](const int edgeIdx) {
                tangent[edgeIdx] =
                    IsInsideQuad(edgeIdx)
@@ -960,6 +962,7 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges) {
              });
 
   halfedgeTangent_ = std::move(tangent);
+  ADVANCE_PHASE_OR_RETURN(ctx);
 
   // Add sharpened edges around faces, just on the face side.
   for (size_t tri = 0; tri < NumTri(); ++tri) {
@@ -972,6 +975,7 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges) {
       }
     }
   }
+  ADVANCE_PHASE_OR_RETURN(ctx);
 
   using Pair = std::pair<Smoothness, Smoothness>;
   // Fill in missing pairs with default smoothness = 1.
@@ -997,10 +1001,11 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges) {
     vertTangents[halfedge_.Start(edge.second.halfedge)].push_back(
         {edge.second, edge.first});
   }
+  ADVANCE_PHASE_OR_RETURN(ctx);
 
   const int numVert = NumVert();
   for_each_n(
-      autoPolicy(numVert, 1e4), countAt(0), numVert,
+      autoPolicy(numVert, 1e4), countAt(0), numVert, ctx,
       [this, &vertTangents, &fixedHalfedge, &vertHalfedge,
        &triIsFlatFace](int v) {
         auto it = vertTangents.find(v);
@@ -1059,9 +1064,13 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges) {
                   });
         }
       });
+  ADVANCE_PHASE_OR_RETURN(ctx);
 
   LinearizeFlatTangents();
+  ADVANCE_PHASE_OR_RETURN(ctx);
+
   DistributeTangents(fixedHalfedge);
+  ADVANCE_PHASE_OR_RETURN(ctx);
 }
 
 bool Manifold::Impl::ValidTangents() const {

--- a/test/context_test.cpp
+++ b/test/context_test.cpp
@@ -21,7 +21,6 @@
 #include <atomic>
 #include <chrono>
 #include <thread>
-#include <type_traits>
 
 #include "../src/execution_impl.h"
 #include "../src/parallel.h"
@@ -782,6 +781,44 @@ TEST(Manifold, ManifoldContextCancelMidEval) {
   EXPECT_EQ(attached.Status(), Manifold::Error::Cancelled);
 }
 
+// FromMeshGL: ctx-aware analog of the `Manifold(MeshGL)` ctor.
+TEST(ExecutionContextFromMeshGL, HappyPath) {
+  ExecutionContext ctx;
+  Manifold tet = ctx.FromMeshGL(TetGL());
+  EXPECT_FALSE(tet.IsEmpty());
+  EXPECT_EQ(tet.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerFromMesh);
+  EXPECT_EQ(ctx.impl_->donePhases.load(), kPhasesPerFromMesh);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
+}
+
+// Equivalent geometry to the plain ctor.
+TEST(ExecutionContextFromMeshGL, MatchesCtor) {
+  MeshGL mesh = Manifold::Sphere(1.0, 32).GetMeshGL();
+  ExecutionContext ctx;
+  Manifold viaCtx = ctx.FromMeshGL(mesh);
+  Manifold viaCtor(mesh);
+  EXPECT_EQ(viaCtx.Status(), viaCtor.Status());
+  EXPECT_EQ(viaCtx.NumTri(), viaCtor.NumTri());
+  EXPECT_EQ(viaCtx.NumVert(), viaCtor.NumVert());
+}
+
+// Pre-cancel beats the heavy path on well-formed input.
+TEST(ExecutionContextFromMeshGL, CancelBeforeIngest) {
+  ExecutionContext ctx;
+  ctx.Cancel();
+  Manifold m = ctx.FromMeshGL(TetGL());
+  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
+}
+
+// Pre-cancel beats the empty-input fast path (would otherwise be NoError).
+TEST(ExecutionContextFromMeshGL, CancelBeforeEmptyInputWinsOverNoError) {
+  ExecutionContext ctx;
+  ctx.Cancel();
+  Manifold m = ctx.FromMeshGL(MeshGL{});
+  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
+}
+
 // Trips `numProp < 3` validation but has enough verts/tris to clear the
 // empty/under-4 short-circuits first. Coupled to ingest validation
 // order: if MissingPositionProperties moved past NotManifold these
@@ -794,126 +831,29 @@ static MeshGL MalformedMissingPositionProperties() {
   return bad;
 }
 
-// Traits describing each ctx-aware static factory: the ctx call, the plain
-// (non-ctx) equivalent for the parity test, and the expected phase count.
-//
-// TODO: this contract is `(ExecutionContext&, const MeshGL&) -> Manifold`
-// only. When a 3rd ctx static factory lands with a non-MeshGL signature
-// (LevelSet takes `(sdf, bounds, edgeLength)`, Hull takes a vector, etc.),
-// either add a parallel typed suite for that shape or refactor to
-// fixture-based traits where each `SmallValid`/`Empty`/`Malformed` is a
-// trait method returning a Manifold. Until then the duplication cost of a
-// per-factory cluster is lower than the generalization cost.
-struct FromMeshGLTraits {
-  static constexpr int kPhases = kPhasesPerFromMesh;
-  static constexpr const char* kName = "FromMeshGL";
-  static Manifold ViaCtx(ExecutionContext& ctx, const MeshGL& mesh) {
-    return ctx.FromMeshGL(mesh);
-  }
-  static Manifold ViaPlain(const MeshGL& mesh) { return Manifold(mesh); }
-};
-
-struct SmoothTraits {
-  static constexpr int kPhases = kPhasesPerSmooth;
-  static constexpr const char* kName = "Smooth";
-  static Manifold ViaCtx(ExecutionContext& ctx, const MeshGL& mesh) {
-    return ctx.Smooth(mesh);
-  }
-  static Manifold ViaPlain(const MeshGL& mesh) {
-    return Manifold::Smooth(mesh);
-  }
-};
-
-// Compile-time contract check: each traits struct must expose `kPhases`
-// (int), `kName` (const char*), and the two static factory methods.
-template <typename T>
-inline constexpr bool kIsStaticFactoryTraits =
-    std::is_same_v<decltype(T::kPhases), const int> &&
-    std::is_convertible_v<decltype(T::kName), const char*> &&
-    std::is_invocable_r_v<Manifold, decltype(&T::ViaCtx), ExecutionContext&,
-                          const MeshGL&> &&
-    std::is_invocable_r_v<Manifold, decltype(&T::ViaPlain), const MeshGL&>;
-static_assert(kIsStaticFactoryTraits<FromMeshGLTraits>);
-static_assert(kIsStaticFactoryTraits<SmoothTraits>);
-
-template <typename Factory>
-class ExecutionContextStaticFactory : public ::testing::Test {};
-
-class FactoryNameGenerator {
- public:
-  template <typename T>
-  static std::string GetName(int) {
-    return T::kName;
-  }
-};
-
-using StaticFactories = ::testing::Types<FromMeshGLTraits, SmoothTraits>;
-TYPED_TEST_SUITE(ExecutionContextStaticFactory, StaticFactories,
-                 FactoryNameGenerator);
-
-TYPED_TEST(ExecutionContextStaticFactory, HappyPath) {
-  ExecutionContext ctx;
-  Manifold m = TypeParam::ViaCtx(ctx, TetGL());
-  EXPECT_FALSE(m.IsEmpty());
-  EXPECT_EQ(m.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(ctx.impl_->totalPhases.load(), TypeParam::kPhases);
-  EXPECT_EQ(ctx.impl_->donePhases.load(), TypeParam::kPhases);
-  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
-}
-
-// Equivalent geometry to the plain (non-ctx) call.
-TYPED_TEST(ExecutionContextStaticFactory, MatchesPlain) {
-  MeshGL mesh = Manifold::Sphere(1.0, 32).GetMeshGL();
-  ExecutionContext ctx;
-  Manifold viaCtx = TypeParam::ViaCtx(ctx, mesh);
-  Manifold viaPlain = TypeParam::ViaPlain(mesh);
-  EXPECT_EQ(viaCtx.Status(), viaPlain.Status());
-  EXPECT_EQ(viaCtx.NumTri(), viaPlain.NumTri());
-  EXPECT_EQ(viaCtx.NumVert(), viaPlain.NumVert());
-}
-
-// Pre-cancel beats the heavy path on well-formed input.
-TYPED_TEST(ExecutionContextStaticFactory, CancelBeforeIngest) {
-  ExecutionContext ctx;
-  ctx.Cancel();
-  EXPECT_EQ(TypeParam::ViaCtx(ctx, TetGL()).Status(),
-            Manifold::Error::Cancelled);
-}
-
-// Pre-cancel beats the empty-input fast path (would otherwise be NoError).
-TYPED_TEST(ExecutionContextStaticFactory,
-           CancelBeforeEmptyInputWinsOverNoError) {
-  ExecutionContext ctx;
-  ctx.Cancel();
-  EXPECT_EQ(TypeParam::ViaCtx(ctx, MeshGL{}).Status(),
-            Manifold::Error::Cancelled);
-}
-
 // Pre-cancel beats validation errors.
-TYPED_TEST(ExecutionContextStaticFactory,
-           CancelBeforeMalformedWinsOverValidation) {
+TEST(ExecutionContextFromMeshGL, CancelBeforeMalformedWinsOverValidation) {
   ExecutionContext ctx;
   ctx.Cancel();
-  EXPECT_EQ(
-      TypeParam::ViaCtx(ctx, MalformedMissingPositionProperties()).Status(),
-      Manifold::Error::Cancelled);
+  Manifold m = ctx.FromMeshGL(MalformedMissingPositionProperties());
+  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
 }
 
-// Validation errors surface unchanged when no cancel is in flight; counters
-// stay at 0/kPhases since no phase ran.
-TYPED_TEST(ExecutionContextStaticFactory, ValidationErrorWithoutCancel) {
+// Validation errors surface unchanged when no cancel is in flight;
+// counters stay at 0/kPhasesPerFromMesh since no phase ran.
+TEST(ExecutionContextFromMeshGL, ValidationErrorWithoutCancel) {
   ExecutionContext ctx;
-  Manifold m = TypeParam::ViaCtx(ctx, MalformedMissingPositionProperties());
+  Manifold m = ctx.FromMeshGL(MalformedMissingPositionProperties());
   EXPECT_EQ(m.Status(), Manifold::Error::MissingPositionProperties);
   EXPECT_EQ(ctx.impl_->donePhases.load(), 0);
-  EXPECT_EQ(ctx.impl_->totalPhases.load(), TypeParam::kPhases);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerFromMesh);
 }
 
-// Concurrent cancel mid-flight. Adaptive backoff guarantees we observe at
-// least one Cancelled outcome; each Cancelled hit pins donePhases <
-// totalPhases.
+// Concurrent cancel mid-ingest. Adaptive backoff guarantees we observe
+// at least one Cancelled outcome (otherwise the cancel path is dead);
+// each Cancelled hit also pins donePhases < totalPhases.
 #if MANIFOLD_PAR == 1
-TYPED_TEST(ExecutionContextStaticFactory, CancelConcurrent) {
+TEST(ExecutionContextFromMeshGL, CancelConcurrent) {
   MeshGL mesh = Manifold::Sphere(1.0, 512).GetMeshGL();  // ~524k tris
   int cancelledHits = 0;
   auto sleep = std::chrono::microseconds(100);
@@ -921,7 +861,7 @@ TYPED_TEST(ExecutionContextStaticFactory, CancelConcurrent) {
     ExecutionContext ctx;
     std::atomic<Manifold::Error> result{Manifold::Error::NoError};
     std::thread evalThread(
-        [&] { result.store(TypeParam::ViaCtx(ctx, mesh).Status()); });
+        [&] { result.store(ctx.FromMeshGL(mesh).Status()); });
     std::this_thread::sleep_for(sleep);
     ctx.Cancel();
     evalThread.join();
@@ -938,11 +878,12 @@ TYPED_TEST(ExecutionContextStaticFactory, CancelConcurrent) {
 }
 #endif  // MANIFOLD_PAR == 1
 
-// Factory then a Boolean on the same ctx: counters reset between.
-TYPED_TEST(ExecutionContextStaticFactory, ReuseForBoolean) {
+// FromMeshGL then a Boolean on the same ctx: counters reset between.
+TEST(ExecutionContextFromMeshGL, ReuseForBoolean) {
   ExecutionContext ctx;
-  ASSERT_EQ(TypeParam::ViaCtx(ctx, TetGL()).Status(), Manifold::Error::NoError);
-  EXPECT_EQ(ctx.impl_->totalPhases.load(), TypeParam::kPhases);
+  Manifold tet = ctx.FromMeshGL(TetGL());
+  ASSERT_EQ(tet.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerFromMesh);
 
   Manifold u = Manifold::Cube() + Manifold::Sphere(0.5);
   EXPECT_EQ(u.WithContext(ctx).Status(), Manifold::Error::NoError);
@@ -951,35 +892,96 @@ TYPED_TEST(ExecutionContextStaticFactory, ReuseForBoolean) {
   EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
 }
 
-// Two factory calls on the same ctx: counters reset between.
-TYPED_TEST(ExecutionContextStaticFactory, ReuseForSecondCall) {
+// Two FromMeshGL calls on the same ctx: counters reset between.
+TEST(ExecutionContextFromMeshGL, ReuseForSecondFromMeshGL) {
   ExecutionContext ctx;
-  ASSERT_EQ(TypeParam::ViaCtx(ctx, TetGL()).Status(), Manifold::Error::NoError);
-  ASSERT_EQ(ctx.impl_->donePhases.load(), TypeParam::kPhases);
-  Manifold second = TypeParam::ViaCtx(ctx, TetGL());
+  ASSERT_EQ(ctx.FromMeshGL(TetGL()).Status(), Manifold::Error::NoError);
+  ASSERT_EQ(ctx.impl_->donePhases.load(), kPhasesPerFromMesh);
+  Manifold second = ctx.FromMeshGL(TetGL());
   EXPECT_EQ(second.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(ctx.impl_->totalPhases.load(), TypeParam::kPhases);
-  EXPECT_EQ(ctx.impl_->donePhases.load(), TypeParam::kPhases);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerFromMesh);
+  EXPECT_EQ(ctx.impl_->donePhases.load(), kPhasesPerFromMesh);
   EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
 }
 
-// Sticky cancel survives across factory calls.
-TYPED_TEST(ExecutionContextStaticFactory, StickyCancelAcrossCalls) {
+// Sticky cancel survives across FromMeshGL calls.
+TEST(ExecutionContextFromMeshGL, StickyCancelAcrossCalls) {
   ExecutionContext ctx;
   ctx.Cancel();
-  EXPECT_EQ(TypeParam::ViaCtx(ctx, TetGL()).Status(),
-            Manifold::Error::Cancelled);
-  EXPECT_EQ(TypeParam::ViaCtx(ctx, TetGL()).Status(),
-            Manifold::Error::Cancelled);
+  EXPECT_EQ(ctx.FromMeshGL(TetGL()).Status(), Manifold::Error::Cancelled);
+  EXPECT_EQ(ctx.FromMeshGL(TetGL()).Status(), Manifold::Error::Cancelled);
 }
 
-// Smooth-only extras (outside the typed suite because no other factory
-// takes a `sharpenedEdges` argument). Cancels mid-flight with a non-empty
-// `sharpenedEdges` and asserts `NumTri() == 0` on Cancelled to lock in
-// that the faceID-restoration loop in `MakeSmoothImpl` is a natural no-op
-// after `MakeEmpty`.
+// Smooth: ctx-aware analog of `Manifold::Smooth(MeshGL[64])`. The shared
+// counter/reuse/validation machinery is the same as FromMeshGL and is covered
+// by that cluster above, so here we only test Smooth's unique paths: the happy
+// path, parity with the plain factory, the entry-time cancel gate in
+// MakeSmoothImpl (distinct from the shared Impl-ctor gate), concurrent cancel
+// through the extra tangent-creation phases, and the sharpenedEdges argument.
+TEST(ExecutionContextSmooth, HappyPath) {
+  ExecutionContext ctx;
+  Manifold tet = ctx.Smooth(TetGL());
+  EXPECT_FALSE(tet.IsEmpty());
+  EXPECT_EQ(tet.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerSmooth);
+  EXPECT_EQ(ctx.impl_->donePhases.load(), kPhasesPerSmooth);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
+}
+
+// Equivalent geometry to the plain factory.
+TEST(ExecutionContextSmooth, MatchesFactory) {
+  MeshGL mesh = Manifold::Sphere(1.0, 32).GetMeshGL();
+  ExecutionContext ctx;
+  Manifold viaCtx = ctx.Smooth(mesh);
+  Manifold viaFactory = Manifold::Smooth(mesh);
+  EXPECT_EQ(viaCtx.Status(), viaFactory.Status());
+  EXPECT_EQ(viaCtx.NumTri(), viaFactory.NumTri());
+  EXPECT_EQ(viaCtx.NumVert(), viaFactory.NumVert());
+}
+
+// Pre-cancel hits Smooth's own entry gate in MakeSmoothImpl and returns
+// before ingest - distinct from the shared Impl-ctor gate FromMeshGL covers.
+TEST(ExecutionContextSmooth, CancelBeforeIngest) {
+  ExecutionContext ctx;
+  ctx.Cancel();
+  Manifold m = ctx.Smooth(TetGL());
+  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
+}
+
+// Concurrent cancel mid-smooth. Adaptive backoff guarantees we observe
+// at least one Cancelled outcome; each Cancelled hit pins donePhases <
+// totalPhases.
 #if MANIFOLD_PAR == 1
-TEST(ExecutionContextSmoothExtras, CancelWithSharpenedEdges) {
+TEST(ExecutionContextSmooth, CancelConcurrent) {
+  MeshGL mesh = Manifold::Sphere(1.0, 512).GetMeshGL();  // ~524k tris
+  int cancelledHits = 0;
+  auto sleep = std::chrono::microseconds(100);
+  for (int attempt = 0; attempt < 12 && cancelledHits == 0; ++attempt) {
+    ExecutionContext ctx;
+    std::atomic<Manifold::Error> result{Manifold::Error::NoError};
+    std::thread evalThread([&] { result.store(ctx.Smooth(mesh).Status()); });
+    std::this_thread::sleep_for(sleep);
+    ctx.Cancel();
+    evalThread.join();
+    EXPECT_TRUE(result.load() == Manifold::Error::Cancelled ||
+                result.load() == Manifold::Error::NoError);
+    if (result.load() == Manifold::Error::Cancelled) {
+      ++cancelledHits;
+      EXPECT_LT(ctx.impl_->donePhases.load(), ctx.impl_->totalPhases.load());
+      EXPECT_LT(ctx.Progress(), 1.0);
+    }
+    sleep *= 2;
+  }
+  EXPECT_GT(cancelledHits, 0);
+}
+#endif  // MANIFOLD_PAR == 1
+
+// Smooth-specific: cancel mid-flight with a non-empty sharpenedEdges
+// vector. Asserts NumTri() == 0 on Cancelled to lock in that the
+// faceID-restoration loop in MakeSmoothImpl is a natural no-op after
+// MakeEmpty.
+#if MANIFOLD_PAR == 1
+TEST(ExecutionContextSmooth, CancelWithSharpenedEdges) {
   MeshGL mesh = Manifold::Sphere(1.0, 512).GetMeshGL();
   std::vector<Smoothness> sharpenedEdges = {{0, 0.0}, {3, 0.5}, {6, 0.0}};
   int cancelledHits = 0;

--- a/test/context_test.cpp
+++ b/test/context_test.cpp
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <chrono>
 #include <thread>
+#include <type_traits>
 
 #include "../src/execution_impl.h"
 #include "../src/parallel.h"
@@ -781,44 +782,6 @@ TEST(Manifold, ManifoldContextCancelMidEval) {
   EXPECT_EQ(attached.Status(), Manifold::Error::Cancelled);
 }
 
-// FromMeshGL: ctx-aware analog of the `Manifold(MeshGL)` ctor.
-TEST(ExecutionContextFromMeshGL, HappyPath) {
-  ExecutionContext ctx;
-  Manifold tet = ctx.FromMeshGL(TetGL());
-  EXPECT_FALSE(tet.IsEmpty());
-  EXPECT_EQ(tet.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerFromMesh);
-  EXPECT_EQ(ctx.impl_->donePhases.load(), kPhasesPerFromMesh);
-  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
-}
-
-// Equivalent geometry to the plain ctor.
-TEST(ExecutionContextFromMeshGL, MatchesCtor) {
-  MeshGL mesh = Manifold::Sphere(1.0, 32).GetMeshGL();
-  ExecutionContext ctx;
-  Manifold viaCtx = ctx.FromMeshGL(mesh);
-  Manifold viaCtor(mesh);
-  EXPECT_EQ(viaCtx.Status(), viaCtor.Status());
-  EXPECT_EQ(viaCtx.NumTri(), viaCtor.NumTri());
-  EXPECT_EQ(viaCtx.NumVert(), viaCtor.NumVert());
-}
-
-// Pre-cancel beats the heavy path on well-formed input.
-TEST(ExecutionContextFromMeshGL, CancelBeforeIngest) {
-  ExecutionContext ctx;
-  ctx.Cancel();
-  Manifold m = ctx.FromMeshGL(TetGL());
-  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
-}
-
-// Pre-cancel beats the empty-input fast path (would otherwise be NoError).
-TEST(ExecutionContextFromMeshGL, CancelBeforeEmptyInputWinsOverNoError) {
-  ExecutionContext ctx;
-  ctx.Cancel();
-  Manifold m = ctx.FromMeshGL(MeshGL{});
-  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
-}
-
 // Trips `numProp < 3` validation but has enough verts/tris to clear the
 // empty/under-4 short-circuits first. Coupled to ingest validation
 // order: if MissingPositionProperties moved past NotManifold these
@@ -831,29 +794,126 @@ static MeshGL MalformedMissingPositionProperties() {
   return bad;
 }
 
-// Pre-cancel beats validation errors.
-TEST(ExecutionContextFromMeshGL, CancelBeforeMalformedWinsOverValidation) {
+// Traits describing each ctx-aware static factory: the ctx call, the plain
+// (non-ctx) equivalent for the parity test, and the expected phase count.
+//
+// TODO: this contract is `(ExecutionContext&, const MeshGL&) -> Manifold`
+// only. When a 3rd ctx static factory lands with a non-MeshGL signature
+// (LevelSet takes `(sdf, bounds, edgeLength)`, Hull takes a vector, etc.),
+// either add a parallel typed suite for that shape or refactor to
+// fixture-based traits where each `SmallValid`/`Empty`/`Malformed` is a
+// trait method returning a Manifold. Until then the duplication cost of a
+// per-factory cluster is lower than the generalization cost.
+struct FromMeshGLTraits {
+  static constexpr int kPhases = kPhasesPerFromMesh;
+  static constexpr const char* kName = "FromMeshGL";
+  static Manifold ViaCtx(ExecutionContext& ctx, const MeshGL& mesh) {
+    return ctx.FromMeshGL(mesh);
+  }
+  static Manifold ViaPlain(const MeshGL& mesh) { return Manifold(mesh); }
+};
+
+struct SmoothTraits {
+  static constexpr int kPhases = kPhasesPerSmooth;
+  static constexpr const char* kName = "Smooth";
+  static Manifold ViaCtx(ExecutionContext& ctx, const MeshGL& mesh) {
+    return ctx.Smooth(mesh);
+  }
+  static Manifold ViaPlain(const MeshGL& mesh) {
+    return Manifold::Smooth(mesh);
+  }
+};
+
+// Compile-time contract check: each traits struct must expose `kPhases`
+// (int), `kName` (const char*), and the two static factory methods.
+template <typename T>
+inline constexpr bool kIsStaticFactoryTraits =
+    std::is_same_v<decltype(T::kPhases), const int> &&
+    std::is_convertible_v<decltype(T::kName), const char*> &&
+    std::is_invocable_r_v<Manifold, decltype(&T::ViaCtx), ExecutionContext&,
+                          const MeshGL&> &&
+    std::is_invocable_r_v<Manifold, decltype(&T::ViaPlain), const MeshGL&>;
+static_assert(kIsStaticFactoryTraits<FromMeshGLTraits>);
+static_assert(kIsStaticFactoryTraits<SmoothTraits>);
+
+template <typename Factory>
+class ExecutionContextStaticFactory : public ::testing::Test {};
+
+class FactoryNameGenerator {
+ public:
+  template <typename T>
+  static std::string GetName(int) {
+    return T::kName;
+  }
+};
+
+using StaticFactories = ::testing::Types<FromMeshGLTraits, SmoothTraits>;
+TYPED_TEST_SUITE(ExecutionContextStaticFactory, StaticFactories,
+                 FactoryNameGenerator);
+
+TYPED_TEST(ExecutionContextStaticFactory, HappyPath) {
+  ExecutionContext ctx;
+  Manifold m = TypeParam::ViaCtx(ctx, TetGL());
+  EXPECT_FALSE(m.IsEmpty());
+  EXPECT_EQ(m.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), TypeParam::kPhases);
+  EXPECT_EQ(ctx.impl_->donePhases.load(), TypeParam::kPhases);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
+}
+
+// Equivalent geometry to the plain (non-ctx) call.
+TYPED_TEST(ExecutionContextStaticFactory, MatchesPlain) {
+  MeshGL mesh = Manifold::Sphere(1.0, 32).GetMeshGL();
+  ExecutionContext ctx;
+  Manifold viaCtx = TypeParam::ViaCtx(ctx, mesh);
+  Manifold viaPlain = TypeParam::ViaPlain(mesh);
+  EXPECT_EQ(viaCtx.Status(), viaPlain.Status());
+  EXPECT_EQ(viaCtx.NumTri(), viaPlain.NumTri());
+  EXPECT_EQ(viaCtx.NumVert(), viaPlain.NumVert());
+}
+
+// Pre-cancel beats the heavy path on well-formed input.
+TYPED_TEST(ExecutionContextStaticFactory, CancelBeforeIngest) {
   ExecutionContext ctx;
   ctx.Cancel();
-  Manifold m = ctx.FromMeshGL(MalformedMissingPositionProperties());
-  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
+  EXPECT_EQ(TypeParam::ViaCtx(ctx, TetGL()).Status(),
+            Manifold::Error::Cancelled);
 }
 
-// Validation errors surface unchanged when no cancel is in flight;
-// counters stay at 0/kPhasesPerFromMesh since no phase ran.
-TEST(ExecutionContextFromMeshGL, ValidationErrorWithoutCancel) {
+// Pre-cancel beats the empty-input fast path (would otherwise be NoError).
+TYPED_TEST(ExecutionContextStaticFactory,
+           CancelBeforeEmptyInputWinsOverNoError) {
   ExecutionContext ctx;
-  Manifold m = ctx.FromMeshGL(MalformedMissingPositionProperties());
+  ctx.Cancel();
+  EXPECT_EQ(TypeParam::ViaCtx(ctx, MeshGL{}).Status(),
+            Manifold::Error::Cancelled);
+}
+
+// Pre-cancel beats validation errors.
+TYPED_TEST(ExecutionContextStaticFactory,
+           CancelBeforeMalformedWinsOverValidation) {
+  ExecutionContext ctx;
+  ctx.Cancel();
+  EXPECT_EQ(
+      TypeParam::ViaCtx(ctx, MalformedMissingPositionProperties()).Status(),
+      Manifold::Error::Cancelled);
+}
+
+// Validation errors surface unchanged when no cancel is in flight; counters
+// stay at 0/kPhases since no phase ran.
+TYPED_TEST(ExecutionContextStaticFactory, ValidationErrorWithoutCancel) {
+  ExecutionContext ctx;
+  Manifold m = TypeParam::ViaCtx(ctx, MalformedMissingPositionProperties());
   EXPECT_EQ(m.Status(), Manifold::Error::MissingPositionProperties);
   EXPECT_EQ(ctx.impl_->donePhases.load(), 0);
-  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerFromMesh);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), TypeParam::kPhases);
 }
 
-// Concurrent cancel mid-ingest. Adaptive backoff guarantees we observe
-// at least one Cancelled outcome (otherwise the cancel path is dead);
-// each Cancelled hit also pins donePhases < totalPhases.
+// Concurrent cancel mid-flight. Adaptive backoff guarantees we observe at
+// least one Cancelled outcome; each Cancelled hit pins donePhases <
+// totalPhases.
 #if MANIFOLD_PAR == 1
-TEST(ExecutionContextFromMeshGL, CancelConcurrent) {
+TYPED_TEST(ExecutionContextStaticFactory, CancelConcurrent) {
   MeshGL mesh = Manifold::Sphere(1.0, 512).GetMeshGL();  // ~524k tris
   int cancelledHits = 0;
   auto sleep = std::chrono::microseconds(100);
@@ -861,7 +921,7 @@ TEST(ExecutionContextFromMeshGL, CancelConcurrent) {
     ExecutionContext ctx;
     std::atomic<Manifold::Error> result{Manifold::Error::NoError};
     std::thread evalThread(
-        [&] { result.store(ctx.FromMeshGL(mesh).Status()); });
+        [&] { result.store(TypeParam::ViaCtx(ctx, mesh).Status()); });
     std::this_thread::sleep_for(sleep);
     ctx.Cancel();
     evalThread.join();
@@ -878,12 +938,11 @@ TEST(ExecutionContextFromMeshGL, CancelConcurrent) {
 }
 #endif  // MANIFOLD_PAR == 1
 
-// FromMeshGL then a Boolean on the same ctx: counters reset between.
-TEST(ExecutionContextFromMeshGL, ReuseForBoolean) {
+// Factory then a Boolean on the same ctx: counters reset between.
+TYPED_TEST(ExecutionContextStaticFactory, ReuseForBoolean) {
   ExecutionContext ctx;
-  Manifold tet = ctx.FromMeshGL(TetGL());
-  ASSERT_EQ(tet.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerFromMesh);
+  ASSERT_EQ(TypeParam::ViaCtx(ctx, TetGL()).Status(), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), TypeParam::kPhases);
 
   Manifold u = Manifold::Cube() + Manifold::Sphere(0.5);
   EXPECT_EQ(u.WithContext(ctx).Status(), Manifold::Error::NoError);
@@ -892,152 +951,35 @@ TEST(ExecutionContextFromMeshGL, ReuseForBoolean) {
   EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
 }
 
-// Two FromMeshGL calls on the same ctx: counters reset between.
-TEST(ExecutionContextFromMeshGL, ReuseForSecondFromMeshGL) {
+// Two factory calls on the same ctx: counters reset between.
+TYPED_TEST(ExecutionContextStaticFactory, ReuseForSecondCall) {
   ExecutionContext ctx;
-  ASSERT_EQ(ctx.FromMeshGL(TetGL()).Status(), Manifold::Error::NoError);
-  ASSERT_EQ(ctx.impl_->donePhases.load(), kPhasesPerFromMesh);
-  Manifold second = ctx.FromMeshGL(TetGL());
+  ASSERT_EQ(TypeParam::ViaCtx(ctx, TetGL()).Status(), Manifold::Error::NoError);
+  ASSERT_EQ(ctx.impl_->donePhases.load(), TypeParam::kPhases);
+  Manifold second = TypeParam::ViaCtx(ctx, TetGL());
   EXPECT_EQ(second.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerFromMesh);
-  EXPECT_EQ(ctx.impl_->donePhases.load(), kPhasesPerFromMesh);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), TypeParam::kPhases);
+  EXPECT_EQ(ctx.impl_->donePhases.load(), TypeParam::kPhases);
   EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
 }
 
-// Sticky cancel survives across FromMeshGL calls.
-TEST(ExecutionContextFromMeshGL, StickyCancelAcrossCalls) {
+// Sticky cancel survives across factory calls.
+TYPED_TEST(ExecutionContextStaticFactory, StickyCancelAcrossCalls) {
   ExecutionContext ctx;
   ctx.Cancel();
-  EXPECT_EQ(ctx.FromMeshGL(TetGL()).Status(), Manifold::Error::Cancelled);
-  EXPECT_EQ(ctx.FromMeshGL(TetGL()).Status(), Manifold::Error::Cancelled);
+  EXPECT_EQ(TypeParam::ViaCtx(ctx, TetGL()).Status(),
+            Manifold::Error::Cancelled);
+  EXPECT_EQ(TypeParam::ViaCtx(ctx, TetGL()).Status(),
+            Manifold::Error::Cancelled);
 }
 
-// Smooth: ctx-aware analog of `Manifold::Smooth(MeshGL[64])`. Mirrors the
-// FromMeshGL cluster above; the ingest phases are reused and the
-// tangent-creation pass adds another set of phase boundaries.
-TEST(ExecutionContextSmooth, HappyPath) {
-  ExecutionContext ctx;
-  Manifold tet = ctx.Smooth(TetGL());
-  EXPECT_FALSE(tet.IsEmpty());
-  EXPECT_EQ(tet.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerSmooth);
-  EXPECT_EQ(ctx.impl_->donePhases.load(), kPhasesPerSmooth);
-  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
-}
-
-// Equivalent geometry to the plain factory.
-TEST(ExecutionContextSmooth, MatchesCtor) {
-  MeshGL mesh = Manifold::Sphere(1.0, 32).GetMeshGL();
-  ExecutionContext ctx;
-  Manifold viaCtx = ctx.Smooth(mesh);
-  Manifold viaFactory = Manifold::Smooth(mesh);
-  EXPECT_EQ(viaCtx.Status(), viaFactory.Status());
-  EXPECT_EQ(viaCtx.NumTri(), viaFactory.NumTri());
-  EXPECT_EQ(viaCtx.NumVert(), viaFactory.NumVert());
-}
-
-// Pre-cancel beats the heavy path on well-formed input.
-TEST(ExecutionContextSmooth, CancelBeforeIngest) {
-  ExecutionContext ctx;
-  ctx.Cancel();
-  Manifold m = ctx.Smooth(TetGL());
-  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
-}
-
-// Pre-cancel beats the empty-input fast path (would otherwise be NoError).
-TEST(ExecutionContextSmooth, CancelBeforeEmptyInputWinsOverNoError) {
-  ExecutionContext ctx;
-  ctx.Cancel();
-  Manifold m = ctx.Smooth(MeshGL{});
-  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
-}
-
-// Pre-cancel beats validation errors.
-TEST(ExecutionContextSmooth, CancelBeforeMalformedWinsOverValidation) {
-  ExecutionContext ctx;
-  ctx.Cancel();
-  Manifold m = ctx.Smooth(MalformedMissingPositionProperties());
-  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
-}
-
-// Validation errors surface unchanged when no cancel is in flight;
-// counters stay at 0/kPhasesPerSmooth since no phase ran.
-TEST(ExecutionContextSmooth, ValidationErrorWithoutCancel) {
-  ExecutionContext ctx;
-  Manifold m = ctx.Smooth(MalformedMissingPositionProperties());
-  EXPECT_EQ(m.Status(), Manifold::Error::MissingPositionProperties);
-  EXPECT_EQ(ctx.impl_->donePhases.load(), 0);
-  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerSmooth);
-}
-
-// Concurrent cancel mid-smooth. Adaptive backoff guarantees we observe
-// at least one Cancelled outcome; each Cancelled hit pins donePhases <
-// totalPhases.
+// Smooth-only extras (outside the typed suite because no other factory
+// takes a `sharpenedEdges` argument). Cancels mid-flight with a non-empty
+// `sharpenedEdges` and asserts `NumTri() == 0` on Cancelled to lock in
+// that the faceID-restoration loop in `MakeSmoothImpl` is a natural no-op
+// after `MakeEmpty`.
 #if MANIFOLD_PAR == 1
-TEST(ExecutionContextSmooth, CancelConcurrent) {
-  MeshGL mesh = Manifold::Sphere(1.0, 512).GetMeshGL();  // ~524k tris
-  int cancelledHits = 0;
-  auto sleep = std::chrono::microseconds(100);
-  for (int attempt = 0; attempt < 12 && cancelledHits == 0; ++attempt) {
-    ExecutionContext ctx;
-    std::atomic<Manifold::Error> result{Manifold::Error::NoError};
-    std::thread evalThread([&] { result.store(ctx.Smooth(mesh).Status()); });
-    std::this_thread::sleep_for(sleep);
-    ctx.Cancel();
-    evalThread.join();
-    EXPECT_TRUE(result.load() == Manifold::Error::Cancelled ||
-                result.load() == Manifold::Error::NoError);
-    if (result.load() == Manifold::Error::Cancelled) {
-      ++cancelledHits;
-      EXPECT_LT(ctx.impl_->donePhases.load(), ctx.impl_->totalPhases.load());
-      EXPECT_LT(ctx.Progress(), 1.0);
-    }
-    sleep *= 2;
-  }
-  EXPECT_GT(cancelledHits, 0);
-}
-#endif  // MANIFOLD_PAR == 1
-
-// Smooth then a Boolean on the same ctx: counters reset between.
-TEST(ExecutionContextSmooth, ReuseForBoolean) {
-  ExecutionContext ctx;
-  Manifold tet = ctx.Smooth(TetGL());
-  ASSERT_EQ(tet.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerSmooth);
-
-  Manifold u = Manifold::Cube() + Manifold::Sphere(0.5);
-  EXPECT_EQ(u.WithContext(ctx).Status(), Manifold::Error::NoError);
-  EXPECT_EQ(ctx.impl_->totalBooleans.load(), 1);
-  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerBoolean);
-  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
-}
-
-// Two Smooth calls on the same ctx: counters reset between.
-TEST(ExecutionContextSmooth, ReuseForSecondSmooth) {
-  ExecutionContext ctx;
-  ASSERT_EQ(ctx.Smooth(TetGL()).Status(), Manifold::Error::NoError);
-  ASSERT_EQ(ctx.impl_->donePhases.load(), kPhasesPerSmooth);
-  Manifold second = ctx.Smooth(TetGL());
-  EXPECT_EQ(second.Status(), Manifold::Error::NoError);
-  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerSmooth);
-  EXPECT_EQ(ctx.impl_->donePhases.load(), kPhasesPerSmooth);
-  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
-}
-
-// Sticky cancel survives across Smooth calls.
-TEST(ExecutionContextSmooth, StickyCancelAcrossCalls) {
-  ExecutionContext ctx;
-  ctx.Cancel();
-  EXPECT_EQ(ctx.Smooth(TetGL()).Status(), Manifold::Error::Cancelled);
-  EXPECT_EQ(ctx.Smooth(TetGL()).Status(), Manifold::Error::Cancelled);
-}
-
-// Smooth-specific: cancel mid-flight with a non-empty sharpenedEdges
-// vector. Asserts NumTri() == 0 on Cancelled to lock in that the
-// faceID-restoration loop in MakeSmoothImpl is a natural no-op after
-// MakeEmpty.
-#if MANIFOLD_PAR == 1
-TEST(ExecutionContextSmooth, CancelWithSharpenedEdges) {
+TEST(ExecutionContextSmoothExtras, CancelWithSharpenedEdges) {
   MeshGL mesh = Manifold::Sphere(1.0, 512).GetMeshGL();
   std::vector<Smoothness> sharpenedEdges = {{0, 0.0}, {3, 0.5}, {6, 0.0}};
   int cancelledHits = 0;

--- a/test/context_test.cpp
+++ b/test/context_test.cpp
@@ -911,3 +911,155 @@ TEST(ExecutionContextFromMeshGL, StickyCancelAcrossCalls) {
   EXPECT_EQ(ctx.FromMeshGL(TetGL()).Status(), Manifold::Error::Cancelled);
   EXPECT_EQ(ctx.FromMeshGL(TetGL()).Status(), Manifold::Error::Cancelled);
 }
+
+// Smooth: ctx-aware analog of `Manifold::Smooth(MeshGL[64])`. Mirrors the
+// FromMeshGL cluster above; the ingest phases are reused and the
+// tangent-creation pass adds another set of phase boundaries.
+TEST(ExecutionContextSmooth, HappyPath) {
+  ExecutionContext ctx;
+  Manifold tet = ctx.Smooth(TetGL());
+  EXPECT_FALSE(tet.IsEmpty());
+  EXPECT_EQ(tet.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerSmooth);
+  EXPECT_EQ(ctx.impl_->donePhases.load(), kPhasesPerSmooth);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
+}
+
+// Equivalent geometry to the plain factory.
+TEST(ExecutionContextSmooth, MatchesCtor) {
+  MeshGL mesh = Manifold::Sphere(1.0, 32).GetMeshGL();
+  ExecutionContext ctx;
+  Manifold viaCtx = ctx.Smooth(mesh);
+  Manifold viaFactory = Manifold::Smooth(mesh);
+  EXPECT_EQ(viaCtx.Status(), viaFactory.Status());
+  EXPECT_EQ(viaCtx.NumTri(), viaFactory.NumTri());
+  EXPECT_EQ(viaCtx.NumVert(), viaFactory.NumVert());
+}
+
+// Pre-cancel beats the heavy path on well-formed input.
+TEST(ExecutionContextSmooth, CancelBeforeIngest) {
+  ExecutionContext ctx;
+  ctx.Cancel();
+  Manifold m = ctx.Smooth(TetGL());
+  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
+}
+
+// Pre-cancel beats the empty-input fast path (would otherwise be NoError).
+TEST(ExecutionContextSmooth, CancelBeforeEmptyInputWinsOverNoError) {
+  ExecutionContext ctx;
+  ctx.Cancel();
+  Manifold m = ctx.Smooth(MeshGL{});
+  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
+}
+
+// Pre-cancel beats validation errors.
+TEST(ExecutionContextSmooth, CancelBeforeMalformedWinsOverValidation) {
+  ExecutionContext ctx;
+  ctx.Cancel();
+  Manifold m = ctx.Smooth(MalformedMissingPositionProperties());
+  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
+}
+
+// Validation errors surface unchanged when no cancel is in flight;
+// counters stay at 0/kPhasesPerSmooth since no phase ran.
+TEST(ExecutionContextSmooth, ValidationErrorWithoutCancel) {
+  ExecutionContext ctx;
+  Manifold m = ctx.Smooth(MalformedMissingPositionProperties());
+  EXPECT_EQ(m.Status(), Manifold::Error::MissingPositionProperties);
+  EXPECT_EQ(ctx.impl_->donePhases.load(), 0);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerSmooth);
+}
+
+// Concurrent cancel mid-smooth. Adaptive backoff guarantees we observe
+// at least one Cancelled outcome; each Cancelled hit pins donePhases <
+// totalPhases.
+#if MANIFOLD_PAR == 1
+TEST(ExecutionContextSmooth, CancelConcurrent) {
+  MeshGL mesh = Manifold::Sphere(1.0, 512).GetMeshGL();  // ~524k tris
+  int cancelledHits = 0;
+  auto sleep = std::chrono::microseconds(100);
+  for (int attempt = 0; attempt < 12 && cancelledHits == 0; ++attempt) {
+    ExecutionContext ctx;
+    std::atomic<Manifold::Error> result{Manifold::Error::NoError};
+    std::thread evalThread([&] { result.store(ctx.Smooth(mesh).Status()); });
+    std::this_thread::sleep_for(sleep);
+    ctx.Cancel();
+    evalThread.join();
+    EXPECT_TRUE(result.load() == Manifold::Error::Cancelled ||
+                result.load() == Manifold::Error::NoError);
+    if (result.load() == Manifold::Error::Cancelled) {
+      ++cancelledHits;
+      EXPECT_LT(ctx.impl_->donePhases.load(), ctx.impl_->totalPhases.load());
+      EXPECT_LT(ctx.Progress(), 1.0);
+    }
+    sleep *= 2;
+  }
+  EXPECT_GT(cancelledHits, 0);
+}
+#endif  // MANIFOLD_PAR == 1
+
+// Smooth then a Boolean on the same ctx: counters reset between.
+TEST(ExecutionContextSmooth, ReuseForBoolean) {
+  ExecutionContext ctx;
+  Manifold tet = ctx.Smooth(TetGL());
+  ASSERT_EQ(tet.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerSmooth);
+
+  Manifold u = Manifold::Cube() + Manifold::Sphere(0.5);
+  EXPECT_EQ(u.WithContext(ctx).Status(), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalBooleans.load(), 1);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerBoolean);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
+}
+
+// Two Smooth calls on the same ctx: counters reset between.
+TEST(ExecutionContextSmooth, ReuseForSecondSmooth) {
+  ExecutionContext ctx;
+  ASSERT_EQ(ctx.Smooth(TetGL()).Status(), Manifold::Error::NoError);
+  ASSERT_EQ(ctx.impl_->donePhases.load(), kPhasesPerSmooth);
+  Manifold second = ctx.Smooth(TetGL());
+  EXPECT_EQ(second.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerSmooth);
+  EXPECT_EQ(ctx.impl_->donePhases.load(), kPhasesPerSmooth);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
+}
+
+// Sticky cancel survives across Smooth calls.
+TEST(ExecutionContextSmooth, StickyCancelAcrossCalls) {
+  ExecutionContext ctx;
+  ctx.Cancel();
+  EXPECT_EQ(ctx.Smooth(TetGL()).Status(), Manifold::Error::Cancelled);
+  EXPECT_EQ(ctx.Smooth(TetGL()).Status(), Manifold::Error::Cancelled);
+}
+
+// Smooth-specific: cancel mid-flight with a non-empty sharpenedEdges
+// vector. Asserts NumTri() == 0 on Cancelled to lock in that the
+// faceID-restoration loop in MakeSmoothImpl is a natural no-op after
+// MakeEmpty.
+#if MANIFOLD_PAR == 1
+TEST(ExecutionContextSmooth, CancelWithSharpenedEdges) {
+  MeshGL mesh = Manifold::Sphere(1.0, 512).GetMeshGL();
+  std::vector<Smoothness> sharpenedEdges = {{0, 0.0}, {3, 0.5}, {6, 0.0}};
+  int cancelledHits = 0;
+  auto sleep = std::chrono::microseconds(100);
+  for (int attempt = 0; attempt < 12 && cancelledHits == 0; ++attempt) {
+    ExecutionContext ctx;
+    std::atomic<Manifold::Error> result{Manifold::Error::NoError};
+    std::atomic<size_t> numTri{0};
+    std::thread evalThread([&] {
+      Manifold m = ctx.Smooth(mesh, sharpenedEdges);
+      result.store(m.Status());
+      numTri.store(m.NumTri());
+    });
+    std::this_thread::sleep_for(sleep);
+    ctx.Cancel();
+    evalThread.join();
+    if (result.load() == Manifold::Error::Cancelled) {
+      ++cancelledHits;
+      EXPECT_EQ(numTri.load(), 0u);
+    }
+    sleep *= 2;
+  }
+  EXPECT_GT(cancelledHits, 0);
+}
+#endif  // MANIFOLD_PAR == 1


### PR DESCRIPTION
Follow-up to #1723: adds `ExecutionContext::Smooth(MeshGL)` and `Smooth(MeshGL64)` as the next ctx-aware static factories. Same pattern, same cancel-vs-validation precedence. Tracks the static-factory direction from #971.

## Changes

- New `MakeSmoothImpl` template in `impl.h` replaces the anonymous `SmoothImpl` in `constructors.cpp`; shared by `Manifold::Smooth` (ctx=nullptr) and `ExecutionContext::Smooth`.
- `Manifold::Impl::CreateTangents(std::vector<Smoothness>)` gains an optional `ExecutionContext::Impl* ctx = nullptr` parameter and 7 `ADVANCE_PHASE_OR_RETURN(ctx)` sites at the heavy boundaries. The two parallel `for_each_n` loops pass `ctx` to the existing ctx-aware overload in `parallel.h` for per-chunk cancel.
- `LinearizeFlatTangents` and `DistributeTangents` stay non-ctx - the boundary belongs at their call site, since both are also called from the unrelated `CreateTangents(int normalIdx)` path.
- New `kPhasesPerSmooth = kPhasesPerFromMesh + 7` (= 14) in `execution_impl.h`.

## Test plan

- [x] `ExecutionContextSmooth.*` (11 new tests) mirror the FromMeshGL cluster: HappyPath, MatchesCtor, CancelBeforeIngest, CancelBeforeEmptyInputWinsOverNoError, CancelBeforeMalformedWinsOverValidation, ValidationErrorWithoutCancel, CancelConcurrent, ReuseForBoolean, ReuseForSecondSmooth, StickyCancelAcrossCalls, plus a Smooth-specific CancelWithSharpenedEdges asserting `NumTri() == 0` on cancel (the faceID-restoration loop is a natural no-op after MakeEmpty).
- [x] Existing 18 `Smooth.*` tests still pass.
- [x] clang-format-20 clean.
- [ ] CI green