### PR TITLE
Make the intersection-vertex merge eps-only

### DIFF
--- a/src/boolean2.cpp
+++ b/src/boolean2.cpp
@@ -138,7 +138,7 @@ void AppendInput(const Polygons& polys, int mult, std::vector<vec2>& verts,
 
 // `bSign` is +1 for Add/Intersect-style accumulation and -1 for Subtract.
 Polygons ApplyFillRule(const Polygons& a, const Polygons& b, int bSign,
-                       WindRule rule, double eps, double tolerance) {
+                       WindRule rule, double eps) {
   DEBUG_ASSERT(bSign == 1 || bSign == -1, logicErr,
                "Boolean2 input multiplicity must be +/-1");
   if (!AllFinite(a) || !AllFinite(b)) return {};
@@ -146,7 +146,6 @@ Polygons ApplyFillRule(const Polygons& a, const Polygons& b, int bSign,
   Polygons localA = TranslatePolygons(a, -origin);
   Polygons localB = TranslatePolygons(b, -origin);
   if (eps <= 0.0) eps = InferEps(localA, localB);
-  if (tolerance < eps) tolerance = eps;
 
   std::vector<vec2> verts;
   std::vector<EdgeM> edges;
@@ -154,8 +153,7 @@ Polygons ApplyFillRule(const Polygons& a, const Polygons& b, int bSign,
   AppendInput(localB, bSign, verts, edges);
   if (verts.empty()) return {};
 
-  OverlapResult r =
-      RemoveOverlaps2D(verts, edges, eps, tolerance, /*debug=*/false, rule);
+  OverlapResult r = RemoveOverlaps2D(verts, edges, eps, /*debug=*/false, rule);
   return TranslatePolygons(OutEdgesToPolygons(r.verts, r.edges), origin);
 }
 
@@ -237,7 +235,7 @@ Polygons OutEdgesToPolygons(const std::vector<vec2>& verts,
 // what construction and Offset use to resolve self-intersections - as opposed
 // to CrossSection::Simplify, which decimates at a user-designated tolerance.
 Polygons ApplyFillRule(const Polygons& polys, double eps) {
-  return ApplyFillRule(polys, {}, 1, WindRule::Add, eps, 0.0);
+  return ApplyFillRule(polys, {}, 1, WindRule::Add, eps);
 }
 
 // Infer eps from a polygon set's coordinate half-extent via Smith's
@@ -253,12 +251,12 @@ double InferEps(const Polygons& a, const Polygons& b) {
 }
 
 // Binary boolean over one combined edge set; Subtract flips B's multiplicity.
-Polygons Boolean2D(const Polygons& a, const Polygons& b, OpType op, double eps,
-                   double tolerance) {
+Polygons Boolean2D(const Polygons& a, const Polygons& b, OpType op,
+                   double eps) {
   const int bSign = op == OpType::Subtract ? -1 : 1;
   const WindRule rule =
       op == OpType::Intersect ? WindRule::Intersect : WindRule::Add;
-  return ApplyFillRule(a, b, bSign, rule, eps, tolerance);
+  return ApplyFillRule(a, b, bSign, rule, eps);
 }
 
 // ===== BVH =====
@@ -1042,10 +1040,8 @@ void MergeNearbyIntersectionVerts(
   // Merge intersection verts only at the eps snap scale; a wider band fuses
   // distinct crossings of one edge into a non-manifold pinch.
   const double newToNewThresh2 = eps * eps;
-  // Fresh intersection vs old endpoint: a 2*eps snap budget (the local combined
-  // eps reach of an old endpoint and a generated crossing). Eps-scale, not
-  // tolerance - tolerance-scale decimation is Simplify's job, and snapping old
-  // geometry at tolerance scale folds the arrangement.
+  // Fresh intersection vs old endpoint: a 2*eps snap budget, the combined eps
+  // reach of an old endpoint and a generated crossing.
   const double newToOldThresh2 = 4 * eps * eps;
   std::vector<std::pair<int, int>> pairs;
   std::vector<std::pair<double, int>> tlist;
@@ -1142,9 +1138,7 @@ void MergeNearbyIntersectionVerts(
 
 OverlapResult RemoveOverlaps2D(const std::vector<vec2>& vertsIn,
                                const std::vector<EdgeM>& edgesIn, double eps,
-                               double tolerance, bool debug, WindRule pred,
-                               Trace* trace) {
-  if (tolerance < eps) tolerance = eps;
+                               bool debug, WindRule pred, Trace* trace) {
   auto& P = GlobalPhases();
   ScopedTiming totalTiming(P.totalNs);
   TraceRecorder traceRecorder(trace, eps, pred);

--- a/src/boolean2.cpp
+++ b/src/boolean2.cpp
@@ -1112,13 +1112,29 @@ void MergeNearbyIntersectionVerts(
   }
   if (distinctClusters == nV) return;
 
+  // Pin a cluster with an old (pre-intersection) vertex to that vertex (nearest
+  // the centroid, like MergeVerts), not the centroid: drifting an old vertex
+  // sub-eps folds the winding walk at a near-coincident tip.
+  std::vector<int> anchor(nV, -1);
+  std::vector<double> anchorDist2(nV, std::numeric_limits<double>::infinity());
+  for (int i = 0; i < oldVertEnd; ++i) {
+    const int r = uf.find(i);
+    const vec2 d = verts[i] - sumPos[r] * (1.0 / sumCnt[r]);
+    const double dist2 = dot(d, d);
+    if (dist2 < anchorDist2[r]) {
+      anchorDist2[r] = dist2;
+      anchor[r] = i;
+    }
+  }
+
   std::vector<int> rootToNew(nV, -1);
   std::vector<vec2> newVerts;
   newVerts.reserve(distinctClusters);
   for (int r = 0; r < nV; ++r) {
     if (sumCnt[r] == 0) continue;
     rootToNew[r] = static_cast<int>(newVerts.size());
-    newVerts.push_back(sumPos[r] * (1.0 / sumCnt[r]));
+    newVerts.push_back(anchor[r] >= 0 ? verts[anchor[r]]
+                                      : sumPos[r] * (1.0 / sumCnt[r]));
   }
   std::vector<int> preMergeToPost(nV);
   for (int i = 0; i < nV; ++i) preMergeToPost[i] = rootToNew[uf.find(i)];

--- a/src/boolean2.cpp
+++ b/src/boolean2.cpp
@@ -1112,29 +1112,13 @@ void MergeNearbyIntersectionVerts(
   }
   if (distinctClusters == nV) return;
 
-  // Pin a cluster with an old (pre-intersection) vertex to that vertex (nearest
-  // the centroid, like MergeVerts), not the centroid: drifting an old vertex
-  // sub-eps folds the winding walk at a near-coincident tip.
-  std::vector<int> anchor(nV, -1);
-  std::vector<double> anchorDist2(nV, std::numeric_limits<double>::infinity());
-  for (int i = 0; i < oldVertEnd; ++i) {
-    const int r = uf.find(i);
-    const vec2 d = verts[i] - sumPos[r] * (1.0 / sumCnt[r]);
-    const double dist2 = dot(d, d);
-    if (dist2 < anchorDist2[r]) {
-      anchorDist2[r] = dist2;
-      anchor[r] = i;
-    }
-  }
-
   std::vector<int> rootToNew(nV, -1);
   std::vector<vec2> newVerts;
   newVerts.reserve(distinctClusters);
   for (int r = 0; r < nV; ++r) {
     if (sumCnt[r] == 0) continue;
     rootToNew[r] = static_cast<int>(newVerts.size());
-    newVerts.push_back(anchor[r] >= 0 ? verts[anchor[r]]
-                                      : sumPos[r] * (1.0 / sumCnt[r]));
+    newVerts.push_back(sumPos[r] * (1.0 / sumCnt[r]));
   }
   std::vector<int> preMergeToPost(nV);
   for (int i = 0; i < nV; ++i) preMergeToPost[i] = rootToNew[uf.find(i)];

--- a/src/boolean2.cpp
+++ b/src/boolean2.cpp
@@ -1031,21 +1031,22 @@ namespace {
 // Unlike MergeVerts, this pass only considers vertices with intersection
 // incidence: newly inserted intersection points and old vertices that an
 // intersection snapped onto. The close-pair threshold is intersection-specific,
-// and endpoint tolerance snaps are limited to truly-new vertices, so this does
-// not re-run broad old-vertex clustering across the input.
+// and endpoint snaps are limited to truly-new vertices, so this does not re-run
+// broad old-vertex clustering across the input.
 void MergeNearbyIntersectionVerts(
     std::vector<vec2>& verts, std::vector<EdgeM>& edges,
     std::vector<std::vector<int>>& lists,
     const std::vector<std::vector<int>>& vertEdges, int oldVertEnd, double eps,
-    double tolerance, std::vector<int>& inputVert2Merged) {
+    std::vector<int>& inputVert2Merged) {
   DisjointSets uf(static_cast<int>(verts.size()));
   // Merge intersection verts only at the eps snap scale; a wider band fuses
   // distinct crossings of one edge into a non-manifold pinch.
-  const double newToNewThresh = eps;
-  const double newToNewThresh2 = newToNewThresh * newToNewThresh;
-  // Fresh intersection vs old endpoint: prior drift plus current-op error.
-  const double newToOldThresh = tolerance + eps;
-  const double newToOldThresh2 = newToOldThresh * newToOldThresh;
+  const double newToNewThresh2 = eps * eps;
+  // Fresh intersection vs old endpoint: a 2*eps snap budget (the local combined
+  // eps reach of an old endpoint and a generated crossing). Eps-scale, not
+  // tolerance - tolerance-scale decimation is Simplify's job, and snapping old
+  // geometry at tolerance scale folds the arrangement.
+  const double newToOldThresh2 = 4 * eps * eps;
   std::vector<std::pair<int, int>> pairs;
   std::vector<std::pair<double, int>> tlist;
   for (size_t e = 0; e < edges.size(); ++e) {
@@ -1058,7 +1059,7 @@ void MergeNearbyIntersectionVerts(
     const double abLen2 = dot(ab, ab);
     if (abLen2 == 0) continue;
     const double abLen = std::sqrt(abLen2);
-    const double tThresh = newToNewThresh / abLen;
+    const double tThresh = eps / abLen;
     tlist.clear();
     tlist.reserve(list.size());
     for (int v : list) {
@@ -1069,7 +1070,7 @@ void MergeNearbyIntersectionVerts(
       const double t = dot(p - a, ab) / abLen2;
       tlist.emplace_back(t, v);
       // Only truly-new verts: widening old-old would stack error across ops.
-      if (v >= oldVertEnd && newToOldThresh > 0.0) {
+      if (v >= oldVertEnd) {
         const vec2 dA = p - a;
         if (dot(dA, dA) <= newToOldThresh2) {
           const int p0 = std::min(v, v0);
@@ -1216,8 +1217,7 @@ OverlapResult RemoveOverlaps2D(const std::vector<vec2>& vertsIn,
   {
     ScopedTiming timing(P.nearbyIxMergeNs);
     MergeNearbyIntersectionVerts(merge.verts, edges, lists, vertEdges,
-                                 numMerged, eps, tolerance,
-                                 merge.inputVert2Merged);
+                                 numMerged, eps, merge.inputVert2Merged);
   }
   traceRecorder.RecordNearbyIntersectionMerge(merge.verts, edges, lists);
   // Sub-edge canonicalization.

--- a/src/boolean2.cpp
+++ b/src/boolean2.cpp
@@ -1039,7 +1039,9 @@ void MergeNearbyIntersectionVerts(
     const std::vector<std::vector<int>>& vertEdges, int oldVertEnd, double eps,
     double tolerance, std::vector<int>& inputVert2Merged) {
   DisjointSets uf(static_cast<int>(verts.size()));
-  const double newToNewThresh = kIntersectionMergeEpsFactor * eps;
+  // Merge intersection verts only at the eps snap scale; a wider band fuses
+  // distinct crossings of one edge into a non-manifold pinch.
+  const double newToNewThresh = eps;
   const double newToNewThresh2 = newToNewThresh * newToNewThresh;
   // Fresh intersection vs old endpoint: prior drift plus current-op error.
   const double newToOldThresh = tolerance + eps;

--- a/src/boolean2.h
+++ b/src/boolean2.h
@@ -254,8 +254,6 @@ NarrowPhaseResult BuildListsAndFindIntersections(
     const std::vector<EdgeM>& edges, const std::vector<vec2>& verts, double eps,
     const std::vector<std::pair<int, int>>& pairs);
 
-inline constexpr double kIntersectionMergeEpsFactor = 10.0;
-
 void CollectIntersectionPairs(const std::vector<EdgeM>& edges,
                               const std::vector<vec2>& verts, double eps,
                               const std::vector<Box2>& edgeBoxes,

--- a/src/boolean2.h
+++ b/src/boolean2.h
@@ -300,14 +300,11 @@ struct OverlapResult {
   int numMergedVerts;
 };
 
-// `eps` is the fresh per-op FP-noise bound (3D analogue: Impl::epsilon_).
-// `tolerance` is the propagated drift bound (3D analogue: Impl::tolerance_).
-// The arrangement is eps-only: no merge or snap consults `tolerance`.
-// TODO: drop `tolerance` from the arrangement entry points; CrossSection still
-// tracks tolerance_ for Simplify's decimation.
+// `eps` is the per-op FP-noise bound (3D: Impl::epsilon_). The arrangement is
+// eps-only; tolerance-scale decimation is Simplify's job, as in boolean3.
 OverlapResult RemoveOverlaps2D(const std::vector<vec2>& vertsIn,
                                const std::vector<EdgeM>& edgesIn, double eps,
-                               double tolerance = 0.0, bool debug = false,
+                               bool debug = false,
                                WindRule pred = WindRule::Add,
                                Trace* trace = nullptr);
 
@@ -322,7 +319,7 @@ Polygons OutEdgesToPolygons(const std::vector<vec2>& verts,
 // machine-scale eps. Fill-rule application, not tolerance decimation.
 Polygons ApplyFillRule(const Polygons& polys, double eps);
 Polygons Boolean2D(const Polygons& a, const Polygons& b, OpType op,
-                   double eps = 0.0, double tolerance = 0.0);
+                   double eps = 0.0);
 
 // Polygon offset backing CrossSection::Offset.
 Polygons Offset(const Polygons& in, double delta, JoinType jt,

--- a/src/boolean2.h
+++ b/src/boolean2.h
@@ -301,10 +301,10 @@ struct OverlapResult {
 };
 
 // `eps` is the fresh per-op FP-noise bound (3D analogue: Impl::epsilon_).
-// `tolerance` is the propagated drift bound (3D analogue: Impl::tolerance_);
-// floored to `eps` if smaller. Nearby-intersection new-to-old snaps use
-// `tolerance + eps` for prior drift plus current-op error; MergeVerts stays at
-// `eps`.
+// `tolerance` is the propagated drift bound (3D analogue: Impl::tolerance_).
+// The arrangement is eps-only: no merge or snap consults `tolerance`.
+// TODO: drop `tolerance` from the arrangement entry points; CrossSection still
+// tracks tolerance_ for Simplify's decimation.
 OverlapResult RemoveOverlaps2D(const std::vector<vec2>& vertsIn,
                                const std::vector<EdgeM>& edgesIn, double eps,
                                double tolerance = 0.0, bool debug = false,

--- a/src/cross_section.cpp
+++ b/src/cross_section.cpp
@@ -352,7 +352,7 @@ CrossSection CrossSection::Boolean(const CrossSection& second,
   const Polygons& b = second.GetPaths()->paths_;
   const double eps = InferEps(a, b);
   const double tolerance = std::max({tolerance_, second.tolerance_, eps});
-  CrossSection result(shared_paths(Boolean2D(a, b, op, eps, tolerance)));
+  CrossSection result(shared_paths(Boolean2D(a, b, op, eps)));
   result.tolerance_ = tolerance;
   return result;
 }
@@ -374,7 +374,7 @@ CrossSection CrossSection::BatchBoolean(
       const double eps = InferEps(result, clip);
       const double tolerance =
           std::max({tol, crossSections[i].tolerance_, eps});
-      result = Boolean2D(result, clip, OpType::Intersect, eps, tolerance);
+      result = Boolean2D(result, clip, OpType::Intersect, eps);
       tol = tolerance;
     }
     CrossSection out(shared_paths(std::move(result)));
@@ -393,7 +393,7 @@ CrossSection CrossSection::BatchBoolean(
   const double eps = InferEps(subject, clips);
   const double tolerance =
       std::max({crossSections[0].tolerance_, clipsTol, eps});
-  CrossSection out(shared_paths(Boolean2D(subject, clips, op, eps, tolerance)));
+  CrossSection out(shared_paths(Boolean2D(subject, clips, op, eps)));
   out.tolerance_ = tolerance;
   return out;
 }


### PR DESCRIPTION
MergeNearbyIntersectionVerts merged intersection verts at two scales, and each
could annihilate a valid arrangement:

- new-to-new: fused crossings sharing an edge within 10*eps
  (kIntersectionMergeEpsFactor). A tiny feature near a host vertex crosses one
  host edge at two distinct points a few eps apart; fusing them pinches the
  arrangement and the winding filter collapses it to empty
  (CrossSectionFuzz.TinyFeatureNearCorner). Dropped the reach to eps.

- new-to-old: snapped a fresh intersection onto an old endpoint within
  tolerance+eps and emitted the cluster centroid, dragging the old endpoint by up
  to ~tolerance. An elevated (propagated) tolerance then folds the arrangement -
  an old corner crosses an incident edge, the winding inverts, and the filter
  returns empty. Two clean ~1-area stars Add to 0.0 at tolerance >= 0.08. Snap at
  2*eps instead and drop tolerance from the merge.

The merge is now eps-only. A near-coincidence more than ~eps apart is a real tiny
feature the arrangement keeps; decimating it is Simplify's job, not the boolean's
(tolerance no longer affects the arrangement at all).

Validated: full Boolean2 + CrossSection suite green, including
SubtractInvariantsEmptyIntersectionDrop (the near-coincidence the old tolerance
snap was added to resolve). Tests on #1755.
