### PR TITLE
Add boolean2 and CrossSection regression and corpus tests

### DIFF
--- a/src/boolean2.cpp
+++ b/src/boolean2.cpp
@@ -36,7 +36,7 @@ namespace {
 bool AllFinite(const Polygons& polys) {
   for (const auto& loop : polys) {
     for (const vec2& v : loop) {
-      if (!std::isfinite(v.x) || !std::isfinite(v.y)) return false;
+      if (!la::all(la::isfinite(v))) return false;
     }
   }
   return true;
@@ -381,7 +381,7 @@ VertexMerge MergeVerts(const std::vector<vec2>& in, double eps) {
         // overlap on [v[i] - eps, v[i] + eps] intersect [v[j] - eps, v[j] +
         // eps].
         const vec2 d = in[i] - in[j];
-        if (std::fabs(d.x) <= 2 * eps && std::fabs(d.y) <= 2 * eps)
+        if (la::all(la::lequal(la::abs(d), vec2(2 * eps))))
           pairs.emplace_back(i, j);
       }
     }
@@ -588,9 +588,9 @@ void RecordEdgeVertHit(const std::vector<EdgeM>& edges,
   const auto& g = edgeG[e];
   if (g.abLen2 == 0) return;
   const vec2 ap = verts[v] - g.a;
-  const double dotAB = ap.x * g.ab.x + ap.y * g.ab.y;
+  const double dotAB = dot(ap, g.ab);
   if (dotAB <= 0 || dotAB >= g.abLen2) return;
-  const double cross = ap.x * g.ab.y - ap.y * g.ab.x;
+  const double cross = la::cross(ap, g.ab);
   const double cross2 = cross * cross;
   const double eps2_abLen2 = eps2 * g.abLen2;
   if (cross2 > eps2_abLen2) return;
@@ -779,14 +779,12 @@ bool SharedEndpointSafelySkippable(const EdgeM& a, const EdgeM& b,
   const vec2& pS = verts[vS];
   const vec2& pA = verts[wA];
   const vec2& pB = verts[wB];
-  const double dAx = pA.x - pS.x;
-  const double dAy = pA.y - pS.y;
-  const double dBx = pB.x - pS.x;
-  const double dBy = pB.y - pS.y;
-  const double cross = dAx * dBy - dAy * dBx;
+  const vec2 dA = pA - pS;
+  const vec2 dB = pB - pS;
+  const double cross = la::cross(dA, dB);
   const double cross2 = cross * cross;
-  const double lenA2 = dAx * dAx + dAy * dAy;
-  const double lenB2 = dBx * dBx + dBy * dBy;
+  const double lenA2 = dot(dA, dA);
+  const double lenB2 = dot(dB, dB);
   const double eps2 = eps * eps;
   // Drop iff w_A is > eps from line B AND w_B is > eps from line A.
   // The check is symmetric in the |cross| numerator, so we only have

--- a/src/boolean2_offset.cpp
+++ b/src/boolean2_offset.cpp
@@ -86,7 +86,7 @@ void AppendRoundJoin(SimplePolygon& out, vec2 V, vec2 nPrev, vec2 nNext,
 // sin alpha; using the more FP-stable form sin / (1 + cos).
 void AppendSquareJoin(SimplePolygon& out, vec2 V, vec2 nPrev, vec2 nNext,
                       double delta) {
-  vec2 bisector(nPrev.x + nNext.x, nPrev.y + nNext.y);
+  vec2 bisector = nPrev + nNext;
   const ScaledDirection bisectorDir = UnitFromScaled(bisector);
   if (bisectorDir.scale == 0) return;  // 180-deg reversal; nothing reasonable
   bisector = bisectorDir.unit;
@@ -95,8 +95,7 @@ void AppendSquareJoin(SimplePolygon& out, vec2 V, vec2 nPrev, vec2 nNext,
   // 180-degree reversal; clamp to 0 so the cap degrades to its limiting
   // half-width (|delta|) instead of vanishing. Exact reversals are handled by
   // the bisectorDir.scale == 0 guard above.
-  const double cosHalf =
-      std::max(0.0, bisector.x * nPrev.x + bisector.y * nPrev.y);
+  const double cosHalf = std::max(0.0, dot(bisector, nPrev));
   const double sinHalf = std::sqrt(std::max(0.0, 1.0 - cosHalf * cosHalf));
   const double half = std::fabs(delta) * sinHalf / (1.0 + cosHalf);
   // Signed delta: the cap follows the offset side (outward for delta > 0,
@@ -114,15 +113,16 @@ vec2 MiterPoint(vec2 V, vec2 nPrev, vec2 nNext, double delta) {
   // The two offset lines pass through V + delta*nPrev (perp to ePrev)
   // and V + delta*nNext (perp to eNext). Their intersection lies along
   // the bisector at distance delta / cos(half-angle).
-  const double dotN = nPrev.x * nNext.x + nPrev.y * nNext.y;
+  const double dotN = dot(nPrev, nNext);
   const double denom = 1.0 + dotN;
   if (denom <= 0) {
     // Opposite normals make the miter unbounded. The caller's miter-limit
     // check handles near-opposite normals before this point.
     return V + delta * nPrev;
   }
-  return V +
-         delta * vec2((nPrev.x + nNext.x) / denom, (nPrev.y + nNext.y) / denom);
+  // Divide before scaling by delta to match the original per-component order
+  // ((sum / denom) * delta), so the linalg rewrite stays numerically identical.
+  return V + delta * ((nPrev + nNext) / denom);
 }
 
 double ValidMiterLimit(double miterLimit) {
@@ -152,8 +152,8 @@ SimplePolygon OffsetContour(const SimplePolygon& contour, double delta,
     const vec2 V = contour[i];
     const vec2 P = contour[(i + n - 1) % n];
     const vec2 N = contour[(i + 1) % n];
-    const vec2 ePrev = vec2(V.x - P.x, V.y - P.y);
-    const vec2 eNext = vec2(N.x - V.x, N.y - V.y);
+    const vec2 ePrev = V - P;
+    const vec2 eNext = N - V;
     const vec2 nPrev = OutwardNormal(ePrev);
     const vec2 nNext = OutwardNormal(eNext);
     if (nPrev == vec2(0, 0) || nNext == vec2(0, 0)) continue;
@@ -169,7 +169,7 @@ SimplePolygon OffsetContour(const SimplePolygon& contour, double delta,
     // Collinearity reuses the canonical CCW predicate, with a scale-derived
     // tolerance from the larger adjacent edge.
     const double eps = EpsilonFromScale(
-        std::sqrt(std::max(dot(ePrev, ePrev), dot(eNext, eNext))));
+        std::sqrt(std::max(la::length2(ePrev), la::length2(eNext))));
     if (CCW(P, V, N, eps) == 0) {
       // Zero cross is either a straight continuation (dot >= 0: nPrev == nNext,
       // so endPrev == startNext - one point suffices) or an antiparallel
@@ -206,7 +206,7 @@ SimplePolygon OffsetContour(const SimplePolygon& contour, double delta,
         // clamped case (and avoids FP-fragility of MiterPoint when
         // the denominator (1 + dot) approaches zero - exactly the
         // case where we'd clamp anyway).
-        const double dotN = nPrev.x * nNext.x + nPrev.y * nNext.y;
+        const double dotN = dot(nPrev, nNext);
         const double miterCosThresh = 2.0 / (miterLimit * miterLimit) - 1.0;
         // Equality is allowed by the miter limit. `dotN` comes from rounded
         // unit normals, so use only the baseline unit-scale predicate epsilon
@@ -256,7 +256,7 @@ Polygons Offset(const Polygons& in, double delta, JoinType jt,
   if (!std::isfinite(delta)) return {};
   for (const auto& ring : in) {
     for (const auto& v : ring) {
-      if (!std::isfinite(v.x) || !std::isfinite(v.y)) return {};
+      if (!la::all(la::isfinite(v))) return {};
     }
   }
   if (delta == 0 || in.empty()) return in;
@@ -326,7 +326,7 @@ bool PointInRing(vec2 p, const SimplePolygon& ring, double eps) {
 // max absolute coordinate); the two diverge for rings far from the origin.
 double BoxScale(const Rect& box) {
   const vec2 size = box.Size();
-  return 0.5 * std::max(size.x, size.y);
+  return 0.5 * la::maxelem(size);
 }
 
 struct RingInfo {
@@ -348,8 +348,8 @@ RingInfo Summarize(const SimplePolygon& ring) {
 // stricter than that test.
 bool BoxInside(const RingInfo& a, const RingInfo& b) {
   const double eps = b.eps;
-  return a.box.min.x >= b.box.min.x - eps && a.box.min.y >= b.box.min.y - eps &&
-         a.box.max.x <= b.box.max.x + eps && a.box.max.y <= b.box.max.y + eps;
+  return la::all(la::gequal(a.box.min, b.box.min - vec2(eps))) &&
+         la::all(la::lequal(a.box.max, b.box.max + vec2(eps)));
 }
 
 bool RingInside(const SimplePolygon& a, const SimplePolygon& b, double bEps) {
@@ -374,7 +374,7 @@ std::vector<Polygons> DecomposeByContainment(const Polygons& polys) {
     // length * epsilon (scale-consistent), matching the CrossSection
     // area-drop idiom rather than comparing an area against a length eps.
     const vec2 size = ri.box.Size();
-    if (std::fabs(ri.area) <= std::max(size.x, size.y) * ri.eps) continue;
+    if (std::fabs(ri.area) <= la::maxelem(size) * ri.eps) continue;
     rings.push_back(r);
     info.push_back(ri);
   }

--- a/src/boolean2_predicates.cpp
+++ b/src/boolean2_predicates.cpp
@@ -98,9 +98,7 @@ double SignedArea(const SimplePolygon& loop) {
   for (size_t i = 0; i < loop.size(); ++i) {
     const auto& a = loop[i];
     const auto& b = loop[(i + 1) % loop.size()];
-    const double ax = a.x - r.x, ay = a.y - r.y;
-    const double bx = b.x - r.x, by = b.y - r.y;
-    sum += ax * by - bx * ay;
+    sum += la::cross(a - r, b - r);
   }
   return 0.5 * sum;
 }

--- a/src/boolean2_winding.cpp
+++ b/src/boolean2_winding.cpp
@@ -88,8 +88,8 @@ int SignInfinitesimal(double base, double delta) {
 // The symbolic side test is an orientation sign. Scale both vectors first so
 // tiny valid inputs do not turn a nonzero L^2 determinant into signed zero.
 int ScaledCrossSign(vec2 a, vec2 b) {
-  const double aScale = std::max(std::fabs(a.x), std::fabs(a.y));
-  const double bScale = std::max(std::fabs(b.x), std::fabs(b.y));
+  const double aScale = la::maxelem(la::abs(a));
+  const double bScale = la::maxelem(la::abs(b));
   if (aScale == 0.0 || bScale == 0.0) return 0;
   if (!std::isfinite(aScale) || !std::isfinite(bScale)) {
     return SignInfinitesimal(la::cross(a, b), 0.0);
@@ -257,7 +257,7 @@ std::vector<OutEdge> FilterByWindingHalfedgesImpl(
           if (bA != bB)
             aFirst = bA < bB;
           else
-            aFirst = (dA.x * dB.y - dA.y * dB.x > 0);
+            aFirst = la::cross(dA, dB) > 0;
           if (!aFirst) std::swap(outFlat[beg], outFlat[beg + 1]);
           return;
         }
@@ -267,7 +267,7 @@ std::vector<OutEdge> FilterByWindingHalfedgesImpl(
               const vec2 dB = verts[halfedges[halfedges[b].twin].origin] - vp;
               const int bA = bucketOf(dA), bB = bucketOf(dB);
               if (bA != bB) return bA < bB;
-              return dA.x * dB.y - dA.y * dB.x > 0;
+              return la::cross(dA, dB) > 0;
             });
       });
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,7 +33,9 @@ set(
   hull_test.cpp
   samples_test.cpp
   boolean_complex_test.cpp
+  boolean2_test.cpp
   cross_section_test.cpp
+  cross_section_offset_corpus_test.cpp
   $<$<BOOL:${MANIFOLD_CBIND}>:manifoldc_test.cpp>
 )
 

--- a/test/boolean2_test.cpp
+++ b/test/boolean2_test.cpp
@@ -1168,3 +1168,10 @@ TEST(Boolean2, IntersectSegmentsSeeds) {
     }
   }
 }
+
+TEST(Boolean2, NonFiniteInputReturnsEmpty) {
+  const double inf = std::numeric_limits<double>::infinity();
+  Polygons bad = {{{0.0, 0.0}, {1.0, 0.0}, {inf, 1.0}, {0.0, 1.0}}};
+  Polygons finite = {{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}}};
+  EXPECT_TRUE(Boolean2D(bad, finite, OpType::Add).empty());
+}

--- a/test/boolean2_test.cpp
+++ b/test/boolean2_test.cpp
@@ -270,7 +270,6 @@ std::vector<EdgeM> EdgesFromOverlapResult(const OverlapResult& result) {
 
 OverlapResult CleanupPassLikeIterate(const OverlapResult& result, double eps) {
   return RemoveOverlaps2D(result.verts, EdgesFromOverlapResult(result), eps,
-                          /*tolerance=*/0.0,
                           /*debug=*/false, WindRule::Add);
 }
 
@@ -518,8 +517,8 @@ TEST(Boolean2, CleanupPassMatchesValidAddSinglePass) {
   Polygons polys{RandomTopologicalRing(8, 15)};
   const double eps = InferEps(polys, {});
   const auto [verts, edges] = PolygonsToInput(polys);
-  const auto pass1 = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/0.0,
-                                      /*debug=*/false, WindRule::Add);
+  const auto pass1 =
+      RemoveOverlaps2D(verts, edges, eps, /*debug=*/false, WindRule::Add);
   EXPECT_TRUE(CheckRetainedGraphValidity(pass1, edges, pass1.inputVert2Merged,
                                          pass1.numMergedVerts, eps));
 
@@ -778,8 +777,8 @@ TEST(Boolean2, BooleanRobustnessMergeTopologyBalance) {
   const auto [verts, edges] = CombinedInput(a, b, /*bMult=*/1);
   ASSERT_FALSE(verts.empty());
   const double eps = InferEps(a, b);
-  const auto overlap = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/0.0,
-                                        /*debug=*/false, WindRule::Add);
+  const auto overlap =
+      RemoveOverlaps2D(verts, edges, eps, /*debug=*/false, WindRule::Add);
   EXPECT_TRUE(CheckRetainedGraphValidity(
       overlap, edges, overlap.inputVert2Merged, overlap.numMergedVerts, eps));
 }
@@ -811,8 +810,8 @@ TEST(Boolean2, BooleanRobustnessDirectCastKeepsExpectedArea) {
   const auto [verts, edges] = CombinedInput(a, b, /*bMult=*/1);
   ASSERT_FALSE(verts.empty());
   const double eps = InferEps(a, b);
-  const auto overlap = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/0.0,
-                                        /*debug=*/false, WindRule::Add);
+  const auto overlap =
+      RemoveOverlaps2D(verts, edges, eps, /*debug=*/false, WindRule::Add);
   EXPECT_TRUE(CheckRetainedGraphValidity(
       overlap, edges, overlap.inputVert2Merged, overlap.numMergedVerts, eps));
 
@@ -875,48 +874,14 @@ TEST(Boolean2, KeepsNearDistinctPresentationVertex) {
   constexpr double kDelta = 1e-12;
   const Polygons input = {
       {{0, 0}, {1, 0}, {1, -1}, {2, -1}, {1 + kDelta, 0}, {1, 1}}};
-  const auto polys = Boolean2D(input, {}, OpType::Add, /*eps=*/1e-15,
-                               /*tolerance=*/1e-9);
+  const auto polys = Boolean2D(input, {}, OpType::Add, /*eps=*/1e-15);
   ASSERT_EQ(polys.size(), 1u);
   EXPECT_EQ(polys[0].size(), 6u);
   EXPECT_NEAR(TotalSignedArea(polys), 1.0 + kDelta, 1e-12);
 }
 
-// The arrangement is eps-only: a crossing a tolerance-scale distance from an
-// old endpoint (5e-4 from corner (0,0), eps 1e-6) is a real tiny feature, kept
-// whatever the op tolerance. Merging it is Simplify's job, not the boolean's.
-TEST(Boolean2, GeneratedCrossingNearEndpointStaysDistinct) {
-  constexpr double eps = 1e-6;
-  const Polygons a = {{{0, 0}, {10, 0}, {10, 1}, {0, 1}}};
-  const Polygons b = {{{5e-4, -0.5}, {0.5, -0.5}, {0.5, 0.5}, {5e-4, 0.5}}};
-  const auto [verts, edges] = CombinedInput(a, b, /*bMult=*/1);
-
-  const auto atEps = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/eps,
-                                      /*debug=*/false, WindRule::Add);
-  const auto atTol = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/1e-3,
-                                      /*debug=*/false, WindRule::Add);
-
-  auto countNear = [](const std::vector<vec2>& points, vec2 target, double r) {
-    int count = 0;
-    for (const vec2& p : points)
-      if (dot(p - target, p - target) <= r * r) ++count;
-    return count;
-  };
-  const vec2 generatedNearOld{5e-4, 0.0};
-
-  // A 1000x-larger tolerance changes nothing.
-  EXPECT_GT(countNear(atEps.verts, generatedNearOld, 10 * eps), 0);
-  EXPECT_GT(countNear(atTol.verts, generatedNearOld, 10 * eps), 0);
-  EXPECT_EQ(atEps.verts.size(), atTol.verts.size());
-  EXPECT_TRUE(CheckRetainedGraphValidity(atEps, edges, atEps.inputVert2Merged,
-                                         atEps.numMergedVerts, eps));
-  EXPECT_TRUE(CheckRetainedGraphValidity(atTol, edges, atTol.inputVert2Merged,
-                                         atTol.numMergedVerts, eps));
-}
-
 // The new-to-old snap is a 2*eps budget: a generated crossing within 2*eps of
-// an old corner fuses into it; beyond 2*eps it stays a distinct vertex. Op
-// tolerance does not enter - this is purely the eps-scale merge.
+// an old corner fuses into it; beyond 2*eps it stays a distinct vertex.
 TEST(Boolean2, NewToOldMergeBudgetIsTwoEps) {
   constexpr double eps = 1e-6;
   const Polygons a = {{{0, 0}, {10, 0}, {10, 1}, {0, 1}}};
@@ -925,8 +890,8 @@ TEST(Boolean2, NewToOldMergeBudgetIsTwoEps) {
   auto runWithLeftEdgeAt = [&](double xLeft) {
     const Polygons b = {{{xLeft, -0.5}, {0.5, -0.5}, {0.5, 0.5}, {xLeft, 0.5}}};
     auto [verts, edges] = CombinedInput(a, b, /*bMult=*/1);
-    auto result = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/eps,
-                                   /*debug=*/false, WindRule::Add);
+    auto result =
+        RemoveOverlaps2D(verts, edges, eps, /*debug=*/false, WindRule::Add);
     return std::make_pair(std::move(result), std::move(edges));
   };
   auto countNear = [](const std::vector<vec2>& points, vec2 target, double r) {
@@ -950,50 +915,13 @@ TEST(Boolean2, NewToOldMergeBudgetIsTwoEps) {
                                          distinct.numMergedVerts, eps));
 }
 
-// Regression: an elevated tolerance used to snap a shared crossing onto an old
-// corner and fold this two-star union to empty. Eps-scale snapping cannot move
-// old geometry that far, so it stays a valid ~2.04 union.
-TEST(Boolean2, ElevatedToleranceDoesNotFoldOverlap) {
-  const Polygons a = {{{-0.057041, 0.823614},
-                       {-0.285626, 0.308351},
-                       {-0.835764, 0.185488},
-                       {-0.416356, -0.191134},
-                       {-0.469509, -0.752313},
-                       {0.018284, -0.469815},
-                       {0.535572, -0.693780},
-                       {0.417637, -0.142565},
-                       {0.790491, 0.280197},
-                       {0.229810, 0.338368}}};
-  const Polygons b = {{{-0.210685, -0.690574},
-                       {-0.062302, -0.062027},
-                       {0.582263, -0.021725},
-                       {0.112117, 0.421051},
-                       {0.399497, 0.999411},
-                       {-0.219032, 0.813641},
-                       {-0.576217, 1.351700},
-                       {-0.724599, 0.723153},
-                       {-1.369164, 0.682852},
-                       {-0.899018, 0.240075},
-                       {-1.186398, -0.338285},
-                       {-0.567870, -0.152515}}};
-  const auto [verts, edges] = CombinedInput(a, b, /*bMult=*/1);
-  constexpr double eps = 1e-9;
-  const auto result = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/0.08,
-                                       /*debug=*/false, WindRule::Add);
-  EXPECT_FALSE(result.edges.empty());
-  EXPECT_TRUE(CheckRetainedGraphValidity(result, edges, result.inputVert2Merged,
-                                         result.numMergedVerts, eps));
-  EXPECT_NEAR(TotalSignedArea(OutEdgesToPolygons(result.verts, result.edges)),
-              2.04, 0.05);
-}
-
 TEST(Boolean2, RemoveOverlapsMergesExactDuplicateCoordinates) {
   const Polygons polys = {{{0, 0}, {1, 0}, {0, 1}}, {{0, 0}, {-1, 0}, {0, -1}}};
   const auto [verts, edges] = PolygonsToInput(polys);
   ASSERT_EQ(verts.size(), 6u);
   const double eps = InferEps(polys, {});
-  const auto overlap = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/0.0,
-                                        /*debug=*/false, WindRule::Add);
+  const auto overlap =
+      RemoveOverlaps2D(verts, edges, eps, /*debug=*/false, WindRule::Add);
   ASSERT_EQ(overlap.inputVert2Merged.size(), verts.size());
   ASSERT_GE(overlap.inputVert2Merged[0], 0);
   ASSERT_LT(overlap.inputVert2Merged[0], overlap.numMergedVerts);

--- a/test/boolean2_test.cpp
+++ b/test/boolean2_test.cpp
@@ -129,6 +129,11 @@ bool PointInSegmentInteriorBand(vec2 p, vec2 a, vec2 b, double eps) {
   return std::fabs(la::cross(d, p - a)) <= eps * std::sqrt(len2);
 }
 
+// Independent oracle for the arrangement RemoveOverlaps2D retains - its
+// predicates are not reused from the engine, so it can't rubber-stamp a bug.
+// Checks: retained verts finite and >eps apart; edges valid and non-eps-zero;
+// edge balance conserved (per-vertex signed multiplicity matches the input's,
+// zero for introduced verts); no two non-adjacent edges strictly cross.
 ::testing::AssertionResult CheckRetainedGraphValidity(
     const OverlapResult& result, const std::vector<EdgeM>& inputEdges,
     const std::vector<int>& inputVert2Merged, int numMergedVerts, double eps) {
@@ -273,6 +278,9 @@ OverlapResult CleanupPassLikeIterate(const OverlapResult& result, double eps) {
                           /*debug=*/false, WindRule::Add);
 }
 
+// Determinism/idempotence check: two arrangements equal up to eps-quantization,
+// comparing sorted per-edge keys (endpoints rounded to eps*0.01 and canonically
+// ordered, with signed multiplicity).
 void ExpectSameFingerprint(const OverlapResult& a, const OverlapResult& b,
                            double eps) {
   using Fingerprint =
@@ -354,12 +362,11 @@ TEST(Boolean2, PropagatesShallowIndependentIntersections) {
   EXPECT_EQ(inserted.lists[4].size(), 2);
 }
 
-// RemoveOverlaps2D produces an edge-balance imbalance for some
-//   vertices on these mixed-scale inputs - 1e-6 alongside 1024.
-//   Likely eps-inference at the extreme-scale-mix boundary or
-//   vertex-merge corner case in RemoveOverlaps2D. Replicated inline
-//   because CheckRetainedGraphValidity isn't exposed via the public
-//   API.
+// Edge balance at a vertex is the signed sum of incident edge multiplicities
+// (outgoing minus incoming); a valid arrangement conserves it. Asserts
+// RemoveOverlaps2D does so through a boolean Add on a hard mixed-scale input
+// (1e-6 alongside 1024). Replicated inline (CheckRetainedGraphValidity isn't
+// public).
 TEST(Boolean2, RemoveOverlaps2DTopologyMixedScale) {
   // Inputs A and B exactly as the BooleanRobustness fuzz target
   // constructs them from the counterexample raw polygons. The

--- a/test/boolean2_test.cpp
+++ b/test/boolean2_test.cpp
@@ -882,40 +882,109 @@ TEST(Boolean2, KeepsNearDistinctPresentationVertex) {
   EXPECT_NEAR(TotalSignedArea(polys), 1.0 + kDelta, 1e-12);
 }
 
-TEST(Boolean2, NewOldToleranceMergesGeneratedNearEndpoint) {
+// The arrangement is eps-only: a crossing a tolerance-scale distance from an
+// old endpoint (5e-4 from corner (0,0), eps 1e-6) is a real tiny feature, kept
+// whatever the op tolerance. Merging it is Simplify's job, not the boolean's.
+TEST(Boolean2, GeneratedCrossingNearEndpointStaysDistinct) {
   constexpr double eps = 1e-6;
-  constexpr double tolerance = 1e-3;
   const Polygons a = {{{0, 0}, {10, 0}, {10, 1}, {0, 1}}};
   const Polygons b = {{{5e-4, -0.5}, {0.5, -0.5}, {0.5, 0.5}, {5e-4, 0.5}}};
   const auto [verts, edges] = CombinedInput(a, b, /*bMult=*/1);
 
-  const auto withoutPrior =
-      RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/eps,
-                       /*debug=*/false, WindRule::Add);
-  const auto withPrior = RemoveOverlaps2D(verts, edges, eps, tolerance,
-                                          /*debug=*/false, WindRule::Add);
+  const auto atEps = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/eps,
+                                      /*debug=*/false, WindRule::Add);
+  const auto atTol = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/1e-3,
+                                      /*debug=*/false, WindRule::Add);
 
-  auto countNear = [](const std::vector<vec2>& points, vec2 target,
-                      double radius) {
+  auto countNear = [](const std::vector<vec2>& points, vec2 target, double r) {
     int count = 0;
-    const double radius2 = radius * radius;
-    for (const vec2& p : points) {
-      const vec2 d = p - target;
-      if (dot(d, d) <= radius2) ++count;
-    }
+    for (const vec2& p : points)
+      if (dot(p - target, p - target) <= r * r) ++count;
     return count;
   };
-
   const vec2 generatedNearOld{5e-4, 0.0};
-  EXPECT_GT(countNear(withoutPrior.verts, generatedNearOld, 10 * eps), 0)
-      << "baseline should retain the generated crossing as distinct";
-  EXPECT_EQ(countNear(withPrior.verts, generatedNearOld, 10 * eps), 0)
-      << "propagated tolerance should merge the generated crossing into the "
-         "nearby old endpoint";
-  EXPECT_EQ(withPrior.verts.size() + 1, withoutPrior.verts.size());
-  EXPECT_TRUE(CheckRetainedGraphValidity(withPrior, edges,
-                                         withPrior.inputVert2Merged,
-                                         withPrior.numMergedVerts, eps));
+
+  // A 1000x-larger tolerance changes nothing.
+  EXPECT_GT(countNear(atEps.verts, generatedNearOld, 10 * eps), 0);
+  EXPECT_GT(countNear(atTol.verts, generatedNearOld, 10 * eps), 0);
+  EXPECT_EQ(atEps.verts.size(), atTol.verts.size());
+  EXPECT_TRUE(CheckRetainedGraphValidity(atEps, edges, atEps.inputVert2Merged,
+                                         atEps.numMergedVerts, eps));
+  EXPECT_TRUE(CheckRetainedGraphValidity(atTol, edges, atTol.inputVert2Merged,
+                                         atTol.numMergedVerts, eps));
+}
+
+// The new-to-old snap is a 2*eps budget: a generated crossing within 2*eps of
+// an old corner fuses into it; beyond 2*eps it stays a distinct vertex. Op
+// tolerance does not enter - this is purely the eps-scale merge.
+TEST(Boolean2, NewToOldMergeBudgetIsTwoEps) {
+  constexpr double eps = 1e-6;
+  const Polygons a = {{{0, 0}, {10, 0}, {10, 1}, {0, 1}}};
+  // b's left edge crosses a's bottom edge at (xLeft, 0), a distance xLeft from
+  // corner (0, 0); only that distance differs between the two runs.
+  auto runWithLeftEdgeAt = [&](double xLeft) {
+    const Polygons b = {{{xLeft, -0.5}, {0.5, -0.5}, {0.5, 0.5}, {xLeft, 0.5}}};
+    auto [verts, edges] = CombinedInput(a, b, /*bMult=*/1);
+    auto result = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/eps,
+                                   /*debug=*/false, WindRule::Add);
+    return std::make_pair(std::move(result), std::move(edges));
+  };
+  auto countNear = [](const std::vector<vec2>& points, vec2 target, double r) {
+    int count = 0;
+    for (const vec2& p : points)
+      if (dot(p - target, p - target) <= r * r) ++count;
+    return count;
+  };
+  const vec2 corner{0, 0};
+  const auto [merged, mergedEdges] = runWithLeftEdgeAt(1.5 * eps);
+  const auto [distinct, distinctEdges] = runWithLeftEdgeAt(2.5 * eps);
+  // Within the budget the corner and the crossing collapse to one vertex;
+  // beyond it the crossing survives alongside the corner.
+  EXPECT_EQ(countNear(merged.verts, corner, 5 * eps), 1);
+  EXPECT_EQ(countNear(distinct.verts, corner, 5 * eps), 2);
+  EXPECT_TRUE(CheckRetainedGraphValidity(merged, mergedEdges,
+                                         merged.inputVert2Merged,
+                                         merged.numMergedVerts, eps));
+  EXPECT_TRUE(CheckRetainedGraphValidity(distinct, distinctEdges,
+                                         distinct.inputVert2Merged,
+                                         distinct.numMergedVerts, eps));
+}
+
+// Regression: an elevated tolerance used to snap a shared crossing onto an old
+// corner and fold this two-star union to empty. Eps-scale snapping cannot move
+// old geometry that far, so it stays a valid ~2.04 union.
+TEST(Boolean2, ElevatedToleranceDoesNotFoldOverlap) {
+  const Polygons a = {{{-0.057041, 0.823614},
+                       {-0.285626, 0.308351},
+                       {-0.835764, 0.185488},
+                       {-0.416356, -0.191134},
+                       {-0.469509, -0.752313},
+                       {0.018284, -0.469815},
+                       {0.535572, -0.693780},
+                       {0.417637, -0.142565},
+                       {0.790491, 0.280197},
+                       {0.229810, 0.338368}}};
+  const Polygons b = {{{-0.210685, -0.690574},
+                       {-0.062302, -0.062027},
+                       {0.582263, -0.021725},
+                       {0.112117, 0.421051},
+                       {0.399497, 0.999411},
+                       {-0.219032, 0.813641},
+                       {-0.576217, 1.351700},
+                       {-0.724599, 0.723153},
+                       {-1.369164, 0.682852},
+                       {-0.899018, 0.240075},
+                       {-1.186398, -0.338285},
+                       {-0.567870, -0.152515}}};
+  const auto [verts, edges] = CombinedInput(a, b, /*bMult=*/1);
+  constexpr double eps = 1e-9;
+  const auto result = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/0.08,
+                                       /*debug=*/false, WindRule::Add);
+  EXPECT_FALSE(result.edges.empty());
+  EXPECT_TRUE(CheckRetainedGraphValidity(result, edges, result.inputVert2Merged,
+                                         result.numMergedVerts, eps));
+  EXPECT_NEAR(TotalSignedArea(OutEdgesToPolygons(result.verts, result.edges)),
+              2.04, 0.05);
 }
 
 TEST(Boolean2, RemoveOverlapsMergesExactDuplicateCoordinates) {

--- a/test/boolean2_test.cpp
+++ b/test/boolean2_test.cpp
@@ -1,0 +1,1164 @@
+// Copyright 2026 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/boolean2.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <random>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "manifold/common.h"
+#include "manifold/cross_section.h"
+#include "manifold/manifold.h"
+
+using namespace manifold;
+
+namespace {
+
+SimplePolygon RandomTopologicalRing(int n, uint64_t seed) {
+  // std::mt19937_64 is portable, but std::uniform_real_distribution and
+  // std::shuffle are not, and std::cos/std::sin vary by a ULP across libm
+  // implementations. Build the ring from raw engine output with portable
+  // integer/float arithmetic only, so the points are bit-identical on every
+  // platform; with boolean2's exact predicates the resulting topology is then
+  // portable too.
+  std::mt19937_64 rng(seed);
+  auto unit = [&rng]() {
+    return static_cast<double>(rng() >> 11) * (1.0 / 9007199254740992.0);
+  };
+  std::vector<vec2> verts(n);
+  for (int i = 0; i < n; ++i) verts[i] = {unit(), unit()};
+
+  std::vector<int> order(n);
+  for (int i = 0; i < n; ++i) order[i] = i;
+  for (int i = n - 1; i > 0; --i) {
+    const int j = static_cast<int>(rng() % static_cast<uint64_t>(i + 1));
+    std::swap(order[i], order[j]);
+  }
+
+  SimplePolygon ring;
+  ring.reserve(n);
+  for (int i : order) ring.push_back(verts[i]);
+  return ring;
+}
+
+template <typename Edge>
+std::map<int, int> ComputeBalance(const std::vector<Edge>& edges) {
+  std::map<int, int> balance;
+  for (const auto& edge : edges) {
+    balance[edge.v0] += edge.mult;
+    balance[edge.v1] -= edge.mult;
+  }
+  return balance;
+}
+
+// The predicates below are an independent oracle for validating engine
+// output, deliberately not reusing the engine's IntersectSegments (that
+// would be circular) or the house CCW (whose zero band normalizes by the
+// longer edge from p0, not by perpendicular distance). Each uses an exact
+// distance-from-line band: |cross(d, p - a)| <= eps * |d|.
+bool ValidVertId(int v, const std::vector<vec2>& verts) {
+  return 0 <= v && v < static_cast<int>(verts.size());
+}
+
+bool PointsCollinearWithinEps(vec2 a, vec2 b, vec2 p, double eps) {
+  const vec2 d = b - a;
+  const double len2 = dot(d, d);
+  if (len2 == 0.0) return false;
+  return std::fabs(la::cross(d, p - a)) <= eps * std::sqrt(len2);
+}
+
+bool SegmentsHavePositiveCollinearOverlap(vec2 a0, vec2 a1, vec2 b0, vec2 b1,
+                                          double eps) {
+  if (!PointsCollinearWithinEps(a0, a1, b0, eps) ||
+      !PointsCollinearWithinEps(a0, a1, b1, eps)) {
+    return false;
+  }
+  const int axis = std::fabs(a1.x - a0.x) >= std::fabs(a1.y - a0.y) ? 0 : 1;
+  const double aMin = std::min(Coord(a0, axis), Coord(a1, axis));
+  const double aMax = std::max(Coord(a0, axis), Coord(a1, axis));
+  const double bMin = std::min(Coord(b0, axis), Coord(b1, axis));
+  const double bMax = std::max(Coord(b0, axis), Coord(b1, axis));
+  return std::min(aMax, bMax) - std::max(aMin, bMin) > eps;
+}
+
+int StrictSide(vec2 a, vec2 b, vec2 p, double eps) {
+  const vec2 d = b - a;
+  const double threshold = eps * std::sqrt(dot(d, d));
+  const double area = la::cross(d, p - a);
+  return (area > threshold) - (area < -threshold);
+}
+
+bool SegmentsHaveStrictCrossing(vec2 a0, vec2 a1, vec2 b0, vec2 b1,
+                                double eps) {
+  const int b0Side = StrictSide(a0, a1, b0, eps);
+  const int b1Side = StrictSide(a0, a1, b1, eps);
+  const int a0Side = StrictSide(b0, b1, a0, eps);
+  const int a1Side = StrictSide(b0, b1, a1, eps);
+  return b0Side * b1Side < 0 && a0Side * a1Side < 0;
+}
+
+bool PointInSegmentInteriorBand(vec2 p, vec2 a, vec2 b, double eps) {
+  const vec2 d = b - a;
+  const double len2 = dot(d, d);
+  if (len2 == 0.0) return false;
+  const double along = dot(p - a, d);
+  if (along <= 0.0 || along >= len2) return false;
+  return std::fabs(la::cross(d, p - a)) <= eps * std::sqrt(len2);
+}
+
+::testing::AssertionResult CheckRetainedGraphValidity(
+    const OverlapResult& result, const std::vector<EdgeM>& inputEdges,
+    const std::vector<int>& inputVert2Merged, int numMergedVerts, double eps) {
+  auto fail = [](const std::string& msg) {
+    return ::testing::AssertionFailure() << msg;
+  };
+
+  for (int v = 0; v < static_cast<int>(result.verts.size()); ++v) {
+    if (!std::isfinite(result.verts[v].x) ||
+        !std::isfinite(result.verts[v].y)) {
+      std::ostringstream out;
+      out << "non-finite retained vertex " << v << " = (" << result.verts[v].x
+          << ", " << result.verts[v].y << ")";
+      return fail(out.str());
+    }
+  }
+
+  const double eps2 = eps * eps;
+  for (int a = 0; a < static_cast<int>(result.verts.size()); ++a) {
+    for (int b = a + 1; b < static_cast<int>(result.verts.size()); ++b) {
+      if (dot(result.verts[b] - result.verts[a],
+              result.verts[b] - result.verts[a]) <= eps2) {
+        std::ostringstream out;
+        out << "retained vertices " << a << " and " << b
+            << " remain within epsilon";
+        return fail(out.str());
+      }
+    }
+  }
+
+  for (int i = 0; i < static_cast<int>(result.edges.size()); ++i) {
+    const auto& edge = result.edges[i];
+    if (!ValidVertId(edge.v0, result.verts) ||
+        !ValidVertId(edge.v1, result.verts)) {
+      std::ostringstream out;
+      out << "retained edge " << i << " has invalid verts " << edge.v0 << " -> "
+          << edge.v1;
+      return fail(out.str());
+    }
+    if (dot(result.verts[edge.v1] - result.verts[edge.v0],
+            result.verts[edge.v1] - result.verts[edge.v0]) <= eps2) {
+      std::ostringstream out;
+      out << "retained edge " << i << " is epsilon-zero: " << edge.v0 << " -> "
+          << edge.v1;
+      return fail(out.str());
+    }
+  }
+
+  std::vector<EdgeM> remapped;
+  remapped.reserve(inputEdges.size());
+  for (const auto& edge : inputEdges) {
+    if (edge.v0 < 0 || edge.v0 >= static_cast<int>(inputVert2Merged.size()) ||
+        edge.v1 < 0 || edge.v1 >= static_cast<int>(inputVert2Merged.size())) {
+      std::ostringstream out;
+      out << "input edge has verts outside inputVert2Merged: " << edge.v0
+          << " -> " << edge.v1;
+      return fail(out.str());
+    }
+    const int a = inputVert2Merged[edge.v0];
+    const int b = inputVert2Merged[edge.v1];
+    if (a != b) remapped.push_back({a, b, edge.mult});
+  }
+
+  const auto expected = ComputeBalance(remapped);
+  const auto actual = ComputeBalance(result.edges);
+  for (const auto& [v, actualBalance] : actual) {
+    if (v < 0 || v >= static_cast<int>(result.verts.size())) {
+      std::ostringstream out;
+      out << "retained balance references invalid vertex " << v;
+      return fail(out.str());
+    }
+    (void)actualBalance;
+  }
+  for (int v = 0; v < static_cast<int>(result.verts.size()); ++v) {
+    const int expectedBalance =
+        expected.count(v) ? expected.find(v)->second : 0;
+    const int actualBalance = actual.count(v) ? actual.find(v)->second : 0;
+    const int target = (v < numMergedVerts) ? expectedBalance : 0;
+    if (actualBalance != target) {
+      std::ostringstream out;
+      out << "retained balance mismatch at vertex " << v << ": expected "
+          << target << ", got " << actualBalance;
+      return fail(out.str());
+    }
+  }
+
+  for (int i = 0; i < static_cast<int>(result.edges.size()); ++i) {
+    const auto& a = result.edges[i];
+    for (int j = i + 1; j < static_cast<int>(result.edges.size()); ++j) {
+      const auto& b = result.edges[j];
+      if (a.v0 == b.v0 || a.v0 == b.v1 || a.v1 == b.v0 || a.v1 == b.v1) {
+        continue;
+      }
+      const vec2 a0 = result.verts[a.v0];
+      const vec2 a1 = result.verts[a.v1];
+      const vec2 b0 = result.verts[b.v0];
+      const vec2 b1 = result.verts[b.v1];
+      if (SegmentsHaveStrictCrossing(a0, a1, b0, b1, eps)) {
+        std::ostringstream out;
+        out << "retained edges " << i << " and " << j
+            << " still have a strict crossing";
+        return fail(out.str());
+      }
+      if (SegmentsHavePositiveCollinearOverlap(a0, a1, b0, b1, eps)) {
+        std::ostringstream out;
+        out << "retained edges " << i << " and " << j
+            << " still have positive collinear overlap";
+        return fail(out.str());
+      }
+    }
+  }
+
+  for (int e = 0; e < static_cast<int>(result.edges.size()); ++e) {
+    const auto& edge = result.edges[e];
+    const vec2 a = result.verts[edge.v0];
+    const vec2 b = result.verts[edge.v1];
+    for (int v = 0; v < static_cast<int>(result.verts.size()); ++v) {
+      if (v == edge.v0 || v == edge.v1) continue;
+      if (PointInSegmentInteriorBand(result.verts[v], a, b, eps)) {
+        std::ostringstream out;
+        out << "retained vertex " << v << " lies in the interior band of edge "
+            << e << " (" << edge.v0 << " -> " << edge.v1 << ")";
+        return fail(out.str());
+      }
+    }
+  }
+
+  return ::testing::AssertionSuccess();
+}
+
+std::vector<EdgeM> EdgesFromOverlapResult(const OverlapResult& result) {
+  std::vector<EdgeM> edges;
+  edges.reserve(result.edges.size());
+  for (const auto& edge : result.edges) {
+    edges.push_back({edge.v0, edge.v1, edge.mult});
+  }
+  return edges;
+}
+
+OverlapResult CleanupPassLikeIterate(const OverlapResult& result, double eps) {
+  return RemoveOverlaps2D(result.verts, EdgesFromOverlapResult(result), eps,
+                          /*tolerance=*/0.0,
+                          /*debug=*/false, WindRule::Add);
+}
+
+void ExpectSameFingerprint(const OverlapResult& a, const OverlapResult& b,
+                           double eps) {
+  using Fingerprint =
+      std::vector<std::tuple<int64_t, int64_t, int64_t, int64_t, int>>;
+  auto fingerprint = [eps](const OverlapResult& r) {
+    const double quantum = eps * 0.01;
+    auto q = [quantum](double x) {
+      return static_cast<int64_t>(std::round(x / quantum));
+    };
+    Fingerprint fp;
+    fp.reserve(r.edges.size());
+    for (const auto& edge : r.edges) {
+      vec2 p0 = r.verts[edge.v0];
+      vec2 p1 = r.verts[edge.v1];
+      auto k0 = std::make_pair(q(p0.x), q(p0.y));
+      auto k1 = std::make_pair(q(p1.x), q(p1.y));
+      int mult = edge.mult;
+      if (k1 < k0) {
+        std::swap(k0, k1);
+        mult = -mult;
+      }
+      fp.emplace_back(k0.first, k0.second, k1.first, k1.second, mult);
+    }
+    manifold::stable_sort(fp.begin(), fp.end());
+    return fp;
+  };
+
+  const auto fpA = fingerprint(a);
+  const auto fpB = fingerprint(b);
+  EXPECT_EQ(fpA, fpB) << "fingerprints differ: lhs edges=" << a.edges.size()
+                      << " rhs edges=" << b.edges.size();
+}
+
+std::pair<std::vector<vec2>, std::vector<EdgeM>> CombinedInput(
+    const Polygons& a, const Polygons& b, int bMult) {
+  auto [verts, edges] = PolygonsToInput(a);
+  auto [bVerts, bEdges] = PolygonsToInput(b);
+  const int base = static_cast<int>(verts.size());
+  verts.insert(verts.end(), bVerts.begin(), bVerts.end());
+  for (auto edge : bEdges) {
+    edge.v0 += base;
+    edge.v1 += base;
+    edge.mult *= bMult;
+    edges.push_back(edge);
+  }
+  return {std::move(verts), std::move(edges)};
+}
+
+}  // namespace
+
+TEST(Boolean2, PropagatesShallowIndependentIntersections) {
+  constexpr double eps = 1e-3;
+  std::vector<vec2> verts = {{-1., 0.},
+                             {1., 0.},
+                             {0., -1.},
+                             {0., 1.},
+                             {-1., 5. * eps},
+                             {1., 5. * eps},
+                             {0., -1. + 5. * eps},
+                             {0., 1. + 5. * eps},
+                             {0., -1.},
+                             {0., 1.}};
+  std::vector<EdgeM> edges = {
+      {0, 1, 1}, {2, 3, 1}, {4, 5, 1}, {6, 7, 1}, {8, 9, 1}};
+  std::vector<Box2> edgeBoxes;
+  edgeBoxes.reserve(edges.size());
+  for (const EdgeM& edge : edges) {
+    edgeBoxes.push_back(BoxOf2DEdge(verts[edge.v0], verts[edge.v1], eps));
+  }
+  const std::vector<std::pair<int, int>> pairs = {{0, 1}, {2, 3}};
+
+  NarrowPhaseResult narrow =
+      BuildListsAndFindIntersections(edges, verts, eps, pairs);
+  IntersectionInsertion inserted = FindAndInsertIntersections(
+      edges, std::move(verts), std::move(narrow.lists), eps, edgeBoxes, BVH{},
+      narrow.intersections);
+
+  ASSERT_EQ(inserted.verts.size(), 12);
+  EXPECT_EQ(inserted.lists[4].size(), 2);
+}
+
+// RemoveOverlaps2D produces an edge-balance imbalance for some
+//   vertices on these mixed-scale inputs - 1e-6 alongside 1024.
+//   Likely eps-inference at the extreme-scale-mix boundary or
+//   vertex-merge corner case in RemoveOverlaps2D. Replicated inline
+//   because CheckRetainedGraphValidity isn't exposed via the public
+//   API.
+TEST(Boolean2, RemoveOverlaps2DTopologyMixedScale) {
+  // Inputs A and B exactly as the BooleanRobustness fuzz target
+  // constructs them from the counterexample raw polygons. The
+  // topology check is on the OUTPUT of the boolean Add, not the
+  // raw inputs.
+  const Polygons polysA = {
+      {{-1e-6, 1e-6}, {-1e-6, -1e-6}, {-0.0, 0.0}, {1.0, 1024.0}},
+      {{1024.0, 1024.0}, {1.0, 1.0}, {1e-6, -1e-6}}};
+  const Polygons polysB = {
+      {{0.0, 1.0},
+       {1e-6, 1024.0},
+       {-1.0, -1024.0},
+       {-0.0, 1024.0},
+       {1.0, -1.0}},
+      {{-260.66988565137592, -0.0},
+       {0.0, -414.46576455279967},
+       {-1.0, -1024.0}},
+      {{1.0, 1.0}, {-1e-6, -0.0}, {1.0, 1024.0}, {1e-6, 0.0}},
+      {{-111.03407576117854, 0.0},
+       {560.59976308273758, 2.9313131393310714},
+       {-1024.0, 1.0},
+       {89.678187020143696, 0.0},
+       {1024.0, 1.0}}};
+  const CrossSection a(polysA);
+  const CrossSection b(polysB);
+  const auto result = a + b;
+  const auto resultPolys = result.ToPolygons();
+
+  // Run RemoveOverlaps2D on the Boolean's output and check that the
+  // per-vertex edge balance is preserved (sum of mult on outgoing
+  // minus incoming) for surviving verts, zero for newly-introduced.
+  const auto [verts, edges] = manifold::PolygonsToInput(resultPolys);
+  if (verts.empty()) GTEST_SKIP() << "Boolean output collapsed to empty";
+  const double eps = manifold::InferEps(resultPolys, {});
+  const auto overlapResult = manifold::RemoveOverlaps2D(verts, edges, eps);
+
+  std::vector<manifold::EdgeM> remapped;
+  for (const auto& edge : edges) {
+    const int aIdx = overlapResult.inputVert2Merged[edge.v0];
+    const int bIdx = overlapResult.inputVert2Merged[edge.v1];
+    if (aIdx != bIdx) remapped.push_back({aIdx, bIdx, edge.mult});
+  }
+  const auto expected = ComputeBalance(remapped);
+  const auto actual = ComputeBalance(overlapResult.edges);
+  for (int v = 0; v < static_cast<int>(overlapResult.verts.size()); ++v) {
+    const int expectedBalance =
+        expected.count(v) ? expected.find(v)->second : 0;
+    const int actualBalance = actual.count(v) ? actual.find(v)->second : 0;
+    const int target = (v < overlapResult.numMergedVerts) ? expectedBalance : 0;
+    EXPECT_EQ(actualBalance, target)
+        << "Vertex " << v
+        << " edge-balance mismatch after RemoveOverlaps2D on boolean "
+        << "Add result: expected=" << target << " actual=" << actualBalance;
+  }
+}
+
+TEST(Boolean2, MergeVertsTransitiveChainCanDriftPastEps) {
+  const double eps = 1.0;
+  const std::vector<vec2> verts = {{0.0, 0.0},  {0.99, 0.0}, {1.98, 0.0},
+                                   {2.97, 0.0}, {3.96, 0.0}, {10.0, 0.0},
+                                   {20.0, 0.0}};
+
+  const VertexMerge merged = MergeVerts(verts, eps);
+
+  ASSERT_EQ(merged.inputVert2Merged.size(), verts.size());
+  ASSERT_EQ(merged.verts.size(), 3);
+  for (int i = 0; i < 5; ++i)
+    EXPECT_EQ(merged.inputVert2Merged[i], merged.inputVert2Merged[0]);
+  EXPECT_NE(merged.inputVert2Merged[5], merged.inputVert2Merged[0]);
+  EXPECT_NE(merged.inputVert2Merged[6], merged.inputVert2Merged[0]);
+
+  EXPECT_NEAR(merged.verts[0].x, 1.98, 1e-12);
+  EXPECT_NEAR(merged.verts[0].y, 0.0, 1e-12);
+  const vec2 endpointDrift = verts.front() - merged.verts[0];
+  EXPECT_GT(std::hypot(endpointDrift.x, endpointDrift.y), eps);
+}
+
+TEST(Boolean2, VertexMergeIdempotenceTightCluster) {
+  const std::vector<vec2> verts = {{-564.24299726366871, -1.},
+                                   {-564.25684749526681, -1.},
+                                   {-564.25684749526681, -1.},
+                                   {-564.25684749526681, 1.3146737456995536},
+                                   {-564.25684749526681, 3.334547678102286},
+                                   {-564.25684749526681, 924.18159456764056},
+                                   {-564.25684749526681, -5.0212043784034019},
+                                   {-564.2434248982521, -3.442978883496882},
+                                   {-564.25684749526681, -882.0023276178074},
+                                   {-564.25684749526681, -3.0103861859513601},
+                                   {-564.25684749526681, -218.03838880073647},
+                                   {-560.99098110791851, 1.1654515551817912},
+                                   {-564.24548426671515, -361.18598495388369},
+                                   {-564.25684749526681, -0.040195183151324976},
+                                   {-564.25684749526681, -229.62237726036881},
+                                   {-564.24797363468235, -3.4005396935541334},
+                                   {-564.25105014358735, -0.37374103257085878},
+                                   {-564.25684749526681, 3.993690857296496},
+                                   {-564.25684749526681, 1.1420137899457909},
+                                   {-564.2650553505373, 210.83410884574982},
+                                   {-564.25684749526681, -3.4038895533070526},
+                                   {-564.25684749526681, -4.3056143084054153},
+                                   {-564.25684749526681, -2.8446598710193314},
+                                   {-564.25684749526681, 0.90992952485448519},
+                                   {-564.25684749526681, -5.1663919232428848},
+                                   {-564.25684749526681, -502.42923749613101},
+                                   {-564.25684749526681, -2.3459351240317718},
+                                   {-564.2565950636108, 223.16662739130152},
+                                   {-564.25684749526681, 810.70082359638945},
+                                   {-564.25684749526681, -3.395314716558568},
+                                   {-564.25684749526681, 0.055697227037768471},
+                                   {-564.25684749526681, -1.6836095819963903}};
+  const double eps = std::pow(10.0, -2.0433270966230594);
+  const auto m1 = MergeVerts(verts, eps);
+  ASSERT_FALSE(m1.verts.empty());
+  const auto m2 = MergeVerts(m1.verts, eps);
+  EXPECT_EQ(m2.verts.size(), m1.verts.size())
+      << "MergeVerts not idempotent: pass1=" << m1.verts.size()
+      << " pass2=" << m2.verts.size() << " (n=" << verts.size()
+      << ", eps=" << eps << ")";
+}
+
+TEST(Boolean2, ValidatorRejectsRetainedVertsWithinEps) {
+  const std::vector<vec2> verts = {{0.0, 0.0}, {10.0, 0.0}, {0.0, 10.0},
+                                   {0.5, 0.5}, {20.0, 0.0}, {20.0, 10.0}};
+  const std::vector<EdgeM> edges = {{0, 1, 1}, {1, 2, 1}, {2, 0, 1},
+                                    {3, 4, 1}, {4, 5, 1}, {5, 3, 1}};
+  const OverlapResult result{verts, edges, {0, 1, 2, 3, 4, 5}, 6};
+
+  EXPECT_FALSE(CheckRetainedGraphValidity(
+      result, edges, result.inputVert2Merged, result.numMergedVerts, 1.0));
+}
+
+TEST(Boolean2, ValidatorRejectsNearEndpointTJunction) {
+  const std::vector<vec2> verts = {{0.0, 0.0},   {10.0, 0.0}, {0.5, 0.9},
+                                   {10.0, 10.0}, {20.0, 5.0}, {20.0, 15.0}};
+  const std::vector<EdgeM> edges = {{0, 1, 1}, {1, 3, 1}, {3, 0, 1},
+                                    {2, 4, 1}, {4, 5, 1}, {5, 2, 1}};
+  const OverlapResult result{verts, edges, {0, 1, 2, 3, 4, 5}, 6};
+
+  EXPECT_FALSE(CheckRetainedGraphValidity(
+      result, edges, result.inputVert2Merged, result.numMergedVerts, 1.0));
+}
+
+TEST(Boolean2, ValidatorRejectsRetainedStrictCrossing) {
+  const std::vector<vec2> verts = {{0.0, 0.0},  {10.0, 10.0}, {0.0, 10.0},
+                                   {10.0, 0.0}, {-10.0, 5.0}, {20.0, 5.0}};
+  const std::vector<EdgeM> edges = {{0, 1, 1}, {1, 4, 1}, {4, 0, 1},
+                                    {2, 3, 1}, {3, 5, 1}, {5, 2, 1}};
+  const OverlapResult result{verts, edges, {0, 1, 2, 3, 4, 5}, 6};
+
+  EXPECT_FALSE(CheckRetainedGraphValidity(
+      result, edges, result.inputVert2Merged, result.numMergedVerts, 0.01));
+}
+
+TEST(Boolean2, CleanupPassMatchesValidAddSinglePass) {
+  Polygons polys{RandomTopologicalRing(8, 15)};
+  const double eps = InferEps(polys, {});
+  const auto [verts, edges] = PolygonsToInput(polys);
+  const auto pass1 = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/0.0,
+                                      /*debug=*/false, WindRule::Add);
+  EXPECT_TRUE(CheckRetainedGraphValidity(pass1, edges, pass1.inputVert2Merged,
+                                         pass1.numMergedVerts, eps));
+
+  const auto pass2 = CleanupPassLikeIterate(pass1, eps);
+  const auto pass2Input = EdgesFromOverlapResult(pass1);
+  EXPECT_TRUE(CheckRetainedGraphValidity(
+      pass2, pass2Input, pass2.inputVert2Merged, pass2.numMergedVerts, eps));
+  ExpectSameFingerprint(pass1, pass2, eps);
+
+  const auto pass3 = CleanupPassLikeIterate(pass2, eps);
+  const auto pass3Input = EdgesFromOverlapResult(pass2);
+  EXPECT_TRUE(CheckRetainedGraphValidity(
+      pass3, pass3Input, pass3.inputVert2Merged, pass3.numMergedVerts, eps));
+  ExpectSameFingerprint(pass2, pass3, eps);
+
+  const auto pass1Polys = OutEdgesToPolygons(pass1.verts, pass1.edges);
+  const auto pass2Polys = OutEdgesToPolygons(pass2.verts, pass2.edges);
+  ASSERT_EQ(pass1Polys.size(), 2);
+  ASSERT_EQ(pass2Polys.size(), 2);
+  EXPECT_EQ(pass1Polys[0].size(), pass2Polys[0].size());
+  EXPECT_EQ(pass1Polys[1].size(), pass2Polys[1].size());
+  EXPECT_NEAR(TotalSignedArea(pass1Polys), TotalSignedArea(pass2Polys), 1e-12);
+}
+
+TEST(Boolean2, OffsetRoundUsesRequestedSegments) {
+  SimplePolygon square = {{0, 0}, {20, 0}, {20, 20}, {0, 20}};
+  const int segments = 20;
+  const double delta = 5.0;
+
+  Polygons rounded = Offset({square}, delta, JoinType::Round, 2.0, segments);
+
+  ASSERT_EQ(rounded.size(), 1);
+  EXPECT_EQ(rounded[0].size(), segments + 4);
+}
+
+TEST(Boolean2, OffsetRoundClampsHugeSegmentCount) {
+  // An absurd requested count is clamped so the vertex count cannot blow up;
+  // the clamp is kMaxRoundJoinSegments == 1 << 15 (file-local in offset.cpp).
+  SimplePolygon square = {{0, 0}, {20, 0}, {20, 20}, {0, 20}};
+  Polygons rounded = Offset({square}, 5.0, JoinType::Round, 2.0, 1 << 20);
+  ASSERT_EQ(rounded.size(), 1);
+  EXPECT_EQ(rounded[0].size(), (1 << 15) + 4);
+}
+
+TEST(Boolean2, OffsetZeroDeltaRejectsNonFiniteInput) {
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  SimplePolygon bad = {{0.0, 0.0}, {1.0, 0.0}, {nan, 1.0}, {0.0, 1.0}};
+
+  EXPECT_TRUE(Offset({bad}, 0.0, JoinType::Miter).empty());
+}
+
+TEST(Boolean2, OffsetExtremeFiniteEdgesStayFinite) {
+  // Large-but-finite coordinates must not yield inf/nan. Collinearity uses the
+  // canonical CCW predicate, whose area products saturate above ~1e77, so the
+  // exercised scale stays under that (still far beyond any real input).
+  const double s = 1e70;
+  const double delta = 1e60;
+  SimplePolygon square = {{0, 0}, {s, 0}, {s, s}, {0, s}};
+
+  Polygons out = Offset({square}, delta, JoinType::Bevel);
+
+  ASSERT_FALSE(out.empty());
+  for (const SimplePolygon& ring : out) {
+    for (const vec2& v : ring) {
+      EXPECT_TRUE(std::isfinite(v.x));
+      EXPECT_TRUE(std::isfinite(v.y));
+    }
+  }
+}
+
+TEST(Boolean2, OffsetSquareJoinKeepsCapOnSharpSpike) {
+  // A near-degenerate spike (base 100, height 1e-9) survives regularization but
+  // drives the square-join half-angle to ~90 degrees, where cosHalf can round
+  // below 0. The caps must still be emitted (area ~204, two ~unit caps) rather
+  // than silently dropped (which previously shrank the area toward ~200).
+  SimplePolygon spike = {{0, 0}, {100, 0}, {50, 1e-9}};
+
+  Polygons out = Offset({spike}, 1.0, JoinType::Square);
+
+  ASSERT_FALSE(out.empty());
+  double area = 0;
+  for (const SimplePolygon& ring : out) area += SignedArea(ring);
+  EXPECT_GT(area, 203.0);
+  EXPECT_LT(area, 206.0);
+}
+
+TEST(Boolean2, DecomposeContainmentBboxUsesTolerance) {
+  const double eps = EpsilonFromScale(0.5);
+  const double d = 0.25 * eps;
+  SimplePolygon outer = {{0, 0}, {1, 0}, {1, 1}, {0, 1}};
+  SimplePolygon hole = {
+      {1 + d, 0.25}, {0.25, 0.25}, {0.25, 0.75}, {1 + d, 0.75}};
+
+  std::vector<Polygons> components = DecomposeByContainment({outer, hole});
+
+  ASSERT_EQ(components.size(), 1);
+  ASSERT_EQ(components[0].size(), 2);
+}
+
+TEST(Boolean2, DecomposeContainmentDropsDegenerateRings) {
+  SimplePolygon outer = {{0, 0}, {1, 0}, {1, 1}, {0, 1}};
+  SimplePolygon line = {{0.25, 0.25}, {0.75, 0.75}};
+
+  std::vector<Polygons> components = DecomposeByContainment({outer, {}, line});
+
+  ASSERT_EQ(components.size(), 1);
+  ASSERT_EQ(components[0].size(), 1);
+  EXPECT_EQ(components[0][0].size(), outer.size());
+}
+
+TEST(Boolean2, OffsetSquareInsetCapStaysOnSolidSide) {
+  // L-shape: 2x2 square minus the top-right [1,2]x[1,2] quadrant (CCW). The
+  // reflex corner at (1,1) routes through the square join when inset.
+  SimplePolygon L = {{0, 0}, {2, 0}, {2, 1}, {1, 1}, {1, 2}, {0, 2}};
+
+  Polygons out = Offset({L}, -0.25, JoinType::Square);
+
+  // Load-bearing: the square cap belongs on the inset (solid) side, never in
+  // the removed notch (1,2)x(1,2). The wrong-side bug puts cap vertices at
+  // ~(1.25,1.10)/(1.10,1.25), strictly inside the notch.
+  for (const SimplePolygon& ring : out) {
+    for (const vec2& v : ring) {
+      const bool inNotch = v.x > 1.0 && v.x < 2.0 && v.y > 1.0 && v.y < 2.0;
+      EXPECT_FALSE(inNotch) << "cap vertex (" << v.x << ", " << v.y
+                            << ") is in the removed notch";
+    }
+  }
+  // Secondary (coarse): the wrong-side cap inflates the area (~1.40 buggy vs
+  // ~1.26 correct). Upper bound discriminates the two; not an equality.
+  EXPECT_LT(std::fabs(TotalSignedArea(out)), 1.35);
+
+  // Dilate is unchanged by the fix (delta == absDelta); guard it stays sane.
+  Polygons grown = Offset({L}, 0.25, JoinType::Square);
+  EXPECT_GT(std::fabs(TotalSignedArea(grown)), 3.0);
+}
+
+TEST(Boolean2, OffsetLargeMiterLimitStaysBounded) {
+  // Thin spike: apex (0,1e6) with near-antiparallel edge normals (1+dotN ~ 1
+  // ULP), so the apex miter is near-unbounded. A huge miter_limit must not let
+  // MiterPoint escape; the square fallback must engage.
+  SimplePolygon spike = {{-0.01291544, 0}, {0.01291544, 0}, {0, 1e6}};
+
+  Polygons out = Offset({spike}, 1.0, JoinType::Miter, 1e10);
+
+  double maxCoord = 0;
+  for (const SimplePolygon& ring : out)
+    for (const vec2& v : ring)
+      maxCoord = std::max(maxCoord, std::max(std::fabs(v.x), std::fabs(v.y)));
+  // Apex sits at y=1e6; a capped corner stays near that scale. The unclamped
+  // miter escapes to ~6e7.
+  EXPECT_LT(maxCoord, 1.0e7) << "miter escaped to " << maxCoord;
+
+  bool leftCap = false;
+  bool rightCap = false;
+  for (const SimplePolygon& ring : out) {
+    for (const vec2& v : ring) {
+      if (v.y > 9.9e5 && v.y < 1.01e6) {
+        leftCap |= v.x < -0.5;
+        rightCap |= v.x > 0.5;
+      }
+    }
+  }
+  EXPECT_TRUE(leftCap);
+  EXPECT_TRUE(rightCap);
+}
+
+TEST(Boolean2, OffsetReversalSpikeKeepsFarCap) {
+  // A near-zero-width spike whose tip edges are antiparallel triggers the
+  // collinear-reversal branch; the offset must still cap the far side rather
+  // than collapse the tip to a single point.
+  SimplePolygon spike = {
+      {-100, -100}, {100, -100}, {100, -1}, {1100, -1}, {100, -1 + 5.63085e-10},
+      {100, 100},   {-100, 100}};
+  Polygons out = Offset({spike}, 5.0, JoinType::Miter);
+  // The tip's far offset endpoint is ~(1100, 4); only the near side (1100,-6)
+  // survives if the reversal cap is dropped.
+  bool farCap = false;
+  for (const SimplePolygon& ring : out)
+    for (const vec2& v : ring)
+      if (v.x > 1090.0 && v.y > 0.0) farCap = true;
+  EXPECT_TRUE(farCap) << "far side of the reversal spike was dropped";
+}
+
+TEST(Boolean2, DecomposeContainmentDropsZeroAreaRing) {
+  SimplePolygon outer = {{0, 0}, {10, 0}, {10, 10}, {0, 10}};
+  SimplePolygon collinear = {{1, 1}, {2, 1}, {3, 1}};  // zero area, size 3
+  auto comps = DecomposeByContainment({outer, collinear});
+  ASSERT_EQ(comps.size(), 1);
+  EXPECT_EQ(comps[0].size(), 1);  // sliver dropped, not leaked as a hole
+}
+
+TEST(Boolean2, DecomposeContainmentKeepsFiniteThinHole) {
+  SimplePolygon outer = {{0, 0}, {10, 0}, {10, 10}, {0, 10}};
+  SimplePolygon thinHole = {{1, 1}, {1, 1.000001}, {9, 1.000001}, {9, 1}};
+
+  auto comps = DecomposeByContainment({outer, thinHole});
+
+  ASSERT_EQ(comps.size(), 1);
+  ASSERT_EQ(comps[0].size(), 2);
+  EXPECT_NEAR(TotalSignedArea(comps[0]), 100.0 - 8e-6, 1e-12);
+}
+
+TEST(Boolean2, DecomposeContainmentKeepsNestedPositiveRing) {
+  SimplePolygon A = {{0, 0}, {10, 0}, {10, 10}, {0, 10}};  // +100
+  SimplePolygon B = {{3, 3}, {7, 3}, {7, 7}, {3, 7}};      // +16, inside A
+  SimplePolygon H = {{4, 4}, {4, 6}, {6, 6}, {6, 4}};      // -4, inside B
+  auto comps = DecomposeByContainment({A, B, H});
+  double retained = 0;
+  for (const auto& c : comps) retained += TotalSignedArea(c);
+  // No silent area loss: the nested positive ring and its hole are kept.
+  EXPECT_NEAR(retained, 112.0, 1e-9);
+}
+
+TEST(Boolean2, DecomposeContainmentToleranceIsSizeScaledOffOrigin) {
+  // Off-origin rings: the containment epsilon must scale with the bbox SIZE,
+  // not the coordinate magnitude. A hole sticking out by 1e-10 (above the
+  // size-scaled eps, below a position-scaled one) is not contained, so it is
+  // dropped. A position-based scale would inflate eps and wrongly attach it.
+  const double k = 1000.0;
+  const double d = 1e-10;
+  SimplePolygon outer = {{k, k}, {k + 1, k}, {k + 1, k + 1}, {k, k + 1}};
+  SimplePolygon hole = {{k + 1 + d, k + 0.25},
+                        {k + 0.25, k + 0.25},
+                        {k + 0.25, k + 0.75},
+                        {k + 1 + d, k + 0.75}};
+  auto comps = DecomposeByContainment({outer, hole});
+  ASSERT_EQ(comps.size(), 1);
+  EXPECT_EQ(comps[0].size(), 1);  // hole sticks out past the size-scaled eps
+}
+
+// Output topology balance check fails after Add on raw
+// multi-contour, near-duplicate-heavy polygons.
+TEST(Boolean2, BooleanRobustnessMergeTopologyBalance) {
+  const Polygons a = {{{1024., 1024.},
+                       {1., 1.},
+                       {9.9999999999999995e-07, -9.9999999999999995e-07}}};
+  const Polygons b = {{{0., 1.},
+                       {9.9999999999999995e-07, 1024.},
+                       {-1., -1024.},
+                       {-0., 1024.},
+                       {1., -1.}},
+                      {{1., 1.},
+                       {-9.9999999999999995e-07, -0.},
+                       {1., 1024.},
+                       {9.9999999999999995e-07, 0.}},
+                      {{-111.03407576117854, 0.},
+                       {560.59976308273758, 2.9313131393310714},
+                       {-1024., 1.},
+                       {89.678187020143696, 0.},
+                       {1024., 1.}},
+                      {{0., 0.},
+                       {3.2408667776584608, 1024.},
+                       {-1000., 9.9999999999999995e-07},
+                       {1024., -1.},
+                       {-1., -0.}}};
+  const auto [verts, edges] = CombinedInput(a, b, /*bMult=*/1);
+  ASSERT_FALSE(verts.empty());
+  const double eps = InferEps(a, b);
+  const auto overlap = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/0.0,
+                                        /*debug=*/false, WindRule::Add);
+  EXPECT_TRUE(CheckRetainedGraphValidity(
+      overlap, edges, overlap.inputVert2Merged, overlap.numMergedVerts, eps));
+}
+
+// Direct-cast disconnected-component winding fallback emitted an
+// open spur after Add.
+TEST(Boolean2, BooleanRobustnessDirectCastKeepsExpectedArea) {
+  const Polygons a = {{{-9.9999999999999995e-07, 9.9999999999999995e-07},
+                       {-9.9999999999999995e-07, -9.9999999999999995e-07},
+                       {-0., 0.},
+                       {1., 1024.}},
+                      {{1024., 1024.},
+                       {1., 1.},
+                       {9.9999999999999995e-07, -9.9999999999999995e-07}}};
+  const Polygons b = {{{0., 1.},
+                       {9.9999999999999995e-07, 1024.},
+                       {-1., -1024.},
+                       {-0., 1024.},
+                       {1., -1.}},
+                      {{1., 1.},
+                       {-9.9999999999999995e-07, -0.},
+                       {1., 1024.},
+                       {9.9999999999999995e-07, 0.}},
+                      {{-111.03407576117854, 0.},
+                       {560.59976308273758, 2.9313131393310714},
+                       {-1024., 1.},
+                       {89.678187020143696, 0.},
+                       {1024., 1.}}};
+  const auto [verts, edges] = CombinedInput(a, b, /*bMult=*/1);
+  ASSERT_FALSE(verts.empty());
+  const double eps = InferEps(a, b);
+  const auto overlap = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/0.0,
+                                        /*debug=*/false, WindRule::Add);
+  EXPECT_TRUE(CheckRetainedGraphValidity(
+      overlap, edges, overlap.inputVert2Merged, overlap.numMergedVerts, eps));
+
+  const auto polys = OutEdgesToPolygons(overlap.verts, overlap.edges);
+  // Exact contour count and full-precision area were brittle on this
+  // un-minimized seed. The open spur this guards manifests as a degenerate
+  // ring, so assert no ring is degenerate directly (a zero-area spur would
+  // slip past an area-only check); the coarser area tolerance still catches
+  // real area loss.
+  EXPECT_FALSE(polys.empty());
+  for (const auto& ring : polys)
+    EXPECT_GE(ring.size(), 3u) << "degenerate ring / open spur";
+  EXPECT_NEAR(TotalSignedArea(polys), 1678.2538553263785,
+              1e-6 * (1.0 + 1678.2538553263785));
+}
+
+// Regression: a single closed directed ring must round-trip through
+// OutEdgesToPolygons. Earlier closure logic detected closure by trying to
+// re-select the start edge as `next`, which is skipped by the visited guard;
+// the natural walk terminates with destV == startV instead.
+TEST(Boolean2, OutEdgesToPolygonsClosesSimpleRing) {
+  const std::vector<vec2> verts = {{0, 0}, {1, 0}, {1, 1}, {0, 1}};
+  const std::vector<OutEdge> edges = {{0, 1}, {1, 2}, {2, 3}, {3, 0}};
+  const auto polys = OutEdgesToPolygons(verts, edges);
+  ASSERT_EQ(polys.size(), 1u);
+  EXPECT_EQ(polys[0].size(), 4u);
+}
+
+TEST(Boolean2, OutEdgesToPolygonsSplitsExactRepeatedVertex) {
+  const std::vector<vec2> verts = {{0, 0}, {1, 0}, {1, -1}, {2, -1}, {1, 1}};
+  const std::vector<OutEdge> edges = {{0, 1}, {1, 2}, {2, 3},
+                                      {3, 1}, {1, 4}, {4, 0}};
+  const auto polys = OutEdgesToPolygons(verts, edges);
+  ASSERT_EQ(polys.size(), 2u);
+  EXPECT_EQ(polys[0].size(), 3u);
+  EXPECT_EQ(polys[1].size(), 3u);
+  EXPECT_NEAR(TotalSignedArea(polys), 1.0, 1e-12);
+}
+
+TEST(Boolean2, OutEdgesToPolygonsKeepsNearDistinctVertex) {
+  constexpr double kDelta = 1e-12;
+  const std::vector<vec2> verts = {{0, 0},  {1, 0}, {1, -1},
+                                   {2, -1}, {1, 1}, {1 + kDelta, 0}};
+  const std::vector<OutEdge> edges = {{0, 1}, {1, 2}, {2, 3},
+                                      {3, 5}, {5, 4}, {4, 0}};
+  const auto polys = OutEdgesToPolygons(verts, edges);
+  ASSERT_EQ(polys.size(), 1u);
+  EXPECT_EQ(polys[0].size(), 6u);
+  EXPECT_NEAR(TotalSignedArea(polys), 1.0 + kDelta, 1e-12);
+
+  const CrossSection reconsumed(polys, CrossSection::FillRule::Positive);
+  EXPECT_FALSE(reconsumed.IsEmpty());
+  EXPECT_NEAR(reconsumed.Area(), 1.0, 1e-9);
+  const Manifold solid = Manifold::Extrude(reconsumed.ToPolygons(), 1.0);
+  EXPECT_EQ(solid.Status(), Manifold::Error::NoError);
+  EXPECT_NEAR(solid.Volume(), reconsumed.Area(), 1e-9);
+}
+
+TEST(Boolean2, KeepsNearDistinctPresentationVertex) {
+  constexpr double kDelta = 1e-12;
+  const Polygons input = {
+      {{0, 0}, {1, 0}, {1, -1}, {2, -1}, {1 + kDelta, 0}, {1, 1}}};
+  const auto polys = Boolean2D(input, {}, OpType::Add, /*eps=*/1e-15,
+                               /*tolerance=*/1e-9);
+  ASSERT_EQ(polys.size(), 1u);
+  EXPECT_EQ(polys[0].size(), 6u);
+  EXPECT_NEAR(TotalSignedArea(polys), 1.0 + kDelta, 1e-12);
+}
+
+TEST(Boolean2, NewOldToleranceMergesGeneratedNearEndpoint) {
+  constexpr double eps = 1e-6;
+  constexpr double tolerance = 1e-3;
+  const Polygons a = {{{0, 0}, {10, 0}, {10, 1}, {0, 1}}};
+  const Polygons b = {{{5e-4, -0.5}, {0.5, -0.5}, {0.5, 0.5}, {5e-4, 0.5}}};
+  const auto [verts, edges] = CombinedInput(a, b, /*bMult=*/1);
+
+  const auto withoutPrior =
+      RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/eps,
+                       /*debug=*/false, WindRule::Add);
+  const auto withPrior = RemoveOverlaps2D(verts, edges, eps, tolerance,
+                                          /*debug=*/false, WindRule::Add);
+
+  auto countNear = [](const std::vector<vec2>& points, vec2 target,
+                      double radius) {
+    int count = 0;
+    const double radius2 = radius * radius;
+    for (const vec2& p : points) {
+      const vec2 d = p - target;
+      if (dot(d, d) <= radius2) ++count;
+    }
+    return count;
+  };
+
+  const vec2 generatedNearOld{5e-4, 0.0};
+  EXPECT_GT(countNear(withoutPrior.verts, generatedNearOld, 10 * eps), 0)
+      << "baseline should retain the generated crossing as distinct";
+  EXPECT_EQ(countNear(withPrior.verts, generatedNearOld, 10 * eps), 0)
+      << "propagated tolerance should merge the generated crossing into the "
+         "nearby old endpoint";
+  EXPECT_EQ(withPrior.verts.size() + 1, withoutPrior.verts.size());
+  EXPECT_TRUE(CheckRetainedGraphValidity(withPrior, edges,
+                                         withPrior.inputVert2Merged,
+                                         withPrior.numMergedVerts, eps));
+}
+
+TEST(Boolean2, RemoveOverlapsMergesExactDuplicateCoordinates) {
+  const Polygons polys = {{{0, 0}, {1, 0}, {0, 1}}, {{0, 0}, {-1, 0}, {0, -1}}};
+  const auto [verts, edges] = PolygonsToInput(polys);
+  ASSERT_EQ(verts.size(), 6u);
+  const double eps = InferEps(polys, {});
+  const auto overlap = RemoveOverlaps2D(verts, edges, eps, /*tolerance=*/0.0,
+                                        /*debug=*/false, WindRule::Add);
+  ASSERT_EQ(overlap.inputVert2Merged.size(), verts.size());
+  ASSERT_GE(overlap.inputVert2Merged[0], 0);
+  ASSERT_LT(overlap.inputVert2Merged[0], overlap.numMergedVerts);
+  ASSERT_GE(overlap.inputVert2Merged[3], 0);
+  ASSERT_LT(overlap.inputVert2Merged[3], overlap.numMergedVerts);
+  EXPECT_EQ(overlap.inputVert2Merged[0], overlap.inputVert2Merged[3]);
+}
+
+TEST(Boolean2, GraphOrderDetectsProperCrossing) {
+  GraphSegment2D a{{0.0, 0.0}, {10.0, 10.0}, 0};
+  GraphSegment2D b{{0.0, 10.0}, {10.0, 0.0}, 1};
+
+  const auto order = CompareProjectedOrder(a, b, /*axis=*/0, 0.0, 10.0);
+  EXPECT_EQ(order.atMinProjection, GraphOrderKind::ALessOrtho);
+  EXPECT_EQ(order.atMaxProjection, GraphOrderKind::AGreaterOrtho);
+  EXPECT_FALSE(order.coincidentOverlap);
+  EXPECT_TRUE(order.properCrossing);
+}
+
+TEST(Boolean2, GraphOrderIsEndpointReversalStable) {
+  GraphSegment2D a{{0.0, 0.0}, {10.0, 10.0}, 0};
+  GraphSegment2D b{{0.0, 10.0}, {10.0, 0.0}, 1};
+  GraphSegment2D aReversed{{10.0, 10.0}, {0.0, 0.0}, 0};
+  GraphSegment2D bReversed{{10.0, 0.0}, {0.0, 10.0}, 1};
+
+  const auto order = CompareProjectedOrder(a, b, /*axis=*/0, 0.0, 10.0);
+  const auto reversed =
+      CompareProjectedOrder(aReversed, bReversed, /*axis=*/0, 0.0, 10.0);
+  EXPECT_EQ(order.atMinProjection, reversed.atMinProjection);
+  EXPECT_EQ(order.atMaxProjection, reversed.atMaxProjection);
+  EXPECT_EQ(order.coincidentOverlap, reversed.coincidentOverlap);
+  EXPECT_EQ(order.properCrossing, reversed.properCrossing);
+  EXPECT_EQ(order.atMinProjection, GraphOrderKind::ALessOrtho);
+  EXPECT_EQ(order.atMaxProjection, GraphOrderKind::AGreaterOrtho);
+
+  const auto aOnlyReversed =
+      CompareProjectedOrder(aReversed, b, /*axis=*/0, 0.0, 10.0);
+  const auto bOnlyReversed =
+      CompareProjectedOrder(a, bReversed, /*axis=*/0, 0.0, 10.0);
+  EXPECT_EQ(order.atMinProjection, aOnlyReversed.atMinProjection);
+  EXPECT_EQ(order.atMaxProjection, aOnlyReversed.atMaxProjection);
+  EXPECT_EQ(order.properCrossing, aOnlyReversed.properCrossing);
+  EXPECT_EQ(order.atMinProjection, bOnlyReversed.atMinProjection);
+  EXPECT_EQ(order.atMaxProjection, bOnlyReversed.atMaxProjection);
+  EXPECT_EQ(order.properCrossing, bOnlyReversed.properCrossing);
+}
+
+TEST(Boolean2, GraphOrderSupportsYAxisProjection) {
+  GraphSegment2D a{{0.0, 0.0}, {10.0, 10.0}, 0};
+  GraphSegment2D b{{10.0, 0.0}, {0.0, 10.0}, 1};
+
+  const auto order = CompareProjectedOrder(a, b, /*axis=*/1, 0.0, 10.0);
+  EXPECT_EQ(order.atMinProjection, GraphOrderKind::ALessOrtho);
+  EXPECT_EQ(order.atMaxProjection, GraphOrderKind::AGreaterOrtho);
+  EXPECT_TRUE(order.properCrossing);
+}
+
+TEST(Boolean2, GraphOrderResolvesCoincidentOverlap) {
+  GraphSegment2D a{{0.0, 0.0}, {10.0, 0.0}, 0};
+  GraphSegment2D b{{0.0, 0.0}, {10.0, 0.0}, 1};
+
+  const auto order = CompareProjectedOrder(a, b, /*axis=*/0, 0.0, 10.0);
+  EXPECT_EQ(order.atMinProjection, GraphOrderKind::ALessOrtho);
+  EXPECT_EQ(order.atMaxProjection, GraphOrderKind::ALessOrtho);
+  EXPECT_TRUE(order.coincidentOverlap);
+  EXPECT_FALSE(order.properCrossing);
+
+  const auto swapped = CompareProjectedOrder(b, a, /*axis=*/0, 0.0, 10.0);
+  EXPECT_EQ(swapped.atMinProjection, GraphOrderKind::AGreaterOrtho);
+  EXPECT_EQ(swapped.atMaxProjection, GraphOrderKind::AGreaterOrtho);
+  EXPECT_TRUE(swapped.coincidentOverlap);
+  EXPECT_FALSE(swapped.properCrossing);
+}
+
+TEST(Boolean2, GraphOrderCanonicalGeometryTieBeforeEdgeId) {
+  GraphSegment2D lower{{0.0, 0.0}, {10.0, 0.0}, 100};
+  GraphSegment2D upper{{0.0, 0.5}, {10.0, 0.5}, 1};
+
+  const auto order =
+      CompareProjectedOrder(lower, upper, /*axis=*/0, 0.0, 10.0, 1.0);
+  EXPECT_TRUE(order.coincidentOverlap);
+  EXPECT_EQ(order.atMinProjection, GraphOrderKind::ALessOrtho);
+  EXPECT_EQ(order.atMaxProjection, GraphOrderKind::ALessOrtho);
+  EXPECT_FALSE(order.properCrossing);
+
+  const auto swapped =
+      CompareProjectedOrder(upper, lower, /*axis=*/0, 0.0, 10.0, 1.0);
+  EXPECT_TRUE(swapped.coincidentOverlap);
+  EXPECT_EQ(swapped.atMinProjection, GraphOrderKind::AGreaterOrtho);
+  EXPECT_EQ(swapped.atMaxProjection, GraphOrderKind::AGreaterOrtho);
+  EXPECT_FALSE(swapped.properCrossing);
+}
+
+TEST(Boolean2, GraphOrderKeepsEndpointTouchDegenerate) {
+  GraphSegment2D a{{0.0, 0.0}, {10.0, 0.0}, 0};
+  GraphSegment2D b{{5.0, 0.0}, {15.0, 1.0}, 1};
+
+  const auto order = CompareProjectedOrder(a, b, /*axis=*/0, 5.0, 10.0);
+  EXPECT_EQ(order.atMinProjection, GraphOrderKind::EndpointTouch);
+  EXPECT_EQ(order.atMaxProjection, GraphOrderKind::ALessOrtho);
+  EXPECT_FALSE(order.coincidentOverlap);
+  EXPECT_FALSE(order.properCrossing);
+}
+
+// Consolidated Boolean2 IntersectSegments predicate cases, one row per case.
+// Each row carries the two segments, eps, expected crossing, and (when it
+// crosses) the expected point verbatim. atTol is that case's point tolerance:
+// 1e-12 for the fixed-geometry cases, and the scale-derived eps for the
+// shallow long-edge case (whose crossing is only resolved to within eps).
+// IntersectSegments is a boolean2-internal predicate.
+namespace {
+struct SegCase {
+  const char* name;
+  GraphSegment2D a, b;
+  double eps;
+  bool crosses;
+  vec2 at;       // expected intersection point, unused when !crosses
+  double atTol;  // point tolerance, unused when !crosses
+};
+
+const SegCase kIntersectSegmentsSeeds[] = {
+    {"FindsStrictCrossing",
+     {{0.0, 0.0}, {10.0, 10.0}, 0},
+     {{0.0, 10.0}, {10.0, 0.0}, 1},
+     0.0,
+     true,
+     {5.0, 5.0},
+     1e-12},
+    {"KeepsOneSidedEpsBandCrossing",
+     {{0.0, 0.0}, {10.0, 0.0}, 0},
+     {{0.0, -0.5}, {10.0, 2.0}, 1},
+     1.0,
+     true,
+     {2.0, 0.0},
+     1e-12},
+    {"KeepsTwoSidedEpsBandCrossing",
+     {{0.0, 0.0}, {10.0, 0.0}, 0},
+     {{0.0, -0.75}, {10.0, 0.75}, 1},
+     1.0,
+     true,
+     {5.0, 0.0},
+     1e-12},
+    {"KeepsUnderflowingSignChange",
+     {{0.0, 0.0}, {10.0, 0.0}, 0},
+     {{0.0, -1e-200}, {10.0, 1e-200}, 1},
+     1.0,
+     true,
+     {5.0, 0.0},
+     1e-12},
+    {"DropsEpsNearEndpointCrossing",
+     {{0.0, 0.0}, {10.0, 0.0}, 0},
+     {{0.5, -1.0}, {0.5, 1.0}, 1},
+     1.0,
+     false,
+     {},
+     0.0},
+    {"KeepsSteepInteriorCrossing",
+     {{0.0, 0.0}, {0.0015, 1000.0}, 0},
+     {{-1.0, 500.0}, {1.0, 500.0}, 1},
+     0.001,
+     true,
+     {0.00075, 500.0},
+     1e-12},
+    {"DropsEndpointTouch",
+     {{0.0, 0.0}, {10.0, 0.0}, 0},
+     {{10.0, 0.0}, {20.0, 10.0}, 1},
+     0.0,
+     false,
+     {},
+     0.0},
+    {"DropsPositiveOverlapTJunction",
+     {{0.0, 0.0}, {10.0, 0.0}, 0},
+     {{5.0, 0.0}, {15.0, 1.0}, 1},
+     0.0,
+     false,
+     {},
+     0.0},
+    {"FindsAxisAlignedStrictCrossing",
+     {{0.0, 5.0}, {10.0, 5.0}, 0},
+     {{5.0, 0.0}, {5.0, 10.0}, 1},
+     0.0,
+     true,
+     {5.0, 5.0},
+     1e-12},
+    {"DropsAxisAlignedEndpointTouch",
+     {{0.0, 0.0}, {10.0, 0.0}, 0},
+     {{10.0, 0.0}, {10.0, 10.0}, 1},
+     0.0,
+     false,
+     {},
+     0.0},
+    {"DropsCoincidentOverlap",
+     {{0.0, 0.0}, {10.0, 0.0}, 0},
+     {{2.0, 0.0}, {8.0, 0.0}, 1},
+     0.0,
+     false,
+     {},
+     0.0},
+    // Formerly standalone, near the merge-verts tests. The shallow long edge
+    // crosses the short edge at the origin but only to within the scale eps,
+    // so its point tolerance is eps, not 1e-12.
+    {"ShallowLongEdgeIntersectionIsNotDropped",
+     {{-0.5, 0.0}, {0.5, 0.0}, 0},
+     {{-1e9, 0.01}, {1e9, -0.01}, 1},
+     EpsilonFromScale(1e9),
+     true,
+     {0.0, 0.0},
+     EpsilonFromScale(1e9)},
+    {"NearEndpointIntersectionOutsideSegmentIsDropped",
+     {{0.0, 0.0}, {10.0, 0.0}, 0},
+     {{8.0, 0.4}, {18.0, 1.4}, 1},
+     1.0,
+     false,
+     {},
+     0.0},
+    {"EndpointTJunctionIntersectionIsDropped",
+     {{0.0, 0.0}, {10.0, 0.0}, 0},
+     {{5.0, 0.0}, {5.0, 0.1}, 1},
+     1.0,
+     false,
+     {},
+     0.0},
+};
+}  // namespace
+
+TEST(Boolean2, IntersectSegmentsSeeds) {
+  for (const auto& c : kIntersectSegmentsSeeds) {
+    SCOPED_TRACE(c.name);
+    std::cerr << "[seed] " << c.name << std::endl;
+    vec2 out;
+    EXPECT_EQ(IntersectSegments(c.a, c.b, c.eps, &out), c.crosses);
+    if (c.crosses) {
+      EXPECT_NEAR(out.x, c.at.x, c.atTol);
+      EXPECT_NEAR(out.y, c.at.y, c.atTol);
+    }
+  }
+}

--- a/test/boolean2_test.cpp
+++ b/test/boolean2_test.cpp
@@ -78,7 +78,10 @@ std::map<int, int> ComputeBalance(const std::vector<Edge>& edges) {
 // output, deliberately not reusing the engine's IntersectSegments (that
 // would be circular) or the house CCW (whose zero band normalizes by the
 // longer edge from p0, not by perpendicular distance). Each uses an exact
-// distance-from-line band: |cross(d, p - a)| <= eps * |d|.
+// distance-from-line band: |cross(d, p - a)| <= eps * |d|. They run only on
+// retained engine output, where the validator has already rejected eps-zero
+// edges, so |b - a| > eps holds and the band is well-defined - this is not a
+// general collinearity test for sub-eps segments.
 bool ValidVertId(int v, const std::vector<vec2>& verts) {
   return 0 <= v && v < static_cast<int>(verts.size());
 }

--- a/test/boolean2_test.cpp
+++ b/test/boolean2_test.cpp
@@ -87,7 +87,7 @@ bool PointsCollinearWithinEps(vec2 a, vec2 b, vec2 p, double eps) {
   const vec2 d = b - a;
   const double len2 = dot(d, d);
   if (len2 == 0.0) return false;
-  return std::fabs(la::cross(d, p - a)) <= eps * std::sqrt(len2);
+  return std::fabs(la::cross(d, p - a)) <= eps * la::length(d);
 }
 
 bool SegmentsHavePositiveCollinearOverlap(vec2 a0, vec2 a1, vec2 b0, vec2 b1,
@@ -96,7 +96,8 @@ bool SegmentsHavePositiveCollinearOverlap(vec2 a0, vec2 a1, vec2 b0, vec2 b1,
       !PointsCollinearWithinEps(a0, a1, b1, eps)) {
     return false;
   }
-  const int axis = std::fabs(a1.x - a0.x) >= std::fabs(a1.y - a0.y) ? 0 : 1;
+  const vec2 spread = la::abs(a1 - a0);
+  const int axis = spread.x >= spread.y ? 0 : 1;
   const double aMin = std::min(Coord(a0, axis), Coord(a1, axis));
   const double aMax = std::max(Coord(a0, axis), Coord(a1, axis));
   const double bMin = std::min(Coord(b0, axis), Coord(b1, axis));
@@ -106,7 +107,7 @@ bool SegmentsHavePositiveCollinearOverlap(vec2 a0, vec2 a1, vec2 b0, vec2 b1,
 
 int StrictSide(vec2 a, vec2 b, vec2 p, double eps) {
   const vec2 d = b - a;
-  const double threshold = eps * std::sqrt(dot(d, d));
+  const double threshold = eps * la::length(d);
   const double area = la::cross(d, p - a);
   return (area > threshold) - (area < -threshold);
 }
@@ -126,7 +127,7 @@ bool PointInSegmentInteriorBand(vec2 p, vec2 a, vec2 b, double eps) {
   if (len2 == 0.0) return false;
   const double along = dot(p - a, d);
   if (along <= 0.0 || along >= len2) return false;
-  return std::fabs(la::cross(d, p - a)) <= eps * std::sqrt(len2);
+  return std::fabs(la::cross(d, p - a)) <= eps * la::length(d);
 }
 
 // Independent oracle for the arrangement RemoveOverlaps2D retains - its
@@ -142,8 +143,7 @@ bool PointInSegmentInteriorBand(vec2 p, vec2 a, vec2 b, double eps) {
   };
 
   for (int v = 0; v < static_cast<int>(result.verts.size()); ++v) {
-    if (!std::isfinite(result.verts[v].x) ||
-        !std::isfinite(result.verts[v].y)) {
+    if (!la::all(la::isfinite(result.verts[v]))) {
       std::ostringstream out;
       out << "non-finite retained vertex " << v << " = (" << result.verts[v].x
           << ", " << result.verts[v].y << ")";
@@ -590,8 +590,7 @@ TEST(Boolean2, OffsetExtremeFiniteEdgesStayFinite) {
   ASSERT_FALSE(out.empty());
   for (const SimplePolygon& ring : out) {
     for (const vec2& v : ring) {
-      EXPECT_TRUE(std::isfinite(v.x));
-      EXPECT_TRUE(std::isfinite(v.y));
+      EXPECT_TRUE(la::all(la::isfinite(v)));
     }
   }
 }
@@ -673,7 +672,7 @@ TEST(Boolean2, OffsetLargeMiterLimitStaysBounded) {
   double maxCoord = 0;
   for (const SimplePolygon& ring : out)
     for (const vec2& v : ring)
-      maxCoord = std::max(maxCoord, std::max(std::fabs(v.x), std::fabs(v.y)));
+      maxCoord = std::max(maxCoord, la::maxelem(la::abs(v)));
   // Apex sits at y=1e6; a capped corner stays near that scale. The unclamped
   // miter escapes to ~6e7.
   EXPECT_LT(maxCoord, 1.0e7) << "miter escaped to " << maxCoord;

--- a/test/cross_section_offset_corpus_test.cpp
+++ b/test/cross_section_offset_corpus_test.cpp
@@ -27,6 +27,7 @@
 // debug build. Raw first pass: it runs the whole corpus, so some pathological
 // cases may still need filtering before this becomes a hard gate.
 
+#ifndef MANIFOLD_NO_IOSTREAM
 namespace {
 using namespace manifold;
 
@@ -88,3 +89,7 @@ TEST(CrossSectionOffsetCorpus, TriangulatesCleanly) {
   // make the triangulation checks vacuous.
   EXPECT_GT(nonEmpty, 0);
 }
+#else
+// The offset corpus test loads fixtures via ReadPolygonCorpus (std::ifstream),
+// so it is skipped under MANIFOLD_NO_IOSTREAM.
+#endif

--- a/test/cross_section_offset_corpus_test.cpp
+++ b/test/cross_section_offset_corpus_test.cpp
@@ -14,14 +14,12 @@
 
 #include <algorithm>
 #include <cmath>
-#include <fstream>
 #include <string>
-#include <utility>
-#include <vector>
 
 #include "gtest/gtest.h"
 #include "manifold/cross_section.h"
 #include "manifold/polygon.h"
+#include "polygon_corpus.h"
 
 // Offset the polygon triangulation corpus across every join type and verify
 // each result triangulates cleanly (a valid, non-overlapping fill). Triangulate
@@ -31,32 +29,6 @@
 
 namespace {
 using namespace manifold;
-
-// Read the polygon corpus (name, expectedNumTri, epsilon, numPolys, then the
-// polygons), keeping just the name and the polygon set.
-std::vector<std::pair<std::string, Polygons>> ReadCorpus(
-    const std::string& path) {
-  std::vector<std::pair<std::string, Polygons>> corpus;
-  std::ifstream f(path);
-  if (!f.is_open()) return corpus;
-  std::string name;
-  double epsilon, x, y;
-  int expectedNumTri, numPolys, numPoints;
-  while (f >> name) {
-    f >> expectedNumTri >> epsilon >> numPolys;
-    Polygons polys;
-    for (int i = 0; i < numPolys; ++i) {
-      polys.emplace_back();
-      f >> numPoints;
-      for (int j = 0; j < numPoints; ++j) {
-        f >> x >> y;
-        polys.back().emplace_back(x, y);
-      }
-    }
-    corpus.emplace_back(name, std::move(polys));
-  }
-  return corpus;
-}
 
 std::string CorpusPath() {
 #ifdef __EMSCRIPTEN__
@@ -73,21 +45,21 @@ std::string CorpusPath() {
 }  // namespace
 
 TEST(CrossSectionOffsetCorpus, TriangulatesCleanly) {
-  const auto corpus = ReadCorpus(CorpusPath());
+  const auto corpus = ReadPolygonCorpus(CorpusPath());
   ASSERT_FALSE(corpus.empty());
   const CrossSection::JoinType joins[] = {
       CrossSection::JoinType::Round, CrossSection::JoinType::Miter,
       CrossSection::JoinType::Square, CrossSection::JoinType::Bevel};
   int nonEmpty = 0;
   for (const auto& entry : corpus) {
-    const CrossSection cs(entry.second);
+    const CrossSection cs(entry.polys);
     const vec2 size = cs.Bounds().Size();
-    const double diag = std::sqrt(size.x * size.x + size.y * size.y);
+    const double diag = la::length(size);
     if (!std::isfinite(diag) || diag <= 0) continue;
     // Offset out and in, by fractions of the bbox diagonal, on every join type.
     for (const double frac : {0.05, -0.02}) {
       for (const CrossSection::JoinType jt : joins) {
-        SCOPED_TRACE(entry.first + " frac=" + std::to_string(frac));
+        SCOPED_TRACE(entry.name + " frac=" + std::to_string(frac));
         const CrossSection off = cs.Offset(frac * diag, jt);
         const Polygons result = off.ToPolygons();
         if (!result.empty()) ++nonEmpty;

--- a/test/cross_section_offset_corpus_test.cpp
+++ b/test/cross_section_offset_corpus_test.cpp
@@ -1,0 +1,101 @@
+// Copyright 2026 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "manifold/cross_section.h"
+#include "manifold/polygon.h"
+
+// Offset the polygon triangulation corpus across every join type and verify
+// each result triangulates cleanly (a valid, non-overlapping fill). Triangulate
+// only throws on overlap under MANIFOLD_DEBUG, so the non-overlap teeth need a
+// debug build. Raw first pass: it runs the whole corpus, so some pathological
+// cases may still need filtering before this becomes a hard gate.
+
+namespace {
+using namespace manifold;
+
+// Read the polygon corpus (name, expectedNumTri, epsilon, numPolys, then the
+// polygons), keeping just the name and the polygon set.
+std::vector<std::pair<std::string, Polygons>> ReadCorpus(
+    const std::string& path) {
+  std::vector<std::pair<std::string, Polygons>> corpus;
+  std::ifstream f(path);
+  if (!f.is_open()) return corpus;
+  std::string name;
+  double epsilon, x, y;
+  int expectedNumTri, numPolys, numPoints;
+  while (f >> name) {
+    f >> expectedNumTri >> epsilon >> numPolys;
+    Polygons polys;
+    for (int i = 0; i < numPolys; ++i) {
+      polys.emplace_back();
+      f >> numPoints;
+      for (int j = 0; j < numPoints; ++j) {
+        f >> x >> y;
+        polys.back().emplace_back(x, y);
+      }
+    }
+    corpus.emplace_back(name, std::move(polys));
+  }
+  return corpus;
+}
+
+std::string CorpusPath() {
+#ifdef __EMSCRIPTEN__
+  // test/polygons is preloaded into the Emscripten FS at /polygons (see
+  // test/CMakeLists.txt); the __FILE__ source path does not exist there.
+  return "/polygons/polygon_corpus.txt";
+#else
+  std::string file = __FILE__;
+  const auto end = std::min(file.rfind('\\'), file.rfind('/'));
+  return file.substr(0, end) + "/polygons/polygon_corpus.txt";
+#endif
+}
+
+}  // namespace
+
+TEST(CrossSectionOffsetCorpus, TriangulatesCleanly) {
+  const auto corpus = ReadCorpus(CorpusPath());
+  ASSERT_FALSE(corpus.empty());
+  const CrossSection::JoinType joins[] = {
+      CrossSection::JoinType::Round, CrossSection::JoinType::Miter,
+      CrossSection::JoinType::Square, CrossSection::JoinType::Bevel};
+  int nonEmpty = 0;
+  for (const auto& entry : corpus) {
+    const CrossSection cs(entry.second);
+    const vec2 size = cs.Bounds().Size();
+    const double diag = std::sqrt(size.x * size.x + size.y * size.y);
+    if (!std::isfinite(diag) || diag <= 0) continue;
+    // Offset out and in, by fractions of the bbox diagonal, on every join type.
+    for (const double frac : {0.05, -0.02}) {
+      for (const CrossSection::JoinType jt : joins) {
+        SCOPED_TRACE(entry.first + " frac=" + std::to_string(frac));
+        const CrossSection off = cs.Offset(frac * diag, jt);
+        const Polygons result = off.ToPolygons();
+        if (!result.empty()) ++nonEmpty;
+        EXPECT_NO_THROW(Triangulate(result));
+      }
+    }
+  }
+  // Guard against a regression that silently empties every offset, which would
+  // make the triangulation checks vacuous.
+  EXPECT_GT(nonEmpty, 0);
+}

--- a/test/cross_section_offset_corpus_test.cpp
+++ b/test/cross_section_offset_corpus_test.cpp
@@ -53,19 +53,36 @@ TEST(CrossSectionOffsetCorpus, TriangulatesCleanly) {
   int nonEmpty = 0;
   for (const auto& entry : corpus) {
     const CrossSection cs(entry.polys);
+    const double inArea = cs.Area();
     const vec2 size = cs.Bounds().Size();
     const double diag = la::length(size);
     if (!std::isfinite(diag) || diag <= 0) continue;
     // Offset out and in, by fractions of the bbox diagonal, on every join type.
+    double outset[4], inset[4];
     for (const double frac : {0.05, -0.02}) {
-      for (const CrossSection::JoinType jt : joins) {
+      for (int j = 0; j < 4; ++j) {
         SCOPED_TRACE(entry.name + " frac=" + std::to_string(frac));
-        const CrossSection off = cs.Offset(frac * diag, jt);
+        const CrossSection off = cs.Offset(frac * diag, joins[j]);
         const Polygons result = off.ToPolygons();
         if (!result.empty()) ++nonEmpty;
         EXPECT_NO_THROW(Triangulate(result));
+        (frac > 0 ? outset : inset)[j] = off.Area();
       }
     }
+    if (inArea <= 0) continue;
+    // An outset never loses area and an inset never gains it; and across a
+    // given outset the join-type areas order Miter >= Square >= Round >= Bevel
+    // (verified over the whole corpus). joins[] is {Round, Miter, Square,
+    // Bevel}.
+    const double tol = 1e-6 * inArea;
+    SCOPED_TRACE(entry.name + " area ordering");
+    for (int j = 0; j < 4; ++j) {
+      EXPECT_GE(outset[j], inArea - tol) << "outset lost area";
+      EXPECT_LE(inset[j], inArea + tol) << "inset gained area";
+    }
+    EXPECT_GE(outset[1], outset[2] - tol);  // Miter >= Square
+    EXPECT_GE(outset[2], outset[0] - tol);  // Square >= Round
+    EXPECT_GE(outset[0], outset[3] - tol);  // Round >= Bevel
   }
   // Guard against a regression that silently empties every offset, which would
   // make the triangulation checks vacuous.

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -413,9 +413,14 @@ TEST(CrossSection, DISABLED_TinyFeatureNearCornerHostDropAtOffset4096) {
     v += vec2(4096.0);
   }
   const CrossSection ca(host), cb(feature);
-  const auto sum =
-      ca.Area() + cb.Area() - ca.Boolean(cb, OpType::Intersect).Area();
-  EXPECT_NEAR((ca + cb).Area(), sum, 1e-3 * (1.0 + ca.Area() + cb.Area()));
+  // The feature only point-touches the host (~1e-9 from a vertex), so they are
+  // disjoint: the intersection is empty and the union is the whole host +
+  // feature. The bound is a loose area-relative one (not eps-derived); the bug
+  // drops a whole big piece (the ~30107-area host), well past any such bound.
+  const auto inter = ca.Boolean(cb, OpType::Intersect);
+  const double tol = 1e-3 * (1.0 + ca.Area() + cb.Area());
+  EXPECT_NEAR(inter.Area(), 0.0, tol) << "feature only point-touches the host";
+  EXPECT_NEAR((ca + cb).Area(), ca.Area() + cb.Area() - inter.Area(), tol);
 }
 
 // Host-drop only at large offset (passes at the origin): the StarRing host plus
@@ -445,9 +450,10 @@ TEST(CrossSection, DISABLED_TinyFeatureNearCornerHostDropAtOffset1024) {
       v += vec2(offset);
     }
     const CrossSection ca(sh), cb(sf);
-    const auto sum =
-        ca.Area() + cb.Area() - ca.Boolean(cb, OpType::Intersect).Area();
-    EXPECT_NEAR((ca + cb).Area(), sum, 1e-3 * (1.0 + ca.Area() + cb.Area()))
+    const auto inter = ca.Boolean(cb, OpType::Intersect);
+    const double tol = 1e-3 * (1.0 + ca.Area() + cb.Area());
+    EXPECT_NEAR(inter.Area(), 0.0, tol) << "offset=" << offset;
+    EXPECT_NEAR((ca + cb).Area(), ca.Area() + cb.Area() - inter.Area(), tol)
         << "offset=" << offset;
   }
 }

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -68,6 +68,13 @@ double AreaTol(const CrossSection& a, const CrossSection& b,
                  std::fabs(c.Area()));
 }
 
+void ExpectUnionRetainsArea(const CrossSection& result, double floorArea,
+                            double tol, const char* context) {
+  if (floorArea <= tol) return;
+  EXPECT_GE(result.Area(), floorArea - tol)
+      << context << " collapsed below a non-empty input area";
+}
+
 // Shared builder for the consolidated star-seed regression tables below
 // (BooleanDistributivity/SubtractInvariants/BooleanCommutativity/
 // BooleanAssociativity *Seeds). Each fuzz seed is a StarRing optionally
@@ -123,6 +130,12 @@ void ExpectTinyFeatureSurvivesNearCorner(
     const auto aIb = a.Boolean(b, OpType::Intersect);
     const CrossSection soup(Polygons{shiftedHost, shiftedFeature});
     const double scale = 1.0 + std::fabs(a.Area()) + std::fabs(b.Area());
+    const double rawHostArea = RawArea(shiftedHost);
+    const double rawFeatureArea = RawArea(shiftedFeature);
+    ExpectUnionRetainsArea(aUb, rawHostArea, 1e-3 * (1.0 + rawHostArea),
+                           "host input");
+    ExpectUnionRetainsArea(aUb, rawFeatureArea, 1e-3 * (1.0 + rawFeatureArea),
+                           "feature input");
     EXPECT_NEAR(aUb.Area(), a.Area() + b.Area() - aIb.Area(), 1e-3 * scale)
         << "inclusion-exclusion violated at offset " << offset;
     EXPECT_NEAR(soup.Area(), aUb.Area(), 1e-5 * scale)
@@ -369,91 +382,114 @@ TEST(CrossSection, TinyFeatureNearCornerHostFeatureSwap) {
       {0.9901767613117145, 0.60823663500743508});
 }
 
-// DISABLED: known winding-robustness failures, not yet fixed. A tiny feature
-// that point-touches a large host ~1e-9 from one of the host's vertices (the
-// two pieces are genuinely disjoint, so the correct union is host + feature)
-// drops one of the two pieces. Which piece drops, and whether, depends on
-// sub-eps details (the intersection-merge emission and the absolute coordinate
-// offset), so the arrangement's winding face-walk is unstable far below eps.
-// These are the fuzzer seeds for that bug; enable them when the winding fix
-// lands.
+// DISABLED: known winding-robustness failures, not yet fixed. A tiny piece that
+// point-touches a big piece ~1e-9 from one of the big piece's vertices (the two
+// pieces are genuinely disjoint, so the correct union is the big plus the tiny
+// piece) drops one of the two pieces. Which piece drops, and whether, depends
+// on sub-eps details (the intersection-merge emission and the absolute
+// coordinate offset), so the arrangement's winding face-walk is unstable far
+// below eps. These are the fuzzer seeds for that bug; enable them when the
+// winding fix lands.
 
-// Host-drop: the host's zero-radius star vertex makes it a thin spike that
-// collapses. Built from raw radii (StarRing's 0.1 floor would remove the
+// Big-piece drop: the big piece's zero-radius star vertex makes it a thin spike
+// that collapses. Built from raw radii (StarRing's 0.1 floor would remove the
 // spike).
 TEST(CrossSection, DISABLED_TinyFeatureNearCornerHostDropAtOffset4096) {
-  const std::vector<double> hostRadii = {
+  const std::vector<double> bigRadii = {
       0., 356.3220416075996, 176.46461822660299, 2.451081611797258, 1.};
-  SimplePolygon host;
+  SimplePolygon big;
   for (int k = 0; k < 5; ++k) {
     const double theta = 2.0 * kPi * k / 5;
-    host.push_back(
-        {hostRadii[k] * std::cos(theta), hostRadii[k] * std::sin(theta)});
+    big.push_back(
+        {bigRadii[k] * std::cos(theta), bigRadii[k] * std::sin(theta)});
   }
-  const std::vector<double> featRadii = {
+  const std::vector<double> tinyRadii = {
       999.86970256972995, 1., 1., 823.03853274897119, 253.38906741827319};
-  SimplePolygon feature;
+  SimplePolygon tiny;
   for (int k = 0; k < 5; ++k) {
     const double theta = 2.0 * kPi * k / 5;
-    feature.push_back({1e-3 * featRadii[k] * std::cos(theta),
-                       1e-3 * featRadii[k] * std::sin(theta)});
+    tiny.push_back({1e-3 * tinyRadii[k] * std::cos(theta),
+                    1e-3 * tinyRadii[k] * std::sin(theta)});
   }
   const double dirX = 0.41098114346248393, dirY = -0.227966841143317;
   const double dlen = std::sqrt(dirX * dirX + dirY * dirY);
-  const vec2 anchor{host[1].x + 1e-9 * dirX / dlen,
-                    host[1].y + 1e-9 * dirY / dlen};
-  const vec2 shift{anchor.x - feature[0].x, anchor.y - feature[0].y};
-  for (auto& v : feature) {
+  const vec2 anchor{big[1].x + 1e-9 * dirX / dlen,
+                    big[1].y + 1e-9 * dirY / dlen};
+  const vec2 shift{anchor.x - tiny[0].x, anchor.y - tiny[0].y};
+  for (auto& v : tiny) {
     v += shift;
   }
-  for (auto& v : host) {
+  for (auto& v : big) {
     v += vec2(4096.0);
   }
-  for (auto& v : feature) {
+  for (auto& v : tiny) {
     v += vec2(4096.0);
   }
-  const CrossSection ca(host), cb(feature);
-  // The feature only point-touches the host (~1e-9 from a vertex), so they are
-  // disjoint: the intersection is empty and the union is the whole host +
-  // feature. The bound is a loose area-relative one (not eps-derived); the bug
-  // drops a whole big piece (the ~30107-area host), well past any such bound.
+  const CrossSection ca(big), cb(tiny);
+  const auto aUb = ca + cb;
+  const double rawBigArea = RawArea(big);
+  const double rawTinyArea = RawArea(tiny);
+  ASSERT_GT(rawBigArea, 0.0);
+  ASSERT_GT(rawTinyArea, 0.0);
+  ExpectUnionRetainsArea(aUb, rawBigArea, 1e-3 * (1.0 + rawBigArea),
+                         "big piece");
+  EXPECT_NEAR(aUb.Area(), rawBigArea + rawTinyArea,
+              1e-3 * (1.0 + rawBigArea + rawTinyArea))
+      << "union does not match independent raw big+tiny area";
+  // The tiny piece only point-touches the big piece (~1e-9 from a vertex), so
+  // they are disjoint: the intersection is empty and the union is the whole
+  // big + tiny piece. The bound is a loose area-relative one (not eps-derived);
+  // the bug drops the whole big piece (the ~30107-area one), well past any such
+  // bound.
   const auto inter = ca.Boolean(cb, OpType::Intersect);
   const double tol = 1e-3 * (1.0 + ca.Area() + cb.Area());
-  EXPECT_NEAR(inter.Area(), 0.0, tol) << "feature only point-touches the host";
-  EXPECT_NEAR((ca + cb).Area(), ca.Area() + cb.Area() - inter.Area(), tol);
+  EXPECT_NEAR(inter.Area(), 0.0, tol)
+      << "tiny piece only point-touches the big piece";
+  EXPECT_NEAR(aUb.Area(), ca.Area() + cb.Area() - inter.Area(), tol);
 }
 
-// Host-drop only at large offset (passes at the origin): the StarRing host plus
-// an 8-vertex feature anchored 1e-9 from host[1].
+// Big-piece drop only at large offset (passes at the origin): the StarRing big
+// piece plus an 8-vertex tiny piece anchored 1e-9 from big[1].
 TEST(CrossSection, DISABLED_TinyFeatureNearCornerHostDropAtOffset1024) {
-  SimplePolygon host = StarRing({0., 1., 0., 181.7694024845519});
-  SimplePolygon feature =
+  SimplePolygon big = StarRing({0., 1., 0., 181.7694024845519});
+  SimplePolygon tiny =
       StarRing({712.03169893044037, 1., 549.34829370834473, 0., 0.,
                 0.84629435037780809, 593.99733078452005, 738.68366086294714});
-  for (auto& v : feature) {
+  for (auto& v : tiny) {
     v *= 1e-3;
   }
   const double dirX = 0.20051392197659679, dirY = -0.51476208035366366;
   const double dlen = std::sqrt(dirX * dirX + dirY * dirY);
-  const vec2 anchor{host[1].x + 1e-9 * dirX / dlen,
-                    host[1].y + 1e-9 * dirY / dlen};
-  const vec2 shift{anchor.x - feature[0].x, anchor.y - feature[0].y};
-  for (auto& v : feature) {
+  const vec2 anchor{big[1].x + 1e-9 * dirX / dlen,
+                    big[1].y + 1e-9 * dirY / dlen};
+  const vec2 shift{anchor.x - tiny[0].x, anchor.y - tiny[0].y};
+  for (auto& v : tiny) {
     v += shift;
   }
   for (double offset : {0.0, 1024.0, 4096.0}) {
-    SimplePolygon sh = host, sf = feature;
-    for (auto& v : sh) {
+    SimplePolygon sBig = big, sTiny = tiny;
+    for (auto& v : sBig) {
       v += vec2(offset);
     }
-    for (auto& v : sf) {
+    for (auto& v : sTiny) {
       v += vec2(offset);
     }
-    const CrossSection ca(sh), cb(sf);
+    const CrossSection ca(sBig), cb(sTiny);
+    const auto aUb = ca + cb;
+    const double rawBigArea = RawArea(sBig);
+    const double rawTinyArea = RawArea(sTiny);
+    ASSERT_GT(rawBigArea, 0.0);
+    ASSERT_GT(rawTinyArea, 0.0);
+    ExpectUnionRetainsArea(aUb, rawBigArea, 1e-3 * (1.0 + rawBigArea),
+                           "big piece");
+    EXPECT_NEAR(aUb.Area(), rawBigArea + rawTinyArea,
+                1e-3 * (1.0 + rawBigArea + rawTinyArea))
+        << "union does not match independent raw big+tiny area at offset="
+        << offset;
     const auto inter = ca.Boolean(cb, OpType::Intersect);
     const double tol = 1e-3 * (1.0 + ca.Area() + cb.Area());
     EXPECT_NEAR(inter.Area(), 0.0, tol) << "offset=" << offset;
-    EXPECT_NEAR((ca + cb).Area(), ca.Area() + cb.Area() - inter.Area(), tol)
+    EXPECT_NEAR(aUb.Area(), ca.Area() + cb.Area() - inter.Area(), tol)
         << "offset=" << offset;
   }
 }
@@ -614,8 +650,7 @@ TEST(CrossSection, OffsetPositiveOnExtremeRadiusStar) {
 // Consolidated SubtractInvariants* fuzz-seed regressions, one row per seed.
 // Each row carries that seed's radii + translate verbatim; SubtractKind
 // selects which assertions the original standalone test made:
-//   Invariants         - ExpectBooleanInvariants (both subtract identities
-//                        plus inclusion-exclusion)
+//   Invariants         - both subtract identities plus inclusion-exclusion
 //   InclusionExclusion - only the inclusion-exclusion identity
 // SubtractInvariantsEmptyIntersectionDrop stays standalone (below): it is
 // boolean2-gated and asserts only a single subtract identity.
@@ -751,15 +786,19 @@ TEST(CrossSection, SubtractInvariantsSeeds) {
       const double tol = AreaTol(a, b);
       EXPECT_NEAR(aUb.Area(), a.Area() + b.Area() - aIb.Area(), tol)
           << "inclusion-exclusion violated";
+      ExpectUnionRetainsArea(aUb, std::max(a.Area(), b.Area()), tol,
+                             "subtract seed union");
     } else {
       const auto aIb = a.Boolean(b, OpType::Intersect);
+      const auto aUb = a + b;
       const double tol = AreaTol(a, b);
       EXPECT_NEAR((a - b).Area() + aIb.Area(), a.Area(), tol)
-          << "area(A - B) + area(A ∩ B) != area(A)";
+          << "area(A - B) + area(A intersection B) != area(A)";
       EXPECT_NEAR((b - a).Area() + aIb.Area(), b.Area(), tol)
-          << "area(B - A) + area(A ∩ B) != area(B)";
-      EXPECT_NEAR((a + b).Area(), a.Area() + b.Area() - aIb.Area(), tol)
+          << "area(B - A) + area(A intersection B) != area(B)";
+      EXPECT_NEAR(aUb.Area(), a.Area() + b.Area() - aIb.Area(), tol)
           << "inclusion-exclusion violated";
+      ExpectUnionRetainsArea(aUb, std::max(a.Area(), b.Area()), tol, "union");
     }
   }
 }
@@ -899,6 +938,8 @@ TEST(CrossSection, BooleanCommutativitySeeds) {
     const double tol = AreaTol(a, b);
     EXPECT_NEAR(aPlusB.Area(), bPlusA.Area(), tol) << "A + B != B + A";
     EXPECT_EQ(aPlusB.NumContour(), bPlusA.NumContour());
+    ExpectUnionRetainsArea(aPlusB, std::max(a.Area(), b.Area()), tol, "A+B");
+    ExpectUnionRetainsArea(bPlusA, std::max(a.Area(), b.Area()), tol, "B+A");
     if (c.checkIntersect) {
       const auto aIntB = a.Boolean(b, OpType::Intersect);
       const auto bIntA = b.Boolean(a, OpType::Intersect);
@@ -1012,6 +1053,10 @@ TEST(CrossSection, BooleanAssociativitySeeds) {
     const auto a_bc = a + (b + cc);
     const double tol = AreaTol(a, b, cc);
     EXPECT_NEAR(ab_c.Area(), a_bc.Area(), tol) << "(A ∪ B) ∪ C != A ∪ (B ∪ C)";
+    ExpectUnionRetainsArea(ab_c, std::max({a.Area(), b.Area(), cc.Area()}), tol,
+                           "(A+B)+C");
+    ExpectUnionRetainsArea(a_bc, std::max({a.Area(), b.Area(), cc.Area()}), tol,
+                           "A+(B+C)");
   }
 }
 
@@ -1019,8 +1064,8 @@ TEST(CrossSection, BooleanAssociativitySeeds) {
 // seed. Each row carries that seed's radii and translate inputs verbatim;
 // DistribKind selects which assertions the original standalone test made:
 //   AreaOnly     - only the area-equality check
-//   Standard     - ExpectDistributesOverUnion (area-equality plus both
-//                  one-directional area-difference checks)
+//   Standard     - area-equality plus both one-directional area-difference
+//                  checks
 //   Monotonicity - the Standard checks plus the two containment checks
 //                  (A intersect B and A intersect C each inside the union)
 // Kept as a single TEST in the CrossSection suite so the CrossSection.*
@@ -1553,11 +1598,15 @@ TEST(CrossSection, BooleanDistributivitySeeds) {
     const CrossSection a = MakeShape(c.a), b = MakeShape(c.b),
                        cc = MakeShape(c.c);
     if (c.kind == DistribKind::AreaOnly) {
+      const auto bUc = b + cc;
+      const double tol = AreaTol(a, b, cc);
+      ExpectUnionRetainsArea(bUc, std::max(b.Area(), cc.Area()), tol,
+                             "B union C");
       EXPECT_NEAR(
-          a.Boolean(b + cc, OpType::Intersect).Area(),
+          a.Boolean(bUc, OpType::Intersect).Area(),
           (a.Boolean(b, OpType::Intersect) + a.Boolean(cc, OpType::Intersect))
               .Area(),
-          AreaTol(a, b, cc))
+          tol)
           << "A ∩ (B ∪ C) != (A ∩ B) ∪ (A ∩ C)";
     } else {
       const auto bUc = b + cc;
@@ -1565,8 +1614,10 @@ TEST(CrossSection, BooleanDistributivitySeeds) {
       const auto right =
           a.Boolean(b, OpType::Intersect) + a.Boolean(cc, OpType::Intersect);
       const double tol = AreaTol(a, b, cc);
+      ExpectUnionRetainsArea(bUc, std::max(b.Area(), cc.Area()), tol,
+                             "B union C");
       EXPECT_NEAR(left.Area(), right.Area(), tol)
-          << "A ∩ (B ∪ C) != (A ∩ B) ∪ (A ∩ C)";
+          << "A intersect (B union C) != (A intersect B) union (A intersect C)";
       EXPECT_NEAR((left - right).Area(), 0.0, tol)
           << "distributivity: left-right difference is non-empty";
       EXPECT_NEAR((right - left).Area(), 0.0, tol)

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -109,6 +109,57 @@ CrossSection MakeShape(const Shape& s) {
   return cs;
 }
 
+// A tiny feature loop anchored ~1e-12 (a few times the op-epsilon) from a host
+// vertex must survive the boolean. Two near-coincident crossings of one host
+// edge by the feature were over-merged into a non-manifold pinch, which the
+// winding filter then collapsed to an empty result. Swept over a coordinate
+// offset because the failure only surfaces where the float grid is finer than
+// the op-epsilon. (CrossSectionFuzz.TinyFeatureNearCorner.)
+void ExpectTinyFeatureSurvivesNearCorner(
+    const std::vector<double>& hostRadii,
+    const std::vector<double>& featureRadii, vec2 dir) {
+  SimplePolygon host = StarRing(hostRadii);
+  SimplePolygon feature = StarRing(featureRadii);
+  for (auto& v : feature) {  // shrink to a tiny feature
+    v.x *= 1e-3;
+    v.y *= 1e-3;
+  }
+  // Anchor the feature 1e-12 from host vertex 0 along the seed's direction.
+  const double dlen = std::sqrt(dir.x * dir.x + dir.y * dir.y);
+  const vec2 anchor{host[0].x + 1e-12 * dir.x / dlen,
+                    host[0].y + 1e-12 * dir.y / dlen};
+  const vec2 shift{anchor.x - feature[0].x, anchor.y - feature[0].y};
+  for (auto& v : feature) {
+    v.x += shift.x;
+    v.y += shift.y;
+  }
+
+  for (double offset : {0.0, 1024.0, 4096.0}) {
+    SimplePolygon shiftedHost = host;
+    SimplePolygon shiftedFeature = feature;
+    for (auto& v : shiftedHost) {
+      v.x += offset;
+      v.y += offset;
+    }
+    for (auto& v : shiftedFeature) {
+      v.x += offset;
+      v.y += offset;
+    }
+    const CrossSection a(shiftedHost);
+    const CrossSection b(shiftedFeature);
+    if (a.IsEmpty() || b.IsEmpty()) continue;
+
+    const auto aUb = a + b;
+    const auto aIb = a.Boolean(b, OpType::Intersect);
+    const CrossSection soup(Polygons{shiftedHost, shiftedFeature});
+    const double scale = 1.0 + std::fabs(a.Area()) + std::fabs(b.Area());
+    EXPECT_NEAR(aUb.Area(), a.Area() + b.Area() - aIb.Area(), 1e-3 * scale)
+        << "inclusion-exclusion violated at offset " << offset;
+    EXPECT_NEAR(soup.Area(), aUb.Area(), 1e-5 * scale)
+        << "edge-soup union disagrees with binary union at offset " << offset;
+  }
+}
+
 }  // namespace
 
 TEST(CrossSection, Square) {
@@ -332,6 +383,20 @@ TEST(CrossSection, TranslatedSmallPolygonKeepsFeatures) {
   const vec2 size = cs.Bounds().Size();
   EXPECT_NEAR(size.x, 10.0, 1e-9);
   EXPECT_NEAR(size.y, 10.0, 1e-9);
+}
+
+TEST(CrossSection, TinyFeatureNearCornerEdgeSoupParity) {
+  ExpectTinyFeatureSurvivesNearCorner(
+      {0., 0.14864156234381307, 0., 0.}, {0., 0., 0., 0.},
+      {0.11230272954875442, 0.72082846036740955});
+}
+
+// Same failure with host and feature roles swapped.
+TEST(CrossSection, TinyFeatureNearCornerHostFeatureSwap) {
+  ExpectTinyFeatureSurvivesNearCorner(
+      {0., 0., 0., 0.},
+      {299.80431860145183, 188.67283503085034, 4.2284094583496739, 0.},
+      {0.9901767613117145, 0.60823663500743508});
 }
 
 // Regression test for the BR-cell hole pattern from Samples.Sponge4. Two

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -16,13 +16,100 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+#ifdef MANIFOLD_DEBUG
+#include <fstream>
+#include <iomanip>
+#include <ostream>
+#endif
+#include <algorithm>
+#include <array>
+#include <iostream>
+#include <limits>
+#include <thread>
 #include <vector>
 
+#include "../src/boolean2.h"
 #include "manifold/common.h"
 #include "manifold/manifold.h"
 #include "test.h"
 
 using namespace manifold;
+
+namespace {
+
+SimplePolygon StarRing(const std::vector<double>& radii) {
+  SimplePolygon ring;
+  ring.reserve(radii.size());
+  const int n = static_cast<int>(radii.size());
+  for (int i = 0; i < n; ++i) {
+    const double r = 0.1 + std::fabs(radii[i]);
+    const double theta = 2.0 * kPi * i / n;
+    ring.push_back({r * std::cos(theta), r * std::sin(theta)});
+  }
+  return ring;
+}
+
+// Expand run-length radius specs for seeds with long repeated-radius runs:
+// Runs({{3, 1000.}, {21, 332.47}}) is 3x 1000. then 21x 332.47.
+std::vector<double> Runs(std::initializer_list<std::pair<int, double>> runs) {
+  std::vector<double> out;
+  for (const auto& run : runs) out.insert(out.end(), run.first, run.second);
+  return out;
+}
+
+double AreaTol(const CrossSection& a, const CrossSection& b) {
+  return 1e-6 * (1.0 + std::fabs(a.Area()) + std::fabs(b.Area()));
+}
+
+double AreaTol(const CrossSection& a, const CrossSection& b,
+               const CrossSection& c) {
+  return 1e-6 * (1.0 + std::fabs(a.Area()) + std::fabs(b.Area()) +
+                 std::fabs(c.Area()));
+}
+
+void ExpectBooleanInvariants(const CrossSection& a, const CrossSection& b) {
+  const auto aIb = a.Boolean(b, OpType::Intersect);
+  const double tol = AreaTol(a, b);
+  EXPECT_NEAR((a - b).Area() + aIb.Area(), a.Area(), tol)
+      << "area(A - B) + area(A ∩ B) != area(A)";
+  EXPECT_NEAR((b - a).Area() + aIb.Area(), b.Area(), tol)
+      << "area(B - A) + area(A ∩ B) != area(B)";
+  EXPECT_NEAR((a + b).Area(), a.Area() + b.Area() - aIb.Area(), tol)
+      << "inclusion-exclusion violated";
+}
+
+void ExpectDistributesOverUnion(const CrossSection& a, const CrossSection& b,
+                                const CrossSection& c) {
+  const auto bUc = b + c;
+  const auto left = a.Boolean(bUc, OpType::Intersect);
+  const auto right =
+      a.Boolean(b, OpType::Intersect) + a.Boolean(c, OpType::Intersect);
+  const double tol = AreaTol(a, b, c);
+  EXPECT_NEAR(left.Area(), right.Area(), tol)
+      << "A ∩ (B ∪ C) != (A ∩ B) ∪ (A ∩ C)";
+  EXPECT_NEAR((left - right).Area(), 0.0, tol)
+      << "distributivity: left-right difference is non-empty";
+  EXPECT_NEAR((right - left).Area(), 0.0, tol)
+      << "distributivity: right-left difference is non-empty";
+}
+
+// Shared builder for the consolidated star-seed regression tables below
+// (BooleanDistributivity/SubtractInvariants/BooleanCommutativity/
+// BooleanAssociativity *Seeds). Each fuzz seed is a StarRing optionally
+// shifted by a translation; rows carry the raw radii + translate verbatim.
+struct Shape {
+  std::vector<double> radii;
+  vec2 translate{0, 0};
+};
+
+CrossSection MakeShape(const Shape& s) {
+  CrossSection cs(StarRing(s.radii));
+  if (s.translate != vec2{0, 0}) cs = cs.Translate(s.translate);
+  return cs;
+}
+
+}  // namespace
 
 TEST(CrossSection, Square) {
   auto a = Manifold::Cube({5, 5, 5});
@@ -91,6 +178,1591 @@ TEST(CrossSection, BevelOffset) {
   EXPECT_NEAR(result.Volume(),
               5 * (((20. + (2 * 5.)) * (20. + (2 * 5.))) - (2 * 5. * 5)), 1);
   EXPECT_EQ(rounded.NumVert(), 4 + 4);
+}
+
+TEST(CrossSection, MiterOffset) {
+  auto square = CrossSection::Square({20., 20.}, true);
+  auto offset = square.Offset(5., CrossSection::JoinType::Miter);
+  auto result = Manifold::Extrude(offset.ToPolygons(), 1.);
+
+  EXPECT_EQ(result.Genus(), 0);
+  EXPECT_NEAR(result.Volume(), 30. * 30., 0.01);
+  // Offset keeps collinear verts on the miter edges; stripping them is
+  // Simplify's job, so check the simplified corner count (4)
+  // backend-agnostically.
+  EXPECT_EQ(offset.Simplify().NumVert(), 4);
+}
+
+TEST(CrossSection, OffsetWithHole) {
+  SimplePolygon outer = {{-10, -10}, {10, -10}, {10, 10}, {-10, 10}};
+  SimplePolygon hole = {{-2, -2}, {-2, 2}, {2, 2}, {2, -2}};
+  // CCW outer + CW hole are already oriented for Positive fill, which yields
+  // the same annulus as EvenOdd here and is the only rule CrossSection
+  // supports.
+  CrossSection cs({outer, hole}, CrossSection::FillRule::Positive);
+
+  auto inflated = cs.Offset(1., CrossSection::JoinType::Miter);
+  EXPECT_NEAR(inflated.Area(), 484. - 4., 0.01);
+
+  auto inset = cs.Offset(-1., CrossSection::JoinType::Miter);
+  EXPECT_NEAR(inset.Area(), 324. - 36., 0.01);
+}
+
+TEST(CrossSection, OffsetThinPinch) {
+  CrossSection thin = CrossSection::Square({100., 2.}, true);
+  auto inset = thin.Offset(-1., CrossSection::JoinType::Miter);
+
+  EXPECT_TRUE(inset.IsEmpty() || inset.Area() < 0.01);
+}
+
+TEST(CrossSection, OffsetMultipleDisjointOuters) {
+  SimplePolygon a = {{0, 0}, {1, 0}, {1, 1}, {0, 1}};
+  SimplePolygon b = {{10, 0}, {11, 0}, {11, 1}, {10, 1}};
+  CrossSection cs({a, b});
+
+  auto separated = cs.Offset(0.5, CrossSection::JoinType::Miter);
+  EXPECT_EQ(separated.NumContour(), 2);
+  EXPECT_NEAR(separated.Area(), 8., 0.01);
+
+  auto merged = cs.Offset(5., CrossSection::JoinType::Miter);
+  EXPECT_EQ(merged.NumContour(), 1);
+}
+
+TEST(CrossSection, FourConcurrentEdges) {
+  auto rhomb = [](double angleDegrees) {
+    const double angle = angleDegrees * kPi / 180.;
+    const double cosA = std::cos(angle);
+    const double sinA = std::sin(angle);
+    constexpr double radius = 1.0;
+    constexpr double width = 0.1;
+    return SimplePolygon{{radius * cosA, radius * sinA},
+                         {-width * sinA, width * cosA},
+                         {-radius * cosA, -radius * sinA},
+                         {width * sinA, -width * cosA}};
+  };
+
+  Polygons polys;
+  for (double angle : {0., 45., 90., 135.}) polys.push_back(rhomb(angle));
+  CrossSection cs(polys, CrossSection::FillRule::Positive);
+
+  EXPECT_EQ(cs.NumContour(), 1);
+  EXPECT_NEAR(cs.Area(), 0.644423, 1e-4);
+  for (const auto& loop : cs.ToPolygons()) {
+    for (const vec2& v : loop) {
+      EXPECT_TRUE(std::isfinite(v.x));
+      EXPECT_TRUE(std::isfinite(v.y));
+      EXPECT_LE(la::length(v), 1.05);
+    }
+  }
+}
+
+TEST(CrossSection, ConcurrentIndependentEdgePairs) {
+  auto rhomb = [](double angleDegrees) {
+    const double angle = angleDegrees * kPi / 180.;
+    const double cosA = std::cos(angle);
+    const double sinA = std::sin(angle);
+    constexpr double radius = 1.0;
+    constexpr double width = 0.08;
+    return SimplePolygon{{radius * cosA, radius * sinA},
+                         {-width * sinA, width * cosA},
+                         {-radius * cosA, -radius * sinA},
+                         {width * sinA, -width * cosA}};
+  };
+
+  Polygons polys;
+  for (double angle : {0., 30., 90., 120.}) polys.push_back(rhomb(angle));
+  CrossSection cs(polys, CrossSection::FillRule::Positive);
+
+  EXPECT_EQ(cs.NumContour(), 1);
+  EXPECT_NEAR(cs.Area(), 0.527482, 1e-4);
+  for (const auto& loop : cs.ToPolygons()) {
+    for (const vec2& v : loop) {
+      EXPECT_TRUE(std::isfinite(v.x));
+      EXPECT_TRUE(std::isfinite(v.y));
+      EXPECT_LE(la::length(v), 1.05);
+    }
+  }
+}
+
+TEST(CrossSection, TranslatedShallowConcurrentEdges) {
+  auto rhomb = [](double angleDegrees, vec2 offset) {
+    const double angle = angleDegrees * kPi / 180.;
+    const double cosA = std::cos(angle);
+    const double sinA = std::sin(angle);
+    constexpr double radius = 1.0;
+    constexpr double width = 0.08;
+    return SimplePolygon{{offset.x + radius * cosA, offset.y + radius * sinA},
+                         {offset.x - width * sinA, offset.y + width * cosA},
+                         {offset.x - radius * cosA, offset.y - radius * sinA},
+                         {offset.x + width * sinA, offset.y - width * cosA}};
+  };
+
+  auto polysAt = [&](vec2 offset) {
+    Polygons polys;
+    for (double angle : {0., 6., 90., 96.})
+      polys.push_back(rhomb(angle, offset));
+    return polys;
+  };
+
+  const double base = std::ldexp(1.0, 40);
+  CrossSection origin(polysAt({0., 0.}), CrossSection::FillRule::Positive);
+  CrossSection shifted(polysAt({base, -base}),
+                       CrossSection::FillRule::Positive);
+  CrossSection shiftedBack = shifted.Translate({-base, base});
+
+  EXPECT_EQ(origin.NumContour(), 1);
+  EXPECT_EQ(shifted.NumContour(), 1);
+  EXPECT_EQ(shiftedBack.NumContour(), origin.NumContour());
+  EXPECT_NEAR(shiftedBack.Area(), origin.Area(), 1e-4);
+  EXPECT_NEAR(shiftedBack.Bounds().Size().x, origin.Bounds().Size().x, 1e-4);
+  EXPECT_NEAR(shiftedBack.Bounds().Size().y, origin.Bounds().Size().y, 1e-4);
+}
+
+TEST(CrossSection, TranslatedSmallPolygonKeepsFeatures) {
+  const double base = std::ldexp(1.0, 49) * 1.5;
+  SimplePolygon square = {{base, -base},
+                          {base + 10.0, -base},
+                          {base + 10.0, -base + 10.0},
+                          {base, -base + 10.0}};
+
+  CrossSection cs(square);
+
+  EXPECT_EQ(cs.NumContour(), 1);
+  EXPECT_EQ(cs.NumVert(), 4);
+  const vec2 size = cs.Bounds().Size();
+  EXPECT_NEAR(size.x, 10.0, 1e-9);
+  EXPECT_NEAR(size.y, 10.0, 1e-9);
+}
+
+// Regression test for the BR-cell hole pattern from Samples.Sponge4. Two
+// CCW polygons that share an endpoint AND form a T-junction at the
+// non-shared endpoint of one edge. Before the broad-phase / fused-pass
+// shared-endpoint filter fix, the (long, short) edge pair was dropped at
+// the broad phase, so the narrow phase never inserted the T-junction
+// vertex on the long edge. Canonical sub-edges came out with the wrong
+// multiplicities, the DCEL face traversal merged faces of different
+// windings, and small CW holes were silently dropped from the output.
+TEST(CrossSection, TJunctionAtSharedEndpoint) {
+  // Outer CCW unit square plus a smaller CCW square sharing the (0,0)
+  // corner. The outer's bottom edge (0,0)->(1,0) has the inner's
+  // (0.5,0) vertex on its interior; both share endpoint (0,0).
+  SimplePolygon outer = {{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}};
+  SimplePolygon inner = {{0.0, 0.0}, {0.5, 0.0}, {0.5, 0.5}, {0.0, 0.5}};
+
+  CrossSection cs(Polygons{outer, inner});
+  // Union with Positive fill rule: the inner CCW square is fully inside
+  // the outer, so the result is just the outer's area.
+  EXPECT_EQ(cs.NumContour(), 1);
+  EXPECT_NEAR(cs.Area(), 1.0, 1e-9);
+
+  // A more demanding case from the same family: a butterfly polygon with
+  // cancel-pair retraces (one CW lobe around a unit cell) combined with
+  // an adjacent CCW staircase polygon whose edge runs along the cell's
+  // boundary, creating a T-junction at a vertex shared with the
+  // butterfly. This is the minimal three-poly pattern that produced a
+  // missing hole in Samples.Sponge4 before the fix.
+  SimplePolygon hex = {{-1.0, -1.0}, {1.0, -1.0}, {1.0, 1.0}, {-1.0, 1.0}};
+  // CW butterfly enclosing the cell (-0.2, -0.2) .. (0.2, 0.2) with a
+  // cancel-pair retrace at (-0.5, 0.0)/(0.0, -0.5) to mimic the Sponge16
+  // shape. Net signed area is negative (a hole-bearing loop).
+  SimplePolygon butterfly = {{-0.2, 0.0}, {-0.2, 0.2}, {-0.5, 0.2}, {-0.2, 0.2},
+                             {0.0, 0.2},  {0.2, 0.2},  {0.2, 0.0},  {0.5, -0.2},
+                             {0.2, -0.2}, {0.2, -0.5}, {0.2, -0.2}, {0.0, -0.2},
+                             {-0.2, -0.2}};
+  // CCW staircase whose v6->v7 edge ((0.2, -0.2) -> (-0.2, -0.2)) is the
+  // butterfly's bottom edge, sharing both endpoints with butterfly
+  // sub-edges (-0.2, -0.2)..(0.0, -0.2)..(0.2, -0.2) and creating a
+  // T-junction at (0.0, -0.2).
+  SimplePolygon staircase = {
+      {0.2, -0.2}, {-0.2, -0.2}, {-0.2, -0.4}, {0.2, -0.4}};
+
+  CrossSection csBR(Polygons{hex, butterfly, staircase});
+  // The butterfly's full interior (cell 0.16 + SE detour triangle 0.03 =
+  // 0.19) is a connected CW hole. The CCW staircase below the cell is
+  // double-covered (winding 2: hex + staircase), so it stays filled.
+  // Expected: outer hex CCW + one CW hole at the butterfly's interior.
+  // Without the fix, the butterfly's edges along y=-0.2 (which share
+  // endpoints with the staircase's edge) miss the T-junction split at
+  // (0.0, -0.2), the canonical mults come out wrong, and the hole
+  // collapses or merges with neighboring faces.
+  EXPECT_EQ(csBR.NumContour(), 2);
+  EXPECT_NEAR(csBR.Area(), 4.0 - 0.19, 1e-9);
+}
+
+// Audit follow-up: regression tests for boolean2 filters the post-
+// Sponge4 audit argued were correct but didn't have a targeted case.
+// Each test verifies a specific topology against a closed-form expected
+// result.
+
+// Audit target: canonical sub-edge multiplicity summing for collinear
+// overlapping edges. Two CCW rectangles share a collinear segment along
+// their boundary but not endpoints; the narrow phase must split A's
+// edge at B's endpoints, then Finalize must sum the contributing mults
+// correctly so the shared interior segment cancels and only the outer
+// "T" outline remains. Without correct mult summing the result would
+// drop the shared bottom strip entirely or carry a spurious interior
+// edge.
+TEST(CrossSection, CollinearSegmentOverlap) {
+  SimplePolygon A = {{0.0, 0.0}, {10.0, 0.0}, {10.0, 1.0}, {0.0, 1.0}};
+  SimplePolygon B = {{3.0, 0.0}, {7.0, 0.0}, {7.0, 2.0}, {3.0, 2.0}};
+
+  CrossSection cs(Polygons{A, B}, CrossSection::FillRule::Positive);
+
+  EXPECT_EQ(cs.NumContour(), 1);
+  // A = 10, B = 8, overlap (4x1 strip on shared bottom) = 4, union = 14.
+  EXPECT_NEAR(cs.Area(), 14.0, 1e-9);
+}
+
+// Audit target: collinearity gate in CollectIntersectionPairs. N polygon
+// wedges all share the origin as a vertex; every pair shares that
+// endpoint. The gate must drop pairs that fan out at the center (no
+// T-junction possible) while letting through pairs that need their
+// non-shared endpoints checked. Result must be the inscribed regular
+// N-gon: one contour, area = N/2 * sin(2pi/N). If the gate over-drops
+// (filters something needed), interior wedge boundaries leak through;
+// if it under-drops (filters nothing), the test still passes but the
+// pre-1a057638 perf gain is gone.
+TEST(CrossSection, ManyPolygonsShareCenterVertex) {
+  constexpr int N = 8;
+  Polygons polys;
+  for (int i = 0; i < N; ++i) {
+    const double a1 = 2.0 * kPi * i / N;
+    const double a2 = 2.0 * kPi * (i + 1) / N;
+    polys.push_back({{0.0, 0.0},
+                     {std::cos(a1), std::sin(a1)},
+                     {std::cos(a2), std::sin(a2)}});
+  }
+  CrossSection cs(polys, CrossSection::FillRule::Positive);
+
+  EXPECT_EQ(cs.NumContour(), 1);
+  const double expectedArea = 0.5 * N * std::sin(2.0 * kPi / N);
+  EXPECT_NEAR(cs.Area(), expectedArea, 1e-9);
+}
+
+// 20-gon with
+//   extreme-magnitude radii alternating between O(0.1) and O(8.9).
+//   Strict Positive-only cleanup with the old single-miter concave raw-offset
+//   emission returned a polygon with area ~ input.Area(), effectively a no-op.
+//   Clipper2-style concave emission should let the positive cleanup expand it.
+TEST(CrossSection, OffsetPositiveOnExtremeRadiusStar) {
+  const std::vector<double> radii = {0.,
+                                     0.40098345505108085,
+                                     4.7498113621644447e-99,
+                                     3.7120810186334277,
+                                     8.8389852354367608,
+                                     7.8626648130962875e-111,
+                                     0.37816850000826657,
+                                     0.,
+                                     2.0448856906274785e-158,
+                                     0.,
+                                     0.2582179499017509,
+                                     0.,
+                                     7.224596115948677e-174,
+                                     0.,
+                                     0.21952411055214244,
+                                     0.,
+                                     9.550952284653982e-128,
+                                     0.18006645730017631,
+                                     0.,
+                                     3.9220883255587997e-118};
+  SimplePolygon ring;
+  ring.reserve(radii.size());
+  const int n = static_cast<int>(radii.size());
+  for (int i = 0; i < n; ++i) {
+    const double r = 0.1 + std::fabs(radii[i]);
+    const double theta = 2.0 * kPi * i / n;
+    ring.push_back({r * std::cos(theta), r * std::sin(theta)});
+  }
+  const CrossSection input(ring);
+  ASSERT_FALSE(input.IsEmpty());
+  ASSERT_GT(std::fabs(input.Area()), 1e-9);
+
+  const double delta = 7.2097955766145416;
+  const auto output = input.Offset(delta, CrossSection::JoinType::Bevel,
+                                   /*miter_limit=*/2.0, /*circularSegments=*/0);
+  EXPECT_FALSE(output.IsEmpty());
+  // A positive offset on a non-self-intersecting ring should always
+  // grow the area. Observed locally: output.Area() ~= input.Area(),
+  // i.e. Offset is effectively a no-op for this input.
+  EXPECT_GE(output.Area(), input.Area() - 1e-6 * (1.0 + input.Area()));
+}
+
+// Consolidated SubtractInvariants* fuzz-seed regressions, one row per seed.
+// Each row carries that seed's radii + translate verbatim; SubtractKind
+// selects which assertions the original standalone test made:
+//   Invariants         - ExpectBooleanInvariants (both subtract identities
+//                        plus inclusion-exclusion)
+//   InclusionExclusion - only the inclusion-exclusion identity
+// SubtractInvariantsEmptyIntersectionDrop stays standalone (below): it is
+// boolean2-gated and asserts only a single subtract identity.
+namespace {
+enum class SubtractKind { Invariants, InclusionExclusion };
+
+struct SubtractCase {
+  const char* name;
+  Shape a, b;
+  SubtractKind kind = SubtractKind::Invariants;
+};
+
+const SubtractCase kSubtractInvariantsSeeds[] = {
+    // Extreme magnitude mismatch
+    //   between two star polygons - A is ~1e-9 scale, B is ~100 scale.
+    //   At least one of the boolean algebraic invariants
+    //   `area(A-B)+area(A∩B)=area(A)` etc. fails. Likely an eps-inference
+    //   or vertex-merge cliff where A's tiny scale gets crushed by B's
+    //   eps.
+    {"TinyVsLargeStars",
+     {{2.0371964671064575e-14, 1.814002251251902e-10, 0.,
+       2.1825088357767143e-09}},
+     {{113.5978182908662, 0., 114.34968677141997, 6.5076626333939721e-10},
+      {0., 4.667562921730494e-33}}},
+    // Two spiky stars at origin - A
+    //   is 5-pointed with mixed magnitudes including two ~1000-radius
+    //   spikes and a near-zero vertex; B is 4-pointed with three
+    //   ~1000-scale spikes plus a near-zero vertex. One of the boolean
+    //   algebraic invariants fails. Likely a different code path than
+    //   the TinyVsLargeStars needle case - this is two large spiky
+    //   shapes, not a tiny shape vs a needle. May share the off-axis
+    //   T-junction root cause diagnosed earlier in this table, but the spike-
+    //   collision geometry could be its own failure mode.
+    {"SpikyStars",
+     {{1000., 886.10628147264833, 1000., 1., 0.}},
+     {{1000., 827.10387617193078, 548.20533789242359, 0.}}},
+    // 17-vertex star with most radii zero collapsed to 0.1, plus a
+    //   4-pointed star with one ~112 spike. area(b - a) + area(a ∩ b) =
+    //   402.04, b.Area() = 634.18 - 232 units of area leak. Different
+    //   geometry from the needle/spiky-star seeds above; the earlier
+    //   winding-seed fix didn't cover this case. Reproduces via direct
+    //   call with these exact args.
+    {"LeakySparseStar",
+     {{627.11994612906153, 0.11978140887764367, 601.04982226530046,
+       102.31660501134466, 2.1549912703437601, 0., 0., 0., 0., 0., 0., 0., 0.,
+       0., 0., 0., 0.}},
+     {{112.00504648760347, 4.3823848227606392, 1.2795858846899296e-07,
+       6.7216166802304542},
+      {-2.7193614970785894e-29, 0.}}},
+    // 19-vertex sparse star with only 2 nonzero radii (~39, ~21) vs a
+    //   4-pointed star with one ~73 spike and tiny radii. area(b - a) +
+    //   area(a ∩ b) is off
+    //   by ~234 from b.Area() (~788). Different geometry from prior
+    //   Subtract seeds.
+    {"TwoNonzeroVsNeedle",
+     {{0., 39.150613710409736, 0., 21.472413919643575, 0., 0., 0., 0., 0., 0.,
+       0., 0., 0., 0., 0., 0., 0., 0., 3.237760857312173e-24}},
+     {{72.814105930277677, 21.384583693573447, 1.6644635543899127e-243,
+       1.6688953794582528e-229}}},
+    // 34-vert star vs 20-vert star
+    //   each with one dominant radius (~33 and ~36) and the rest very
+    //   small. Inclusion-exclusion violated by ~8 absolute on a∪b≈10.
+    //   Verified against post-68cbade7 binary.
+    {"DominantSpikeStars",
+     {{0.15588462038906103,
+       0.00015361176400222398,
+       5.8511202761938412e-16,
+       3.3009196314697135e-10,
+       2.7199740700330746e-09,
+       4.690497141269639e-14,
+       8.9922571322790269e-10,
+       6.3553011716417212e-16,
+       4.2872009761335588e-18,
+       5.6483346599537904e-17,
+       3.479258338980731e-12,
+       9.9500479914355979e-14,
+       1.822663758661907e-10,
+       3.7366088533519133e-05,
+       7.6137290475474603e-12,
+       1.5917667211519553e-08,
+       1.3293803091881353e-06,
+       6.5804393417497265e-09,
+       0.0015777855119048808,
+       3.5317048943785664e-07,
+       1.353313563107637e-09,
+       1.1788667553671715e-05,
+       0.00014847370669519226,
+       1.509263403954591e-11,
+       6.5516568176598574e-10,
+       3.8749326674543751e-07,
+       3.450117114134831e-06,
+       8.3840226251340948e-08,
+       3.0175612629932874e-07,
+       33.778786246753299,
+       0.033251289695133752,
+       0.,
+       0.,
+       1.5817601023378236}},
+     {{3.910135632588194e-07,
+       1.0064704530951155e-13,
+       2.0158855952179934e-14,
+       1.4165380430901347e-21,
+       3.6148752792123783e-11,
+       1.3306453783491879e-10,
+       2.3794160990202857e-13,
+       4.0821728496033454e-14,
+       4.6816579341479393e-18,
+       1.7855060689360453e-17,
+       2.4858744170474308e-10,
+       1.5313588823631113e-11,
+       6.6960358868004941e-08,
+       2.1802650917628242e-10,
+       5.5611296920831909e-13,
+       1.9586931478995027e-08,
+       0.,
+       36.09032519236748,
+       0.,
+       7.5123873966542927e-05},
+      {0.72140998591309213, 0.}},
+     SubtractKind::InclusionExclusion},
+};
+}  // namespace
+
+TEST(CrossSection, SubtractInvariantsSeeds) {
+  for (const auto& c : kSubtractInvariantsSeeds) {
+    SCOPED_TRACE(c.name);
+    // Flush the seed name so a hard crash is still attributable.
+    std::cerr << "[seed] " << c.name << std::endl;
+    const CrossSection a = MakeShape(c.a), b = MakeShape(c.b);
+    if (c.kind == SubtractKind::InclusionExclusion) {
+      const auto aIb = a.Boolean(b, OpType::Intersect);
+      const auto aUb = a + b;
+      const double tol = AreaTol(a, b);
+      EXPECT_NEAR(aUb.Area(), a.Area() + b.Area() - aIb.Area(), tol)
+          << "inclusion-exclusion violated";
+    } else {
+      ExpectBooleanInvariants(a, b);
+    }
+  }
+}
+
+// Consolidated BooleanCommutativity* fuzz-seed regressions, one row per seed.
+// Each row carries that seed's radii + translate verbatim. Every seed asserts
+// union commutativity (A + B vs B + A: area + contour count); checkIntersect
+// additionally asserts intersect commutativity (A ∩ B vs B ∩ A: area +
+// contour count).
+namespace {
+struct CommCase {
+  const char* name;
+  Shape a, b;
+  bool checkIntersect = false;
+};
+
+const CommCase kBooleanCommutativitySeeds[] = {
+    // Asymmetric handling of two
+    //   inputs in the boolean engine - A+B and B+A produce different
+    //   results. A is an 11-pointed star with mixed magnitudes
+    //   (~115 down to ~1e-32); B is a 6-pointed star with mixed
+    //   magnitudes (~96 down to ~1e-53); translation (-0.72, -4.58).
+    //   The boolean engine treats one input as "subject" and one as
+    //   "clip"; an order-dependent bug in vertex merge or winding sign
+    //   would surface here.
+    {"MixedScaleStars",
+     {{3.0969192681814191e-32, 2.3071236813515518e-31, 2.353005480384586e-24,
+       115.24729490924352, 83.850539440722784, 4.3348536506605848,
+       3.0129653594607548, 3.1208956318387746, 4.4747952332988792,
+       51.973983183682101, 5.99364665010221e-15}},
+     {{3.9905161863280855e-53, 0., 96.331001430191975, 0., 0.43952001502476951,
+       48.319452987958854},
+      {-0.72134106089064531, -4.5808240251267858}},
+     /*checkIntersect=*/true},
+    // 11-vertex star vs 12-vertex
+    //   star both with extreme-magnitude radii ranging from O(1e-40)
+    //   to O(55), translated by (-0.36, 2.83). A+B = 11.12 but B+A =
+    //   72.75 - off by ~62. Different inputs from
+    //   DISABLED_BooleanCommutativityMixedScaleStars.
+    {"VeryMixedStars",
+     {{5.5755616189085049e-09, 55.713117722084, 0.24425911685471227,
+       12.355613962816753, 3.2696445771376686e-21, 7.7223346956456043e-27,
+       9.1566312909847612e-29, 1.1757300951916251e-32, 7.5589164688107744e-40,
+       2.1073720366622818e-34, 4.7311936525798036e-23}},
+     {{0., 55.263016827250659, 0., 2.1568234275576556e-26,
+       4.3751784176513804e-26, 3.0217717245002794e-34, 0., 0., 0.,
+       5.2142580450244983e-22, 6.1161686141794186e-15, 2.8398350775198264},
+      {-0.35827067719250716, 2.8298129605573439}}},
+    // A+B and B+A produce different
+    //   contour counts: A+B has 14, B+A has 13. Order-dependent
+    //   commutativity violation: depending on which input is "subject"
+    //   vs "clip", one contour appears/vanishes. Input shapes are
+    //   adversarial - 42-vertex star A with extreme magnitudes
+    //   (mix of 0, 1, 1000) vs 33-vertex star B with mostly small
+    //   radii plus a few in the 700-900 range, translated by
+    //   (1.71, -0.50). Likely a vertex-merge or sort tie-break path
+    //   that depends on input order rather than canonical position.
+    {"ExtremeMagStars",
+     {Runs({{1, 849.58267006542974},
+            {1, 1000.},
+            {1, 1.},
+            {1, 1000.},
+            {2, 0.},
+            {1, 1.},
+            {2, 0.},
+            {1, 673.91660850339099},
+            {1, 641.26963903267847},
+            {1, 0.84355834285842513},
+            {6, 0.},
+            {1, 633.12578243694929},
+            {1, 52.949291739509349},
+            {1, 596.41353494815576},
+            {1, 659.59815503253992},
+            {1, 907.85583546669454},
+            {1, 2.3971527824334933},
+            {1, 0.},
+            {1, 744.77799184771879},
+            {1, 0.},
+            {1, 668.48707869911436},
+            {1, 436.35135227432249},
+            {3, 0.},
+            {1, 1000.},
+            {1, 0.},
+            {1, 938.50101700824371},
+            {1, 84.188304887665581},
+            {1, 470.75422504731279},
+            {1, 89.810808608112893},
+            {1, 992.99533690532235},
+            {1, 152.76119378800999},
+            {1, 1000.},
+            {1, 0.}})},
+     {{681.1551582487607,
+       1.,
+       226.83285963348141,
+       25.271695356113401,
+       903.10565859434519,
+       25.271695356113401,
+       27.294237080468665,
+       205.64018204902527,
+       708.55499051253935,
+       934.95934725410712,
+       597.99208744386829,
+       937.31857430425612,
+       1.,
+       3.0503172192082628,
+       1.,
+       1.,
+       1000.,
+       1000.,
+       1.,
+       1.,
+       901.26525729886407,
+       1.,
+       1000.,
+       1.6267135216510802,
+       449.23493668120602,
+       449.23493668120602,
+       3.1828449559882372,
+       6.9538585160876147,
+       1.7485381697954843,
+       696.88681861119551,
+       1.,
+       183.08811014255667,
+       1.},
+      {1.7126290778198534, -0.5023590407011973}}},
+};
+}  // namespace
+
+TEST(CrossSection, BooleanCommutativitySeeds) {
+  for (const auto& c : kBooleanCommutativitySeeds) {
+    SCOPED_TRACE(c.name);
+    // Flush the seed name so a hard crash is still attributable.
+    std::cerr << "[seed] " << c.name << std::endl;
+    const CrossSection a = MakeShape(c.a), b = MakeShape(c.b);
+    const auto aPlusB = a + b;
+    const auto bPlusA = b + a;
+    const double tol = AreaTol(a, b);
+    EXPECT_NEAR(aPlusB.Area(), bPlusA.Area(), tol) << "A + B != B + A";
+    EXPECT_EQ(aPlusB.NumContour(), bPlusA.NumContour());
+    if (c.checkIntersect) {
+      const auto aIntB = a.Boolean(b, OpType::Intersect);
+      const auto bIntA = b.Boolean(a, OpType::Intersect);
+      EXPECT_NEAR(aIntB.Area(), bIntA.Area(), tol) << "A ∩ B != B ∩ A";
+      EXPECT_EQ(aIntB.NumContour(), bIntA.NumContour());
+    }
+  }
+}
+
+// Consolidated PrismBooleanMatchesCrossSection fuzz-seed regressions, one row
+// per seed. Each builds two regular triangles at near-equal circumradii,
+// extrudes them to prisms, and asserts the union's Volume matches the 2D union
+// area times the height. Rows differ only in the two radii. Ungated: runs on
+// both backends.
+namespace {
+struct PrismCase {
+  const char* name;
+  double radiusA, radiusB;
+};
+
+const PrismCase kPrismSeeds[] = {
+    // Two equilateral triangles with
+    //   circumradii 0.1 and 0.1+6.88e-13, op=Add. Two near-IDENTICAL
+    //   triangles - the union should be essentially one triangle.
+    //   Volume check fails by ~0.26 absolute on h=5; the
+    //   narrowing of Prism only skipped Project/Slice for Subtract,
+    //   not the Volume check which catches this.
+    {"NearIdenticalTriangles", 0.10000000000000001, 0.10000000000068791},
+    // Two equilateral triangles
+    //   with circumradii 1.675 vs 1.669, op=Add. Volume check fails by
+    //   ~20 absolute on h=5. Different from the earlier
+    //   PrismNearIdenticalTrianglesAdd seed which had radii differing
+    //   by 6.88e-13; this one has a ~0.4% radius difference. Verified
+    //   against post-68cbade7 binary..
+    {"CloseRadiiTriangles", 1.6750962039134867, 1.6691810932888278},
+};
+}  // namespace
+
+TEST(CrossSection, PrismSeeds) {
+  auto regular = [](int sides, double radius) {
+    SimplePolygon ring;
+    const double r = 0.1 + std::fabs(radius);
+    for (int i = 0; i < sides; ++i) {
+      const double th = 2.0 * kPi * i / sides;
+      ring.push_back({r * std::cos(th), r * std::sin(th)});
+    }
+    return ring;
+  };
+  for (const auto& c : kPrismSeeds) {
+    SCOPED_TRACE(c.name);
+    std::cerr << "[seed] " << c.name << std::endl;
+    const CrossSection a(regular(3, c.radiusA));
+    const CrossSection b(regular(3, c.radiusB));
+    const auto expected = a + b;
+    const double h = 5.0;
+    const auto solidA = Manifold::Extrude(a.ToPolygons(), h);
+    const auto solidB = Manifold::Extrude(b.ToPolygons(), h);
+    const auto result = solidA + solidB;
+    const double tolScale = 1.0 + std::fabs(a.Area()) + std::fabs(b.Area()) +
+                            std::fabs(expected.Area());
+    EXPECT_NEAR(result.Volume(), expected.Area() * h, 1e-5 * tolScale * h);
+  }
+}
+
+// Consolidated BooleanAssociativity* fuzz-seed regressions, one row per seed.
+// Each row carries that seed's radii + translate verbatim. Both seeds assert
+// union-associativity area equality ((A ∪ B) ∪ C vs A ∪ (B ∪ C)); neither
+// asserted intersect associativity.
+namespace {
+struct AssocCase {
+  const char* name;
+  Shape a, b, c;
+};
+
+const AssocCase kBooleanAssociativitySeeds[] = {
+    // Three 4-vertex stars with
+    //   mixed magnitudes; (A∪B)∪C = 2.994 but A∪(B∪C) = 5.472 - off
+    //   by 2.48. Intersection associativity is fine (matches to 3e-17),
+    //   so the asymmetry is in the union's binary-vs-batch path.
+    //   Translations are all near-zero (~1e-35 to 1e-28); the trigger
+    //   is the radii distribution, not translation.
+    {"UnionMixedTriples",
+     {{24.575460587300253, 2.4572617728922851e-10, 3.3952718785303559e-06, 0.}},
+     {{29.731318514644453, 1.5729051003875837e-06, 0.0082858661009423962, 0.},
+      {-9.1863209962415243e-35, -9.8444830049208569e-28}},
+     {{0., 0., 6.5474426075871467e-16, 2.9296729904240054e-06},
+      {-6.0489837474564476e-29, 0.}}},
+    // Three 4-vertex stars with
+    //   near-zero radii. (A∪B)∪C = 0.04 but A∪(B∪C) = 0.02 - the
+    //   second form drops one unit of area, likely a contour-merge
+    //   bug. Distinct from
+    //   UnionMixedTriples seed above, which had
+    //   larger radii. Verified against post-68cbade7 binary.
+    {"TinyStars",
+     {{0., 0., 0., 2.9078938473355343e-13}},
+     {{1.4795645772678251e-12, 2.4342935254638573e-13, 1.4800031437954507e-12,
+       1.1368244372782033e-305},
+      {0., 0.}},
+     {{0., 0., 0., 0.}}},
+};
+}  // namespace
+
+TEST(CrossSection, BooleanAssociativitySeeds) {
+  for (const auto& c : kBooleanAssociativitySeeds) {
+    SCOPED_TRACE(c.name);
+    // Flush the seed name so a hard crash is still attributable.
+    std::cerr << "[seed] " << c.name << std::endl;
+    const CrossSection a = MakeShape(c.a), b = MakeShape(c.b),
+                       cc = MakeShape(c.c);
+    const auto ab_c = (a + b) + cc;
+    const auto a_bc = a + (b + cc);
+    const double tol = AreaTol(a, b, cc);
+    EXPECT_NEAR(ab_c.Area(), a_bc.Area(), tol) << "(A ∪ B) ∪ C != A ∪ (B ∪ C)";
+  }
+}
+
+// Consolidated BooleanDistributivity* fuzz-seed regressions, one row per
+// seed. Each row carries that seed's radii and translate inputs verbatim;
+// DistribKind selects which assertions the original standalone test made:
+//   AreaOnly     - only the area-equality check
+//   Standard     - ExpectDistributesOverUnion (area-equality plus both
+//                  one-directional area-difference checks)
+//   Monotonicity - the Standard checks plus the two containment checks
+//                  (A intersect B and A intersect C each inside the union)
+// Kept as a single TEST in the CrossSection suite so the CrossSection.*
+// CI filter keeps exercising every seed.
+namespace {
+enum class DistribKind { Standard, AreaOnly, Monotonicity };
+
+struct DistribCase {
+  const char* name;
+  Shape a, b, c;
+  DistribKind kind = DistribKind::Standard;
+};
+
+const DistribCase kDistributivitySeeds[] = {
+    // Three 4-vertex stars with all
+    //   near-zero radii. A∩(B∪C) returns 0 but (A∩B)∪(A∩C) returns
+    //   0.02 - off by 0.02. Tiny inputs near eps; the distributivity
+    //   path may have lost a contour during simplification. Verified
+    //   against post-68cbade7 binary.
+    {"TinyStars",
+     {{0., 0., 0., 0.}},
+     {{0., 0., 0., 2.6526376418441693e-13}, {0., 0.}},
+     {{5.8033140339376039e-12, 4.8677534136980153e-13, 0., 0.},
+      {-2.4305117516652688e-13, 0.}},
+     DistribKind::AreaOnly},
+    // Left side `A ∩ (B ∪ C)` has
+    //   NumContour=24, right side `(A ∩ B) ∪ (A ∩ C)` has NumContour=23.
+    //   Off-by-one in contour decomposition. Inputs are three mid-size
+    //   stars (34/46/48 verts) with extreme-magnitude radii (mix of 0,
+    //   1, 1000-ish) and translations in [-2.4, 3.9] x [-1.0, 2.4].
+    //   Likely the interleaved Union+Intersect path produces or drops
+    //   a contour relative to the (Intersect, Intersect, Union)
+    //   ordering. Related to but distinct from previously-drained
+    //   BooleanCommutativity / BooleanAssociativity classes.
+    {"ExtremeMagStars",
+     {{22.40352672886273,
+       1000.,
+       1.930469114705216,
+       1000.,
+       995.07901723564635,
+       450.42497103653432,
+       1.,
+       1000.,
+       442.67830885450564,
+       974.26213405728731,
+       762.40083808845225,
+       375.22374612076686,
+       311.70408869554416,
+       4.6596927406080066,
+       1000.,
+       993.53293688808651,
+       545.61942022366179,
+       902.87869535025561,
+       857.23036058152354,
+       1.,
+       997.14305195601548,
+       998.81543502854458,
+       4.287799655231888,
+       1.9578049801330417,
+       212.99717518614997,
+       539.98252283023282,
+       814.2147123777587,
+       6.4135462648884491,
+       386.69166945488905,
+       642.25190405836315,
+       671.02238904111891,
+       1000.,
+       0.,
+       959.32882825167917}},
+     {{596.78699570023025,
+       0.,
+       0.,
+       4.8215130310908281,
+       134.35969768300723,
+       514.84369184653679,
+       514.84369184653679,
+       514.84369184653679,
+       134.35969768300723,
+       134.35969768300723,
+       1000.,
+       1.,
+       1000.,
+       0.,
+       926.29500965174145,
+       0.,
+       134.35969768300723,
+       0.90493025476122824,
+       95.854999537523781,
+       1000.,
+       0.,
+       0.,
+       460.32237309958083,
+       2.9791218075989327,
+       30.186663600739344,
+       1.,
+       5.732788180417673,
+       487.77994489187455,
+       1.,
+       639.36782925291504,
+       1.,
+       1.,
+       405.85342012592389,
+       405.85342012592389,
+       405.85342012592389,
+       706.56289376450047,
+       405.85342012592389,
+       405.85342012592389,
+       1.,
+       1.,
+       872.8336783186561,
+       5.1830997334306659,
+       313.84753596061228,
+       3.3318960586713984,
+       22.317598513501498,
+       4.1956604335614083},
+      {3.4425093025001434, -0.89018350575014171}},
+     {{279.68331311398725,
+       670.56312431772176,
+       812.15251441725718,
+       1000.,
+       0.,
+       996.64035079388486,
+       1.,
+       1000.,
+       1.,
+       146.36259356992105,
+       1000.,
+       1.2440205144455736,
+       2.4903214421341642,
+       558.11442117895865,
+       667.56514527125182,
+       601.28991029625661,
+       0.,
+       0.,
+       1.,
+       485.29900078511309,
+       205.35289543499823,
+       1.,
+       1.,
+       999.13575735403208,
+       0.,
+       343.12355139003932,
+       124.51182502694519,
+       0.44553220583928932,
+       512.45895098827191,
+       2.5455428684940777,
+       0.,
+       1000.,
+       1000.,
+       0.,
+       595.63567011806413,
+       2.5851695628219766,
+       3.2720224325713057,
+       354.45821723238265,
+       4.2476895774067867,
+       956.03225557664916,
+       0.,
+       1000.,
+       0.,
+       98.799661756610732,
+       0.,
+       619.55626420041142,
+       0.,
+       999.86711403007541},
+      {3.8936971336588151, 2.3137657561842939}},
+     DistribKind::AreaOnly},
+    // A ∩ (B ∪ C) != (A ∩ B) ∪ (A ∩ C)
+    //   on large-area stars. left.Area=216374, right.Area=215961, diff=412
+    //   (relative ~0.2%, exceeds 1e-6 * sum-of-areas tol of 2.34).
+    //   Inputs: 16-vertex star A with mixed radii, 4-vertex star B (small),
+    //   37-vertex star C with most radii repeated as 332.47 (degenerate-ish
+    //   shape). Translations: B by (4.89, 3.65), C by (-1.53, -2.63).
+    //   Distinct from previously-fixed BooleanDistributivityExtremeMagStars
+    //   (hash 659ec969) - that was a contour-count off-by-one, this is
+    //   area drift in absolute terms.
+    {"RepeatedRadiusStarC",
+     {{1., 283.64569337262878, 0., 705.96814039386641, 332.07185213769458,
+       534.61157622175767, 1000., 1000., 1000., 1000., 1000., 1000., 1000., 1.,
+       1., 1000.}},
+     {{974.53903971669604, 443.79612063734504, 0.60212977272176105,
+       601.54223181860084},
+      {4.890230810667985, 3.6470913496183108}},
+     {Runs({{1, 2.8991656937704362},
+            {1, 1000.},
+            {1, 1.},
+            {21, 332.4725376862869},
+            {2, 384.70682133429182},
+            {2, 332.4725376862869},
+            {1, 682.65150344752476},
+            {1, 737.43471827249516},
+            {1, 327.59982985461647},
+            {2, 332.4725376862869},
+            {1, 1.},
+            {3, 1000.}}),
+      {-1.5262817329731697, -2.6347725451611175}}},
+    // Sibling of the just-drained
+    //   RepeatedRadiusStarC. Smaller magnitude (left.Area=80787,
+    //   right.Area=80781, diff=5.9 vs tol=1.28). Star C has many zeros
+    //   mixed with mid-range values - a different degeneracy pattern
+    //   than the previous all-repeated-radius case.
+    {"ZeroMixStarC",
+     {{1000.,
+       1000.,
+       255.79995725682645,
+       1.,
+       454.29432950304715,
+       995.65401133735929,
+       1000.,
+       811.86733957046874,
+       1.,
+       437.04103091878892,
+       195.25477231407794,
+       1.8268273914683537,
+       4.5954160688751484,
+       3.2030613706914481,
+       511.5935307510378,
+       2.0771806846580496,
+       570.21917979539887,
+       1.9769538901315753,
+       467.93526395973339,
+       1.,
+       959.79674877569607,
+       0.076792444298594276,
+       503.25635714266843,
+       0.,
+       89.215459767705454,
+       0.,
+       1000.,
+       0.06374847983784826,
+       995.14671048524883,
+       1.,
+       0.}},
+     {{271.39306287742255, 997.96011166439871, 909.94463259654469,
+       364.30795394492606},
+      {0.12749108485042271, 2.533194291154123}},
+     {{812.15251441725718,
+       0.,
+       601.28991029625661,
+       0.,
+       482.34411167146169,
+       0.,
+       588.04482477271347,
+       0.,
+       169.03839642543201,
+       0.44553220583928932,
+       4.0649812370918958,
+       512.45895098827191,
+       0.,
+       1000.,
+       0.,
+       999.90271349806335,
+       459.5889801989477,
+       105.49723198609914,
+       0.,
+       0.,
+       748.07738025389699,
+       1.7632947108253827,
+       0.,
+       0.,
+       4.9202747062496162,
+       751.85659442712381,
+       732.78647234489199,
+       0.,
+       375.32896975602767,
+       0.},
+      {-2.5843878979814856, -4.3357952411613461}}},
+    // Residual distributivity failure
+    //   after a9cfd4ff "Use nonzero union for boolean2 set add". A is a
+    //   33-radii star, C is a 32-radii star with zeros interleaved with
+    //   mid-large radii. Area asymmetry: left.Area ~ 71882, right.Area
+    //   ~ 66448, diff 5435 (~7%). The right side (A ∩ B) ∪ (A ∩ C) is
+    //   contained in left ((right - left).Area == 0) but is missing
+    //   5435 area units. NumContour also diverges (left=1, right=5).
+    //   The zero-radius vertices collapse to the 0.1 baseline floor,
+    //   producing dense near-degenerate slivers that the intersect path
+    //   appears to drop on one side of the distributivity identity.
+    {"NonzeroUnionResidual",
+     {{1000.,
+       1000.,
+       1.,
+       454.29432950304715,
+       995.65401133735929,
+       1000.,
+       1.,
+       1000.,
+       437.04103091878892,
+       195.25477231407794,
+       1.8268273914683537,
+       4.5954160688751484,
+       3.2030613706914481,
+       511.5935307510378,
+       2.0771806846580496,
+       643.7557324509894,
+       570.21917979539887,
+       1.9769538901315753,
+       467.93526395973339,
+       2.8343333181297945,
+       832.7231586632563,
+       1.9935416909420567,
+       3.4941254801335897,
+       503.25635714266843,
+       0.,
+       677.87894521363603,
+       1000.,
+       0.,
+       1000.,
+       0.06374847983784826,
+       995.14671048524883,
+       1.,
+       0.}},
+     {{381.47868752207233, 271.38539902365324, 902.29172154497269,
+       369.78142089265032},
+      {-4.2594328040756597, -3.826038498814941}},
+     {{812.15251441725718,
+       0.,
+       996.64035079388486,
+       1.2440205144455736,
+       845.2781504274202,
+       1.7150332286725525,
+       601.28991029625661,
+       0.,
+       482.34411167146169,
+       0.,
+       588.04482477271347,
+       0.,
+       169.03839642543201,
+       512.45895098827191,
+       3.4002817704521431,
+       793.8531142632803,
+       234.81914439627278,
+       0.,
+       999.90271349806335,
+       105.49723198609914,
+       0.,
+       1000.,
+       0.,
+       705.33517104963164,
+       2.2547666355380791,
+       949.94413913719598,
+       0.,
+       4.9202747062496162,
+       751.85659442712381,
+       0.,
+       375.32896975602767,
+       0.},
+      {-4.6033649212771799, -4.3357952411613461}},
+     DistribKind::Monotonicity},
+    // Companion to
+    //   DISABLED_BooleanDistributivityNonzeroUnionResidual above, but
+    //   with the zeros in A and an intermediate-sized B - 28-radii A
+    //   with leading 0., 0. plus repeated 85.93 values, 16-radii B
+    //   dominated by 1000s with a few small/zero values, 4-radii simple
+    //   C. Same failure shape: left has 1 contour, right has 3, right
+    //   strictly contained in left, missing ~4001 area units out of
+    //   ~16255 (~25%). Confirms the intersect-path sliver-drop bug is
+    //   not specific to which input carries the zeros.
+    {"ZerosInANonzeroUnion",
+     {Runs({{2, 0.},
+            {2, 85.932045280269435},
+            {1, 503.627431790542},
+            {1, 85.932045280269435},
+            {2, 90.069450175585047},
+            {7, 1.},
+            {1, 3.0409033274230679},
+            {1, 90.340071855270295},
+            {1, 88.580867960622072},
+            {1, 261.53938936688053},
+            {1, 1.},
+            {6, 85.932045280269435},
+            {1, 1000.},
+            {1, 1.}})},
+     {{0., 1000., 1000., 150.433665233841, 1000., 1000., 1., 1000., 1000.,
+       1000., 1000., 177.35813950095334, 0.04587971958967612,
+       635.76724699191789, 0., 801.00098835163021},
+      {0.70686431311486997, 4.2881751021813148}},
+     {{2.2620915191424817, 352.8271046252292, 124.40008725909412,
+       583.15656615652506},
+      {1.9937691377314026, 4.7666664390133615}},
+     DistribKind::Monotonicity},
+    // Small-residual failure on the
+    //   OPPOSITE side from the previous nonzero-union residuals: here
+    //   right > left, with left.Area=172524 and right.Area=172618 -
+    //   diff only 94.6 (~0.06%) but (left-right).Area==0 and
+    //   (right-left).Area=94. NumContour also reversed: left=25,
+    //   right=8 - right side collapses many contours into fewer.
+    //   Suggests the right-hand `(A∩B) ∪ (A∩C)` is over-merging
+    //   adjacent components and accidentally including area that the
+    //   left-hand `A ∩ (B∪C)` correctly carves out. Distinct from the
+    //   "right is strictly contained in left, missing area" shape of
+    //   86029efb/278f30ca seeds which were fixed by the recent
+    //   nonzero-outer-face classifier change.
+    {"RightOverMerges",
+     {{1000., 995.07901723564635, 1., 1000., 974.26213405728731,
+       974.26213405728731, 887.65436435582899, 1000., 0., 1000., 1000.,
+       0.06374847983784826, 671.02238904111891, 671.02238904111891,
+       671.02238904111891, 0.}},
+     {Runs({{1, 165.9646574194592},
+            {2, 134.35969768300723},
+            {3, 0.},
+            {1, 134.35969768300723},
+            {1, 0.90493025476122824},
+            {1, 95.854999537523781},
+            {1, 0.},
+            {1, 730.30962259021919},
+            {1, 0.},
+            {1, 460.32237309958083},
+            {1, 2.9791218075989327},
+            {1, 30.186663600739344},
+            {1, 1.},
+            {1, 90.446292042234916},
+            {1, 5.732788180417673},
+            {1, 487.77994489187455},
+            {1, 4.5933105105744643},
+            {1, 110.52720785200476},
+            {3, 1.},
+            {1, 338.4042053897046},
+            {2, 1.},
+            {2, 405.85342012592389},
+            {1, 0.},
+            {1, 1.},
+            {1, 405.85342012592389},
+            {1, 706.56289376450047},
+            {2, 405.85342012592389},
+            {9, 1.}}),
+      {0.61958285855050033, -2.9878148015921839}},
+     {{279.68331311398725,
+       814.7527470368675,
+       812.15251441725718,
+       1000.,
+       0.,
+       996.64035079388486,
+       1.,
+       1000.,
+       1.,
+       0.,
+       146.36259356992105,
+       1000.,
+       1.2440205144455736,
+       2.4903214421341642,
+       1.4267332381508839,
+       1.0658012274682902,
+       937.2477438999249,
+       601.28991029625661,
+       0.,
+       482.34411167146169,
+       0.,
+       999.13575735403208,
+       0.,
+       124.51182502694519,
+       0.44553220583928932,
+       4.0649812370918958,
+       512.45895098827191,
+       1000.,
+       0.,
+       0.,
+       0.,
+       595.63567011806413,
+       2.5851695628219766,
+       354.45821723238265,
+       4.2476895774067867,
+       956.03225557664916,
+       0.,
+       0.,
+       98.799661756610732,
+       0.,
+       1000.,
+       1.},
+      {2.4887547431653907, 4.8411440198518338}}},
+    // Same failure shape as the
+    //   already-drained 86029efb/278f30ca residuals - right strictly
+    //   contained in left, missing area - but on larger inputs (34/19/45
+    //   radii). Area diff 26631 (~19% of left), NumContour 11 vs 10.
+    //   Demonstrates that the nonzero-outer-face classifier fix did not
+    //   fully drain the bug class: the specific seeded counterexamples
+    //   pass, but neighbors in the same family with larger zero/repeat
+    //   counts still trigger the same misclassification.
+    {"LargeInputsResidual",
+     {Runs({{1, 215.54119679461166},
+            {1, 0.},
+            {1, 1000.},
+            {2, 85.932045280269435},
+            {1, 503.627431790542},
+            {1, 85.932045280269435},
+            {1, 1.6560313083633313},
+            {2, 90.069450175585047},
+            {4, 1.},
+            {1, 0.},
+            {4, 1.},
+            {1, 87.027104618165325},
+            {1, 85.932045280269435},
+            {1, 258.81750993550418},
+            {1, 1000.},
+            {1, 1.},
+            {1, 0.},
+            {1, 89.294011990045064},
+            {5, 85.932045280269435},
+            {2, 1000.},
+            {1, 1.}})},
+     {{1000., 0., 997.02489346940774, 997.07890660881435, 319.71364680208376,
+       675.57216392823045, 997.55565490398703, 619.18266326889307,
+       345.22578984765374, 3.1502725292253997, 121.95185049831551,
+       585.41131030666656, 999.93563090020007, 1000., 0., 177.35813950095334,
+       0.04587971958967612, 882.24641989432973, 1.1946278115288917},
+      {-4.3860291464683625, 2.2730433830580954}},
+     {Runs({{1, 1.},
+            {1, 1000.},
+            {1, 1.},
+            {1, 282.41410155737179},
+            {1, 1.},
+            {4, 282.41410155737179},
+            {1, 1000.},
+            {1, 1.},
+            {2, 1000.},
+            {2, 0.},
+            {15, 1000.},
+            {1, 578.55699544670244},
+            {13, 1000.},
+            {1, 1.}}),
+      {0.99578244833742113, -4.0475870932225444}}},
+};
+}  // namespace
+
+TEST(CrossSection, BooleanDistributivitySeeds) {
+  for (const auto& c : kDistributivitySeeds) {
+    SCOPED_TRACE(c.name);
+    // Print the seed name unconditionally: SCOPED_TRACE is not flushed on a
+    // raw abort/segfault, so this line is what attributes a hard crash to a
+    // specific seed.
+    std::cerr << "[seed] " << c.name << std::endl;
+    const CrossSection a = MakeShape(c.a), b = MakeShape(c.b),
+                       cc = MakeShape(c.c);
+    if (c.kind == DistribKind::AreaOnly) {
+      EXPECT_NEAR(
+          a.Boolean(b + cc, OpType::Intersect).Area(),
+          (a.Boolean(b, OpType::Intersect) + a.Boolean(cc, OpType::Intersect))
+              .Area(),
+          AreaTol(a, b, cc))
+          << "A ∩ (B ∪ C) != (A ∩ B) ∪ (A ∩ C)";
+    } else {
+      ExpectDistributesOverUnion(a, b, cc);
+    }
+    if (c.kind == DistribKind::Monotonicity) {
+      const double tol = AreaTol(a, b, cc);
+      const auto right =
+          a.Boolean(b, OpType::Intersect) + a.Boolean(cc, OpType::Intersect);
+      EXPECT_NEAR((a.Boolean(b, OpType::Intersect) - right).Area(), 0.0, tol)
+          << "union monotonicity: (A ∩ B) is not contained in right";
+      EXPECT_NEAR((a.Boolean(cc, OpType::Intersect) - right).Area(), 0.0, tol)
+          << "union monotonicity: (A ∩ C) is not contained in right";
+    }
+  }
+}
+
+// Regression in CrossSection::Offset (src/cross_section.cpp).
+//   Regular triangle, Miter join exactly on the miter_limit=2.0
+//   threshold; the Offset(d).Offset(-d) round-trip drifts -0.35% in area
+//   in a way that's scale-invariant (same percentage at r=0.15, r=1.5,
+//   r=15). n>=4 has zero drift (verified probe), so the bug is specific
+//   to the miter-limit boundary of the equilateral triangle.
+TEST(CrossSection, OffsetInverseTriangleMiter) {
+  // Equilateral triangle inscribed in r=0.15 (effective radius via the
+  // 0.1 + |radius| convention used in cross_section_fuzz).
+  SimplePolygon ring;
+  const double r = 0.15;
+  for (int i = 0; i < 3; ++i) {
+    const double theta = 2.0 * kPi * i / 3;
+    ring.push_back({r * std::cos(theta), r * std::sin(theta)});
+  }
+  const CrossSection input(ring);
+  const double delta = -0.0094938192047002799;
+
+  const auto expanded =
+      input.Offset(delta, CrossSection::JoinType::Miter, /*miter_limit=*/2.0,
+                   /*circularSegments=*/0);
+  const auto roundTrip = expanded.Offset(-delta, CrossSection::JoinType::Miter,
+                                         /*miter_limit=*/2.0,
+                                         /*circularSegments=*/0);
+
+  // For Miter join with miter_limit=2.0 exactly at the equilateral triangle
+  // threshold, equality should still take the miter path. Observed:
+  // 0.357% absolute drift when rounded normals spuriously square the join.
+  const double tol = 1e-4 * (1.0 + std::fabs(input.Area()));
+  EXPECT_NEAR(roundTrip.Area(), input.Area(), tol)
+      << "Triangle Miter Offset round-trip drifted by "
+      << (roundTrip.Area() - input.Area()) / input.Area() * 100 << "%";
+  EXPECT_EQ(roundTrip.NumContour(), input.NumContour());
+}
+
+// CrossSection::Decompose path,
+//   most likely the containment/face-classification step that picks
+//   which rings to emit per component. An 8-vertex star outer with
+//   a small translated hole produces a 2-contour CrossSection
+//   (NumContour=2: outer+hole, Area=911.40 = 911.70 outer - 0.30
+//   hole). Decompose returns 1 component whose Area=911.70 and
+//   NumContour=1 - the hole is silently dropped. Compose then gives
+//   a full-outer result, losing 0.3 area worth of hole. Area
+//   conservation invariant violated; bidirectional Decompose/Compose
+//   should be the identity on multi-ring inputs.
+TEST(CrossSection, DecomposeRecomposeOuterStarWithSmallHole) {
+  const std::vector<double> outerRadii = {
+      1., 1., 1., 50., 50., 0., 3.987798525003551, 1.};
+  const std::vector<double> holeRadii = {0., 0., 1., 0.29444504003509697};
+  const CrossSection outer(StarRing(outerRadii));
+  const CrossSection hole =
+      CrossSection(StarRing(holeRadii)).Translate({0., 1.});
+  const auto holed = outer - hole;
+  ASSERT_EQ(holed.NumContour(), 2u);  // sanity: subtract produced
+                                      // outer + hole
+  const double holedArea = holed.Area();
+
+  const auto components = holed.Decompose();
+  ASSERT_FALSE(components.empty());
+
+  double componentArea = 0.0;
+  size_t componentContourSum = 0;
+  for (const auto& component : components) {
+    componentArea += component.Area();
+    componentContourSum += component.NumContour();
+  }
+  const double tol = 1e-6 * (1.0 + std::fabs(holedArea));
+  EXPECT_NEAR(componentArea, holedArea, tol)
+      << "Decompose lost area on holed input: " << "sum(components.Area)="
+      << componentArea << " vs holed.Area()=" << holedArea;
+  EXPECT_EQ(componentContourSum, holed.NumContour())
+      << "Decompose lost contours on holed input: "
+      << "sum(components.NumContour)=" << componentContourSum
+      << " vs holed.NumContour()=" << holed.NumContour();
+
+  const auto recomposed = CrossSection::Compose(components);
+  EXPECT_NEAR(recomposed.Area(), holedArea, tol);
+  EXPECT_EQ(recomposed.NumContour(), holed.NumContour());
+}
+
+// Same Decompose area-conservation
+//   class as DecomposeRecomposeOuterStarWithSmallHole but a distinct
+//   counterexample. 5-vertex outer star (radii skewed: 48.55, 5.05,
+//   1, 1, 50 - one large spike) minus a 5-vertex inner star
+//   (radii 1, 3.75, 0.573, 1, 0) translated by (0, 1.0012).
+//   componentArea=1304.5424 but holed.Area()=1304.5751, diff 0.0327
+//   exceeds tol 0.0013. Decompose drops a chunk of hole-adjacent
+//   area rather than the entire hole this time. Possible: when the
+//   hole is near-tangent to the outer (the 1.0012 offset puts it
+//   very close to an outer edge), face classification miscategorizes
+//   a sliver that gets dropped on the decompose path.
+TEST(CrossSection, DecomposeRecomposeNearTangentSmallHole) {
+  // Match the fuzz target's exact construction (outer - hole) so the
+  // reproducer goes through the same Boolean Subtract -> Decompose
+  // path that fuzzing exercised.
+  const std::vector<double> outerRadii = {48.55001516665169, 5.0536385110757127,
+                                          1., 1., 50.};
+  const std::vector<double> holeRadii = {1., 3.7464608085566375,
+                                         0.57299724595371804, 1., 0.};
+  const CrossSection outer(StarRing(outerRadii));
+  const CrossSection hole =
+      CrossSection(StarRing(holeRadii)).Translate({-0., 1.0011960822937693});
+  const auto holed = outer - hole;
+  ASSERT_FALSE(holed.IsEmpty());
+  ASSERT_GE(holed.NumContour(), 2u)
+      << "expected outer + hole, got NumContour=" << holed.NumContour();
+  const double holedArea = holed.Area();
+
+  const auto components = holed.Decompose();
+  ASSERT_FALSE(components.empty());
+
+  double componentArea = 0.0;
+  size_t componentContourSum = 0;
+  for (const auto& c : components) {
+    componentArea += c.Area();
+    componentContourSum += c.NumContour();
+  }
+  const double tol = 1e-6 * (1.0 + std::fabs(holedArea));
+  EXPECT_NEAR(componentArea, holedArea, tol)
+      << "Decompose lost area on holed input: sum(components.Area)="
+      << componentArea << " vs holed.Area()=" << holedArea;
+  EXPECT_EQ(componentContourSum, holed.NumContour())
+      << "Decompose split or merged contours unexpectedly";
+
+  const auto recomposed = CrossSection::Compose(components);
+  EXPECT_NEAR(recomposed.Area(), holedArea, tol)
+      << "Compose(Decompose(holed)) changed area";
+  EXPECT_EQ(recomposed.NumContour(), holed.NumContour())
+      << "Compose(Decompose(holed)) changed contour count";
+}
+
+// Inclusion-exclusion fails when
+//   one vertex of B is set exactly coincident with a vertex of A
+//   (op=2 in the DegenerateInputFuzz harness). Both stars are 6
+//   vertices with mid-range radii. unionAB.Area=436995 but
+//   ca.Area+cb.Area-intersectAB.Area=434285, diff 2710 (~0.6%) far
+//   above the 4.34 tol. intersectAB.Area only 0.51 - tiny sliver,
+//   yet the union absorbs ~2710 extra area. Likely the coincident
+//   vertex is mis-classified during merge, creating phantom area
+//   in the union or losing it from the intersection.
+TEST(CrossSection, DegenerateCoincidentVertexUnion) {
+  const std::vector<double> radiiA = {1.0169016983060246, 1000., 1.,
+                                      578.85382959129936, 0.,    0.};
+  const std::vector<double> radiiB = {0.,
+                                      1000.,
+                                      999.83083173100238,
+                                      7.275875880519048,
+                                      726.89009231357352,
+                                      3.880747251022969};
+  SimplePolygon a = StarRing(radiiA);
+  SimplePolygon b = StarRing(radiiB);
+  for (auto& v : b) {
+    v.x += 0.0030378301550779696;
+  }
+  // op=94 % 4 = 2 in DegenerateInputFuzz: set b[j] = a[i] to create
+  // a coincident-vertex degeneracy. idxA=25 % 6 = 1, idxB=52 % 6 = 4.
+  b[4] = a[1];
+
+  const CrossSection ca(a);
+  const CrossSection cb(b);
+  const auto unionAB = ca + cb;
+  const auto intersectAB = ca.Boolean(cb, OpType::Intersect);
+  const double sum = ca.Area() + cb.Area() - intersectAB.Area();
+  const double tol = 1e-5 * (1.0 + std::fabs(ca.Area()) + std::fabs(cb.Area()));
+  EXPECT_NEAR(unionAB.Area(), sum, tol)
+      << "Inclusion-exclusion violated on coincident-vertex degenerate input";
+}
+
+// Reduced from DegenerateCoincidentVertexUnion after constructor round-trip:
+// already-regularized inputs still reproduce the original ~2710 area residual.
+// This keeps both B triangles and drops two A vertices.
+TEST(CrossSection, DegenerateCoincidentVertexUnionReduced) {
+  const Polygons a = {{
+      {500.05000000000018, 866.11200632481712},
+      {-0.54999999999999716, 0.95262794416288443},
+      {-578.95382959129938, 5.6843418860808015e-14},
+      {-0.049999999999997158, -0.08660254037846471},
+  }};
+  const Polygons b = {
+      {{500.04999974215514, 866.1120058797319},
+       {-499.96237803534598, 865.96550230635103},
+       {-7.3728380503639697, 0}},
+      {{500.04999974215514, 866.1120058797319},
+       {499.66038873910634, 865.43178211833663},
+       {500.05303783015518, 866.11200632481712}},
+  };
+
+  const CrossSection ca(a);
+  const CrossSection cb(b);
+  const auto unionAB = ca + cb;
+  const auto intersectAB = ca.Boolean(cb, OpType::Intersect);
+  const CrossSection combined(Polygons{a[0], b[0], b[1]});
+  const double sum = ca.Area() + cb.Area() - intersectAB.Area();
+  const double tol = 1e-5 * (1.0 + std::fabs(ca.Area()) + std::fabs(cb.Area()));
+  EXPECT_NEAR(unionAB.Area(), sum, tol)
+      << "Inclusion-exclusion violated on reduced coincident-vertex input";
+  EXPECT_NEAR(combined.Area(), sum, tol)
+      << "Constructor edge soup lost area on reduced coincident-vertex input";
+}
+
+// Smaller 4+3 reduction from the same parked seed: keeping only the tiny top
+// B triangle isolates the near-corner edge-vertex double-hit that used to make
+// both binary union and single-constructor edge soup lose the large A contour.
+TEST(CrossSection, DegenerateCoincidentVertexUnionTinyTriangle) {
+  const Polygons a = {{
+      {500.05000000000018, 866.11200632481712},
+      {-0.54999999999999716, 0.95262794416288443},
+      {-578.95382959129938, 5.6843418860808015e-14},
+      {-0.049999999999997158, -0.08660254037846471},
+  }};
+  const Polygons b = {{
+      {500.04999974215514, 866.1120058797319},
+      {499.66038873910634, 865.43178211833663},
+      {500.05303783015518, 866.11200632481712},
+  }};
+
+  auto translate = [](Polygons polys, double delta) {
+    for (auto& loop : polys) {
+      for (vec2& p : loop) {
+        p.x += delta;
+        p.y += delta;
+      }
+    }
+    return polys;
+  };
+
+  for (double offset : {0.0, 1024.0, 4096.0, 8192.0}) {
+    SCOPED_TRACE(offset);
+    const Polygons shiftedA = translate(a, offset);
+    const Polygons shiftedB = translate(b, offset);
+    const CrossSection ca(shiftedA);
+    const CrossSection cb(shiftedB);
+    const auto unionAB = ca + cb;
+    const auto intersectAB = ca.Boolean(cb, OpType::Intersect);
+    const CrossSection combined(Polygons{shiftedA[0], shiftedB[0]});
+    const double sum = ca.Area() + cb.Area() - intersectAB.Area();
+    const double tol =
+        1e-5 * (1.0 + std::fabs(ca.Area()) + std::fabs(cb.Area()));
+    const double tinyContributionTol = 0.01 * cb.Area();
+    EXPECT_GT(cb.Area(), 1e-4);
+    EXPECT_GT(unionAB.Area(), ca.Area() + 0.5 * cb.Area())
+        << "Binary union dropped most of the tiny triangle contribution";
+    EXPECT_GT(combined.Area(), ca.Area() + 0.5 * cb.Area())
+        << "Constructor edge soup dropped most of the tiny triangle "
+           "contribution";
+    EXPECT_NEAR(unionAB.Area(), sum, tol)
+        << "Inclusion-exclusion violated on tiny-triangle reduction";
+    EXPECT_NEAR(unionAB.Area(), sum, tinyContributionTol)
+        << "Binary union dropped the tiny triangle contribution";
+    EXPECT_NEAR(combined.Area(), sum, tinyContributionTol)
+        << "Constructor edge soup dropped the tiny triangle contribution";
+  }
+}
+
+TEST(CrossSection, NonFiniteInputReturnsEmpty) {
+  const double inf = std::numeric_limits<double>::infinity();
+  SimplePolygon bad = {{0.0, 0.0}, {1.0, 0.0}, {inf, 1.0}, {0.0, 1.0}};
+
+  CrossSection constructed(bad);
+  EXPECT_TRUE(constructed.IsEmpty());
+
+  Polygons finite = {{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}}};
+  EXPECT_TRUE(Boolean2D(Polygons{bad}, finite, OpType::Add).empty());
+}
+
+TEST(CrossSection, OffsetIsInvariantUnderLargeTranslation) {
+  const CrossSection square = CrossSection::Square({10.0, 10.0}, true);
+  const CrossSection origin =
+      square.Offset(1.0, CrossSection::JoinType::Round, 2.0, 8);
+  const CrossSection translated =
+      square.Translate({1e12, -1e12})
+          .Offset(1.0, CrossSection::JoinType::Round, 2.0, 8)
+          .Translate({-1e12, 1e12});
+
+  EXPECT_EQ(translated.NumContour(), origin.NumContour());
+  EXPECT_EQ(translated.NumVert(), origin.NumVert());
+  EXPECT_NEAR(translated.Area(), origin.Area(), 1e-3);
+}
+
+TEST(CrossSection, SimplifyPostFiltersBoolean2Output) {
+  const double apex = 1.0148512233354445e-6;
+  const SimplePolygon tri = {{-1.0, 0.0}, {1.0, 0.0}, {0.0, apex}};
+  const SimplePolygon quad = {
+      {-0.05, -1.0}, {0.05, -1.0}, {0.05, 2.0}, {-0.05, 2.0}};
+  const CrossSection input(Polygons{tri, quad},
+                           CrossSection::FillRule::Positive);
+
+  const CrossSection once = input.Simplify();
+  const CrossSection twice = once.Simplify();
+
+  // 10 verts (incl. the apex just above the 1e-6 default eps), matching
+  // clipper2: Simplify regularizes at the geometry eps then RDP-reduces at eps.
+  EXPECT_EQ(once.NumContour(), 1);
+  EXPECT_EQ(once.NumVert(), 10);
+  EXPECT_EQ(twice.NumContour(), once.NumContour());
+  EXPECT_EQ(twice.NumVert(), once.NumVert());
+  EXPECT_NEAR(twice.Area(), once.Area(), 1e-12);
+}
+
+TEST(CrossSection, SimplifyRemovesCollinearVertices) {
+  // RDP: vertices within eps of the line through their neighbors (the edge
+  // midpoints here) are dropped; the four corners are kept.
+  const SimplePolygon boxWithMidpoints = {{0, 0}, {1, 0}, {2, 0}, {2, 1},
+                                          {2, 2}, {1, 2}, {0, 2}, {0, 1}};
+  const CrossSection simplified = CrossSection(boxWithMidpoints).Simplify(1e-3);
+  EXPECT_EQ(simplified.NumVert(), 4);
+  EXPECT_NEAR(simplified.Area(), 4.0, 1e-9);
+}
+
+TEST(CrossSection, SimplifyReducesCurveWithoutCollapsing) {
+  // A moderate epsilon reduces a dense curve but must never delete it
+  // (regression: feeding epsilon as the boolean merge tolerance collapsed
+  // circles to empty once epsilon exceeded the vertex spacing).
+  const CrossSection circle = CrossSection::Circle(10.0, 64);
+  const double area0 = circle.Area();
+  const CrossSection simplified = circle.Simplify(0.5);
+  EXPECT_FALSE(simplified.IsEmpty());
+  EXPECT_LT(simplified.NumVert(), 64u);
+  EXPECT_GT(simplified.NumVert(), 4u);
+  EXPECT_GT(simplified.Area(), 0.9 * area0);
 }
 
 TEST(CrossSection, Empty) {
@@ -171,6 +1843,164 @@ TEST(CrossSection, Decompose) {
             Manifold::Extrude(recomp.ToPolygons(), 1.).GetMeshGL());
 }
 
+TEST(CrossSection, DecomposeNestedHoleAndIsland) {
+  SimplePolygon outer = {{-5, -5}, {5, -5}, {5, 5}, {-5, 5}};
+  SimplePolygon hole = {{-3, -3}, {-3, 3}, {3, 3}, {3, -3}};
+  SimplePolygon island = {{-1, -1}, {1, -1}, {1, 1}, {-1, 1}};
+  CrossSection input({outer, hole, island}, CrossSection::FillRule::Positive);
+
+  auto components = input.Decompose();
+  ASSERT_EQ(components.size(), 2);
+
+  double totalArea = 0.0;
+  size_t donutCount = 0;
+  size_t islandCount = 0;
+  for (const auto& component : components) {
+    totalArea += component.Area();
+    if (component.NumContour() == 2) {
+      ++donutCount;
+    } else if (component.NumContour() == 1) {
+      ++islandCount;
+    }
+  }
+
+  EXPECT_EQ(donutCount, 1);
+  EXPECT_EQ(islandCount, 1);
+  EXPECT_NEAR(totalArea, input.Area(), 1e-9);
+  EXPECT_NEAR(CrossSection::Compose(components).Area(), input.Area(), 1e-9);
+}
+
+TEST(CrossSection, WarpAffineMatchesScaleTranslate) {
+  CrossSection sq = CrossSection::Square({10, 10}, true);
+  CrossSection scaled = sq.Scale({2, 3}).Translate({5, -1});
+  CrossSection warped =
+      sq.Warp([](vec2& v) { v = {2 * v.x + 5, 3 * v.y - 1}; });
+  EXPECT_EQ(warped.NumVert(), scaled.NumVert());
+  EXPECT_NEAR(warped.Area(), scaled.Area(), 1e-6);
+  EXPECT_NEAR(warped.Bounds().min.x, scaled.Bounds().min.x, 1e-6);
+}
+
+TEST(CrossSection, ShearTransformPreservesArea) {
+  CrossSection sq = CrossSection::Square({10, 10}, true);
+  CrossSection sheared = sq.Transform(mat2x3({1, 0}, {0.5, 1}, {0, 0}));
+  CrossSection warped = sq.Warp([](vec2& v) { v.x += 0.5 * v.y; });
+  EXPECT_NEAR(sheared.Area(), 100.0, 1e-6);  // shear preserves area
+  EXPECT_NEAR(sheared.Area(), warped.Area(), 1e-6);
+}
+
+// Native-only: the WASM build is single-threaded (no pthread), so std::thread
+// construction throws, which aborts under -fno-exceptions.
+#ifndef __EMSCRIPTEN__
+TEST(CrossSection, ConcurrentConstAccessorsAreRaceFree) {
+  // Meaningful under TSan (the upstream continuous-fuzz lane builds with it):
+  // 16 threads materialize the lazy transform and read const accessors.
+  const CrossSection cs = CrossSection::Circle(10, 64).Translate({1e6, -1e6});
+  std::array<double, 16> results{};
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 16; ++i) {
+    threads.emplace_back(
+        [&, i] { results[i] = cs.Area() + cs.Bounds().Size().x; });
+  }
+  for (auto& t : threads) t.join();
+  for (double r : results) EXPECT_EQ(r, results[0]);
+}
+#endif
+
+TEST(CrossSection, PublicRoundOffsetRoundTripsMismatchCount) {
+  const int segments = 420;
+  CrossSection square = CrossSection::Square({20, 20}, true);
+
+  CrossSection rounded =
+      square.Offset(5.0, CrossSection::JoinType::Round, 2.0, segments);
+
+  EXPECT_EQ(rounded.NumVert(), segments + 4);
+}
+
+TEST(CrossSection, OffsetRoundNonFiniteAndHugeDelta) {
+  // Round offset derives its default segment count from |delta| via
+  // Quality::GetCircularSegments, whose internal 2*pi*r/edge -> int conversion
+  // would be undefined for non-finite or very large radii; it is guarded at the
+  // source (double, not int, intermediate). Non-finite delta is rejected by
+  // Offset (empty); huge finite delta still yields a finite bounded result.
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const double inf = std::numeric_limits<double>::infinity();
+  CrossSection square = CrossSection::Square({10, 10}, true);
+
+  EXPECT_EQ(square.Offset(nan, CrossSection::JoinType::Round).NumVert(), 0u);
+  EXPECT_EQ(square.Offset(inf, CrossSection::JoinType::Round).NumVert(), 0u);
+
+  CrossSection huge = square.Offset(1e9, CrossSection::JoinType::Round);
+  EXPECT_GT(huge.NumVert(), 0u);
+  for (const SimplePolygon& ring : huge.ToPolygons())
+    for (const vec2& v : ring) {
+      EXPECT_TRUE(std::isfinite(v.x));
+      EXPECT_TRUE(std::isfinite(v.y));
+    }
+}
+
+TEST(CrossSection, OffsetDoesNotInflateToleranceDownstream) {
+  // A Round offset must not fold its round-join faceting sagitta into
+  // tolerance_: that would silently over-merge features finer than the sagitta
+  // in the next boolean. The offset output must behave like a fresh
+  // reconstruction of the same paths.
+  CrossSection sq = CrossSection::Square({100, 100}, true);
+  CrossSection rounded = sq.Offset(50.0, CrossSection::JoinType::Round);
+  CrossSection fresh(rounded.ToPolygons());  // same geometry, fresh tolerance
+  // A thin sliver (~7.5 area) far below the faceting sagitta (~0.19); folding
+  // that sagitta into tolerance_ on `rounded` would over-merge it, diverging
+  // from fresh.
+  CrossSection slivR = rounded - rounded.Scale({0.9999, 0.9999});
+  CrossSection slivF = fresh - fresh.Scale({0.9999, 0.9999});
+  ASSERT_GT(slivF.Area(), 1.0);  // the sliver is a real feature
+  EXPECT_NEAR(slivR.Area(), slivF.Area(), 1e-6);
+  EXPECT_EQ(slivR.NumVert(), slivF.NumVert());
+}
+
+TEST(CrossSection, PublicOffsetSquareInsetCapStaysOnSolidSide) {
+  SimplePolygon L = {{0, 0}, {2, 0}, {2, 1}, {1, 1}, {1, 2}, {0, 2}};
+
+  CrossSection out(L);
+  out = out.Offset(-0.25, CrossSection::JoinType::Square);
+
+  for (const SimplePolygon& ring : out.ToPolygons()) {
+    for (const vec2& v : ring) {
+      const bool inNotch = v.x > 1.0 && v.x < 2.0 && v.y > 1.0 && v.y < 2.0;
+      EXPECT_FALSE(inNotch) << "cap vertex (" << v.x << ", " << v.y
+                            << ") is in the removed notch";
+    }
+  }
+  EXPECT_LT(out.Area(), 1.35);
+}
+
+TEST(CrossSection, HullDegenerateInputIsEmpty) {
+  // Collinear/coincident points have no 2D hull: empty, not a degenerate
+  // 2-vertex zero-area contour that would extrude to an invalid solid.
+  EXPECT_TRUE(
+      CrossSection::Hull(SimplePolygon{{0, 0}, {1, 1}, {2, 2}}).IsEmpty());
+  EXPECT_TRUE(
+      CrossSection::Hull(SimplePolygon{{5, 5}, {5, 5}, {5, 5}}).IsEmpty());
+  EXPECT_TRUE(CrossSection::Hull(SimplePolygon{{0, 0}, {1, 1}}).IsEmpty());
+}
+
+TEST(CrossSection, TransformNonFiniteIsNoOp) {
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  CrossSection sq = CrossSection::Square({10, 10}, true);
+  CrossSection t = sq.Transform(mat2x3({nan, 0}, {0, 1}, {0, 0}));
+  EXPECT_NEAR(t.Area(), sq.Area(), 1e-9);  // garbage transform -> no-op
+  EXPECT_TRUE(std::isfinite(t.Bounds().Size().x));
+  EXPECT_TRUE(
+      CrossSection::Hull(SimplePolygon{{0, 0}, {1, 0}, {nan, 1}}).IsEmpty());
+}
+
+TEST(CrossSection, SquareDegenerateDimIsEmpty) {
+  // boolean2 returns empty for zero-extent inputs (clipper2 emits degenerate
+  // contours here); pin the intended behavior.
+  EXPECT_TRUE(CrossSection::Square({5, 0}, true).IsEmpty());
+  EXPECT_TRUE(CrossSection::Square({0, 5}, false).IsEmpty());
+  EXPECT_TRUE(CrossSection::Circle(0.0).IsEmpty());
+  EXPECT_TRUE(CrossSection::BatchBoolean({}, OpType::Add).IsEmpty());
+}
+
 TEST(CrossSection, FillRule) {
   SimplePolygon polygon = {
       {-7, 13},   //
@@ -248,6 +2078,66 @@ TEST(CrossSection, BatchBoolean) {
 
   EXPECT_FLOAT_EQ(subtract.Area(), 7234.478452);
   EXPECT_FLOAT_EQ(subtract.NumVert(), 42);
+}
+
+// A is a 37-vertex star with many zero-radius vertices producing a dense
+// near-degenerate shape; B is a 5-vertex star translated by ~5e-5 in x. The
+// intersection A ∩ B returns area=0 even though both inputs are non-empty and
+// overlap geometrically. (A - B) + (A ∩ B) ends up at 39605 versus
+// a.Area=90895, missing ~51290 area units. The tiny x translation puts B's
+// vertices just inside the eps band of A's; the intersect path appears to
+// mis-classify the overlap region as empty.
+TEST(CrossSection, SubtractInvariantsEmptyIntersectionDrop) {
+  const std::vector<double> rA = Runs({{1, 1000.},
+                                       {1, 0.},
+                                       {2, 1000.},
+                                       {1, 68.955135217866953},
+                                       {1, 0.},
+                                       {1, 1.},
+                                       {9, 0.},
+                                       {1, 805.7907155879783},
+                                       {1, 1.},
+                                       {5, 0.},
+                                       {1, 4.7952714181195555},
+                                       {3, 0.},
+                                       {1, 1.2064064151490697},
+                                       {1, 0.},
+                                       {1, 3.2013961172280205},
+                                       {3, 0.},
+                                       {1, 13.934542696929423},
+                                       {1, 363.29755584701081},
+                                       {2, 0.}});
+  const std::vector<double> rB = {1000., 731.51526963704362, 680.25141414501888,
+                                  1000., 571.57429580441226};
+  const CrossSection a(StarRing(rA));
+  const CrossSection b =
+      CrossSection(StarRing(rB)).Translate({-4.725175119801861e-05, -0.0});
+  const auto aMinusB = a - b;
+  const auto aIntersectB = a.Boolean(b, OpType::Intersect);
+  const double tol = AreaTol(a, b);
+  EXPECT_NEAR(aMinusB.Area() + aIntersectB.Area(), a.Area(), tol)
+      << "area(A - B) + area(A ∩ B) != area(A)";
+}
+
+TEST(CrossSection, BooleanOperatorAssignments) {
+  CrossSection a = CrossSection::Square({10, 10});
+  CrossSection b = CrossSection::Square({10, 10}).Translate({5, 0});
+
+  EXPECT_NEAR((a + b).Area(), 150.0, 1e-9);
+  EXPECT_NEAR((a - b).Area(), 50.0, 1e-9);
+  EXPECT_NEAR((a ^ b).Area(), 50.0, 1e-9);
+
+  CrossSection add = a;
+  add += b;
+  EXPECT_NEAR(add.Area(), 150.0, 1e-9);
+
+  CrossSection subtract = a;
+  subtract -= b;
+  EXPECT_NEAR(subtract.Area(), 50.0, 1e-9);
+
+  CrossSection intersect = a;
+  intersect ^= b;
+  EXPECT_NEAR(intersect.Area(), 50.0, 1e-9);
 }
 
 TEST(CrossSection, NegativeOffset) {

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -143,6 +143,31 @@ void ExpectTinyFeatureSurvivesNearCorner(
   }
 }
 
+// Row types for the consolidated fuzz-seed regression tables below.
+struct SubtractCase {
+  const char* name;
+  Shape a, b;
+};
+struct CommCase {
+  const char* name;
+  Shape a, b;
+  bool checkIntersect = false;
+};
+struct PrismCase {
+  const char* name;
+  double radiusA, radiusB;
+};
+struct AssocCase {
+  const char* name;
+  Shape a, b, c;
+};
+enum class DistribKind { Standard, AreaOnly, Monotonicity };
+struct DistribCase {
+  const char* name;
+  Shape a, b, c;
+  DistribKind kind = DistribKind::Standard;
+};
+
 }  // namespace
 
 TEST(CrossSection, Square) {
@@ -647,52 +672,27 @@ TEST(CrossSection, OffsetPositiveOnExtremeRadiusStar) {
   EXPECT_GE(output.Area(), input.Area() - 1e-6 * (1.0 + input.Area()));
 }
 
-// Consolidated SubtractInvariants* fuzz-seed regressions, one row per seed.
-// Each row carries that seed's radii + translate verbatim; SubtractKind
-// selects which assertions the original standalone test made:
-//   Invariants         - both subtract identities plus inclusion-exclusion
-//   InclusionExclusion - only the inclusion-exclusion identity
+// Consolidated SubtractInvariants* fuzz-seed regressions, one row per seed,
+// radii + translate verbatim. Each was a real area-invariant failure that now
+// passes; the per-seed note records the distinguishing geometry.
 // SubtractInvariantsEmptyIntersectionDrop stays standalone (below): it is
 // boolean2-gated and asserts only a single subtract identity.
-namespace {
-enum class SubtractKind { Invariants, InclusionExclusion };
-
-struct SubtractCase {
-  const char* name;
-  Shape a, b;
-  SubtractKind kind = SubtractKind::Invariants;
-};
-
 const SubtractCase kSubtractInvariantsSeeds[] = {
-    // Extreme magnitude mismatch
-    //   between two star polygons - A is ~1e-9 scale, B is ~100 scale.
-    //   At least one of the boolean algebraic invariants
-    //   `area(A-B)+area(A∩B)=area(A)` etc. fails. Likely an eps-inference
-    //   or vertex-merge cliff where A's tiny scale gets crushed by B's
-    //   eps.
+    // Extreme magnitude mismatch: A ~1e-9 scale, B ~100 scale. The subtract
+    // invariants used to break where A's tiny scale got crushed by B's eps.
     {"TinyVsLargeStars",
      {{2.0371964671064575e-14, 1.814002251251902e-10, 0.,
        2.1825088357767143e-09}},
      {{113.5978182908662, 0., 114.34968677141997, 6.5076626333939721e-10},
       {0., 4.667562921730494e-33}}},
-    // Two spiky stars at origin - A
-    //   is 5-pointed with mixed magnitudes including two ~1000-radius
-    //   spikes and a near-zero vertex; B is 4-pointed with three
-    //   ~1000-scale spikes plus a near-zero vertex. One of the boolean
-    //   algebraic invariants fails. Likely a different code path than
-    //   the TinyVsLargeStars needle case - this is two large spiky
-    //   shapes, not a tiny shape vs a needle. May share the off-axis
-    //   T-junction root cause diagnosed earlier in this table, but the spike-
-    //   collision geometry could be its own failure mode.
+    // Two spiky stars at origin: A 5-pointed with two ~1000 spikes and a
+    // near-zero vertex, B 4-pointed with three ~1000 spikes. Large-spike
+    // collision geometry, distinct from the TinyVsLargeStars needle case.
     {"SpikyStars",
      {{1000., 886.10628147264833, 1000., 1., 0.}},
      {{1000., 827.10387617193078, 548.20533789242359, 0.}}},
-    // 17-vertex star with most radii zero collapsed to 0.1, plus a
-    //   4-pointed star with one ~112 spike. area(b - a) + area(a ∩ b) =
-    //   402.04, b.Area() = 634.18 - 232 units of area leak. Different
-    //   geometry from the needle/spiky-star seeds above; the earlier
-    //   winding-seed fix didn't cover this case. Reproduces via direct
-    //   call with these exact args.
+    // 17-vertex star (most radii ~0.1) vs a 4-pointed star with one ~112
+    // spike. Used to leak ~232 of b.Area()=634 from the subtract identity.
     {"LeakySparseStar",
      {{627.11994612906153, 0.11978140887764367, 601.04982226530046,
        102.31660501134466, 2.1549912703437601, 0., 0., 0., 0., 0., 0., 0., 0.,
@@ -700,20 +700,16 @@ const SubtractCase kSubtractInvariantsSeeds[] = {
      {{112.00504648760347, 4.3823848227606392, 1.2795858846899296e-07,
        6.7216166802304542},
       {-2.7193614970785894e-29, 0.}}},
-    // 19-vertex sparse star with only 2 nonzero radii (~39, ~21) vs a
-    //   4-pointed star with one ~73 spike and tiny radii. area(b - a) +
-    //   area(a ∩ b) is off
-    //   by ~234 from b.Area() (~788). Different geometry from prior
-    //   Subtract seeds.
+    // 19-vertex sparse star (2 nonzero radii ~39, ~21) vs a 4-pointed star
+    // with one ~73 spike. Used to be off by ~234 from b.Area()=788.
     {"TwoNonzeroVsNeedle",
      {{0., 39.150613710409736, 0., 21.472413919643575, 0., 0., 0., 0., 0., 0.,
        0., 0., 0., 0., 0., 0., 0., 0., 3.237760857312173e-24}},
      {{72.814105930277677, 21.384583693573447, 1.6644635543899127e-243,
        1.6688953794582528e-229}}},
-    // 34-vert star vs 20-vert star
-    //   each with one dominant radius (~33 and ~36) and the rest very
-    //   small. Inclusion-exclusion violated by ~8 absolute on a∪b≈10.
-    //   Verified against post-68cbade7 binary.
+    // 34-vert star vs 20-vert star, each with one dominant radius (~33, ~36)
+    // and the rest tiny. Inclusion-exclusion used to be violated by ~8 on a
+    // combined area of ~10.
     {"DominantSpikeStars",
      {{0.15588462038906103,
        0.00015361176400222398,
@@ -769,10 +765,8 @@ const SubtractCase kSubtractInvariantsSeeds[] = {
        36.09032519236748,
        0.,
        7.5123873966542927e-05},
-      {0.72140998591309213, 0.}},
-     SubtractKind::InclusionExclusion},
+      {0.72140998591309213, 0.}}},
 };
-}  // namespace
 
 TEST(CrossSection, SubtractInvariantsSeeds) {
   for (const auto& c : kSubtractInvariantsSeeds) {
@@ -780,26 +774,16 @@ TEST(CrossSection, SubtractInvariantsSeeds) {
     // Flush the seed name so a hard crash is still attributable.
     std::cerr << "[seed] " << c.name << std::endl;
     const CrossSection a = MakeShape(c.a), b = MakeShape(c.b);
-    if (c.kind == SubtractKind::InclusionExclusion) {
-      const auto aIb = a.Boolean(b, OpType::Intersect);
-      const auto aUb = a + b;
-      const double tol = AreaTol(a, b);
-      EXPECT_NEAR(aUb.Area(), a.Area() + b.Area() - aIb.Area(), tol)
-          << "inclusion-exclusion violated";
-      ExpectUnionRetainsArea(aUb, std::max(a.Area(), b.Area()), tol,
-                             "subtract seed union");
-    } else {
-      const auto aIb = a.Boolean(b, OpType::Intersect);
-      const auto aUb = a + b;
-      const double tol = AreaTol(a, b);
-      EXPECT_NEAR((a - b).Area() + aIb.Area(), a.Area(), tol)
-          << "area(A - B) + area(A intersection B) != area(A)";
-      EXPECT_NEAR((b - a).Area() + aIb.Area(), b.Area(), tol)
-          << "area(B - A) + area(A intersection B) != area(B)";
-      EXPECT_NEAR(aUb.Area(), a.Area() + b.Area() - aIb.Area(), tol)
-          << "inclusion-exclusion violated";
-      ExpectUnionRetainsArea(aUb, std::max(a.Area(), b.Area()), tol, "union");
-    }
+    const auto aIb = a ^ b;
+    const auto aUb = a + b;
+    const double tol = AreaTol(a, b);
+    EXPECT_NEAR((a - b).Area() + aIb.Area(), a.Area(), tol)
+        << "area(A - B) + area(A intersection B) != area(A)";
+    EXPECT_NEAR((b - a).Area() + aIb.Area(), b.Area(), tol)
+        << "area(B - A) + area(A intersection B) != area(B)";
+    EXPECT_NEAR(aUb.Area(), a.Area() + b.Area() - aIb.Area(), tol)
+        << "inclusion-exclusion violated";
+    ExpectUnionRetainsArea(aUb, std::max(a.Area(), b.Area()), tol, "union");
   }
 }
 
@@ -808,13 +792,6 @@ TEST(CrossSection, SubtractInvariantsSeeds) {
 // union commutativity (A + B vs B + A: area + contour count); checkIntersect
 // additionally asserts intersect commutativity (A ∩ B vs B ∩ A: area +
 // contour count).
-namespace {
-struct CommCase {
-  const char* name;
-  Shape a, b;
-  bool checkIntersect = false;
-};
-
 const CommCase kBooleanCommutativitySeeds[] = {
     // Asymmetric handling of two
     //   inputs in the boolean engine - A+B and B+A produce different
@@ -925,7 +902,6 @@ const CommCase kBooleanCommutativitySeeds[] = {
        1.},
       {1.7126290778198534, -0.5023590407011973}}},
 };
-}  // namespace
 
 TEST(CrossSection, BooleanCommutativitySeeds) {
   for (const auto& c : kBooleanCommutativitySeeds) {
@@ -954,12 +930,6 @@ TEST(CrossSection, BooleanCommutativitySeeds) {
 // extrudes them to prisms, and asserts the union's Volume matches the 2D union
 // area times the height. Rows differ only in the two radii. Ungated: runs on
 // both backends.
-namespace {
-struct PrismCase {
-  const char* name;
-  double radiusA, radiusB;
-};
-
 const PrismCase kPrismSeeds[] = {
     // Two equilateral triangles with
     //   circumradii 0.1 and 0.1+6.88e-13, op=Add. Two near-IDENTICAL
@@ -976,7 +946,6 @@ const PrismCase kPrismSeeds[] = {
     //   against post-68cbade7 binary..
     {"CloseRadiiTriangles", 1.6750962039134867, 1.6691810932888278},
 };
-}  // namespace
 
 TEST(CrossSection, PrismSeeds) {
   auto regular = [](int sides, double radius) {
@@ -1008,12 +977,6 @@ TEST(CrossSection, PrismSeeds) {
 // Each row carries that seed's radii + translate verbatim. Both seeds assert
 // union-associativity area equality ((A ∪ B) ∪ C vs A ∪ (B ∪ C)); neither
 // asserted intersect associativity.
-namespace {
-struct AssocCase {
-  const char* name;
-  Shape a, b, c;
-};
-
 const AssocCase kBooleanAssociativitySeeds[] = {
     // Three 4-vertex stars with
     //   mixed magnitudes; (A∪B)∪C = 2.994 but A∪(B∪C) = 5.472 - off
@@ -1040,7 +1003,6 @@ const AssocCase kBooleanAssociativitySeeds[] = {
       {0., 0.}},
      {{0., 0., 0., 0.}}},
 };
-}  // namespace
 
 TEST(CrossSection, BooleanAssociativitySeeds) {
   for (const auto& c : kBooleanAssociativitySeeds) {
@@ -1070,15 +1032,6 @@ TEST(CrossSection, BooleanAssociativitySeeds) {
 //                  (A intersect B and A intersect C each inside the union)
 // Kept as a single TEST in the CrossSection suite so the CrossSection.*
 // CI filter keeps exercising every seed.
-namespace {
-enum class DistribKind { Standard, AreaOnly, Monotonicity };
-
-struct DistribCase {
-  const char* name;
-  Shape a, b, c;
-  DistribKind kind = DistribKind::Standard;
-};
-
 const DistribCase kDistributivitySeeds[] = {
     // Three 4-vertex stars with all
     //   near-zero radii. A∩(B∪C) returns 0 but (A∩B)∪(A∩C) returns
@@ -1586,7 +1539,6 @@ const DistribCase kDistributivitySeeds[] = {
             {1, 1.}}),
       {0.99578244833742113, -4.0475870932225444}}},
 };
-}  // namespace
 
 TEST(CrossSection, BooleanDistributivitySeeds) {
   for (const auto& c : kDistributivitySeeds) {
@@ -2268,13 +2220,10 @@ TEST(CrossSection, BatchBoolean) {
   EXPECT_FLOAT_EQ(subtract.NumVert(), 42);
 }
 
-// A is a 37-vertex star with many zero-radius vertices producing a dense
-// near-degenerate shape; B is a 5-vertex star translated by ~5e-5 in x. The
-// intersection A ∩ B returns area=0 even though both inputs are non-empty and
-// overlap geometrically. (A - B) + (A ∩ B) ends up at 39605 versus
-// a.Area=90895, missing ~51290 area units. The tiny x translation puts B's
-// vertices just inside the eps band of A's; the intersect path appears to
-// mis-classify the overlap region as empty.
+// A is a 37-vertex near-degenerate star (many zero-radius vertices); B is a
+// 5-vertex star translated ~5e-5 in x so its vertices land just inside A's eps
+// band. The intersection of A and B used to return area=0, leaking ~51290 of
+// a.Area=90895 from the subtract identity below.
 TEST(CrossSection, SubtractInvariantsEmptyIntersectionDrop) {
   const std::vector<double> rA = Runs({{1, 1000.},
                                        {1, 0.},
@@ -2301,7 +2250,7 @@ TEST(CrossSection, SubtractInvariantsEmptyIntersectionDrop) {
   const CrossSection b =
       CrossSection(StarRing(rB)).Translate({-4.725175119801861e-05, -0.0});
   const auto aMinusB = a - b;
-  const auto aIntersectB = a.Boolean(b, OpType::Intersect);
+  const auto aIntersectB = a ^ b;
   const double tol = AreaTol(a, b);
   EXPECT_NEAR(aMinusB.Area() + aIntersectB.Area(), a.Area(), tol)
       << "area(A - B) + area(A ∩ B) != area(A)";

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -95,29 +95,25 @@ void ExpectTinyFeatureSurvivesNearCorner(
   SimplePolygon host = StarRing(hostRadii);
   SimplePolygon feature = StarRing(featureRadii);
   for (auto& v : feature) {  // shrink to a tiny feature
-    v.x *= 1e-3;
-    v.y *= 1e-3;
+    v *= 1e-3;
   }
   // Anchor the feature 1e-12 from host vertex 0 along the seed's direction.
-  const double dlen = std::sqrt(dir.x * dir.x + dir.y * dir.y);
+  const double dlen = la::length(dir);
   const vec2 anchor{host[0].x + 1e-12 * dir.x / dlen,
                     host[0].y + 1e-12 * dir.y / dlen};
   const vec2 shift{anchor.x - feature[0].x, anchor.y - feature[0].y};
   for (auto& v : feature) {
-    v.x += shift.x;
-    v.y += shift.y;
+    v += shift;
   }
 
   for (double offset : {0.0, 1024.0, 4096.0}) {
     SimplePolygon shiftedHost = host;
     SimplePolygon shiftedFeature = feature;
     for (auto& v : shiftedHost) {
-      v.x += offset;
-      v.y += offset;
+      v += vec2(offset);
     }
     for (auto& v : shiftedFeature) {
-      v.x += offset;
-      v.y += offset;
+      v += vec2(offset);
     }
     const CrossSection a(shiftedHost);
     const CrossSection b(shiftedFeature);
@@ -317,10 +313,9 @@ TEST(CrossSection, TranslatedShallowConcurrentEdges) {
     const double sinA = std::sin(angle);
     constexpr double radius = 1.0;
     constexpr double width = 0.08;
-    return SimplePolygon{{offset.x + radius * cosA, offset.y + radius * sinA},
-                         {offset.x - width * sinA, offset.y + width * cosA},
-                         {offset.x - radius * cosA, offset.y - radius * sinA},
-                         {offset.x + width * sinA, offset.y - width * cosA}};
+    return SimplePolygon{
+        offset + radius * vec2(cosA, sinA), offset + width * vec2(-sinA, cosA),
+        offset - radius * vec2(cosA, sinA), offset + width * vec2(sinA, -cosA)};
   };
 
   auto polysAt = [&](vec2 offset) {
@@ -409,16 +404,13 @@ TEST(CrossSection, DISABLED_TinyFeatureNearCornerHostDropAtOffset4096) {
                     host[1].y + 1e-9 * dirY / dlen};
   const vec2 shift{anchor.x - feature[0].x, anchor.y - feature[0].y};
   for (auto& v : feature) {
-    v.x += shift.x;
-    v.y += shift.y;
+    v += shift;
   }
   for (auto& v : host) {
-    v.x += 4096.0;
-    v.y += 4096.0;
+    v += vec2(4096.0);
   }
   for (auto& v : feature) {
-    v.x += 4096.0;
-    v.y += 4096.0;
+    v += vec2(4096.0);
   }
   const CrossSection ca(host), cb(feature);
   const auto sum =
@@ -434,8 +426,7 @@ TEST(CrossSection, DISABLED_TinyFeatureNearCornerHostDropAtOffset1024) {
       StarRing({712.03169893044037, 1., 549.34829370834473, 0., 0.,
                 0.84629435037780809, 593.99733078452005, 738.68366086294714});
   for (auto& v : feature) {
-    v.x *= 1e-3;
-    v.y *= 1e-3;
+    v *= 1e-3;
   }
   const double dirX = 0.20051392197659679, dirY = -0.51476208035366366;
   const double dlen = std::sqrt(dirX * dirX + dirY * dirY);
@@ -443,18 +434,15 @@ TEST(CrossSection, DISABLED_TinyFeatureNearCornerHostDropAtOffset1024) {
                     host[1].y + 1e-9 * dirY / dlen};
   const vec2 shift{anchor.x - feature[0].x, anchor.y - feature[0].y};
   for (auto& v : feature) {
-    v.x += shift.x;
-    v.y += shift.y;
+    v += shift;
   }
   for (double offset : {0.0, 1024.0, 4096.0}) {
     SimplePolygon sh = host, sf = feature;
     for (auto& v : sh) {
-      v.x += offset;
-      v.y += offset;
+      v += vec2(offset);
     }
     for (auto& v : sf) {
-      v.x += offset;
-      v.y += offset;
+      v += vec2(offset);
     }
     const CrossSection ca(sh), cb(sf);
     const auto sum =
@@ -1961,10 +1949,7 @@ TEST(CrossSection, Transform) {
 TEST(CrossSection, Warp) {
   auto sq = CrossSection::Square({10., 10.});
   auto a = sq.Scale({2, 3}).Translate({4, 5});
-  auto b = sq.Warp([](vec2& v) {
-    v.x = v.x * 2 + 4;
-    v.y = v.y * 3 + 5;
-  });
+  auto b = sq.Warp([](vec2& v) { v = v * vec2(2, 3) + vec2(4, 5); });
 
   EXPECT_EQ(sq.NumVert(), 4);
   EXPECT_EQ(sq.NumContour(), 1);
@@ -2080,8 +2065,7 @@ TEST(CrossSection, OffsetRoundNonFiniteAndHugeDelta) {
   EXPECT_GT(huge.NumVert(), 0u);
   for (const SimplePolygon& ring : huge.ToPolygons())
     for (const vec2& v : ring) {
-      EXPECT_TRUE(std::isfinite(v.x));
-      EXPECT_TRUE(std::isfinite(v.y));
+      EXPECT_TRUE(la::all(la::isfinite(v)));
     }
 }
 

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -29,7 +29,6 @@
 #include <thread>
 #include <vector>
 
-#include "../src/boolean2.h"
 #include "manifold/common.h"
 #include "manifold/manifold.h"
 #include "test.h"
@@ -1847,9 +1846,6 @@ TEST(CrossSection, NonFiniteInputReturnsEmpty) {
 
   CrossSection constructed(bad);
   EXPECT_TRUE(constructed.IsEmpty());
-
-  Polygons finite = {{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}}};
-  EXPECT_TRUE(Boolean2D(Polygons{bad}, finite, OpType::Add).empty());
 }
 
 TEST(CrossSection, OffsetIsInvariantUnderLargeTranslation) {

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -68,32 +68,6 @@ double AreaTol(const CrossSection& a, const CrossSection& b,
                  std::fabs(c.Area()));
 }
 
-void ExpectBooleanInvariants(const CrossSection& a, const CrossSection& b) {
-  const auto aIb = a.Boolean(b, OpType::Intersect);
-  const double tol = AreaTol(a, b);
-  EXPECT_NEAR((a - b).Area() + aIb.Area(), a.Area(), tol)
-      << "area(A - B) + area(A ∩ B) != area(A)";
-  EXPECT_NEAR((b - a).Area() + aIb.Area(), b.Area(), tol)
-      << "area(B - A) + area(A ∩ B) != area(B)";
-  EXPECT_NEAR((a + b).Area(), a.Area() + b.Area() - aIb.Area(), tol)
-      << "inclusion-exclusion violated";
-}
-
-void ExpectDistributesOverUnion(const CrossSection& a, const CrossSection& b,
-                                const CrossSection& c) {
-  const auto bUc = b + c;
-  const auto left = a.Boolean(bUc, OpType::Intersect);
-  const auto right =
-      a.Boolean(b, OpType::Intersect) + a.Boolean(c, OpType::Intersect);
-  const double tol = AreaTol(a, b, c);
-  EXPECT_NEAR(left.Area(), right.Area(), tol)
-      << "A ∩ (B ∪ C) != (A ∩ B) ∪ (A ∩ C)";
-  EXPECT_NEAR((left - right).Area(), 0.0, tol)
-      << "distributivity: left-right difference is non-empty";
-  EXPECT_NEAR((right - left).Area(), 0.0, tol)
-      << "distributivity: right-left difference is non-empty";
-}
-
 // Shared builder for the consolidated star-seed regression tables below
 // (BooleanDistributivity/SubtractInvariants/BooleanCommutativity/
 // BooleanAssociativity *Seeds). Each fuzz seed is a StarRing optionally
@@ -783,7 +757,14 @@ TEST(CrossSection, SubtractInvariantsSeeds) {
       EXPECT_NEAR(aUb.Area(), a.Area() + b.Area() - aIb.Area(), tol)
           << "inclusion-exclusion violated";
     } else {
-      ExpectBooleanInvariants(a, b);
+      const auto aIb = a.Boolean(b, OpType::Intersect);
+      const double tol = AreaTol(a, b);
+      EXPECT_NEAR((a - b).Area() + aIb.Area(), a.Area(), tol)
+          << "area(A - B) + area(A ∩ B) != area(A)";
+      EXPECT_NEAR((b - a).Area() + aIb.Area(), b.Area(), tol)
+          << "area(B - A) + area(A ∩ B) != area(B)";
+      EXPECT_NEAR((a + b).Area(), a.Area() + b.Area() - aIb.Area(), tol)
+          << "inclusion-exclusion violated";
     }
   }
 }
@@ -1584,7 +1565,17 @@ TEST(CrossSection, BooleanDistributivitySeeds) {
           AreaTol(a, b, cc))
           << "A ∩ (B ∪ C) != (A ∩ B) ∪ (A ∩ C)";
     } else {
-      ExpectDistributesOverUnion(a, b, cc);
+      const auto bUc = b + cc;
+      const auto left = a.Boolean(bUc, OpType::Intersect);
+      const auto right =
+          a.Boolean(b, OpType::Intersect) + a.Boolean(cc, OpType::Intersect);
+      const double tol = AreaTol(a, b, cc);
+      EXPECT_NEAR(left.Area(), right.Area(), tol)
+          << "A ∩ (B ∪ C) != (A ∩ B) ∪ (A ∩ C)";
+      EXPECT_NEAR((left - right).Area(), 0.0, tol)
+          << "distributivity: left-right difference is non-empty";
+      EXPECT_NEAR((right - left).Area(), 0.0, tol)
+          << "distributivity: right-left difference is non-empty";
     }
     if (c.kind == DistribKind::Monotonicity) {
       const double tol = AreaTol(a, b, cc);

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -213,8 +213,9 @@ TEST(CrossSection, MiterOffset) {
   EXPECT_EQ(result.Genus(), 0);
   EXPECT_NEAR(result.Volume(), 30. * 30., 0.01);
   // Offset keeps collinear verts on the miter edges; stripping them is
-  // Simplify's job, so check the simplified corner count (4)
-  // backend-agnostically.
+  // Simplify's job, so the raw offset has more than 4 verts and Simplify
+  // reduces it to the 4 corners (checked backend-agnostically).
+  EXPECT_GT(offset.NumVert(), 4);
   EXPECT_EQ(offset.Simplify().NumVert(), 4);
 }
 
@@ -274,9 +275,9 @@ TEST(CrossSection, FourConcurrentEdges) {
   EXPECT_NEAR(cs.Area(), 0.644423, 1e-4);
   for (const auto& loop : cs.ToPolygons()) {
     for (const vec2& v : loop) {
-      EXPECT_TRUE(std::isfinite(v.x));
-      EXPECT_TRUE(std::isfinite(v.y));
-      EXPECT_LE(la::length(v), 1.05);
+      // The rhombi sit on the unit circle (radius 1), so the union must too:
+      // a bound just above 1 is a no-blowup guard (and trips on NaN).
+      EXPECT_LE(la::length(v), 1.0 + 1e-6);
     }
   }
 }
@@ -302,9 +303,9 @@ TEST(CrossSection, ConcurrentIndependentEdgePairs) {
   EXPECT_NEAR(cs.Area(), 0.527482, 1e-4);
   for (const auto& loop : cs.ToPolygons()) {
     for (const vec2& v : loop) {
-      EXPECT_TRUE(std::isfinite(v.x));
-      EXPECT_TRUE(std::isfinite(v.y));
-      EXPECT_LE(la::length(v), 1.05);
+      // The rhombi sit on the unit circle (radius 1), so the union must too:
+      // a bound just above 1 is a no-blowup guard (and trips on NaN).
+      EXPECT_LE(la::length(v), 1.0 + 1e-6);
     }
   }
 }

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -399,6 +399,96 @@ TEST(CrossSection, TinyFeatureNearCornerHostFeatureSwap) {
       {0.9901767613117145, 0.60823663500743508});
 }
 
+// DISABLED: known winding-robustness failures, not yet fixed. A tiny feature
+// that point-touches a large host ~1e-9 from one of the host's vertices (the
+// two pieces are genuinely disjoint, so the correct union is host + feature)
+// drops one of the two pieces. Which piece drops, and whether, depends on
+// sub-eps details (the intersection-merge emission and the absolute coordinate
+// offset), so the arrangement's winding face-walk is unstable far below eps.
+// These are the fuzzer seeds for that bug; enable them when the winding fix
+// lands.
+
+// Host-drop: the host's zero-radius star vertex makes it a thin spike that
+// collapses. Built from raw radii (StarRing's 0.1 floor would remove the
+// spike).
+TEST(CrossSection, DISABLED_TinyFeatureNearCornerHostDropAtOffset4096) {
+  const std::vector<double> hostRadii = {
+      0., 356.3220416075996, 176.46461822660299, 2.451081611797258, 1.};
+  SimplePolygon host;
+  for (int k = 0; k < 5; ++k) {
+    const double theta = 2.0 * kPi * k / 5;
+    host.push_back(
+        {hostRadii[k] * std::cos(theta), hostRadii[k] * std::sin(theta)});
+  }
+  const std::vector<double> featRadii = {
+      999.86970256972995, 1., 1., 823.03853274897119, 253.38906741827319};
+  SimplePolygon feature;
+  for (int k = 0; k < 5; ++k) {
+    const double theta = 2.0 * kPi * k / 5;
+    feature.push_back({1e-3 * featRadii[k] * std::cos(theta),
+                       1e-3 * featRadii[k] * std::sin(theta)});
+  }
+  const double dirX = 0.41098114346248393, dirY = -0.227966841143317;
+  const double dlen = std::sqrt(dirX * dirX + dirY * dirY);
+  const vec2 anchor{host[1].x + 1e-9 * dirX / dlen,
+                    host[1].y + 1e-9 * dirY / dlen};
+  const vec2 shift{anchor.x - feature[0].x, anchor.y - feature[0].y};
+  for (auto& v : feature) {
+    v.x += shift.x;
+    v.y += shift.y;
+  }
+  for (auto& v : host) {
+    v.x += 4096.0;
+    v.y += 4096.0;
+  }
+  for (auto& v : feature) {
+    v.x += 4096.0;
+    v.y += 4096.0;
+  }
+  const CrossSection ca(host), cb(feature);
+  const auto sum =
+      ca.Area() + cb.Area() - ca.Boolean(cb, OpType::Intersect).Area();
+  EXPECT_NEAR((ca + cb).Area(), sum, 1e-3 * (1.0 + ca.Area() + cb.Area()));
+}
+
+// Host-drop only at large offset (passes at the origin): the StarRing host plus
+// an 8-vertex feature anchored 1e-9 from host[1].
+TEST(CrossSection, DISABLED_TinyFeatureNearCornerHostDropAtOffset1024) {
+  SimplePolygon host = StarRing({0., 1., 0., 181.7694024845519});
+  SimplePolygon feature =
+      StarRing({712.03169893044037, 1., 549.34829370834473, 0., 0.,
+                0.84629435037780809, 593.99733078452005, 738.68366086294714});
+  for (auto& v : feature) {
+    v.x *= 1e-3;
+    v.y *= 1e-3;
+  }
+  const double dirX = 0.20051392197659679, dirY = -0.51476208035366366;
+  const double dlen = std::sqrt(dirX * dirX + dirY * dirY);
+  const vec2 anchor{host[1].x + 1e-9 * dirX / dlen,
+                    host[1].y + 1e-9 * dirY / dlen};
+  const vec2 shift{anchor.x - feature[0].x, anchor.y - feature[0].y};
+  for (auto& v : feature) {
+    v.x += shift.x;
+    v.y += shift.y;
+  }
+  for (double offset : {0.0, 1024.0, 4096.0}) {
+    SimplePolygon sh = host, sf = feature;
+    for (auto& v : sh) {
+      v.x += offset;
+      v.y += offset;
+    }
+    for (auto& v : sf) {
+      v.x += offset;
+      v.y += offset;
+    }
+    const CrossSection ca(sh), cb(sf);
+    const auto sum =
+        ca.Area() + cb.Area() - ca.Boolean(cb, OpType::Intersect).Area();
+    EXPECT_NEAR((ca + cb).Area(), sum, 1e-3 * (1.0 + ca.Area() + cb.Area()))
+        << "offset=" << offset;
+  }
+}
+
 // Regression test for the BR-cell hole pattern from Samples.Sponge4. Two
 // CCW polygons that share an endpoint AND form a T-junction at the
 // non-shared endpoint of one edge. Before the broad-phase / fused-pass

--- a/test/polygon_corpus.h
+++ b/test/polygon_corpus.h
@@ -1,0 +1,68 @@
+// Copyright 2026 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "manifold/common.h"
+
+#ifndef MANIFOLD_NO_IOSTREAM
+#include <fstream>
+#endif
+
+namespace manifold {
+
+// One entry of the shared polygon test corpus: a test name, its expected
+// triangle count and epsilon, and the polygon set.
+struct PolygonCorpusEntry {
+  std::string name;
+  int expectedNumTri;
+  double epsilon;
+  Polygons polys;
+};
+
+#ifndef MANIFOLD_NO_IOSTREAM
+// Read a polygon corpus file - per entry: name, expectedNumTri, epsilon,
+// numPolys, then each polygon's point count and its vertices. Returns empty if
+// the file cannot be opened.
+inline std::vector<PolygonCorpusEntry> ReadPolygonCorpus(
+    const std::string& path) {
+  std::vector<PolygonCorpusEntry> corpus;
+  std::ifstream f(path);
+  if (!f.is_open()) return corpus;
+  std::string name;
+  double epsilon, x, y;
+  int expectedNumTri, numPolys, numPoints;
+  while (f >> name) {
+    f >> expectedNumTri >> epsilon >> numPolys;
+    Polygons polys;
+    for (int i = 0; i < numPolys; ++i) {
+      polys.emplace_back();
+      f >> numPoints;
+      for (int j = 0; j < numPoints; ++j) {
+        f >> x >> y;
+        polys.back().emplace_back(x, y);
+      }
+    }
+    corpus.push_back(
+        {std::move(name), expectedNumTri, epsilon, std::move(polys)});
+  }
+  return corpus;
+}
+#endif  // MANIFOLD_NO_IOSTREAM
+
+}  // namespace manifold

--- a/test/polygon_test.cpp
+++ b/test/polygon_test.cpp
@@ -20,6 +20,7 @@
 #endif
 #include <limits>
 
+#include "polygon_corpus.h"
 #include "test.h"
 
 namespace {
@@ -83,42 +84,18 @@ class PolygonTestFixture : public testing::Test {
 
 #ifndef MANIFOLD_NO_IOSTREAM
 void RegisterPolygonTestsFile(const std::string& filename) {
-  auto f = std::ifstream(filename);
-  EXPECT_TRUE(f.is_open());
-
-  // for each test:
-  //   test name, expectedNumTri, epsilon, num polygons
-  //   for each polygon:
-  //     num points
-  //     for each vertex:
-  //       x coord, y coord
-  //
-  // note that we should not have commas in the file
-
-  std::string name;
-  double epsilon, x, y;
-  int expectedNumTri, numPolys, numPoints;
-
-  while (1) {
-    f >> name;
-    if (f.eof()) break;
-    f >> expectedNumTri >> epsilon >> numPolys;
-    Polygons polys;
-    for (int i = 0; i < numPolys; i++) {
-      polys.emplace_back();
-      f >> numPoints;
-      for (int j = 0; j < numPoints; j++) {
-        f >> x >> y;
-        polys.back().emplace_back(x, y);
-      }
-    }
+  const std::vector<PolygonCorpusEntry> corpus = ReadPolygonCorpus(filename);
+  // The corpus files are committed, so an empty read means a missing or
+  // unreadable file; fail loudly rather than silently registering no tests.
+  EXPECT_FALSE(corpus.empty()) << "no polygon corpus read from " << filename;
+  for (const auto& entry : corpus) {
     testing::RegisterTest(
-        "Polygon", name.c_str(), nullptr, nullptr, __FILE__, __LINE__,
-        [=, polys = std::move(polys)]() -> PolygonTestFixture* {
+        "Polygon", entry.name.c_str(), nullptr, nullptr, __FILE__, __LINE__,
+        [polys = entry.polys, epsilon = entry.epsilon,
+         expectedNumTri = entry.expectedNumTri]() -> PolygonTestFixture* {
           return new PolygonTestFixture(polys, epsilon, expectedNumTri);
         });
   }
-  f.close();
 }
 #endif
 }  // namespace

--- a/test/test.h
+++ b/test/test.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cmath>
+
 #include "gtest/gtest.h"
 #include "manifold/common.h"
 #include "manifold/manifold.h"
@@ -38,6 +40,21 @@ struct ManifoldParamGuard {
   ManifoldParamGuard() { params = ManifoldParams(); }
   ~ManifoldParamGuard() { ManifoldParams() = params; }
 };
+
+inline double RawSignedArea(const manifold::SimplePolygon& ring) {
+  if (ring.size() < 3) return 0.0;
+  double sum = 0.0;
+  for (size_t i = 0; i < ring.size(); ++i) {
+    const manifold::vec2& a = ring[i];
+    const manifold::vec2& b = ring[(i + 1) % ring.size()];
+    sum += la::cross(a, b);
+  }
+  return 0.5 * sum;
+}
+
+inline double RawArea(const manifold::SimplePolygon& ring) {
+  return std::fabs(RawSignedArea(ring));
+}
 
 Polygons SquareHole(double xOffset = 0.0);
 MeshGL Csaszar();


### PR DESCRIPTION
Test suite for the boolean2 cutover - #1707 staging item 5, following #1722/#1749/#1751/#1754. Adds 79 tests:

- `test/boolean2_test.cpp` (new): 37 white-box tests of the engine in suite `Boolean2` - graph order, vertex merge, edge-vertex lists, intersection insertion, the retained-graph validator, and winding filtering. The validator's geometric predicates are deliberately independent of the engine's (using `IntersectSegments` to check its own output would be circular); a comment in the file records how their epsilon band differs from `CCW`'s.
- `test/cross_section_test.cpp`: extended from its existing 15 tests with 41 new public-API tests - Boolean/BatchBoolean invariants (commutativity, distributivity, area conservation), Offset join types and edge cases, Decompose containment, Simplify, and degenerate/non-finite inputs.
- `test/cross_section_offset_corpus_test.cpp` (new): offsets the polygon triangulation corpus across every join type and gates on clean triangulation; runs on WASM via the preloaded corpus.

Most regression cases are seeds from a fuzz campaign against the backend, kept as literal geometry with a short note on what each shape triggers; the fuzz harness itself follows in a separate PR. Two of these - tiny-feature point contacts near a host vertex - are marked `DISABLED_`; they expose an arrangement/winding-robustness issue tracked separately. White-box `../src` includes follow the existing pattern (boolean_test, manifold_test, and three others). Suite runs green on Linux/Mac/Windows/WASM and under ASan+UBSan.

