### PR TITLE
Thread ExecutionContext into LevelSet via ExecutionContext::LevelSet

### DIFF
--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <cmath>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <vector>
@@ -35,6 +36,7 @@ template <typename Precision, typename I = uint32_t>
 struct MeshGLP;
 using MeshGL = MeshGLP<float>;
 using MeshGL64 = MeshGLP<double, uint64_t>;
+struct Box;  // defined below; needed by ExecutionContext::LevelSet
 
 /** @addtogroup Math
  * @ingroup Core
@@ -276,6 +278,13 @@ class ExecutionContext {
                   const std::vector<Smoothness>& sharpenedEdges = {});
   Manifold Smooth(const MeshGL64& mesh,
                   const std::vector<Smoothness>& sharpenedEdges = {});
+
+  /// Eager ctx-aware `Manifold::LevelSet`. The voxel-sampling and
+  /// mesh-extraction phases check cancel and credit `Progress()` between
+  /// phases. A Cancel() before or during the call yields a Cancelled result.
+  Manifold LevelSet(std::function<double(vec3)> sdf, Box bounds,
+                    double edgeLength, double level = 0, double tolerance = -1,
+                    bool canParallel = true);
 
   /// @internal Opaque implementation. Defined in src/execution_impl.h;
   /// accessible only to internal code that includes that header.

--- a/src/execution_impl.cpp
+++ b/src/execution_impl.cpp
@@ -84,4 +84,14 @@ Manifold ExecutionContext::Smooth(
   return Manifold::FromImpl(MakeSmoothImpl(mesh, sharpenedEdges, impl_.get()));
 }
 
+Manifold ExecutionContext::LevelSet(std::function<double(vec3)> sdf, Box bounds,
+                                    double edgeLength, double level,
+                                    double tolerance, bool canParallel) {
+  ResetForStaticFactory(impl_.get(), kPhasesPerLevelSet);
+  auto pImpl = std::make_shared<Manifold::Impl>();
+  pImpl->CreateLevelSet(sdf, bounds, edgeLength, level, tolerance, canParallel,
+                        impl_.get());
+  return Manifold::FromImpl(pImpl);
+}
+
 }  // namespace manifold

--- a/src/execution_impl.h
+++ b/src/execution_impl.h
@@ -50,6 +50,17 @@ constexpr int kPhasesPerSmooth = kPhasesPerFromMesh + 7;
 
 /** @ingroup Private
  *
+ * Heavy phases in `Manifold::Impl::CreateLevelSet(...)`: the four grid
+ * loops (voxel SDF sampling, NearSurface, ComputeVerts, BuildTris)
+ * followed by one lumped finalize phase (CreateHalfedges through
+ * SetNormalsAndCoplanar). The NearSurface hash-table resize loop may
+ * re-run NearSurface, but counts as a single phase regardless. Bump in
+ * lockstep with `ADVANCE_PHASE_OR_RETURN(ctx)` sites in CreateLevelSet.
+ */
+constexpr int kPhasesPerLevelSet = 5;
+
+/** @ingroup Private
+ *
  * Pimpl for ExecutionContext. `cancel` is private; use `IsCancelled(ctx)`
  * to read it -- this is the canonical reader, enforced by the type system.
  * `totalBooleans`, `doneBooleans`, `totalPhases`, and `donePhases` are

--- a/src/impl.h
+++ b/src/impl.h
@@ -99,6 +99,13 @@ struct Manifold::Impl {
   Impl(const MeshGLP<Precision, I>& meshGL,
        ExecutionContext::Impl* ctx = nullptr);
 
+  // sdf.cpp. Populates an empty Impl with the level set of `sdf`. `ctx`
+  // (when non-null) checks cancel and credits Progress() between the five
+  // phases counted by kPhasesPerLevelSet.
+  void CreateLevelSet(std::function<double(vec3)> sdf, Box bounds,
+                      double edgeLength, double level, double tolerance,
+                      bool canParallel, ExecutionContext::Impl* ctx = nullptr);
+
   template <typename F>
   inline void ForVert(int halfedge, F func);
 

--- a/src/sdf.cpp
+++ b/src/sdf.cpp
@@ -14,6 +14,7 @@
 
 #include <cmath>
 
+#include "execution_impl.h"
 #include "hashtable.h"
 #include "impl.h"
 #include "manifold/manifold.h"
@@ -468,12 +469,31 @@ namespace manifold {
 Manifold Manifold::LevelSet(std::function<double(vec3)> sdf, Box bounds,
                             double edgeLength, double level, double tolerance,
                             bool canParallel) {
+  auto pImpl = std::make_shared<Impl>();
+  pImpl->CreateLevelSet(sdf, bounds, edgeLength, level, tolerance, canParallel);
+  return Manifold(pImpl);
+}
+
+// Shared body of Manifold::LevelSet and ExecutionContext::LevelSet. Populates
+// this (empty) Impl. When ctx is non-null, the grid loops check cancel per
+// chunk and the ADVANCE_PHASE_OR_RETURN sites credit Progress(); their count
+// must equal kPhasesPerLevelSet (whose docstring enumerates the phases).
+void Manifold::Impl::CreateLevelSet(std::function<double(vec3)> sdf, Box bounds,
+                                    double edgeLength, double level,
+                                    double tolerance, bool canParallel,
+                                    ExecutionContext::Impl* ctx) {
+  // Pre-cancel wins over the (potentially large) voxel allocation and the
+  // sampling pass below.
+  if (IsCancelled(ctx)) {
+    MakeEmpty(Error::Cancelled);
+    return;
+  }
+
   if (tolerance <= 0) {
     tolerance = std::numeric_limits<double>::infinity();
   }
 
-  auto pImpl_ = std::make_shared<Impl>();
-  auto& vertPos = pImpl_->vertPos_;
+  auto& vertPos = vertPos_;
 
   const vec3 dim = bounds.Size();
   const ivec3 gridSize(dim / edgeLength + 1.0);
@@ -490,12 +510,15 @@ Manifold Manifold::LevelSet(std::function<double(vec3)> sdf, Box bounds,
 
   const vec3 origin = bounds.min;
   Vec<double> voxels(maxIndex);
+  // Per-chunk cancel only: a cancel cannot interrupt a single in-flight user
+  // sdf evaluation, same granularity as the other eager ops.
   for_each_n(
-      pol, countAt(0_uz), maxIndex,
+      pol, countAt(0_uz), maxIndex, ctx,
       [&voxels, sdf, level, origin, spacing, gridSize, gridPow](uint64_t idx) {
         voxels[idx] = BoundedSDF(DecodeIndex(idx, gridPow) - kVoxelOffset,
                                  origin, spacing, gridSize, level, sdf);
       });
+  ADVANCE_PHASE_OR_RETURN(ctx);
 
   const uint64_t tableSizeCap =
       static_cast<uint64_t>(std::numeric_limits<size_t>::max());
@@ -514,10 +537,17 @@ Manifold Manifold::LevelSet(std::function<double(vec3)> sdf, Box bounds,
   while (1) {
     Vec<int> index(1, 0);
     for_each_n(pol, countAt(0_uz), EncodeIndex(ivec4(gridSize, 1), gridPow),
+               ctx,
                NearSurface({vertPos, index, gridVerts.D(), voxels, sdf, origin,
                             gridSize, gridPow, spacing, level, tolerance}));
 
     if (gridVerts.Full()) {  // Resize HashTable
+      // Skip the reallocation and the NearSurface re-run if cancel landed
+      // during this pass, before reading partial NearSurface output below.
+      if (IsCancelled(ctx)) {
+        MakeEmpty(Error::Cancelled);
+        return;
+      }
       const vec3 lastVert = vertPos[index[0] - 1];
       const uint64_t lastIndex =
           EncodeIndex(ivec4(ivec3((lastVert - origin) / spacing), 1), gridPow);
@@ -530,10 +560,13 @@ Manifold Manifold::LevelSet(std::function<double(vec3)> sdf, Box bounds,
       gridVerts = HashTable<GridVert>(tableSize);
       vertPos = Vec<vec3>(gridVerts.Size() * 7);
     } else {  // Success
+      // NearSurface counts as one phase regardless of resize iterations.
+      ADVANCE_PHASE_OR_RETURN(ctx);
       for_each_n(
-          pol, countAt(0), gridVerts.Size(),
+          pol, countAt(0), gridVerts.Size(), ctx,
           ComputeVerts({vertPos, index, gridVerts.D(), voxels, sdf, origin,
                         gridSize, gridPow, spacing, level, tolerance}));
+      ADVANCE_PHASE_OR_RETURN(ctx);
       vertPos.resize(index[0]);
       break;
     }
@@ -542,18 +575,28 @@ Manifold Manifold::LevelSet(std::function<double(vec3)> sdf, Box bounds,
   Vec<ivec3> triVerts(gridVerts.Entries() * 12);  // worst case
 
   Vec<int> index(1, 0);
-  for_each_n(pol, countAt(0), gridVerts.Size(),
+  for_each_n(pol, countAt(0), gridVerts.Size(), ctx,
              BuildTris({triVerts, index, gridVerts.D(), gridPow}));
+  ADVANCE_PHASE_OR_RETURN(ctx);
   triVerts.resize(index[0]);
 
-  pImpl_->CreateHalfedges(triVerts);
-  pImpl_->CleanupTopology();
-  pImpl_->RemoveUnreferencedVerts();
-  pImpl_->InitializeOriginal();
-  pImpl_->CalculateBBox();
-  pImpl_->SetEpsilon();
-  pImpl_->SortGeometry();
-  pImpl_->SetNormalsAndCoplanar();
-  return Manifold(pImpl_);
+  // Finalize, lumped as one phase. (This sequence differs from the
+  // Manifold(MeshGL) ingest pipeline; do not route through that.) SortGeometry
+  // is the heavy step, so it takes ctx for cancel responsiveness like the
+  // sibling ops; its contract then requires a cancel check before its
+  // partial-on-cancel output feeds an unconditional consumer.
+  CreateHalfedges(triVerts);
+  CleanupTopology();
+  RemoveUnreferencedVerts();
+  InitializeOriginal();
+  CalculateBBox();
+  SetEpsilon();
+  SortGeometry(ctx);
+  if (IsCancelled(ctx)) {
+    MakeEmpty(Error::Cancelled);
+    return;
+  }
+  SetNormalsAndCoplanar();
+  ADVANCE_PHASE_OR_RETURN(ctx);
 }
 }  // namespace manifold

--- a/test/context_test.cpp
+++ b/test/context_test.cpp
@@ -1007,3 +1007,81 @@ TEST(ExecutionContextSmooth, CancelWithSharpenedEdges) {
   EXPECT_GT(cancelledHits, 0);
 }
 #endif  // MANIFOLD_PAR == 1
+
+// LevelSet: ctx-aware analog of `Manifold::LevelSet`. The shared
+// counter/reuse/validation machinery is the same as FromMeshGL and is covered
+// by that cluster above, so here we only test LevelSet's unique paths: the
+// happy path, parity with the plain factory, the entry-time cancel gate in
+// CreateLevelSet, and concurrent cancel through the dominant voxel-sampling
+// phase.
+TEST(ExecutionContextLevelSet, HappyPath) {
+  // Sphere SDF: positive inside, negative outside.
+  auto sphere = [](vec3 p) { return 1.0 - la::length(p); };
+  ExecutionContext ctx;
+  Manifold m = ctx.LevelSet(sphere, {vec3(-1.1), vec3(1.1)}, 0.1);
+  EXPECT_FALSE(m.IsEmpty());
+  EXPECT_EQ(m.Status(), Manifold::Error::NoError);
+  EXPECT_EQ(ctx.impl_->totalPhases.load(), kPhasesPerLevelSet);
+  EXPECT_EQ(ctx.impl_->donePhases.load(), kPhasesPerLevelSet);
+  EXPECT_DOUBLE_EQ(ctx.Progress(), 1.0);
+}
+
+// Equivalent geometry to the plain factory. (Named MatchesFactory, not
+// MatchesCtor - LevelSet has no constructor form.)
+TEST(ExecutionContextLevelSet, MatchesFactory) {
+  auto sphere = [](vec3 p) { return 1.0 - la::length(p); };
+  const Box bounds = {vec3(-1.1), vec3(1.1)};
+  const double edgeLength = 0.1;
+  ExecutionContext ctx;
+  Manifold viaCtx = ctx.LevelSet(sphere, bounds, edgeLength);
+  Manifold viaFactory = Manifold::LevelSet(sphere, bounds, edgeLength);
+  EXPECT_EQ(viaCtx.Status(), viaFactory.Status());
+  EXPECT_EQ(viaCtx.NumTri(), viaFactory.NumTri());
+  EXPECT_EQ(viaCtx.NumVert(), viaFactory.NumVert());
+}
+
+// Pre-cancel hits CreateLevelSet's entry gate and returns before allocating or
+// sampling the voxel grid - LevelSet's analog of Smooth's CancelBeforeIngest.
+TEST(ExecutionContextLevelSet, CancelBeforeSampling) {
+  auto sphere = [](vec3 p) { return 1.0 - la::length(p); };
+  ExecutionContext ctx;
+  ctx.Cancel();
+  Manifold m = ctx.LevelSet(sphere, {vec3(-1.1), vec3(1.1)}, 0.1);
+  EXPECT_EQ(m.Status(), Manifold::Error::Cancelled);
+}
+
+// Concurrent cancel mid-sampling. A deliberately slow sdf (a few us per
+// evaluation) over a largish grid keeps the voxel-sampling phase running long
+// enough that cancel reliably lands before the first phase boundary. Adaptive
+// backoff guarantees at least one Cancelled outcome; each pins donePhases <
+// totalPhases.
+#if MANIFOLD_PAR == 1
+TEST(ExecutionContextLevelSet, CancelConcurrent) {
+  auto slowSphere = [](vec3 p) {
+    std::this_thread::sleep_for(std::chrono::microseconds(5));
+    return 1.0 - la::length(p);
+  };
+  int cancelledHits = 0;
+  auto sleep = std::chrono::microseconds(100);
+  for (int attempt = 0; attempt < 12 && cancelledHits == 0; ++attempt) {
+    ExecutionContext ctx;
+    std::atomic<Manifold::Error> result{Manifold::Error::NoError};
+    std::thread evalThread([&] {
+      result.store(
+          ctx.LevelSet(slowSphere, {vec3(-1), vec3(1)}, 0.05).Status());
+    });
+    std::this_thread::sleep_for(sleep);
+    ctx.Cancel();
+    evalThread.join();
+    EXPECT_TRUE(result.load() == Manifold::Error::Cancelled ||
+                result.load() == Manifold::Error::NoError);
+    if (result.load() == Manifold::Error::Cancelled) {
+      ++cancelledHits;
+      EXPECT_LT(ctx.impl_->donePhases.load(), ctx.impl_->totalPhases.load());
+      EXPECT_LT(ctx.Progress(), 1.0);
+    }
+    sleep *= 2;
+  }
+  EXPECT_GT(cancelledHits, 0);
+}
+#endif  // MANIFOLD_PAR == 1


### PR DESCRIPTION
Adds `ExecutionContext::LevelSet`, an eager ctx-aware factory for
`Manifold::LevelSet` so a build can report `Progress()` and honor `Cancel()`.
Continues the #971 eager-ops work, same shape as `FromMeshGL` (#1723) and
`Smooth` (#1734).

- Factors the body into `Impl::CreateLevelSet`; `Manifold::LevelSet` becomes a
  thin `ctx=nullptr` wrapper (behavior unchanged).
- 5 progress phases (`kPhasesPerLevelSet`); cancel checked at an entry gate, the
  resize loop, the four grid loops (per chunk), and `SortGeometry` in finalize.
- Tests `ExecutionContextLevelSet`: HappyPath, MatchesFactory,
  CancelBeforeSampling, CancelConcurrent (trimmed to LevelSet-unique paths).

Python + wasm bindings for the ctx variant follow in a separate PR.
