### PR TITLE
document manifoldcad global settings

### DIFF
--- a/bindings/wasm/tsconfig.json
+++ b/bindings/wasm/tsconfig.json
@@ -27,10 +27,10 @@
   ],
   "files": [
     "./types/manifoldCAD.d.ts",
-    "./types/manifoldCADGlobals.d.ts"
+    "./types/manifoldCADGlobals.d.ts",
+    "./types/manifoldCADUserGuide.d.ts"
   ],
   "exclude": [
     "./lib/*.test.ts"
   ]
 }
-

--- a/bindings/wasm/typedoc.user.json
+++ b/bindings/wasm/typedoc.user.json
@@ -4,7 +4,7 @@
   "name": "ManifoldCAD User Guide",
   "customCss": "./documents/user-guide.css",
   "out": "docs/jsuser",
-  "entryPoints": [ "./types/manifoldCAD.d.ts" ],
+  "entryPoints": [ "./types/manifoldCADUserGuide.d.ts" ],
   "alwaysCreateEntryPointModule": false,
   "excludeInternal": true,
   "readme": "none",

--- a/bindings/wasm/types/manifoldCADUserGuide.d.ts
+++ b/bindings/wasm/types/manifoldCADUserGuide.d.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * {@include ../README.md#IncludeInUserGuide}
+ *
+ * {@include ../documents/using-manifoldcad.md}
+ *
+ * {@include ../documents/tips.md}
+ *
+ * @packageDocumentation
+ */
+
+export * from './manifoldCAD.d.ts';
+export * from './manifoldCADGlobals.d.ts';


### PR DESCRIPTION
fixes #1773

the user guide only passed manifoldCAD.d.ts to typedoc, so the top level settings declared in manifoldCADGlobals.d.ts were never analyzed. this adds a docs entry point that reexports both declaration files while keeping typedoc on a single module.

that documents setCircularSegments and the other global animation and circular settings without changing any existing documentation urls. the existing package introduction is also preserved.

validation

* generated the user guide with npx typedoc@0.28.16 --options typedoc.user.json --skipErrorChecking
* compared the baseline and updated output paths and confirmed every existing url is retained
* confirmed all seven global setting pages are generated
* ran clang-format in dry run mode with warnings treated as errors

this sparse checkout does not contain the generated wasm declarations or full dependency tree, so typedoc type checking and the full npm build were not run.