### PR TITLE
Fix Windows CI on the windows-2025-vs2026 runner (bump CMake to 4.3.3)

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -28,7 +28,6 @@ jobs:
     - uses: lukka/get-cmake@v4.3.3
       with:
         cmakeVersion: 4.3.3
-        useCloudCache: false
     - &clone-tbb
       uses: ./.github/actions/git-clone
       with:

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -28,6 +28,7 @@ jobs:
     - uses: lukka/get-cmake@v4.3.3
       with:
         cmakeVersion: 4.3.3
+        useCloudCache: false
     - &clone-tbb
       uses: ./.github/actions/git-clone
       with:

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: windows-2025
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@v4.2.3
+    - uses: lukka/get-cmake@v4.3.3
       with:
-        cmakeVersion: 4.0.2
+        cmakeVersion: 4.3.3
     - &clone-tbb
       uses: ./.github/actions/git-clone
       with:


### PR DESCRIPTION
`windows-2025` is migrating to `windows-2025-vs2026` (Visual Studio 18 / MSVC 14.51). The pinned CMake 4.0.2 has no "Visual Studio 18 2026" generator, so it falls back to `NMake Makefiles` and then fails on the `-A x64` platform spec; all four Windows jobs error at `project()` with "CMAKE_CXX_COMPILER not set".

The "Visual Studio 18 2026" generator landed in CMake 4.2, so this bumps the Windows job to CMake 4.3.3. `get-cmake` pins its catalog to the CMake version it ships, so the action tag moves to `v4.3.3` to match. No coverage change: same four Windows variants and runner, only the pinned CMake moves (and it keeps testing the current VS 2026 toolchain). Verified all four Windows jobs pass on the vs2026 runner.