### PR TITLE
Fix originalID races on shared CSG nodes (#1740)

### DIFF
--- a/src/csg_tree.cpp
+++ b/src/csg_tree.cpp
@@ -94,7 +94,14 @@ CsgLeafNode::CsgLeafNode(std::shared_ptr<const Manifold::Impl> pImpl_,
                          mat3x4 transform_)
     : pImpl_(pImpl_), transform_(transform_) {}
 
+CsgLeafNode::CsgLeafNode(const CsgLeafNode& other) {
+  std::lock_guard<std::mutex> lock(other.mutex_);
+  pImpl_ = other.pImpl_;
+  transform_ = other.transform_;
+}
+
 std::shared_ptr<const Manifold::Impl> CsgLeafNode::GetImpl() const {
+  std::lock_guard<std::mutex> lock(mutex_);
   if (transform_ == mat3x4(la::identity)) return pImpl_;
   pImpl_ =
       std::make_shared<const Manifold::Impl>(pImpl_->Transform(transform_));
@@ -108,6 +115,7 @@ std::shared_ptr<CsgLeafNode> CsgLeafNode::ToLeafNode(
 }
 
 std::shared_ptr<CsgNode> CsgLeafNode::Transform(const mat3x4& m) const {
+  std::lock_guard<std::mutex> lock(mutex_);
   return std::make_shared<CsgLeafNode>(pImpl_, m * Mat4(transform_));
 }
 
@@ -117,6 +125,7 @@ Box CsgLeafNode::GetBoundingBox() const {
   // Compute transformed bounding box without triggering full mesh transform.
   // This is an approximation - the actual bounding box of the transformed mesh
   // may be tighter, but this is sufficient for overlap checks.
+  std::lock_guard<std::mutex> lock(mutex_);
   const Box& box = pImpl_->bBox_;
   if (transform_ == mat3x4(la::identity)) {
     return box;
@@ -139,7 +148,10 @@ Box CsgLeafNode::GetBoundingBox() const {
   return Box{newMin, newMax};
 }
 
-size_t CsgLeafNode::NumVert() const { return pImpl_->NumVert(); }
+size_t CsgLeafNode::NumVert() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return pImpl_->NumVert();
+}
 
 std::shared_ptr<CsgLeafNode> ImplToLeaf(Manifold::Impl&& impl) {
   return std::make_shared<CsgLeafNode>(
@@ -631,7 +643,12 @@ struct CsgStackFrame {
 std::shared_ptr<CsgLeafNode> CsgOpNode::ToLeafNode(
     ExecutionContext::Impl* ctx) const {
   ZoneScoped;
-  if (cache_ != nullptr) return cache_;
+  {
+    // cache_ is published under impl_'s guard below; read it under the same
+    // lock so a concurrent eval of a shared op node can't tear it.
+    auto guard = impl_.GetGuard();
+    if (cache_ != nullptr) return cache_;
+  }
 
   // Note: We do need a pointer here to avoid vector pointers from being
   // invalidated after pushing elements into the explicit stack.

--- a/src/csg_tree.h
+++ b/src/csg_tree.h
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #pragma once
+#include <mutex>
+
 #include "manifold/manifold.h"
 #include "utils.h"
 
@@ -47,6 +49,8 @@ class CsgLeafNode final : public CsgNode {
   CsgLeafNode();
   CsgLeafNode(std::shared_ptr<const Manifold::Impl> pImpl_);
   CsgLeafNode(std::shared_ptr<const Manifold::Impl> pImpl_, mat3x4 transform_);
+  // mutex_ is not copyable; snapshot the source under its lock.
+  CsgLeafNode(const CsgLeafNode& other);
 
   std::shared_ptr<const Manifold::Impl> GetImpl() const;
 
@@ -72,6 +76,9 @@ class CsgLeafNode final : public CsgNode {
  private:
   mutable std::shared_ptr<const Manifold::Impl> pImpl_;
   mutable mat3x4 transform_ = la::identity;
+  // Lazy realization mutates these through const accessors on a shared node,
+  // so every access takes mutex_.
+  mutable std::mutex mutex_;
 };
 
 class CsgOpNode final : public CsgNode {

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -23,6 +23,31 @@
 
 using namespace manifold;
 
+#if MANIFOLD_PAR == 1
+namespace {
+// Sense-reversing spin barrier (std::barrier is C++20). Lazy CSG-node
+// realization is one-shot, so all workers must first-touch a shared node
+// together to race deterministically under ThreadSanitizer. Used by the
+// concurrent-shared-node tests below.
+struct SpinBarrier {
+  const int n;
+  std::atomic<int> arrived{0};
+  std::atomic<int> generation{0};
+  explicit SpinBarrier(int n) : n(n) {}
+  void Sync() {
+    const int gen = generation.load(std::memory_order_acquire);
+    if (arrived.fetch_add(1, std::memory_order_acq_rel) + 1 == n) {
+      arrived.store(0, std::memory_order_release);
+      generation.fetch_add(1, std::memory_order_acq_rel);
+    } else {
+      while (generation.load(std::memory_order_acquire) == gen)
+        std::this_thread::yield();
+    }
+  }
+};
+}  // namespace
+#endif
+
 /**
  * The very simplest Boolean operation test.
  */
@@ -847,6 +872,84 @@ TEST(Boolean, BatchBooleanComposeMeshIDStable) {
   EXPECT_EQ(orphans.load(), 0)
       << "Compose produced runs with originalID = -1; indicates a "
          "non-atomic meshIDCounter_ snapshot.";
+}
+
+// Regression: a CSG leaf is realized lazily on first const access -
+// CsgLeafNode::GetImpl rewrites pImpl_/transform_. A Manifold and its copies
+// share the node but not its lock, so two threads realizing one shared node at
+// once tore the meshID mapping and faces came back with originalID = -1.
+TEST(Boolean, ConcurrentSharedNodeOriginalIDStable) {
+  constexpr int kThreads = 8;
+  constexpr int kRounds = 256;
+  // Each view shares original's realized Impl with a pending transform, so its
+  // first touch realizes it - the contended write.
+  const Manifold original = Manifold::Cube(vec3(2)).AsOriginal();
+  const auto origID = static_cast<uint32_t>(original.OriginalID());
+  const size_t expectTri = original.NumTri();
+  std::vector<Manifold> shared;
+  shared.reserve(kRounds);
+  for (int r = 0; r < kRounds; ++r)
+    shared.push_back(original.Translate({0.1 * r, 0, 0}));
+
+  SpinBarrier barrier(kThreads);
+  std::atomic<int> bad{0};
+  auto worker = [&]() {
+    for (int r = 0; r < kRounds; ++r) {
+      barrier.Sync();
+      const MeshGL m = shared[r].GetMeshGL();
+      if (m.NumTri() != expectTri) ++bad;
+      // A transformed view keeps the original's per-face id in runOriginalID.
+      for (uint32_t orig : m.runOriginalID)
+        if (orig != origID) ++bad;  // includes the -1 (UINT32_MAX) collapse
+    }
+  };
+  std::vector<std::thread> ts;
+  for (int t = 0; t < kThreads; ++t) ts.emplace_back(worker);
+  for (auto& t : ts) t.join();
+
+  EXPECT_EQ(bad.load(), 0)
+      << "concurrent realization of a shared CSG leaf corrupted originalID or "
+         "the mesh; also flagged as a data race under ThreadSanitizer.";
+}
+
+// Companion for CsgOpNode's lazy-eval cache_: a shared, unevaluated op node is
+// evaluated by all threads at once via per-thread Manifold copies (which share
+// pNode_ but get their own pNodeMutex_). Without the guarded cache_
+// read/publish the concurrent evaluation tears the result.
+TEST(Boolean, ConcurrentSharedOpNodeOriginalIDStable) {
+  constexpr int kThreads = 8;
+  constexpr int kRounds = 256;
+  const Manifold a = Manifold::Cube(vec3(2)).AsOriginal();
+  // Disjoint union: each result keeps runs from both originals, none collapsed.
+  std::vector<Manifold> shared;
+  shared.reserve(kRounds);
+  for (int r = 0; r < kRounds; ++r)
+    shared.push_back(
+        a + Manifold::Cube(vec3(0.2)).Translate({10.0 + 0.1 * r, 0, 0}));
+  // Probe a throwaway union so the shared nodes stay unevaluated until the
+  // race.
+  const size_t expectTri =
+      (a + Manifold::Cube(vec3(0.2)).Translate({10, 0, 0})).NumTri();
+
+  SpinBarrier barrier(kThreads);
+  std::atomic<int> bad{0};
+  auto worker = [&]() {
+    for (int r = 0; r < kRounds; ++r) {
+      Manifold m = shared[r];  // copy shares the op node, own pNodeMutex_
+      barrier.Sync();
+      const MeshGL mesh = m.GetMeshGL();
+      if (mesh.NumTri() != expectTri) ++bad;
+      for (uint32_t orig : mesh.runOriginalID)
+        if (orig == std::numeric_limits<uint32_t>::max()) ++bad;  // -1 collapse
+    }
+  };
+  std::vector<std::thread> ts;
+  for (int t = 0; t < kThreads; ++t) ts.emplace_back(worker);
+  for (auto& t : ts) t.join();
+
+  EXPECT_EQ(bad.load(), 0)
+      << "concurrent evaluation of a shared CsgOpNode corrupted originalID or "
+         "the mesh; also flagged as a data race under ThreadSanitizer.";
 }
 #endif  // MANIFOLD_PAR == 1
 


### PR DESCRIPTION
## Problem

#1740 reports faces coming back with `originalID = -1` when CSG ops run across threads on master. It's a data race on lazily-evaluated CSG nodes, separate from #1688.

`Manifold` is meant to be safe for concurrent const access (#1636), but lazy evaluation mutates shared node state through `const` methods with no per-node lock:
- `CsgLeafNode::GetImpl` realizes a pending transform by rewriting `mutable pImpl_`/`transform_`.
- `CsgOpNode::ToLeafNode` publishes `mutable cache_`.

A `Manifold` and its copies share the underlying node (`pNode_`) but each has its own `pNodeMutex_`, and `GetCsgLeafNode` drops that lock before `GetImpl`/`cache_` runs. So two threads touching one shared node at once - e.g. reading `OriginalID()` to exclude boundary faces, the reporter's case - tear the meshID map; `IncrementMeshIDs` collapses the orphaned IDs and `GetMeshGL` emits `originalID = -1`. Single-threaded, or with copies that don't share a node, it's fine, which matches the report.

## Fix

- A per-node `std::mutex` guards `CsgLeafNode`'s one-shot realize and the const accessors that read `pImpl_`/`transform_` (`GetImpl`, `Transform`, `GetBoundingBox`, `NumVert`, plus a copy ctor). The lock lives on the node, not the `Manifold`, because nodes are shared across different `Manifold`s via `CsgOpNode` children.
- `CsgOpNode` reads and publishes `cache_` under `impl_`'s existing guard (the writes were already guarded; this makes the read consistent), including the cancellation path.
- `Compose`'s direct field reads stay unlocked but are documented as requiring thread-local leaves.

The boolean path is untouched: it copies leaf operands (`node->Transform`) before `GetImpl`, so it never mutates a shared node.

## Testing

Two regression tests, committed first (without the fix) so the failure is visible, then fixed in the second commit:
- `Boolean.ConcurrentSharedNodeOriginalIDStable` - the leaf `GetImpl` path.
- `Boolean.ConcurrentSharedOpNodeOriginalIDStable` - the op-node `cache_` path.

Both halt the TSAN lane without the fix and pass with it (8 threads barrier-synced onto one shared node). Full suite passes; clang-format-20 clean.

Fixes #1740. (@elalish edited this to fixed so it closes the issue; seems likely, and we can always reopen if the reporter continues to have trouble). 
