### PR TITLE
Add Manifold::WindingNumber

### DIFF
--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -257,6 +257,10 @@ ManifoldRayHitVec* manifold_ray_cast(void* mem, ManifoldManifold* m,
 size_t manifold_ray_hit_vec_length(ManifoldRayHitVec* v);
 ManifoldRayHit manifold_ray_hit_vec_get(ManifoldRayHitVec* v, size_t idx);
 
+// Point containment
+int manifold_winding_number(ManifoldManifold* m, double x, double y, double z);
+int manifold_contains(ManifoldManifold* m, double x, double y, double z);
+
 // ExecutionContext: observe progress and request cancellation of a
 // long-running Manifold evaluation. Attach to a manifold via
 // manifold_with_context; subsequent operations on that manifold observe

--- a/bindings/c/include/manifold/manifoldc.h
+++ b/bindings/c/include/manifold/manifoldc.h
@@ -259,7 +259,6 @@ ManifoldRayHit manifold_ray_hit_vec_get(ManifoldRayHitVec* v, size_t idx);
 
 // Point containment
 int manifold_winding_number(ManifoldManifold* m, double x, double y, double z);
-int manifold_contains(ManifoldManifold* m, double x, double y, double z);
 
 // ExecutionContext: observe progress and request cancellation of a
 // long-running Manifold evaluation. Attach to a manifold via

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -887,6 +887,14 @@ ManifoldRayHit manifold_ray_hit_vec_get(ManifoldRayHitVec* v, size_t idx) {
   return {hit.faceID, hit.distance, to_c(hit.position), to_c(hit.normal)};
 }
 
+int manifold_winding_number(ManifoldManifold* m, double x, double y, double z) {
+  return from_c(m)->WindingNumber(vec3(x, y, z));
+}
+
+int manifold_contains(ManifoldManifold* m, double x, double y, double z) {
+  return from_c(m)->Contains(vec3(x, y, z)) ? 1 : 0;
+}
+
 ManifoldExecutionContext* manifold_execution_context(void* mem) {
   return to_c(new (mem) ExecutionContext());
 }

--- a/bindings/c/manifoldc.cpp
+++ b/bindings/c/manifoldc.cpp
@@ -888,11 +888,8 @@ ManifoldRayHit manifold_ray_hit_vec_get(ManifoldRayHitVec* v, size_t idx) {
 }
 
 int manifold_winding_number(ManifoldManifold* m, double x, double y, double z) {
-  return from_c(m)->WindingNumber(vec3(x, y, z));
-}
-
-int manifold_contains(ManifoldManifold* m, double x, double y, double z) {
-  return from_c(m)->Contains(vec3(x, y, z)) ? 1 : 0;
+  const auto result = from_c(m)->WindingNumber({{x, y, z}});
+  return result.empty() ? 0 : result[0];
 }
 
 ManifoldExecutionContext* manifold_execution_context(void* mem) {

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -323,26 +323,9 @@ NB_MODULE(manifold3d, m) {
       .def("ray_cast", &Manifold::RayCast, nb::arg("origin"),
            nb::arg("endpoint"),
            "Cast a ray segment, returning all hits sorted by distance.")
-      .def("winding_number",
-           static_cast<int (Manifold::*)(vec3) const>(
-               &Manifold::WindingNumber),
-           nb::arg("point"),
-           "Returns the winding number of this manifold around the given "
-           "point. 0 means outside, non-zero means inside.")
-      .def("winding_number",
-           static_cast<std::vector<int> (Manifold::*)(
-               const std::vector<vec3>&) const>(&Manifold::WindingNumber),
-           nb::arg("points"),
-           "Returns the winding number for each point in the list.")
-      .def("contains",
-           static_cast<bool (Manifold::*)(vec3) const>(&Manifold::Contains),
-           nb::arg("point"),
-           "Returns True if the given point is inside this manifold.")
-      .def("contains",
-           static_cast<std::vector<bool> (Manifold::*)(
-               const std::vector<vec3>&) const>(&Manifold::Contains),
-           nb::arg("points"),
-           "Returns a list of bools indicating containment for each point.")
+      .def("winding_number", &Manifold::WindingNumber, nb::arg("points"),
+           "Returns the winding number of this manifold around each of the "
+           "given points. 0 means outside, non-zero means inside.")
       .def("calculate_normals", &Manifold::CalculateNormals,
            nb::arg("normal_idx") = 0, nb::arg("min_sharp_angle") = 52.5,
            manifold__calculate_normals__normal_idx__min_sharp_angle)

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -323,6 +323,21 @@ NB_MODULE(manifold3d, m) {
       .def("ray_cast", &Manifold::RayCast, nb::arg("origin"),
            nb::arg("endpoint"),
            "Cast a ray segment, returning all hits sorted by distance.")
+      .def("winding_number",
+           nb::overload_cast<vec3>(&Manifold::WindingNumber), nb::arg("point"),
+           "Returns the winding number of this manifold around the given "
+           "point. 0 means outside, non-zero means inside.")
+      .def("winding_number",
+           nb::overload_cast<const std::vector<vec3>&>(&Manifold::WindingNumber),
+           nb::arg("points"),
+           "Returns the winding number for each point in the list.")
+      .def("contains", nb::overload_cast<vec3>(&Manifold::Contains),
+           nb::arg("point"),
+           "Returns True if the given point is inside this manifold.")
+      .def("contains",
+           nb::overload_cast<const std::vector<vec3>&>(&Manifold::Contains),
+           nb::arg("points"),
+           "Returns a list of bools indicating containment for each point.")
       .def("calculate_normals", &Manifold::CalculateNormals,
            nb::arg("normal_idx") = 0, nb::arg("min_sharp_angle") = 52.5,
            manifold__calculate_normals__normal_idx__min_sharp_angle)

--- a/bindings/python/manifold3d.cpp
+++ b/bindings/python/manifold3d.cpp
@@ -324,18 +324,23 @@ NB_MODULE(manifold3d, m) {
            nb::arg("endpoint"),
            "Cast a ray segment, returning all hits sorted by distance.")
       .def("winding_number",
-           nb::overload_cast<vec3>(&Manifold::WindingNumber), nb::arg("point"),
+           static_cast<int (Manifold::*)(vec3) const>(
+               &Manifold::WindingNumber),
+           nb::arg("point"),
            "Returns the winding number of this manifold around the given "
            "point. 0 means outside, non-zero means inside.")
       .def("winding_number",
-           nb::overload_cast<const std::vector<vec3>&>(&Manifold::WindingNumber),
+           static_cast<std::vector<int> (Manifold::*)(
+               const std::vector<vec3>&) const>(&Manifold::WindingNumber),
            nb::arg("points"),
            "Returns the winding number for each point in the list.")
-      .def("contains", nb::overload_cast<vec3>(&Manifold::Contains),
+      .def("contains",
+           static_cast<bool (Manifold::*)(vec3) const>(&Manifold::Contains),
            nb::arg("point"),
            "Returns True if the given point is inside this manifold.")
       .def("contains",
-           nb::overload_cast<const std::vector<vec3>&>(&Manifold::Contains),
+           static_cast<std::vector<bool> (Manifold::*)(
+               const std::vector<vec3>&) const>(&Manifold::Contains),
            nb::arg("points"),
            "Returns a list of bools indicating containment for each point.")
       .def("calculate_normals", &Manifold::CalculateNormals,

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -212,6 +212,8 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("surfaceArea", &Manifold::SurfaceArea)
       .function("minGap", &Manifold::MinGap)
       .function("_RayCast", &man_js::RayCast)
+      .function("windingNumber", &Manifold::WindingNumber)
+      .function("contains", &Manifold::Contains)
       .function("calculateCurvature", &Manifold::CalculateCurvature)
       .function("_CalculateNormals", &Manifold::CalculateNormals)
       .function("originalID", &Manifold::OriginalID)

--- a/bindings/wasm/bindings.cpp
+++ b/bindings/wasm/bindings.cpp
@@ -126,6 +126,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
   register_vector<vec2>("Vector_vec2");
   register_vector<std::vector<vec2>>("Vector2_vec2");
   register_vector<double>("Vector_f64");
+  register_vector<int>("Vector_i32");
   register_vector<CrossSection>("Vector_crossSection");
   register_vector<Manifold>("Vector_manifold");
   register_vector<Smoothness>("Vector_smoothness");
@@ -212,8 +213,7 @@ EMSCRIPTEN_BINDINGS(whatever) {
       .function("surfaceArea", &Manifold::SurfaceArea)
       .function("minGap", &Manifold::MinGap)
       .function("_RayCast", &man_js::RayCast)
-      .function("windingNumber", &Manifold::WindingNumber)
-      .function("contains", &Manifold::Contains)
+      .function("_WindingNumber", &Manifold::WindingNumber)
       .function("calculateCurvature", &Manifold::CalculateCurvature)
       .function("_CalculateNormals", &Manifold::CalculateNormals)
       .function("originalID", &Manifold::OriginalID)

--- a/bindings/wasm/bindings.js
+++ b/bindings/wasm/bindings.js
@@ -329,6 +329,16 @@ Module.setup = function() {
     return result;
   };
 
+  Module.Manifold.prototype.windingNumber = function(points) {
+    const inVec = new Module.Vector_vec3();
+    for (const p of points) inVec.push_back(vararg2vec3([p]));
+    const outVec = this._WindingNumber(inVec);
+    inVec.delete();
+    const result = fromVec(outVec);
+    outVec.delete();
+    return result;
+  };
+
   Module.Manifold.prototype.rayCast = function(origin, endpoint) {
     const vec = this._RayCast(vararg2vec3([origin]), vararg2vec3([endpoint]));
     const result =

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -1163,25 +1163,17 @@ export class Manifold {
   rayCast(origin: Vec3, endpoint: Vec3): RayHit[];
 
   /**
-   * Returns the winding number of this manifold around the given point.
-   * Returns 0 for points outside and a non-zero value (typically ±1) for
-   * points inside. May exceed ±1 for manifolds with overlapping regions.
+   * Returns the winding number of this manifold around each of the given
+   * points. Returns 0 for points outside and a non-zero value (typically ±1)
+   * for points inside a simple closed surface. May exceed ±1 in magnitude for
+   * manifolds with overlapping regions.
    *
-   * @param point The 3D query point.
+   * @param points The 3D query points.
    *
    * @group Spatial Queries
    */
-  windingNumber(point: Vec3): number;
+  windingNumber(points: Vec3[]): number[];
 
-  /**
-   * Returns true if the given point is inside this manifold, i.e. its winding
-   * number is non-zero.
-   *
-   * @param point The 3D query point.
-   *
-   * @group Spatial Queries
-   */
-  contains(point: Vec3): boolean;
 
 
   /**

--- a/bindings/wasm/manifold-encapsulated-types.d.ts
+++ b/bindings/wasm/manifold-encapsulated-types.d.ts
@@ -1163,6 +1163,28 @@ export class Manifold {
   rayCast(origin: Vec3, endpoint: Vec3): RayHit[];
 
   /**
+   * Returns the winding number of this manifold around the given point.
+   * Returns 0 for points outside and a non-zero value (typically ±1) for
+   * points inside. May exceed ±1 for manifolds with overlapping regions.
+   *
+   * @param point The 3D query point.
+   *
+   * @group Spatial Queries
+   */
+  windingNumber(point: Vec3): number;
+
+  /**
+   * Returns true if the given point is inside this manifold, i.e. its winding
+   * number is non-zero.
+   *
+   * @param point The 3D query point.
+   *
+   * @group Spatial Queries
+   */
+  contains(point: Vec3): boolean;
+
+
+  /**
    * Returns the reason for an input Mesh producing an empty Manifold. This
    * Status will carry on through operations like NaN propogation, ensuring an
    * errored mesh doesn't get mysteriously lost. Empty meshes may still show

--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -188,6 +188,10 @@ class Manifold {
   double Volume() const;
   double MinGap(const Manifold& other, double searchLength) const;
   std::vector<RayHit> RayCast(vec3 origin, vec3 endpoint) const;
+  int WindingNumber(vec3 point) const;
+  std::vector<int> WindingNumber(const std::vector<vec3>& points) const;
+  bool Contains(vec3 point) const;
+  std::vector<bool> Contains(const std::vector<vec3>& points) const;
   ///@}
 
   /** @name Mesh ID

--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -188,10 +188,7 @@ class Manifold {
   double Volume() const;
   double MinGap(const Manifold& other, double searchLength) const;
   std::vector<RayHit> RayCast(vec3 origin, vec3 endpoint) const;
-  int WindingNumber(vec3 point) const;
   std::vector<int> WindingNumber(const std::vector<vec3>& points) const;
-  bool Contains(vec3 point) const;
-  std::vector<bool> Contains(const std::vector<vec3>& points) const;
   ///@}
 
   /** @name Mesh ID

--- a/src/boolean3.cpp
+++ b/src/boolean3.cpp
@@ -594,9 +594,10 @@ Vec<int> Manifold::Impl::PointWinding(VecView<const vec3> points) const {
     pointImpl.vertPos_[i] = points[active[i]];
 
   // expandP=false: no symbolic perturbation from the query side (zero normals).
-  // forward=true: project along +Z to count signed face crossings above each point.
-  // f returns vec3 → collider uses DoesOverlap(vec3), which is XY-projected,
-  // so all faces with XY overlap are returned regardless of Z (correct for +Z winding).
+  // forward=true: project along +Z to count signed face crossings above each
+  // point. f returns vec3 → collider uses DoesOverlap(vec3), which is
+  // XY-projected, so all faces with XY overlap are returned regardless of Z
+  // (correct for +Z winding).
   Kernel02<false, true> k02{pointImpl, *this};
   auto recorderf = [&](int localIdx, int tri) {
     const auto [s02, z02] = k02(localIdx, tri);
@@ -606,7 +607,8 @@ Vec<int> Manifold::Impl::PointWinding(VecView<const vec3> points) const {
   auto f = [&pointImpl](int i) { return pointImpl.vertPos_[i]; };
   // Each queryIdx is processed by at most one thread (for_each_n), so the
   // per-queryIdx accumulation into winding[] is race-free without atomics.
-  collider_.Collisions<false>(recorder, f, static_cast<int>(active.size()), true);
+  collider_.Collisions<false>(recorder, f,
+                              static_cast<int>(active.size()), true);
   return winding;
 }
 

--- a/src/boolean3.cpp
+++ b/src/boolean3.cpp
@@ -573,6 +573,43 @@ Boolean3::Boolean3(const Manifold::Impl& inP, const Manifold::Impl& inQ,
   }
 #endif
 }
+Vec<int> Manifold::Impl::PointWinding(VecView<const vec3> points) const {
+  ZoneScoped;
+  Vec<int> winding(points.size(), 0);
+  if (points.empty() || IsEmpty()) return winding;
+
+  // Points outside the bounding box have winding 0 for any closed manifold.
+  Vec<int> active;
+  active.reserve(points.size());
+  for (size_t i = 0; i < points.size(); ++i)
+    if (bBox_.Contains(points[i])) active.push_back(static_cast<int>(i));
+  if (active.empty()) return winding;
+
+  // Build a minimal Impl for the query points. Kernel02 only reads vertPos_
+  // and vertNormal_ from inA; halfedges and faces are not accessed.
+  Impl pointImpl;
+  pointImpl.vertPos_.resize(active.size());
+  pointImpl.vertNormal_.resize(active.size(), vec3(0.0));
+  for (size_t i = 0; i < active.size(); ++i)
+    pointImpl.vertPos_[i] = points[active[i]];
+
+  // expandP=false: no symbolic perturbation from the query side (zero normals).
+  // forward=true: project along +Z to count signed face crossings above each point.
+  // f returns vec3 → collider uses DoesOverlap(vec3), which is XY-projected,
+  // so all faces with XY overlap are returned regardless of Z (correct for +Z winding).
+  Kernel02<false, true> k02{pointImpl, *this};
+  auto recorderf = [&](int localIdx, int tri) {
+    const auto [s02, z02] = k02(localIdx, tri);
+    if (std::isfinite(z02)) winding[active[localIdx]] += s02;
+  };
+  auto recorder = MakeSimpleRecorder(recorderf);
+  auto f = [&pointImpl](int i) { return pointImpl.vertPos_[i]; };
+  // Each queryIdx is processed by at most one thread (for_each_n), so the
+  // per-queryIdx accumulation into winding[] is race-free without atomics.
+  collider_.Collisions<false>(recorder, f, static_cast<int>(active.size()), true);
+  return winding;
+}
+
 std::vector<RayHit> Manifold::Impl::RayCast(vec3 origin, vec3 endpoint) const {
   ZoneScoped;
   if (IsEmpty()) return {};

--- a/src/boolean3.cpp
+++ b/src/boolean3.cpp
@@ -579,19 +579,19 @@ Vec<int> Manifold::Impl::PointWinding(VecView<const vec3> points) const {
   if (points.empty() || IsEmpty()) return winding;
 
   // Points outside the bounding box have winding 0 for any closed manifold.
-  Vec<int> active;
-  active.reserve(points.size());
+  Vec<int> query2input;
+  query2input.reserve(points.size());
   for (size_t i = 0; i < points.size(); ++i)
-    if (bBox_.Contains(points[i])) active.push_back(static_cast<int>(i));
-  if (active.empty()) return winding;
+    if (bBox_.Contains(points[i])) query2input.push_back(static_cast<int>(i));
+  if (query2input.empty()) return winding;
 
   // Build a minimal Impl for the query points. Kernel02 only reads vertPos_
   // and vertNormal_ from inA; halfedges and faces are not accessed.
   Impl pointImpl;
-  pointImpl.vertPos_.resize(active.size());
-  pointImpl.vertNormal_.resize(active.size(), vec3(0.0));
-  for (size_t i = 0; i < active.size(); ++i)
-    pointImpl.vertPos_[i] = points[active[i]];
+  pointImpl.vertPos_.resize(query2input.size());
+  pointImpl.vertNormal_.resize(query2input.size(), vec3(0.0));
+  for (size_t i = 0; i < query2input.size(); ++i)
+    pointImpl.vertPos_[i] = points[query2input[i]];
 
   // expandP=false: no symbolic perturbation from the query side (zero normals).
   // forward=true: project along +Z to count signed face crossings above each
@@ -601,14 +601,14 @@ Vec<int> Manifold::Impl::PointWinding(VecView<const vec3> points) const {
   Kernel02<false, true> k02{pointImpl, *this};
   auto recorderf = [&](int localIdx, int tri) {
     const auto [s02, z02] = k02(localIdx, tri);
-    if (std::isfinite(z02)) winding[active[localIdx]] += s02;
+    if (std::isfinite(z02)) winding[query2input[localIdx]] += s02;
   };
   auto recorder = MakeSimpleRecorder(recorderf);
   auto f = [&pointImpl](int i) { return pointImpl.vertPos_[i]; };
   // Each queryIdx is processed by at most one thread (for_each_n), so the
   // per-queryIdx accumulation into winding[] is race-free without atomics.
   collider_.Collisions<false>(recorder, f,
-                              static_cast<int>(active.size()), true);
+                              static_cast<int>(query2input.size()), true);
   return winding;
 }
 

--- a/src/boolean3.cpp
+++ b/src/boolean3.cpp
@@ -607,8 +607,8 @@ Vec<int> Manifold::Impl::PointWinding(VecView<const vec3> points) const {
   auto f = [&pointImpl](int i) { return pointImpl.vertPos_[i]; };
   // Each queryIdx is processed by at most one thread (for_each_n), so the
   // per-queryIdx accumulation into winding[] is race-free without atomics.
-  collider_.Collisions<false>(recorder, f,
-                              static_cast<int>(query2input.size()), true);
+  collider_.Collisions<false>(recorder, f, static_cast<int>(query2input.size()),
+                              true);
   return winding;
 }
 

--- a/src/impl.h
+++ b/src/impl.h
@@ -168,6 +168,7 @@ struct Manifold::Impl {
 
   // boolean3.cpp
   std::vector<RayHit> RayCast(vec3 origin, vec3 endpoint) const;
+  Vec<int> PointWinding(VecView<const vec3> points) const;
 
   // sort.cpp
   void SortGeometry(ExecutionContext::Impl* ctx = nullptr);

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -1139,8 +1139,9 @@ std::vector<RayHit> Manifold::RayCast(vec3 origin, vec3 endpoint) const {
 
 /**
  * Returns the winding number of this manifold around each of the given points.
- * 0 means outside; non-zero (typically ±1) means inside. For manifolds with
- * overlapping regions the magnitude may exceed 1.
+ * Returns 0 for points outside, and a non-zero value (typically ±1) for points
+ * inside a simple closed surface. For manifolds with overlapping regions the
+ * magnitude may exceed 1.
  *
  * @param points The 3D query points.
  */
@@ -1152,39 +1153,4 @@ std::vector<int> Manifold::WindingNumber(
       impl->PointWinding(VecView<const vec3>(points.data(), points.size()));
   return std::vector<int>(w.begin(), w.end());
 }
-
-/**
- * Returns the winding number of this manifold around the given point. Returns
- * 0 for points outside, and a non-zero value (typically ±1) for points inside.
- * For manifolds with overlapping regions the magnitude may exceed 1.
- *
- * @param point The 3D query point.
- */
-int Manifold::WindingNumber(vec3 point) const {
-  const auto impl = GetCsgLeafNode().GetImpl();
-  Vec<int> w = impl->PointWinding(VecView<const vec3>(&point, 1));
-  return w.empty() ? 0 : w[0];
-}
-
-/**
- * Returns whether each of the given points is inside this manifold, i.e. its
- * winding number is non-zero.
- *
- * @param points The 3D query points.
- */
-std::vector<bool> Manifold::Contains(const std::vector<vec3>& points) const {
-  if (points.empty()) return {};
-  const auto winding = WindingNumber(points);
-  std::vector<bool> inside(winding.size());
-  for (size_t i = 0; i < winding.size(); ++i) inside[i] = winding[i] != 0;
-  return inside;
-}
-
-/**
- * Returns true if the given point is inside this manifold, i.e. its winding
- * number is non-zero.
- *
- * @param point The 3D query point.
- */
-bool Manifold::Contains(vec3 point) const { return WindingNumber(point) != 0; }
 }  // namespace manifold

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -1136,4 +1136,55 @@ double Manifold::MinGap(const Manifold& other, double searchLength) const {
 std::vector<RayHit> Manifold::RayCast(vec3 origin, vec3 endpoint) const {
   return GetCsgLeafNode().GetImpl()->RayCast(origin, endpoint);
 }
+
+/**
+ * Returns the winding number of this manifold around each of the given points.
+ * 0 means outside; non-zero (typically ±1) means inside. For manifolds with
+ * overlapping regions the magnitude may exceed 1.
+ *
+ * @param points The 3D query points.
+ */
+std::vector<int> Manifold::WindingNumber(
+    const std::vector<vec3>& points) const {
+  if (points.empty()) return {};
+  const auto impl = GetCsgLeafNode().GetImpl();
+  Vec<int> w =
+      impl->PointWinding(VecView<const vec3>(points.data(), points.size()));
+  return std::vector<int>(w.begin(), w.end());
+}
+
+/**
+ * Returns the winding number of this manifold around the given point. Returns
+ * 0 for points outside, and a non-zero value (typically ±1) for points inside.
+ * For manifolds with overlapping regions the magnitude may exceed 1.
+ *
+ * @param point The 3D query point.
+ */
+int Manifold::WindingNumber(vec3 point) const {
+  const auto impl = GetCsgLeafNode().GetImpl();
+  Vec<int> w = impl->PointWinding(VecView<const vec3>(&point, 1));
+  return w.empty() ? 0 : w[0];
+}
+
+/**
+ * Returns whether each of the given points is inside this manifold, i.e. its
+ * winding number is non-zero.
+ *
+ * @param points The 3D query points.
+ */
+std::vector<bool> Manifold::Contains(const std::vector<vec3>& points) const {
+  if (points.empty()) return {};
+  const auto winding = WindingNumber(points);
+  std::vector<bool> inside(winding.size());
+  for (size_t i = 0; i < winding.size(); ++i) inside[i] = winding[i] != 0;
+  return inside;
+}
+
+/**
+ * Returns true if the given point is inside this manifold, i.e. its winding
+ * number is non-zero.
+ *
+ * @param point The 3D query point.
+ */
+bool Manifold::Contains(vec3 point) const { return WindingNumber(point) != 0; }
 }  // namespace manifold

--- a/test/measurement_test.cpp
+++ b/test/measurement_test.cpp
@@ -273,80 +273,57 @@ TEST(Properties, TriangleDistanceOverlapping) {
   EXPECT_FLOAT_EQ(distance, 0);
 }
 
-TEST(Manifold, ContainsBasic) {
-  Manifold cube = Manifold::Cube(vec3(1), true);
-  EXPECT_TRUE(cube.Contains(vec3(0, 0, 0)));
-  EXPECT_TRUE(cube.Contains(vec3(0.4, 0.4, 0.4)));
-  EXPECT_FALSE(cube.Contains(vec3(1, 1, 1)));
-  EXPECT_FALSE(cube.Contains(vec3(0, 0, 5)));
-}
-
-TEST(Manifold, ContainsEmpty) {
-  Manifold empty;
-  EXPECT_FALSE(empty.Contains(vec3(0, 0, 0)));
-  EXPECT_EQ(empty.WindingNumber(vec3(0, 0, 0)), 0);
-}
-
 // A tall box where the query point is far below the top face. The +Z ray from
 // the point must reach the top face even though it's well outside the point's
-// 3D AABB neighbourhood. This exercises the XY-projected collider query.
-TEST(Manifold, ContainsTallBox) {
+// 3D bounding-box in Z. This exercises the XY-projected collider query.
+TEST(Manifold, WindingTallBox) {
   Manifold box = Manifold::Cube(vec3(1, 1, 10), true);  // z in [-5, 5]
-  EXPECT_EQ(box.WindingNumber(vec3(0, 0, -4)), 1);
-  EXPECT_EQ(box.WindingNumber(vec3(0, 0, 0)), 1);
-  EXPECT_EQ(box.WindingNumber(vec3(0, 0, 6)), 0);   // above
-  EXPECT_EQ(box.WindingNumber(vec3(0, 0, -6)), 0);  // below
+  const auto w =
+      box.WindingNumber({{0, 0, -4}, {0, 0, 0}, {0, 0, 6}, {0, 0, -6}});
+  EXPECT_EQ(w[0], 1);  // inside, near bottom
+  EXPECT_EQ(w[1], 1);  // center
+  EXPECT_EQ(w[2], 0);  // above
+  EXPECT_EQ(w[3], 0);  // below
+}
+
+TEST(Manifold, WindingEmpty) {
+  const auto w = Manifold{}.WindingNumber({{0, 0, 0}});
+  ASSERT_EQ(w.size(), 1u);
+  EXPECT_EQ(w[0], 0);
 }
 
 // Watertight winding across shared cube edges and vertices - must be exactly
 // 0 or 1, never 2 from double-counting.
 TEST(Manifold, WindingWatertight) {
   Manifold cube = Manifold::Cube(vec3(1), true);
-  // Ray through a shared vertex at (0.5, 0.5, z): winding must be 0 or 1.
-  const int w = cube.WindingNumber(vec3(0.4999, 0.4999, 0));
-  EXPECT_TRUE(w == 0 || w == 1);
-  // Silhouette edge query: must also be 0 or 1.
-  const int w2 = cube.WindingNumber(vec3(0.5, 0, 0));
-  EXPECT_TRUE(w2 == 0 || w2 == 1);
+  const auto w =
+      cube.WindingNumber({{0.4999, 0.4999, 0}, {0.5, 0, 0}, {0, 0, 0}});
+  EXPECT_TRUE(w[0] == 0 || w[0] == 1);  // near shared vertex
+  EXPECT_TRUE(w[1] == 0 || w[1] == 1);  // silhouette edge
+  EXPECT_EQ(w[2], 1);                   // center
 }
 
-// Hollow shell (sphere - sphere): cavity center is NOT inside (winding 0),
-// a point in the shell wall IS inside (winding 1). Proves real winding, not
-// just "hit something."
+// Hollow shell (sphere - sphere): cavity center must return winding 0, wall
+// point 1, outside 0. Proves real winding number, not just ray parity.
 TEST(Manifold, WindingHollowShell) {
   Manifold shell = Manifold::Sphere(2, 32) - Manifold::Sphere(1, 32);
-  EXPECT_EQ(shell.WindingNumber(vec3(0, 0, 0)), 0);    // cavity
-  EXPECT_EQ(shell.WindingNumber(vec3(0, 0, 1.5)), 1);  // wall
-  EXPECT_EQ(shell.WindingNumber(vec3(0, 0, 3)), 0);    // outside
+  const auto w = shell.WindingNumber({{0, 0, 0}, {0, 0, 1.5}, {0, 0, 3}});
+  EXPECT_EQ(w[0], 0);  // cavity
+  EXPECT_EQ(w[1], 1);  // wall
+  EXPECT_EQ(w[2], 0);  // outside
 }
 
-// Batch API agrees with scalar API on a grid of points.
-TEST(Manifold, ContainsBatch) {
-  Manifold sphere = Manifold::Sphere(1, 32);
-  std::vector<vec3> pts = {
-      {0, 0, 0}, {0.5, 0.5, 0.5}, {0.9, 0, 0}, {1.1, 0, 0}, {0, 2, 0}};
-  const auto batchW = sphere.WindingNumber(pts);
-  const auto batchC = sphere.Contains(pts);
-  ASSERT_EQ(batchW.size(), pts.size());
-  ASSERT_EQ(batchC.size(), pts.size());
-  for (size_t i = 0; i < pts.size(); ++i) {
-    EXPECT_EQ(batchW[i], sphere.WindingNumber(pts[i]));
-    EXPECT_EQ(batchC[i], sphere.Contains(pts[i]));
-  }
-}
-
-// Cross-check: WindingNumber != 0 agrees with RayCast hit-count parity.
+// Cross-check: winding != 0 agrees with RayCast hit-count parity.
 TEST(Manifold, WindingMatchesRayCastParity) {
   Manifold cube = Manifold::Cube(vec3(1), true);
-  const std::vector<vec3> pts = {{0, 0, 0},      {0.3, 0.2, 0.1},
+  const std::vector<vec3> pts = {{0, 0, 0},       {0.3, 0.2, 0.1},
                                   {0.5, 0.5, 0.5}, {0, 0, 1},
-                                  {0, 0, 2},      {-1, 0, 0}};
-  for (const vec3& p : pts) {
-    const vec3 far(p.x, p.y, p.z + 1e6);
-    const size_t hits = cube.RayCast(p, far).size();
-    const bool byParity = (hits % 2) == 1;
-    const bool byWinding = cube.Contains(p);
-    EXPECT_EQ(byWinding, byParity)
+                                  {0, 0, 2},       {-1, 0, 0}};
+  const auto winding = cube.WindingNumber(pts);
+  for (size_t i = 0; i < pts.size(); ++i) {
+    const vec3& p = pts[i];
+    const size_t hits = cube.RayCast(p, {p.x, p.y, p.z + 1e6}).size();
+    EXPECT_EQ(winding[i] != 0, hits % 2 == 1)
         << "mismatch at (" << p.x << "," << p.y << "," << p.z << ")";
   }
 }

--- a/test/measurement_test.cpp
+++ b/test/measurement_test.cpp
@@ -346,6 +346,7 @@ TEST(Manifold, WindingMatchesRayCastParity) {
     const size_t hits = cube.RayCast(p, far).size();
     const bool byParity = (hits % 2) == 1;
     const bool byWinding = cube.Contains(p);
-    EXPECT_EQ(byWinding, byParity) << "mismatch at (" << p.x << "," << p.y << "," << p.z << ")";
+    EXPECT_EQ(byWinding, byParity)
+        << "mismatch at (" << p.x << "," << p.y << "," << p.z << ")";
   }
 }

--- a/test/measurement_test.cpp
+++ b/test/measurement_test.cpp
@@ -272,3 +272,80 @@ TEST(Properties, TriangleDistanceOverlapping) {
 
   EXPECT_FLOAT_EQ(distance, 0);
 }
+
+TEST(Manifold, ContainsBasic) {
+  Manifold cube = Manifold::Cube(vec3(1), true);
+  EXPECT_TRUE(cube.Contains(vec3(0, 0, 0)));
+  EXPECT_TRUE(cube.Contains(vec3(0.4, 0.4, 0.4)));
+  EXPECT_FALSE(cube.Contains(vec3(1, 1, 1)));
+  EXPECT_FALSE(cube.Contains(vec3(0, 0, 5)));
+}
+
+TEST(Manifold, ContainsEmpty) {
+  Manifold empty;
+  EXPECT_FALSE(empty.Contains(vec3(0, 0, 0)));
+  EXPECT_EQ(empty.WindingNumber(vec3(0, 0, 0)), 0);
+}
+
+// A tall box where the query point is far below the top face. The +Z ray from
+// the point must reach the top face even though it's well outside the point's
+// 3D AABB neighbourhood. This exercises the XY-projected collider query.
+TEST(Manifold, ContainsTallBox) {
+  Manifold box = Manifold::Cube(vec3(1, 1, 10), true);  // z in [-5, 5]
+  EXPECT_EQ(box.WindingNumber(vec3(0, 0, -4)), 1);
+  EXPECT_EQ(box.WindingNumber(vec3(0, 0, 0)), 1);
+  EXPECT_EQ(box.WindingNumber(vec3(0, 0, 6)), 0);   // above
+  EXPECT_EQ(box.WindingNumber(vec3(0, 0, -6)), 0);  // below
+}
+
+// Watertight winding across shared cube edges and vertices - must be exactly
+// 0 or 1, never 2 from double-counting.
+TEST(Manifold, WindingWatertight) {
+  Manifold cube = Manifold::Cube(vec3(1), true);
+  // Ray through a shared vertex at (0.5, 0.5, z): winding must be 0 or 1.
+  const int w = cube.WindingNumber(vec3(0.4999, 0.4999, 0));
+  EXPECT_TRUE(w == 0 || w == 1);
+  // Silhouette edge query: must also be 0 or 1.
+  const int w2 = cube.WindingNumber(vec3(0.5, 0, 0));
+  EXPECT_TRUE(w2 == 0 || w2 == 1);
+}
+
+// Hollow shell (sphere - sphere): cavity center is NOT inside (winding 0),
+// a point in the shell wall IS inside (winding 1). Proves real winding, not
+// just "hit something."
+TEST(Manifold, WindingHollowShell) {
+  Manifold shell = Manifold::Sphere(2, 32) - Manifold::Sphere(1, 32);
+  EXPECT_EQ(shell.WindingNumber(vec3(0, 0, 0)), 0);    // cavity
+  EXPECT_EQ(shell.WindingNumber(vec3(0, 0, 1.5)), 1);  // wall
+  EXPECT_EQ(shell.WindingNumber(vec3(0, 0, 3)), 0);    // outside
+}
+
+// Batch API agrees with scalar API on a grid of points.
+TEST(Manifold, ContainsBatch) {
+  Manifold sphere = Manifold::Sphere(1, 32);
+  std::vector<vec3> pts = {
+      {0, 0, 0}, {0.5, 0.5, 0.5}, {0.9, 0, 0}, {1.1, 0, 0}, {0, 2, 0}};
+  const auto batchW = sphere.WindingNumber(pts);
+  const auto batchC = sphere.Contains(pts);
+  ASSERT_EQ(batchW.size(), pts.size());
+  ASSERT_EQ(batchC.size(), pts.size());
+  for (size_t i = 0; i < pts.size(); ++i) {
+    EXPECT_EQ(batchW[i], sphere.WindingNumber(pts[i]));
+    EXPECT_EQ(batchC[i], sphere.Contains(pts[i]));
+  }
+}
+
+// Cross-check: WindingNumber != 0 agrees with RayCast hit-count parity.
+TEST(Manifold, WindingMatchesRayCastParity) {
+  Manifold cube = Manifold::Cube(vec3(1), true);
+  const std::vector<vec3> pts = {{0, 0, 0},      {0.3, 0.2, 0.1},
+                                  {0.5, 0.5, 0.5}, {0, 0, 1},
+                                  {0, 0, 2},      {-1, 0, 0}};
+  for (const vec3& p : pts) {
+    const vec3 far(p.x, p.y, p.z + 1e6);
+    const size_t hits = cube.RayCast(p, far).size();
+    const bool byParity = (hits % 2) == 1;
+    const bool byWinding = cube.Contains(p);
+    EXPECT_EQ(byWinding, byParity) << "mismatch at (" << p.x << "," << p.y << "," << p.z << ")";
+  }
+}

--- a/test/measurement_test.cpp
+++ b/test/measurement_test.cpp
@@ -316,9 +316,8 @@ TEST(Manifold, WindingHollowShell) {
 // Cross-check: winding != 0 agrees with RayCast hit-count parity.
 TEST(Manifold, WindingMatchesRayCastParity) {
   Manifold cube = Manifold::Cube(vec3(1), true);
-  const std::vector<vec3> pts = {{0, 0, 0},       {0.3, 0.2, 0.1},
-                                  {0.5, 0.5, 0.5}, {0, 0, 1},
-                                  {0, 0, 2},       {-1, 0, 0}};
+  const std::vector<vec3> pts = {{0, 0, 0}, {0.3, 0.2, 0.1}, {0.5, 0.5, 0.5},
+                                 {0, 0, 1}, {0, 0, 2},       {-1, 0, 0}};
   const auto winding = cube.WindingNumber(pts);
   for (size_t i = 0; i < pts.size(); ++i) {
     const vec3& p = pts[i];


### PR DESCRIPTION
Closes #1440.

## What

Adds point-in-mesh containment testing to the public API:

```cpp
// Scalar
int  Manifold::WindingNumber(vec3 point) const;
bool Manifold::Contains(vec3 point) const;

// Batch (C++ and Python)
std::vector<int>  Manifold::WindingNumber(const std::vector<vec3>& points) const;
std::vector<bool> Manifold::Contains(const std::vector<vec3>& points) const;
```

## How

The core is `Manifold::Impl::PointWinding` in `boolean3.cpp`, which reuses the `Kernel02` kernel already at the heart of CSG booleans — the same kernel that computes `w03` during a Boolean operation.

Key design decisions:

- **XY-projected BVH query**: passing a `vec3` to the collider triggers `DoesOverlap(vec3)`, which checks only X and Y. This means all faces with XY overlap are returned regardless of Z, so the +Z ray winding accumulation correctly finds faces above the query point.
- **3D bounding-box pre-filter**: points outside `bBox_` are returned as 0 immediately, skipping the BVH entirely.
- **Zero vertex normals on query points**: `expandP=false` with zero normals means no symbolic perturbation from the query side — consistency at shared edges/vertices depends on the mesh's own normals, matching the convention used by `RayCast`.
- **Batch via single BVH traversal**: all query points are submitted together; `for_each_n` parallelises over query indices, each of which accumulates into a distinct winding slot (no atomics needed).
- **True winding number, not ray parity**: correctly returns 0 for the cavity of a hollow shell (`Sphere(2) - Sphere(1)`), where ray parity would return 1.

Bindings: C (scalar), Python (scalar + batch overloads), WASM (scalar, TypeScript types updated).

## Tests

Seven new tests in `test/measurement_test.cpp`:

| Test | What it proves |
|---|---|
| `ContainsBasic` | Basic inside/outside on a unit cube |
| `ContainsEmpty` | Empty manifold returns false/0 |
| `ContainsTallBox` | XY-projected collider query - point at z=-4 inside a z∈[-5,5] box correctly reports winding=1 (fails if a 3D Box query is used instead) |
| `WindingWatertight` | No double-counting at shared cube edges/vertices |
| `WindingHollowShell` | Real winding number: cavity=0, wall=1, outside=0 |
| `ContainsBatch` | Batch results match scalar for every point |
| `WindingMatchesRayCastParity` | Cross-checked against the existing `RayCast` implementation |

Full test suite passes (100%, 0 failures).