### PR TITLE
Expose ExecutionContext factories in bindings (C/Python/WASM)

### DIFF
--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -268,6 +268,30 @@ void manifold_execution_context_cancel(ManifoldExecutionContext* ctx);
 int manifold_execution_context_cancelled(ManifoldExecutionContext* ctx);
 double manifold_execution_context_progress(ManifoldExecutionContext* ctx);
 
+// ctx-aware static factories. These ops have no source manifold to attach via
+// manifold_with_context, so they run on the ExecutionContext directly to report
+// progress / observe cancellation. Mirror manifold_level_set /
+// manifold_of_meshgl / manifold_smooth; `sdf_context` is the SDF callback's
+// user-data.
+ManifoldManifold* manifold_execution_context_level_set(
+    void* mem, ManifoldExecutionContext* ec, ManifoldSdf sdf,
+    ManifoldBox* bounds, double edge_length, double level, double tolerance,
+    void* sdf_context);
+ManifoldManifold* manifold_execution_context_level_set_seq(
+    void* mem, ManifoldExecutionContext* ec, ManifoldSdf sdf,
+    ManifoldBox* bounds, double edge_length, double level, double tolerance,
+    void* sdf_context);
+ManifoldManifold* manifold_execution_context_of_meshgl(
+    void* mem, ManifoldExecutionContext* ec, ManifoldMeshGL* mesh);
+ManifoldManifold* manifold_execution_context_of_meshgl64(
+    void* mem, ManifoldExecutionContext* ec, ManifoldMeshGL64* mesh);
+ManifoldManifold* manifold_execution_context_smooth(
+    void* mem, ManifoldExecutionContext* ec, ManifoldMeshGL* mesh,
+    size_t* half_edges, double* smoothness, size_t n_edges);
+ManifoldManifold* manifold_execution_context_smooth64(
+    void* mem, ManifoldExecutionContext* ec, ManifoldMeshGL64* mesh,
+    size_t* half_edges, double* smoothness, size_t n_edges);
+
 // CrossSection Shapes/Constructors
 ManifoldCrossSection* manifold_cross_section_empty(void* mem);
 ManifoldCrossSection* manifold_cross_section_copy(void* mem,

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -32,7 +32,7 @@ namespace {
 ManifoldManifold* level_set(
     void* mem, double (*sdf_context)(double, double, double, void*),
     ManifoldBox* bounds, double edge_length, double level, double tolerance,
-    bool seq, void* ctx) {
+    bool seq, void* ctx, ExecutionContext* ec = nullptr) {
   // Bind function with context argument to one without
   using namespace std::placeholders;
   std::function<double(double, double, double)> sdf =
@@ -40,8 +40,12 @@ ManifoldManifold* level_set(
   std::function<double(vec3)> fun = [sdf](vec3 v) {
     return (sdf(v.x, v.y, v.z));
   };
-  return to_c(new (mem) Manifold(Manifold::LevelSet(
-      fun, *from_c(bounds), edge_length, level, tolerance, !seq)));
+  // Run under the ExecutionContext when given, so progress/cancel are observed.
+  Manifold result = ec ? ec->LevelSet(fun, *from_c(bounds), edge_length, level,
+                                      tolerance, !seq)
+                       : Manifold::LevelSet(fun, *from_c(bounds), edge_length,
+                                            level, tolerance, !seq);
+  return to_c(new (mem) Manifold(result));
 }
 
 // Raw uninitialized storage for a T — callers must placement-new into it
@@ -897,6 +901,57 @@ int manifold_execution_context_cancelled(ManifoldExecutionContext* ctx) {
 
 double manifold_execution_context_progress(ManifoldExecutionContext* ctx) {
   return from_c(ctx)->Progress();
+}
+
+// ctx-aware static factories: the FromMeshGL / LevelSet / Smooth ops have no
+// source Manifold to attach via manifold_with_context, so they run directly on
+// the ExecutionContext. Each mirrors its plain factory but observes progress /
+// cancellation. `sdf_context` is the SDF callback's user-data (distinct from
+// the ExecutionContext `ec`).
+ManifoldManifold* manifold_execution_context_level_set(
+    void* mem, ManifoldExecutionContext* ec,
+    double (*sdf)(double, double, double, void*), ManifoldBox* bounds,
+    double edge_length, double level, double tolerance, void* sdf_context) {
+  return level_set(mem, sdf, bounds, edge_length, level, tolerance, false,
+                   sdf_context, from_c(ec));
+}
+
+ManifoldManifold* manifold_execution_context_level_set_seq(
+    void* mem, ManifoldExecutionContext* ec,
+    double (*sdf)(double, double, double, void*), ManifoldBox* bounds,
+    double edge_length, double level, double tolerance, void* sdf_context) {
+  return level_set(mem, sdf, bounds, edge_length, level, tolerance, true,
+                   sdf_context, from_c(ec));
+}
+
+ManifoldManifold* manifold_execution_context_of_meshgl(
+    void* mem, ManifoldExecutionContext* ec, ManifoldMeshGL* mesh) {
+  return to_c(new (mem) Manifold(from_c(ec)->FromMeshGL(*from_c(mesh))));
+}
+
+ManifoldManifold* manifold_execution_context_of_meshgl64(
+    void* mem, ManifoldExecutionContext* ec, ManifoldMeshGL64* mesh) {
+  return to_c(new (mem) Manifold(from_c(ec)->FromMeshGL(*from_c(mesh))));
+}
+
+ManifoldManifold* manifold_execution_context_smooth(
+    void* mem, ManifoldExecutionContext* ec, ManifoldMeshGL* mesh,
+    size_t* half_edges, double* smoothness, size_t n_edges) {
+  auto smooth = std::vector<Smoothness>();
+  for (size_t i = 0; i < n_edges; ++i) {
+    smooth.push_back({half_edges[i], smoothness[i]});
+  }
+  return to_c(new (mem) Manifold(from_c(ec)->Smooth(*from_c(mesh), smooth)));
+}
+
+ManifoldManifold* manifold_execution_context_smooth64(
+    void* mem, ManifoldExecutionContext* ec, ManifoldMeshGL64* mesh,
+    size_t* half_edges, double* smoothness, size_t n_edges) {
+  auto smooth = std::vector<Smoothness>();
+  for (size_t i = 0; i < n_edges; ++i) {
+    smooth.push_back({half_edges[i], smoothness[i]});
+  }
+  return to_c(new (mem) Manifold(from_c(ec)->Smooth(*from_c(mesh), smooth)));
 }
 
 ManifoldManifold* manifold_calculate_normals(void* mem, ManifoldManifold* m,

--- a/bindings/python/examples/all_apis.py
+++ b/bindings/python/examples/all_apis.py
@@ -119,6 +119,26 @@ def all_manifold():
     cancelled_ctx.cancel()
     tree = (Manifold.cube() + Manifold.sphere(1)).with_context(cancelled_ctx)
     assert tree.status() == Error.Cancelled
+    # ctx-aware static factories: these ops have no source Manifold to attach a
+    # context to via with_context, so they run on the context directly.
+    ingest_ctx = ExecutionContext()
+    assert ingest_ctx.from_mesh(Manifold.cube().to_mesh()).status() == Error.NoError
+    assert ingest_ctx.progress() == 1.0
+    sdf_ctx = ExecutionContext()
+    sphere = sdf_ctx.level_set(
+        lambda x, y, z: 1 - (x * x + y * y + z * z) ** 0.5,
+        [-1.1, -1.1, -1.1, 1.1, 1.1, 1.1],
+        0.2,
+    )
+    assert sphere.status() == Error.NoError
+    smooth_ctx = ExecutionContext()
+    m = smooth_ctx.smooth(Manifold.cube().to_mesh(), [0], [0.5])
+    # A pre-cancelled ctx propagates through a factory; this proves the ctx is
+    # wired, since NoError + progress==1 also hold for an untouched ctx.
+    cancel_factory_ctx = ExecutionContext()
+    cancel_factory_ctx.cancel()
+    cancelled = cancel_factory_ctx.from_mesh(Manifold.cube().to_mesh())
+    assert cancelled.status() == Error.Cancelled
     m = Manifold.tetrahedron()
     mesh = m.to_mesh()
     ok = mesh.merge()

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -739,7 +739,83 @@ NB_MODULE(manifold3d, m) {
       .def(nb::init<>())
       .def("cancel", &ExecutionContext::Cancel)
       .def("cancelled", &ExecutionContext::Cancelled)
-      .def("progress", &ExecutionContext::Progress);
+      .def("progress", &ExecutionContext::Progress)
+      // ctx-aware static factories: like Manifold.from_mesh / level_set /
+      // smooth, but run under this context so progress / cancellation are
+      // observed (these ops have no source Manifold to attach via
+      // with_context).
+      .def(
+          "from_mesh",
+          [](ExecutionContext& ctx, const MeshGL& mesh) {
+            return ctx.FromMeshGL(mesh);
+          },
+          nb::arg("mesh"),
+          "Ingest a MeshGL into a Manifold under this context, so the ingest "
+          "reports progress and observes cancellation.")
+      .def(
+          "from_mesh",
+          [](ExecutionContext& ctx, const MeshGL64& mesh) {
+            return ctx.FromMeshGL(mesh);
+          },
+          nb::arg("mesh"),
+          "Ingest a MeshGL64 into a Manifold under this context, so the ingest "
+          "reports progress and observes cancellation.")
+      .def(
+          "level_set",
+          [](ExecutionContext& ctx,
+             const std::function<double(double, double, double)>& f,
+             std::vector<double> bounds, double edgeLength, double level,
+             double tolerance) {
+            Box bound = {vec3(bounds[0], bounds[1], bounds[2]),
+                         vec3(bounds[3], bounds[4], bounds[5])};
+            std::function<double(vec3)> cppToPython = [&f](vec3 v) {
+              return f(v.x, v.y, v.z);
+            };
+            return ctx.LevelSet(cppToPython, bound, edgeLength, level,
+                                tolerance, false);
+          },
+          nb::arg("f"), nb::arg("bounds"), nb::arg("edgeLength"),
+          nb::arg("level") = 0.0, nb::arg("tolerance") = -1,
+          "Like Manifold.level_set, run under this context so the level-set "
+          "evaluation reports progress and observes cancellation.")
+      .def(
+          "smooth",
+          [](ExecutionContext& ctx, const MeshGL& mesh,
+             std::vector<size_t> sharpened_edges,
+             std::vector<double> edge_smoothness) {
+            if (sharpened_edges.size() != edge_smoothness.size()) {
+              throw std::runtime_error(
+                  "sharpened_edges.size() != edge_smoothness.size()");
+            }
+            std::vector<Smoothness> vec(sharpened_edges.size());
+            for (size_t i = 0; i < vec.size(); i++) {
+              vec[i] = {sharpened_edges[i], edge_smoothness[i]};
+            }
+            return ctx.Smooth(mesh, vec);
+          },
+          nb::arg("mesh"), nb::arg("sharpened_edges") = nb::list(),
+          nb::arg("edge_smoothness") = nb::list(),
+          "Like Manifold.smooth, run under this context so progress and "
+          "cancellation are observed.")
+      .def(
+          "smooth",
+          [](ExecutionContext& ctx, const MeshGL64& mesh,
+             std::vector<size_t> sharpened_edges,
+             std::vector<double> edge_smoothness) {
+            if (sharpened_edges.size() != edge_smoothness.size()) {
+              throw std::runtime_error(
+                  "sharpened_edges.size() != edge_smoothness.size()");
+            }
+            std::vector<Smoothness> vec(sharpened_edges.size());
+            for (size_t i = 0; i < vec.size(); i++) {
+              vec[i] = {sharpened_edges[i], edge_smoothness[i]};
+            }
+            return ctx.Smooth(mesh, vec);
+          },
+          nb::arg("mesh"), nb::arg("sharpened_edges") = nb::list(),
+          nb::arg("edge_smoothness") = nb::list(),
+          "Like Manifold.smooth, run under this context so progress and "
+          "cancellation are observed.");
 
   nb::enum_<Manifold::Error>(m, "Error")
       .value("NoError", Manifold::Error::NoError)

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -115,7 +115,10 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .constructor<>()
       .function("cancel", &ExecutionContext::Cancel)
       .function("cancelled", &ExecutionContext::Cancelled)
-      .function("progress", &ExecutionContext::Progress);
+      .function("progress", &ExecutionContext::Progress)
+      .function("_FromMesh", &man_js::ExecutionContextFromMesh)
+      .function("_Smooth", &man_js::ExecutionContextSmooth)
+      .function("_LevelSet", &man_js::ExecutionContextLevelSet);
 
   register_vector<RayHit>("Vector_rayHit");
   register_vector<ivec3>("Vector_ivec3");

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -724,6 +724,40 @@ Module.setup = function() {
     return out;
   };
 
+  // ctx-aware static factories: mirror Manifold.ofMesh / smooth / levelSet but
+  // run under this ExecutionContext so progress/cancellation are observed.
+  Module.ExecutionContext.prototype.fromMesh = function(mesh) {
+    return this._FromMesh(mesh);
+  };
+
+  Module.ExecutionContext.prototype.smooth = function(
+      mesh, sharpenedEdges = []) {
+    const sharp = new Module.Vector_smoothness();
+    toVec(sharp, sharpenedEdges);
+    const result = this._Smooth(mesh, sharp);
+    sharp.delete();
+    return result;
+  };
+
+  Module.ExecutionContext.prototype.levelSet = function(
+      sdf, bounds, edgeLength, level = 0, tolerance = -1) {
+    const bounds2 = {
+      min: {x: bounds.min[0], y: bounds.min[1], z: bounds.min[2]},
+      max: {x: bounds.max[0], y: bounds.max[1], z: bounds.max[2]},
+    };
+    const wasmFuncPtr = addFunction(function(vec3Ptr) {
+      const x = getValue(vec3Ptr, 'double');
+      const y = getValue(vec3Ptr + 8, 'double');
+      const z = getValue(vec3Ptr + 16, 'double');
+      const vert = [x, y, z];
+      return sdf(vert);
+    }, 'di');
+    const out =
+        this._LevelSet(wasmFuncPtr, bounds2, edgeLength, level, tolerance);
+    removeFunction(wasmFuncPtr);
+    return out;
+  };
+
   function pushVec3(vec, ps) {
     toVec(vec, ps, p => {
       if (p instanceof Array) return {x: p[0], y: p[1], z: p[2]};

--- a/bindings/wasm/helpers.cpp
+++ b/bindings/wasm/helpers.cpp
@@ -251,6 +251,26 @@ Manifold LevelSet(uintptr_t funcPtr, Box bounds, double edgeLength,
   return Manifold::LevelSet(f, bounds, edgeLength, level, tolerance, false);
 }
 
+// ctx-aware static factories: like the plain factories above, but run under an
+// ExecutionContext so progress / cancellation are observed (these ops have no
+// source Manifold to attach via withContext). Bound as ExecutionContext methods
+// (first arg is the receiver).
+Manifold ExecutionContextFromMesh(ExecutionContext& ctx, const val& mesh) {
+  return ctx.FromMeshGL(js::MeshJS2GL(mesh));
+}
+
+Manifold ExecutionContextSmooth(ExecutionContext& ctx, const val& mesh,
+                                const std::vector<Smoothness>& sharpenedEdges) {
+  return ctx.Smooth(js::MeshJS2GL(mesh), sharpenedEdges);
+}
+
+Manifold ExecutionContextLevelSet(ExecutionContext& ctx, uintptr_t funcPtr,
+                                  Box bounds, double edgeLength, double level,
+                                  double tolerance) {
+  double (*f)(const vec3&) = reinterpret_cast<double (*)(const vec3&)>(funcPtr);
+  return ctx.LevelSet(f, bounds, edgeLength, level, tolerance, false);
+}
+
 std::string ErrorToString(Manifold::Error error) {
   switch (error) {
     case Manifold::Error::NoError:

--- a/bindings/wasm/manifold-global-types.d.ts
+++ b/bindings/wasm/manifold-global-types.d.ts
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Type-only import for the ctx-aware factories on ExecutionContext below.
+import type {Manifold, Mesh} from './manifold-encapsulated-types';
+
 /**
  * @inline
  * @hidden
@@ -144,6 +147,19 @@ export interface ExecutionContext {
    * complete -- e.g. a single-leaf manifold has nothing to evaluate).
    */
   progress(): number;
+
+  // ctx-aware static factories: like Manifold.ofMesh / smooth / levelSet, but
+  // run under this context so progress / cancellation are observed (these ops
+  // have no source Manifold to attach via Manifold.withContext).
+
+  /** Like {@link Manifold.ofMesh}, observed/cancellable via this context. */
+  fromMesh(mesh: Mesh): Manifold;
+  /** Like {@link Manifold.smooth}, observed/cancellable via this context. */
+  smooth(mesh: Mesh, sharpenedEdges?: readonly Smoothness[]): Manifold;
+  /** Like {@link Manifold.levelSet}, observed/cancellable via this context. */
+  levelSet(
+      sdf: (point: Vec3) => number, bounds: Box, edgeLength: number,
+      level?: number, tolerance?: number): Manifold;
 
   // Memory
 

--- a/bindings/wasm/test/bindings.test.ts
+++ b/bindings/wasm/test/bindings.test.ts
@@ -90,6 +90,38 @@ suite('Manifold Bindings', () => {
     ctx.delete();
   });
 
+  test('ExecutionContext static factories', () => {
+    // levelSet via the context: no source Manifold to attach via withContext.
+    const sdfCtx = new manifoldModule.ExecutionContext();
+    const sphere = sdfCtx.levelSet(
+        ([x, y, z]) => 1 - Math.sqrt(x * x + y * y + z * z),
+        {min: [-1.1, -1.1, -1.1], max: [1.1, 1.1, 1.1]}, 0.2);
+    expect(sphere.status()).toEqual('NoError');
+    expect(sdfCtx.progress()).toEqual(1);
+
+    // fromMesh via the context.
+    const ingestCtx = new manifoldModule.ExecutionContext();
+    const cube = manifoldModule.Manifold.cube([2, 2, 2], true);
+    const ingested = ingestCtx.fromMesh(cube.getMesh());
+    expect(ingested.status()).toEqual('NoError');
+    expect(ingestCtx.progress()).toEqual(1);
+
+    // A pre-cancelled ctx propagates through a factory; this proves the ctx is
+    // wired (NoError + progress==1 also hold for an untouched ctx).
+    const cancelCtx = new manifoldModule.ExecutionContext();
+    cancelCtx.cancel();
+    const cancelled = cancelCtx.fromMesh(cube.getMesh());
+    expect(cancelled.status()).toEqual('Cancelled');
+
+    sphere.delete();
+    cube.delete();
+    ingested.delete();
+    cancelled.delete();
+    sdfCtx.delete();
+    ingestCtx.delete();
+    cancelCtx.delete();
+  });
+
   test('refineToTolerance does not throw (issue #1545)', () => {
     // Reproduces the original failing geometry from issue #1545: a flat-faced
     // mesh with normals set via calculateNormals + smoothByNormals. On flat

--- a/test/manifoldc_test.cpp
+++ b/test/manifoldc_test.cpp
@@ -256,6 +256,66 @@ TEST(CBIND, level_set) {
   free(context);
 }
 
+TEST(CBIND, execution_context_factories) {
+  double (*sdf)(double, double, double, void*) = [](double x, double y,
+                                                    double z, void*) {
+    return 15.0 - sqrtf(x * x + y * y + z * z);
+  };
+  const double bb = 30;
+  ManifoldBox* bounds =
+      manifold_box(alloc_box_buffer(), -bb, -bb, -bb, bb, bb, bb);
+
+  // LevelSet under an ExecutionContext: runs to completion, progress hits 1.
+  ManifoldExecutionContext* ec =
+      manifold_execution_context(malloc(manifold_execution_context_size()));
+  ManifoldManifold* sdf_man = manifold_execution_context_level_set(
+      alloc_manifold_buffer(), ec, sdf, bounds, 0.5, 0, -1, NULL);
+  EXPECT_EQ(manifold_status(sdf_man), MANIFOLD_NO_ERROR);
+  EXPECT_FALSE(manifold_execution_context_cancelled(ec));
+  EXPECT_DOUBLE_EQ(manifold_execution_context_progress(ec), 1.0);
+
+  // FromMeshGL under an ExecutionContext: round-trip a cube's mesh.
+  ManifoldManifold* cube =
+      manifold_cube(alloc_manifold_buffer(), 2.0, 2.0, 2.0, 1);
+  ManifoldMeshGL* mesh = manifold_get_meshgl(alloc_meshgl_buffer(), cube);
+  ManifoldExecutionContext* ec2 =
+      manifold_execution_context(malloc(manifold_execution_context_size()));
+  ManifoldManifold* ingested =
+      manifold_execution_context_of_meshgl(alloc_manifold_buffer(), ec2, mesh);
+  EXPECT_EQ(manifold_status(ingested), MANIFOLD_NO_ERROR);
+  EXPECT_DOUBLE_EQ(manifold_execution_context_progress(ec2), 1.0);
+
+  // A pre-cancelled ctx must propagate through the factory. This is what
+  // distinguishes the ctx factory from the plain one: NoError + progress==1
+  // alone would also pass if the binding bypassed the ctx (a fresh ctx reads
+  // progress 1.0), so assert the cancel actually lands.
+  ManifoldExecutionContext* ec3 =
+      manifold_execution_context(malloc(manifold_execution_context_size()));
+  manifold_execution_context_cancel(ec3);
+  ManifoldManifold* cancelled = manifold_execution_context_level_set(
+      alloc_manifold_buffer(), ec3, sdf, bounds, 0.5, 0, -1, NULL);
+  EXPECT_EQ(manifold_status(cancelled), MANIFOLD_CANCELLED);
+
+  manifold_destruct_execution_context(ec);
+  manifold_destruct_execution_context(ec2);
+  manifold_destruct_execution_context(ec3);
+  manifold_destruct_manifold(sdf_man);
+  manifold_destruct_manifold(cube);
+  manifold_destruct_manifold(ingested);
+  manifold_destruct_manifold(cancelled);
+  manifold_destruct_meshgl(mesh);
+  manifold_destruct_box(bounds);
+  free(ec);
+  free(ec2);
+  free(ec3);
+  free(sdf_man);
+  free(bounds);
+  free(cube);
+  free(mesh);
+  free(ingested);
+  free(cancelled);
+}
+
 TEST(CBIND, level_set_64) {
   // can't convert lambda with captures to funptr
   double (*sdf)(double, double, double, void*) = [](double x, double y,


### PR DESCRIPTION
The `ExecutionContext` object and `Manifold::WithContext` are already bound, but the ctx-aware static factories - `FromMeshGL`, `LevelSet`, `Smooth` - aren't, so ops with no source Manifold to attach a context to (notably MeshGL ingest) can't be observed or cancelled from the bindings. This adds them as methods on the context in all three layers, each documented and a thin pass-through to the already-reviewed `ExecutionContext` methods.

- **C**: `manifold_execution_context_{level_set,level_set_seq,of_meshgl,of_meshgl64,smooth,smooth64}`. Names mirror the existing `manifold_execution_context_cancel/cancelled/progress`; the SDF user-data arg is renamed `sdf_context` to keep it distinct from the `ExecutionContext`. (Happy to switch to `manifold_<op>_with_context` if you'd rather.)
- **Python**: `ExecutionContext.{from_mesh, level_set, smooth}`.
- **WASM**: `ExecutionContext.{fromMesh, smooth, levelSet}` (embind + JS wrapper + `.d.ts`).

Each layer's tests assert a pre-cancelled context propagates through a factory (`status() == Cancelled`) - the meaningful check, since `NoError` / `progress() == 1` also hold for an untouched context.

External C-API bindings (Java, OCaml, Rust) will need out-of-tree updates for the six new functions.

Closes #971.
