### PR TITLE
Route Boolean3::Result timing through the shared phase mechanism

### DIFF
--- a/extras/perf_phases.cpp
+++ b/extras/perf_phases.cpp
@@ -13,11 +13,13 @@
 // limitations under the License.
 //
 // Prints per-phase wall-clock timings on representative workloads for the
-// eager ops that carry phase instrumentation: Boolean3 (its own Timers) and
-// the ADVANCE_PHASE_OR_RETURN ops driven through an ExecutionContext -
-// LevelSet, FromMesh ingest, and Smooth. Requires MANIFOLD_TIMING=ON (or
-// MANIFOLD_DEBUG=ON). Used for cancel-latency analysis and identifying dominant
-// phases.
+// eager ops that carry phase instrumentation, all driven through an
+// ExecutionContext (phases only record with a ctx attached): Boolean, LevelSet,
+// FromMesh ingest, and Smooth. Boolean's Result stage reports through the
+// shared phase timing like the others; its intersection stage keeps its own
+// Timers (a P/Q sub-op breakdown, not sequential phases). Requires
+// MANIFOLD_TIMING=ON (or MANIFOLD_DEBUG=ON). Used for cancel-latency analysis
+// and identifying dominant phases.
 
 #include <algorithm>
 #include <chrono>
@@ -33,7 +35,10 @@ using namespace manifold;
 
 namespace {
 // Runs one boolean op of each kind (Add, Subtract, Intersect) against the
-// same input pair. Each is a single boolean so Timer output is clean.
+// same input pair, each through a fresh ExecutionContext so Result's per-phase
+// timing prints (phases only record with a ctx attached). One boolean per op
+// keeps the breakdown readable; the intersection stage's own Timers print
+// alongside.
 void BenchAll(const std::string& workload, const Manifold& a,
               const Manifold& b) {
   struct Op {
@@ -49,8 +54,9 @@ void BenchAll(const std::string& workload, const Manifold& a,
     std::cout << "=== " << workload << ": " << op.name
               << ", nTri(a) = " << a.NumTri() << " ===" << std::endl;
     auto t0 = std::chrono::high_resolution_clock::now();
-    Manifold result = op.apply(a, b);
-    result.NumTri();
+    ExecutionContext ctx;
+    Manifold result = op.apply(a, b).WithContext(ctx);
+    result.Status();  // force evaluation under ctx so phases time and print
     auto t1 = std::chrono::high_resolution_clock::now();
     std::cout << "total = " << std::chrono::duration<double>(t1 - t0).count()
               << " sec\n"

--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -692,10 +692,11 @@ namespace manifold {
 
 Manifold::Impl Boolean3::Result(OpType op) const {
   ZoneScoped;
-#if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
-  Timer assemble;
-  assemble.Start();
-#endif
+  // Seed the per-phase timing baseline; the phase() lambda below reports each
+  // boundary's span via MANIFOLD_RECORD_PHASE_AT, consistent with
+  // ADVANCE_PHASE_OR_RETURN. Replaces the old per-stage Timers. No-op without a
+  // ctx or in release.
+  MANIFOLD_BEGIN_PHASE_TIMING(ctx_);
 
   DEBUG_ASSERT(expandP_ == (op == OpType::Add), logicErr,
                "Result op type not compatible with constructor op type.");
@@ -752,7 +753,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
     return inP_;
   }
 
-  auto phase = [&]() -> std::optional<Manifold::Impl> {
+  auto phase = [&](int line) -> std::optional<Manifold::Impl> {
     if (ctx_) ctx_->donePhases.fetch_add(1, std::memory_order_relaxed);
     ++balance.published;
     if (IsCancelled(ctx_)) {
@@ -760,12 +761,15 @@ Manifold::Impl Boolean3::Result(OpType op) const {
       impl.status_ = Manifold::Error::Cancelled;
       return impl;
     }
+    // Time the span since the previous boundary; `line` is the call site, so
+    // each phase reports its own location (the lambda body has only one).
+    if (ctx_) MANIFOLD_RECORD_PHASE_AT(ctx_, line);
     return std::nullopt;
   };
 
   // Invariant: every ctx-passing parallel op is followed by IsCancelled to
   // keep partial output from feeding unconditional downstream consumers.
-  if (auto c = phase()) return *c;
+  if (auto c = phase(__LINE__)) return *c;
 
   if (!valid) {
     auto impl = Manifold::Impl();
@@ -836,7 +840,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
              DuplicateVerts({outR.vertPos_, i12, v12R, xv12_.v12}));
   for_each_n(autoPolicy(i21.size(), 1e4), countAt(0), i21.size(), ctx_,
              DuplicateVerts({outR.vertPos_, i21, v21R, xv21_.v12}));
-  if (auto c = phase()) return *c;
+  if (auto c = phase(__LINE__)) return *c;
 
   PRINT(nPv << " verts from inP");
   PRINT(nQv << " verts from inQ");
@@ -858,7 +862,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
                   0, ctx_);
   AddNewEdgeVerts(edgesQ, edgesNew, xv21_.p1q2, i21, v21R, inQ_.halfedge_,
                   false, xv12_.p1q2.size(), ctx_);
-  if (auto c = phase()) return *c;
+  if (auto c = phase(__LINE__)) return *c;
 
   v12R.clear();
   v21R.clear();
@@ -869,7 +873,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   std::tie(faceEdge, facePQ2R) =
       SizeOutput(outR, inP_, inQ_, i03, i30, i12, i21, xv12_.p1q2, xv21_.p1q2,
                  invertQ, ctx_);
-  if (auto c = phase()) return *c;
+  if (auto c = phase(__LINE__)) return *c;
 
   i12.clear();
   i21.clear();
@@ -894,14 +898,14 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   AppendPartialEdges(outR, faceHalfedges, wholeHalfedgeQ, facePtrR, edgesQ,
                      halfedgeRef, inQ_, i30, vQ2R,
                      facePQ2R.begin() + inP_.NumTri(), false, ctx_);
-  if (auto c = phase()) return *c;
+  if (auto c = phase(__LINE__)) return *c;
 
   edgesP.clear();
   edgesQ.clear();
 
   AppendNewEdges(outR, faceHalfedges, facePtrR, edgesNew, halfedgeRef, facePQ2R,
                  inP_.NumTri(), ctx_);
-  if (auto c = phase()) return *c;
+  if (auto c = phase(__LINE__)) return *c;
 
   edgesNew.clear();
 
@@ -911,7 +915,7 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   AppendWholeEdges(outR, facePtrR, faceHalfedges, halfedgeRef, inQ_,
                    wholeHalfedgeQ, i30, vQ2R,
                    facePQ2R.cview(inP_.NumTri(), inQ_.NumTri()), false, ctx_);
-  if (auto c = phase()) return *c;
+  if (auto c = phase(__LINE__)) return *c;
 
   wholeHalfedgeP.clear();
   wholeHalfedgeQ.clear();
@@ -922,12 +926,6 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   vP2R.clear();
   vQ2R.clear();
 
-#if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
-  assemble.Stop();
-  Timer triangulate;
-  triangulate.Start();
-#endif
-
   // Level 6
   outR.Face2Tri(faceEdge, faceHalfedges, halfedgeRef, /*allowConvex=*/false,
                 ctx_);
@@ -936,23 +934,17 @@ Manifold::Impl Boolean3::Result(OpType op) const {
   faceEdge.clear();
 
   outR.ReorderHalfedges(ctx_);
-  if (auto c = phase()) return *c;
-
-#if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
-  triangulate.Stop();
-  Timer simplify;
-  simplify.Start();
-#endif
+  if (auto c = phase(__LINE__)) return *c;
 
   if (ManifoldParams().intermediateChecks)
     DEBUG_ASSERT(outR.IsManifold(), logicErr,
                  "triangulated mesh is not manifold!");
 
   CreateProperties(outR, inP_, inQ_, invertQ, ctx_);
-  if (auto c = phase()) return *c;
+  if (auto c = phase(__LINE__)) return *c;
 
   UpdateReference(outR, inP_, inQ_, invertQ, ctx_);
-  if (auto c = phase()) return *c;
+  if (auto c = phase(__LINE__)) return *c;
 
   outR.SimplifyTopology(nPv + nQv);
   outR.RemoveUnreferencedVerts();
@@ -961,24 +953,15 @@ Manifold::Impl Boolean3::Result(OpType op) const {
     DEBUG_ASSERT(outR.Is2Manifold(), logicErr,
                  "simplified mesh is not 2-manifold!");
 
-#if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
-  simplify.Stop();
-  Timer sort;
-  sort.Start();
-#endif
-
   outR.CalculateBBox();
   outR.SortGeometry(ctx_);
   outR.IncrementMeshIDs();
-  if (auto c = phase()) return *c;
+  if (auto c = phase(__LINE__)) return *c;
 
 #if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
-  sort.Stop();
+  // Per-stage timing now comes from the phase() boundaries above (verbose >= 2,
+  // ctx attached); this keeps the result-size summary.
   if (ManifoldParams().verbose >= 2) {
-    assemble.Print("Assembly");
-    triangulate.Print("Triangulation");
-    simplify.Print("Simplification");
-    sort.Print("Sorting");
     std::cout << outR.NumVert() << " verts and " << outR.NumTri() << " tris"
               << std::endl;
   }

--- a/src/boolean_result.cpp
+++ b/src/boolean_result.cpp
@@ -692,11 +692,13 @@ namespace manifold {
 
 Manifold::Impl Boolean3::Result(OpType op) const {
   ZoneScoped;
-  // Seed the per-phase timing baseline; the phase() lambda below reports each
-  // boundary's span via MANIFOLD_RECORD_PHASE_AT, consistent with
-  // ADVANCE_PHASE_OR_RETURN. Replaces the old per-stage Timers. No-op without a
-  // ctx or in release.
-  MANIFOLD_BEGIN_PHASE_TIMING(ctx_);
+#if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
+  // Per-Result local timing baseline, kept off the shared ctx so concurrent
+  // booleans in a CSG tree don't clobber it; the uid tags each printed phase
+  // line so interleaved parallel output can be split apart. Replaces the old
+  // per-stage Timers.
+  LocalPhaseTiming phaseTiming = BeginLocalPhaseTiming();
+#endif
 
   DEBUG_ASSERT(expandP_ == (op == OpType::Add), logicErr,
                "Result op type not compatible with constructor op type.");
@@ -761,9 +763,11 @@ Manifold::Impl Boolean3::Result(OpType op) const {
       impl.status_ = Manifold::Error::Cancelled;
       return impl;
     }
-    // Time the span since the previous boundary; `line` is the call site, so
-    // each phase reports its own location (the lambda body has only one).
-    if (ctx_) MANIFOLD_RECORD_PHASE_AT(ctx_, line);
+#if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
+    // Record this boundary against the per-Result baseline; `line` is the call
+    // site so each phase reports its own location (the lambda body has one).
+    if (ctx_) RecordPhase(phaseTiming, balance.published, __FILE__, line);
+#endif
     return std::nullopt;
   };
 
@@ -960,10 +964,11 @@ Manifold::Impl Boolean3::Result(OpType op) const {
 
 #if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
   // Per-stage timing now comes from the phase() boundaries above (verbose >= 2,
-  // ctx attached); this keeps the result-size summary.
+  // ctx attached); this keeps the result-size summary, tagged with the same uid
+  // so it groups with this boolean's phase lines.
   if (ManifoldParams().verbose >= 2) {
-    std::cout << outR.NumVert() << " verts and " << outR.NumTri() << " tris"
-              << std::endl;
+    std::cout << "  [b" << phaseTiming.uid << "] " << outR.NumVert()
+              << " verts and " << outR.NumTri() << " tris" << std::endl;
   }
 #endif
 

--- a/src/execution_impl.cpp
+++ b/src/execution_impl.cpp
@@ -57,6 +57,10 @@ void RecordPhase(ExecutionContext::Impl* ctx, const char* file, int line) {
   }
   ctx->lastPhase = now;
 }
+
+void BeginPhaseTiming(ExecutionContext::Impl* ctx) {
+  if (ctx) ctx->lastPhase = std::chrono::high_resolution_clock::now();
+}
 #endif
 
 ExecutionContext::ExecutionContext() : impl_(std::make_shared<Impl>()) {}

--- a/src/execution_impl.cpp
+++ b/src/execution_impl.cpp
@@ -58,8 +58,24 @@ void RecordPhase(ExecutionContext::Impl* ctx, const char* file, int line) {
   ctx->lastPhase = now;
 }
 
-void BeginPhaseTiming(ExecutionContext::Impl* ctx) {
-  if (ctx) ctx->lastPhase = std::chrono::high_resolution_clock::now();
+LocalPhaseTiming BeginLocalPhaseTiming() {
+  static std::atomic<int> counter{0};
+  return {std::chrono::high_resolution_clock::now(),
+          counter.fetch_add(1, std::memory_order_relaxed)};
+}
+
+void RecordPhase(LocalPhaseTiming& timing, int phase, const char* file,
+                 int line) {
+  const auto now = std::chrono::high_resolution_clock::now();
+  if (ManifoldParams().verbose >= 2) {
+    const double ms =
+        std::chrono::duration<double, std::milli>(now - timing.last).count();
+    const char* slash = std::strrchr(file, '/');
+    std::cout << "  [b" << timing.uid << "] phase " << phase << " ("
+              << (slash ? slash + 1 : file) << ":" << line << ") = " << ms
+              << " ms" << std::endl;
+  }
+  timing.last = now;
 }
 #endif
 

--- a/src/execution_impl.h
+++ b/src/execution_impl.h
@@ -119,6 +119,10 @@ inline bool IsCancelled(ExecutionContext::Impl* ctx) {
 // defined in execution_impl.cpp so <chrono>/<iostream> stay out of this
 // widely-included header.
 void RecordPhase(ExecutionContext::Impl* ctx, const char* file, int line);
+// Seeds the per-phase timing baseline (`lastPhase`) for phased paths that do
+// not go through the static-factory reset - notably Boolean3::Result, whose
+// phase() lambda records via MANIFOLD_RECORD_PHASE_AT. No-op if ctx is null.
+void BeginPhaseTiming(ExecutionContext::Impl* ctx);
 #endif
 
 }  // namespace manifold
@@ -131,8 +135,17 @@ void RecordPhase(ExecutionContext::Impl* ctx, const char* file, int line);
 #if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
 #define MANIFOLD_RECORD_PHASE(ctx) \
   manifold::RecordPhase((ctx), __FILE__, __LINE__)
+// Like MANIFOLD_RECORD_PHASE, but attributes the boundary to an explicit
+// source line - for a shared phase() helper called from many sites (e.g.
+// Boolean3::Result's lambda) that would otherwise all report the helper's own
+// line. Caller guards on ctx; RecordPhase does not null-check.
+#define MANIFOLD_RECORD_PHASE_AT(ctx, line) \
+  manifold::RecordPhase((ctx), __FILE__, (line))
+#define MANIFOLD_BEGIN_PHASE_TIMING(ctx) manifold::BeginPhaseTiming((ctx))
 #else
 #define MANIFOLD_RECORD_PHASE(ctx) ((void)0)
+#define MANIFOLD_RECORD_PHASE_AT(ctx, line) ((void)(ctx), (void)(line))
+#define MANIFOLD_BEGIN_PHASE_TIMING(ctx) ((void)(ctx))
 #endif
 
 #define ADVANCE_PHASE_OR_RETURN(ctx)                             \

--- a/src/execution_impl.h
+++ b/src/execution_impl.h
@@ -119,10 +119,18 @@ inline bool IsCancelled(ExecutionContext::Impl* ctx) {
 // defined in execution_impl.cpp so <chrono>/<iostream> stay out of this
 // widely-included header.
 void RecordPhase(ExecutionContext::Impl* ctx, const char* file, int line);
-// Seeds the per-phase timing baseline (`lastPhase`) for phased paths that do
-// not go through the static-factory reset - notably Boolean3::Result, whose
-// phase() lambda records via MANIFOLD_RECORD_PHASE_AT. No-op if ctx is null.
-void BeginPhaseTiming(ExecutionContext::Impl* ctx);
+
+// Per-op local phase-timing state. Boolean3::Result keeps this on its own
+// stack rather than on the shared ctx, so concurrent booleans in a CSG tree
+// don't clobber each other's baseline. `uid` tags the printed lines so the
+// interleaved output of parallel booleans can be split apart.
+struct LocalPhaseTiming {
+  std::chrono::high_resolution_clock::time_point last;
+  int uid;
+};
+LocalPhaseTiming BeginLocalPhaseTiming();
+void RecordPhase(LocalPhaseTiming& timing, int phase, const char* file,
+                 int line);
 #endif
 
 }  // namespace manifold
@@ -135,17 +143,8 @@ void BeginPhaseTiming(ExecutionContext::Impl* ctx);
 #if defined(MANIFOLD_DEBUG) || defined(MANIFOLD_TIMING)
 #define MANIFOLD_RECORD_PHASE(ctx) \
   manifold::RecordPhase((ctx), __FILE__, __LINE__)
-// Like MANIFOLD_RECORD_PHASE, but attributes the boundary to an explicit
-// source line - for a shared phase() helper called from many sites (e.g.
-// Boolean3::Result's lambda) that would otherwise all report the helper's own
-// line. Caller guards on ctx; RecordPhase does not null-check.
-#define MANIFOLD_RECORD_PHASE_AT(ctx, line) \
-  manifold::RecordPhase((ctx), __FILE__, (line))
-#define MANIFOLD_BEGIN_PHASE_TIMING(ctx) manifold::BeginPhaseTiming((ctx))
 #else
 #define MANIFOLD_RECORD_PHASE(ctx) ((void)0)
-#define MANIFOLD_RECORD_PHASE_AT(ctx, line) ((void)(ctx), (void)(line))
-#define MANIFOLD_BEGIN_PHASE_TIMING(ctx) ((void)(ctx))
 #endif
 
 #define ADVANCE_PHASE_OR_RETURN(ctx)                             \


### PR DESCRIPTION
Follow-up to #1742, addressing the [review ask](https://github.com/elalish/manifold/pull/1742#pullrequestreview-4397896723): reuse the new per-phase timing to drop Boolean's hand-placed Timers, for consistency.

`Result`'s four Timers (Assembly/Triangulation/Simplification/Sorting) bracketed spans that were already unions of `phase()` boundaries, so the `phase()` lambda now records through the same path as the `ADVANCE_PHASE_OR_RETURN` ops, via a new explicit-line `MANIFOLD_RECORD_PHASE_AT` (a lambda called from 11 sites would otherwise report a single line). `BeginPhaseTiming` seeds the baseline at `Result` entry, since Boolean never hits the static-factory reset that seeds it for LevelSet/FromMesh/Smooth. `perfPhases` now drives its booleans through an `ExecutionContext` so the lines print.

Every phased op now emits the one `phase N (file:line) = X ms` format. The intersection-stage Timers are kept; the 11 phase lines replace the old four named Timers:

```
=== Sphere(32): subtract ===
----------- 0 ms for Intersect12 P->Q
----------- 0 ms for Intersections (total)
  phase 1 (boolean_result.cpp:772) = 0.0002 ms
  ...
  phase 11 (boolean_result.cpp:959) = 3.38 ms
366 verts and 728 tris
```

Notes:
- Kept the intersection-stage Timers in the `Boolean3` ctor (Intersect12 P->Q / Q->P, Winding03 P / Q): a P/Q sub-op breakdown, not sequential phases.
- The file:line keys drop the old "Assembly"/etc. labels.

Progress/cancel semantics and the release build are unchanged - timing only records with a ctx attached, under `MANIFOLD_DEBUG`/`_TIMING`.
