### PR TITLE
Fix &v[size] UB in normals test sentinel pointers (fixes #1735)

### DIFF
--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -429,8 +429,11 @@ TEST(Manifold, GetNormalLegacyContract) {
         la::inverse(la::transpose(mat3(gl_legacy.GetRunTransform(run)))) *
         (gl_legacy.Backside(run) ? -1.0 : 1.0);
     const mat3 inv = la::inverse(fwd);
-    for (uint32_t* itr = &gl_legacy.triVerts[gl_legacy.runIndex[run]];
-         itr < &gl_legacy.triVerts[gl_legacy.runIndex[run + 1]]; ++itr) {
+    // `data() + i` rather than `&v[i]`: the latter is UB when `i == size()`
+    // (one-past-the-end of the final run) and traps under libc++ fast
+    // hardening - see #1735.
+    for (uint32_t* itr = gl_legacy.triVerts.data() + gl_legacy.runIndex[run];
+         itr < gl_legacy.triVerts.data() + gl_legacy.runIndex[run + 1]; ++itr) {
       const uint32_t v = *itr;
       if (visited[v]) continue;
       visited[v] = true;

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -350,8 +350,11 @@ void RelatedGL(const Manifold& out, const std::vector<MeshGL>& originals,
           runHasN ? mat3(la::identity)
                   : la::inverse(la::transpose(mat3(runTransforms[run]))) *
                         (output.Backside(run) ? -1.0 : 1.0);
-      for (uint32_t* itr = &output.triVerts[output.runIndex[run]];
-           itr < &output.triVerts[output.runIndex[run + 1]]; ++itr) {
+      // `data() + i` rather than `&v[i]`: the latter is UB when
+      // `i == size()` (one-past-the-end of the final run) and traps under
+      // libc++ fast hardening - see #1735.
+      for (uint32_t* itr = output.triVerts.data() + output.runIndex[run];
+           itr < output.triVerts.data() + output.runIndex[run + 1]; ++itr) {
         const uint32_t v = *itr;
         if (vertUpdated[v]) continue;
         vertUpdated[v] = true;


### PR DESCRIPTION
Fixes #1735.

## Summary

Two test sites added in #1718 use `&triVerts[runIndex[run + 1]]` as a one-past-end sentinel. When the final run's end index equals `triVerts.size()`, this is `&v[v.size()]` - UB even when only used for pointer comparison. libc++'s fast hardening (`_LIBCPP_HARDENING_MODE_FAST`, default in nixpkgs and used by the failing nix openscad-unstable build) traps in `operator[]` before returning the reference. Switch to `v.data() + i`, which is well-defined at `i == size()`. Production code is unaffected.

## Test plan

- [x] With `CXXFLAGS=-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST -stdlib=libc++` and clang 18, the three previously-trapping tests now pass: `Manifold.GetNormalLegacyContract`, `Boolean.Normals`, `BooleanComplex.InterpolatedNormals`.
- [x] Full suite clean under hardening: 420/420.
- [x] clang-format-20 clean.
- [ ] CI green.

## Follow-up

#1737 adds a Linux clang + libc++ + EXTENSIVE hardening lane so the next instance of this UB class is caught at PR time. It depends on this PR landing first.