### PR TITLE
remove async free

### DIFF
--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -80,14 +80,6 @@ double FromChars(T buffer) {
 
 namespace manifold {
 
-#if (MANIFOLD_PAR == 1)
-#if (TBB_VERSION_MAJOR < 2021)
-tbb::task_arena gc_arena(1, 1);
-#else
-tbb::task_arena gc_arena(1, 1, tbb::task_arena::priority::low);
-#endif
-#endif
-
 std::atomic<uint32_t> Manifold::Impl::meshIDCounter_(1);
 
 uint32_t Manifold::Impl::ReserveIDs(uint32_t n) {

--- a/src/vec.h
+++ b/src/vec.h
@@ -38,10 +38,6 @@
 
 namespace manifold {
 
-#if (MANIFOLD_PAR == 1)
-extern tbb::task_arena gc_arena;
-#endif
-
 struct Empty {};
 
 template <typename T, bool shared = false>
@@ -232,7 +228,8 @@ class Vec : public VecView<T> {
         manifold::copy(autoPolicy(this->size_), this->ptr_,
                        this->ptr_ + this->size_, newBuffer);
       if (this->ptr_ != nullptr) {
-        free_async(this->ptr_, capacity_);
+        TracyFreeS(this->ptr_, 3);
+        free(this->ptr_);
       }
       this->ptr_ = newBuffer;
       capacity_ = n;
@@ -280,7 +277,8 @@ class Vec : public VecView<T> {
       manifold::copy(this->ptr_, this->ptr_ + this->size_, newBuffer);
     }
     if (this->ptr_ != nullptr) {
-      free_async(this->ptr_, capacity_);
+      TracyFreeS(this->ptr_, 3);
+      free(this->ptr_);
     }
     this->ptr_ = newBuffer;
     capacity_ = this->size_;
@@ -322,7 +320,8 @@ class Vec : public VecView<T> {
       this->count_ = nullptr;
     }
     if (this->ptr_ != nullptr) {
-      Vec<T, false>::free_async(this->ptr_, this->capacity_);
+      TracyFreeS(this->ptr_, 3);
+      free(this->ptr_);
     }
     this->ptr_ = nullptr;
     this->size_ = 0;
@@ -343,24 +342,5 @@ class Vec : public VecView<T> {
   // This is required so we can access private fields between shared and
   // non-shared vectors.
   friend Vec<T, !shared>;
-
-  static void free_async(T* ptr, size_t size) {
-    // Only do async free if the size is large, because otherwise we may be able
-    // to reuse the allocation, and the deallocation probably won't trigger
-    // munmap.
-    // Currently it is set to 64 pages (4kB page).
-    constexpr size_t ASYNC_FREE_THRESHOLD = 1 << 18;
-    TracyFreeS(ptr, 3);
-#if defined(__has_feature)
-#if !__has_feature(address_sanitizer)
-#if (MANIFOLD_PAR == 1)
-    if (size * sizeof(T) > ASYNC_FREE_THRESHOLD)
-      gc_arena.enqueue([ptr]() { free(ptr); });
-    else
-#endif
-#endif
-#endif
-      free(ptr);
-  }
 };
 }  // namespace manifold


### PR DESCRIPTION
fix https://projects.blender.org/blender/blender/issues/158737

It seems that the performance benefit mostly comes from deferring the deallocation work to later, when we are less busy. Unfortunately, adding a simple limit on the maximum amount of garbage we can allow to defer seems to make things worse... Maybe unmap is not that bad when the OS can reuse memory. I am removing it entirely now.