### PR TITLE
Per-phase timing in ADVANCE_PHASE_OR_RETURN; extend perfPhases

### DIFF
--- a/extras/perf_phases.cpp
+++ b/extras/perf_phases.cpp
@@ -12,13 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Prints per-phase Boolean3 wall-clock timings on representative workloads.
-// Requires MANIFOLD_TIMING=ON (or MANIFOLD_DEBUG=ON) so Timer::Print fires.
-// Used for cancel-latency analysis and for identifying dominant phases.
+// Prints per-phase wall-clock timings on representative workloads for the
+// eager ops that carry phase instrumentation: Boolean3 (its own Timers) and
+// the ADVANCE_PHASE_OR_RETURN ops driven through an ExecutionContext -
+// LevelSet, FromMesh ingest, and Smooth. Requires MANIFOLD_TIMING=ON (or
+// MANIFOLD_DEBUG=ON). Used for cancel-latency analysis and identifying dominant
+// phases.
 
+#include <algorithm>
 #include <chrono>
+#include <functional>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include "manifold/manifold.h"
 #include "samples.h"
@@ -51,6 +57,61 @@ void BenchAll(const std::string& workload, const Manifold& a,
               << std::endl;
   }
 }
+
+// Runs one LevelSet through an ExecutionContext. The wall-clock total is
+// printed here; ADVANCE_PHASE_OR_RETURN prints the per-phase breakdown under
+// verbose >= 2 (it only records phases when a ctx is attached). One op per
+// call keeps that breakdown readable.
+void BenchLevelSet(const std::string& workload,
+                   const std::function<double(vec3)>& sdf, Box bounds,
+                   double edgeLength, double tolerance, bool canParallel) {
+  std::cout << "=== " << workload << ": edge=" << edgeLength
+            << ", tol=" << tolerance << ", " << (canParallel ? "Par" : "Seq")
+            << " ===" << std::endl;
+  auto t0 = std::chrono::high_resolution_clock::now();
+  ExecutionContext ctx;
+  Manifold result =
+      ctx.LevelSet(sdf, bounds, edgeLength, 0, tolerance, canParallel);
+  result.NumTri();
+  auto t1 = std::chrono::high_resolution_clock::now();
+  std::cout << "total = " << std::chrono::duration<double>(t1 - t0).count()
+            << " sec\n"
+            << std::endl;
+}
+
+// Re-ingests a MeshGL through ExecutionContext::FromMeshGL (kPhasesPerFromMesh
+// = 7: CreateHalfedges, CleanupTopology, DedupePropVerts,
+// SetNormalsAndCoplanar, RemoveDegenerates, RemoveUnreferencedVerts,
+// SortGeometry).
+void BenchFromMesh(const std::string& workload, const MeshGL& gl) {
+  std::cout << "=== FromMesh " << workload << ": nTri = " << gl.NumTri()
+            << " ===" << std::endl;
+  auto t0 = std::chrono::high_resolution_clock::now();
+  ExecutionContext ctx;
+  Manifold result = ctx.FromMeshGL(gl);
+  result.NumTri();
+  auto t1 = std::chrono::high_resolution_clock::now();
+  std::cout << "total = " << std::chrono::duration<double>(t1 - t0).count()
+            << " sec\n"
+            << std::endl;
+}
+
+// Smooths a control-cage MeshGL through ExecutionContext::Smooth
+// (kPhasesPerSmooth = 14: the 7 FromMesh ingest phases plus 7 tangent/smoothing
+// phases), then refines to materialize the tessellation. The phase lines come
+// from the Smooth call; Refine is just to make it a realistic workload.
+void BenchSmooth(const std::string& workload, const MeshGL& gl, int refine) {
+  std::cout << "=== Smooth " << workload << ": nTri = " << gl.NumTri()
+            << ", refine = " << refine << " ===" << std::endl;
+  auto t0 = std::chrono::high_resolution_clock::now();
+  ExecutionContext ctx;
+  Manifold result = ctx.Smooth(gl, {}).Refine(refine);
+  result.NumTri();
+  auto t1 = std::chrono::high_resolution_clock::now();
+  std::cout << "total = " << std::chrono::duration<double>(t1 - t0).count()
+            << " sec\n"
+            << std::endl;
+}
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -73,5 +134,78 @@ int main(int argc, char** argv) {
     Manifold sponge2 = sponge.Translate(vec3(0.3));
     sponge.NumTri();  // force construction before timing the ops
     BenchAll("MengerSponge(" + std::to_string(level) + ")", sponge, sponge2);
+  }
+
+  // ---- LevelSet phase timings ----
+  // Three SDF regimes chosen to move the dominant phase around:
+  //  - cheap sphere: sparse near-surface set, trivial per-call cost.
+  //  - cheap gyroid: same trivial cost but the surface threads most cells, so
+  //    NearSurface touches a large fraction of the grid (Emmett's hypothesis).
+  //  - expensive sphere: identical surface to the cheap sphere, but each sdf
+  //    call carries a vanishing transcendental sum (no sleep - that would
+  //    distort parallel timing), so sampling should dominate.
+  // The tolerance axis (off vs a small positive value) toggles FindSurface
+  // root-finding in NearSurface/ComputeVerts, the other lever on SDF cost.
+  auto sphereSdf = [](vec3 p) { return 1.0 - la::length(p); };
+  auto gyroidSdf = [](vec3 p) {
+    return std::cos(p.x) * std::sin(p.y) + std::cos(p.y) * std::sin(p.z) +
+           std::cos(p.z) * std::sin(p.x);
+  };
+  auto expensiveSphereSdf = [](vec3 p) {
+    double noise = 0;
+    for (int k = 1; k <= 40; ++k)
+      noise += std::sin(k * p.x) * std::cos(k * p.y) * std::sin(k * p.z);
+    return (1.0 - la::length(p)) + 1e-12 * noise;  // surface unmoved
+  };
+
+  struct SdfCase {
+    const char* name;
+    std::function<double(vec3)> sdf;
+    Box bounds;
+    bool expensive;
+  };
+  const Box sphereBounds(vec3(-1.1), vec3(1.1));
+  const Box gyroidBounds(vec3(-kTwoPi), vec3(kTwoPi));
+  const SdfCase cases[] = {
+      {"sphere(cheap)", sphereSdf, sphereBounds, false},
+      {"gyroid(cheap,high-area)", gyroidSdf, gyroidBounds, false},
+      {"sphere(expensive)", expensiveSphereSdf, sphereBounds, true},
+  };
+
+  for (const auto& c : cases) {
+    const vec3 s = c.bounds.Size();
+    const double maxDim = std::max({s.x, s.y, s.z});
+    // Cap the expensive SDF at coarser grids; the per-call cost makes fine
+    // grids slow without changing which phase wins.
+    const std::vector<int> resolutions =
+        c.expensive ? std::vector<int>{32, 64} : std::vector<int>{32, 64, 128};
+    for (int n : resolutions) {
+      const double edge = maxDim / n;
+      for (bool par : {false, true}) {
+        for (double tol : {-1.0, edge * 0.01}) {
+          BenchLevelSet(std::string(c.name) + " n=" + std::to_string(n), c.sdf,
+                        c.bounds, edge, tol, par);
+        }
+      }
+    }
+  }
+
+  // ---- FromMesh ingest phase timings ----
+  // Round-trip representative meshes back through the MeshGL ingest pipeline.
+  for (int segments : {64, 128, 256}) {
+    const MeshGL gl = Manifold::Sphere(1, segments).GetMeshGL();
+    BenchFromMesh("Sphere(" + std::to_string(segments) + ")", gl);
+  }
+  {
+    Manifold sponge = MengerSponge(4);
+    sponge.NumTri();  // force construction before measuring the ingest
+    BenchFromMesh("MengerSponge(4)", sponge.GetMeshGL());
+  }
+
+  // ---- Smooth phase timings ----
+  // A coarse control cage smoothed (FromMesh ingest + tangent phases) then
+  // refined; the phase breakdown comes from the Smooth call.
+  for (int refine : {16, 64}) {
+    BenchSmooth("Sphere(32)", Manifold::Sphere(1, 32).GetMeshGL(), refine);
   }
 }

--- a/src/execution_impl.cpp
+++ b/src/execution_impl.cpp
@@ -14,6 +14,12 @@
 
 #include "execution_impl.h"
 
+#if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#endif
+
 #include "impl.h"
 #include "manifold/manifold.h"
 #include "manifold/mesh.h"
@@ -30,10 +36,28 @@ void ResetForStaticFactory(ExecutionContext::Impl* ctx, int totalPhases) {
   ctx->donePhases.store(0, std::memory_order_relaxed);
   ctx->totalBooleans.store(0, std::memory_order_relaxed);
   ctx->totalPhases.store(totalPhases, std::memory_order_relaxed);
+#if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
+  ctx->lastPhase = std::chrono::high_resolution_clock::now();
+#endif
 }
 
 }  // namespace
 namespace manifold {
+
+#if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
+void RecordPhase(ExecutionContext::Impl* ctx, const char* file, int line) {
+  const auto now = std::chrono::high_resolution_clock::now();
+  if (ManifoldParams().verbose >= 2) {
+    const double ms =
+        std::chrono::duration<double, std::milli>(now - ctx->lastPhase).count();
+    const char* slash = std::strrchr(file, '/');
+    std::cout << "  phase " << ctx->donePhases.load(std::memory_order_relaxed)
+              << " (" << (slash ? slash + 1 : file) << ":" << line
+              << ") = " << ms << " ms" << std::endl;
+  }
+  ctx->lastPhase = now;
+}
+#endif
 
 ExecutionContext::ExecutionContext() : impl_(std::make_shared<Impl>()) {}
 ExecutionContext::~ExecutionContext() = default;

--- a/src/execution_impl.h
+++ b/src/execution_impl.h
@@ -14,6 +14,9 @@
 
 #pragma once
 #include <atomic>
+#if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
+#include <chrono>
+#endif
 
 #include "manifold/common.h"
 
@@ -81,6 +84,12 @@ struct ExecutionContext::Impl {
   std::atomic<int> doneBooleans{0};
   std::atomic<int> totalPhases{0};
   std::atomic<int> donePhases{0};
+#if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
+  // Wall-clock of the last phase boundary, for per-phase timing via
+  // ADVANCE_PHASE_OR_RETURN. Stamped at the static-factory reset; touched only
+  // by the op's own thread.
+  std::chrono::high_resolution_clock::time_point lastPhase{};
+#endif
 
  private:
   std::atomic<bool> cancel{false};
@@ -104,6 +113,14 @@ inline bool IsCancelled(ExecutionContext::Impl* ctx) {
   return ctx && ctx->cancel.load(std::memory_order_relaxed);
 }
 
+#if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
+// Times the span since the previous phase boundary (or the static-factory
+// reset) and prints it when verbose >= 2. Called by ADVANCE_PHASE_OR_RETURN;
+// defined in execution_impl.cpp so <chrono>/<iostream> stay out of this
+// widely-included header.
+void RecordPhase(ExecutionContext::Impl* ctx, const char* file, int line);
+#endif
+
 }  // namespace manifold
 
 /** @ingroup Private
@@ -111,11 +128,21 @@ inline bool IsCancelled(ExecutionContext::Impl* ctx) {
  * Phase-boundary checkpoint for `Manifold::Impl` methods (relies on
  * `this->MakeEmpty`). Call count must equal the method's `kPhasesPer*`.
  */
-#define ADVANCE_PHASE_OR_RETURN(ctx)                                    \
-  do {                                                                  \
-    if (manifold::IsCancelled(ctx)) {                                   \
-      MakeEmpty(manifold::Manifold::Error::Cancelled);                  \
-      return;                                                           \
-    }                                                                   \
-    if (ctx) (ctx)->donePhases.fetch_add(1, std::memory_order_relaxed); \
+#if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
+#define MANIFOLD_RECORD_PHASE(ctx) \
+  manifold::RecordPhase((ctx), __FILE__, __LINE__)
+#else
+#define MANIFOLD_RECORD_PHASE(ctx) ((void)0)
+#endif
+
+#define ADVANCE_PHASE_OR_RETURN(ctx)                             \
+  do {                                                           \
+    if (manifold::IsCancelled(ctx)) {                            \
+      MakeEmpty(manifold::Manifold::Error::Cancelled);           \
+      return;                                                    \
+    }                                                            \
+    if (ctx) {                                                   \
+      (ctx)->donePhases.fetch_add(1, std::memory_order_relaxed); \
+      MANIFOLD_RECORD_PHASE(ctx);                                \
+    }                                                            \
   } while (0)


### PR DESCRIPTION
Follow-up to #1739. Rather than hand-placing `Timer`s per op, `ADVANCE_PHASE_OR_RETURN` now records the time since the previous boundary (baseline at `ResetForStaticFactory`, `lastPhase` on `ExecutionContext::Impl`) and prints `phase N (file:line) = X ms` under `verbose >= 2`. All behind `MANIFOLD_DEBUG || MANIFOLD_TIMING`, so release is unchanged. One change times every phased op, in sync with the cancel/Progress boundaries: LevelSet (5), FromMesh (7), Smooth (14). It records only with a ctx attached; `extras/perfPhases` drives the ops through an `ExecutionContext` and adds FromMesh/Smooth sections.

**Per-phase timings** (single-threaded, ms; % of phase sum)

LevelSet:

| workload | sampling | NearSurface | ComputeVerts | BuildTris | finalize |
|---|---|---|---|---|---|
| cheap sphere n=128 | 196 (9%) | **1597 (73%)** | 77 | 49 | 274 (12%) |
| cheap gyroid n=128 | 413 (12%) | **1440 (41%)** | 376 | 352 | 902 (26%) |
| expensive sphere n=64 | **1004 (76%)** | 213 (16%) | 11 | 9 | 78 |

FromMesh ingest:

| mesh (tris) | CreateHalfedges | Cleanup | Dedupe | SetNormals | RemoveDegen | RemoveUnref | Sort |
|---|---|---|---|---|---|---|---|
| Sphere(256), 33k | 10 | 2 | 0 | 7 | **15** | 0 | 10 |
| MengerSponge(4), 395k | 80 | 54 | 0 | 130 | **166** | 9 | 82 |

(Smooth's 14 phases are sub-ms on a small control cage; the work is the unphased `Refine` after.)

Matches #1739: NearSurface dominates cheap SDFs, sampling dominates the expensive one. Release compiles with timing guarded out (verified).
