### PR TITLE
Reuse triangulator scratch buffers

### DIFF
--- a/src/face_op.cpp
+++ b/src/face_op.cpp
@@ -194,6 +194,7 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
   Vec<TriRef>& triRef = meshRelation_.triRef;
   triRef.clear();
   Vec<int> contour2Tri(faceHalfedge.size(), -1);
+  PolygonTriangulatorStore triangulators;
 
   auto generalTriangulation = [&](int face) {
     const vec3 normal = faceNormal_[face];
@@ -203,7 +204,8 @@ void Manifold::Impl::Face2Tri(const Vec<int>& faceEdge,
                           faceHalfedge.cbegin() + faceEdge[face + 1],
                           faceEdge[face]),
         faceHalfedge, vertPos_, projection);
-    return TriangulateIdxHalfedges(polys, epsilon_, allowConvex);
+    return TriangulateIdxHalfedges(polys, epsilon_, allowConvex,
+                                   triangulators.local());
   };
 
   auto outputFace = [&](int face, size_t firstTri,

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -15,6 +15,8 @@
 #include "manifold/polygon.h"
 
 #include <map>
+#include <memory>
+#include <optional>
 #include <set>
 #include <utility>
 
@@ -837,7 +839,7 @@ class EarClip {
   // Create a collider of all vertices in this polygon, each expanded by
   // epsilon_. Each ear uses this BVH to quickly find a subset of vertices to
   // check for cost.
-  IdxCollider& VertCollider(VertItr start) {
+  void BuildVertCollider(VertItr start) {
     ZoneScoped;
     collider_.points.clear(false);
     collider_.itr.clear();
@@ -848,7 +850,6 @@ class EarClip {
     });
 
     BuildTwoDTree(collider_.points);
-    return collider_;
   }
 
   // The main ear-clipping loop. This is called once for each simple polygon -
@@ -856,9 +857,9 @@ class EarClip {
   void TriangulatePoly(VertItr start) {
     ZoneScoped;
 
-    IdxCollider& vertCollider = VertCollider(start);
+    BuildVertCollider(start);
 
-    if (vertCollider.itr.empty()) {
+    if (collider_.itr.empty()) {
       PRINT("Empty poly");
       return;
     }
@@ -868,7 +869,7 @@ class EarClip {
     earsQueue_.clear();
 
     auto QueueVert = [&](VertItr v) {
-      ProcessEar(v, vertCollider);
+      ProcessEar(v, collider_);
       ++numTri;
       v->PrintVert();
     };
@@ -891,8 +892,8 @@ class EarClip {
       ClipEar(v);
       --numTri;
 
-      ProcessEar(v->left, vertCollider);
-      ProcessEar(v->right, vertCollider);
+      ProcessEar(v->left, collider_);
+      ProcessEar(v->right, collider_);
       // This is a backup vert that is used if the queue is empty (geometrically
       // invalid polygon), to ensure manifoldness.
       v = v->right;
@@ -927,30 +928,11 @@ class EarClip {
 #endif
   }
 };
-}  // namespace
 
-namespace manifold {
-
-/**
- * @brief Triangulates a set of &epsilon;-valid polygons. If the input is not
- * &epsilon;-valid, the triangulation may overlap, but will always return a
- * manifold result that matches the input edge directions.
- *
- * @param polys The set of polygons, wound CCW and representing multiple
- * polygons and/or holes. These have 2D-projected positions as well as
- * references back to the original vertices.
- * @param epsilon The value of &epsilon;, bounding the uncertainty of the
- * input.
- * @param allowConvex If true (default), the triangulator will use a fast
- * triangulation if the input is convex, falling back to ear-clipping if not.
- * The triangle quality may be lower, so set to false to disable this
- * optimization.
- * @return HalfedgeTriangulation The contour and triangle halfedges,
- * referencing the original vertex indicies.
- */
-HalfedgeTriangulation TriangulateIdxHalfedges(const PolygonsIdx& polys,
-                                              double epsilon,
-                                              bool allowConvex) {
+template <typename GetTriangulator>
+HalfedgeTriangulation TriangulateIdxHalfedgesImpl(
+    const PolygonsIdx& polys, double epsilon, bool allowConvex,
+    GetTriangulator getTriangulator) {
   HalfedgeTriangulation result;
   double updatedEpsilon = epsilon;
 #ifdef MANIFOLD_DEBUG
@@ -959,7 +941,7 @@ HalfedgeTriangulation TriangulateIdxHalfedges(const PolygonsIdx& polys,
     if (allowConvex && IsConvex(polys, epsilon)) {  // fast path
       result = TriangulateConvex(polys);
     } else {
-      thread_local static EarClip triangulator;
+      auto& triangulator = getTriangulator();
       result = triangulator.Triangulate(polys, epsilon);
       updatedEpsilon = triangulator.GetPrecision();
     }
@@ -987,6 +969,60 @@ HalfedgeTriangulation TriangulateIdxHalfedges(const PolygonsIdx& polys,
   }
 #endif
   return result;
+}
+}  // namespace
+
+namespace manifold {
+
+struct PolygonTriangulator::Impl {
+  EarClip earClip;
+};
+
+PolygonTriangulator::PolygonTriangulator() = default;
+
+PolygonTriangulator::~PolygonTriangulator() = default;
+
+HalfedgeTriangulation PolygonTriangulator::Triangulate(const PolygonsIdx& polys,
+                                                       double epsilon) {
+  if (!impl_) impl_ = std::make_unique<Impl>();
+  return impl_->earClip.Triangulate(polys, epsilon);
+}
+
+double PolygonTriangulator::GetPrecision() const {
+  return impl_->earClip.GetPrecision();
+}
+
+/**
+ * @brief Triangulates epsilon-valid polygons. Invalid input can produce
+ * overlapping output that remains manifold and follows input edge directions.
+ *
+ * @param polys The set of polygons, wound CCW and representing multiple
+ * polygons and/or holes. These have 2D-projected positions as well as
+ * references back to the original vertices.
+ * @param epsilon The value of &epsilon;, bounding the uncertainty of the
+ * input.
+ * @param allowConvex If true (default), the triangulator will use a fast
+ * triangulation if the input is convex, falling back to ear-clipping if not.
+ * The triangle quality may be lower, so set to false to disable this
+ * optimization.
+ * @return HalfedgeTriangulation The contour and triangle halfedges,
+ * referencing the original vertex indices.
+ */
+HalfedgeTriangulation TriangulateIdxHalfedges(const PolygonsIdx& polys,
+                                              double epsilon,
+                                              bool allowConvex) {
+  std::optional<EarClip> triangulator;
+  return TriangulateIdxHalfedgesImpl(
+      polys, epsilon, allowConvex,
+      [&]() -> EarClip& { return triangulator.emplace(); });
+}
+
+HalfedgeTriangulation TriangulateIdxHalfedges(
+    const PolygonsIdx& polys, double epsilon, bool allowConvex,
+    PolygonTriangulator& triangulator) {
+  return TriangulateIdxHalfedgesImpl(
+      polys, epsilon, allowConvex,
+      [&]() -> PolygonTriangulator& { return triangulator; });
 }
 
 std::vector<ivec3> TriangulateIdx(const PolygonsIdx& polys, double epsilon,

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -16,6 +16,7 @@
 
 #include <map>
 #include <set>
+#include <utility>
 
 #include "manifold/manifold.h"
 #include "manifold/optional_assert.h"
@@ -232,8 +233,10 @@ HalfedgeTriangulation TriangulateConvex(const PolygonsIdx& polys) {
 
 class EarClip {
  public:
-  EarClip(const PolygonsIdx& polys, double epsilon) : epsilon_(epsilon) {
+  HalfedgeTriangulation Triangulate(const PolygonsIdx& polys, double epsilon) {
     ZoneScoped;
+
+    Reset(epsilon);
 
     size_t numVert = 0;
     for (const SimplePolygonIdx& poly : polys) {
@@ -241,19 +244,15 @@ class EarClip {
     }
     polygon_.reserve(numVert + 2 * polys.size());
 
-    std::vector<VertItr> starts = Initialize(polys);
+    Initialize(polys);
 
     for (VertItr v = polygon_.begin(); v != polygon_.end(); ++v) {
       ClipIfDegenerate(v);
     }
 
-    for (const VertItr first : starts) {
+    for (const VertItr first : starts_) {
       FindStart(first);
     }
-  }
-
-  HalfedgeTriangulation Triangulate() {
-    ZoneScoped;
 
     for (const VertItr start : holes_) {
       CutKeyhole(start);
@@ -263,7 +262,7 @@ class EarClip {
       TriangulatePoly(start);
     }
 
-    return result_;
+    return std::move(result_);
   }
 
   double GetPrecision() const { return epsilon_; }
@@ -284,8 +283,15 @@ class EarClip {
   };
   using qItr = std::set<VertItr, MinCost>::iterator;
 
+  struct IdxCollider {
+    Vec<PolyVert> points;
+    std::vector<VertItr> itr;
+  };
+
   // The flat list where all the Verts are stored. Not used much for traversal.
   std::vector<Vert> polygon_;
+  // Initial contour starts, kept as scratch storage between calls.
+  std::vector<VertItr> starts_;
   // The set of right-most starting points, one for each negative-area contour.
   std::multiset<VertItr, MaxX> holes_;
   // The set of starting points, one for each positive-area contour.
@@ -296,17 +302,14 @@ class EarClip {
   std::map<VertItr, Rect> hole2BBox_;
   // A priority queue of valid ears - the multiset allows them to be updated.
   std::multiset<VertItr, MinCost> earsQueue_;
+  // Per-polygon collision data, kept as scratch storage between calls.
+  IdxCollider collider_;
   // The output triangulation, represented directly as halfedges.
   HalfedgeTriangulation result_;
   // Bounding box of the entire set of polygons
   Rect bBox_;
   // Working epsilon: max of float error and input value.
   double epsilon_;
-
-  struct IdxCollider {
-    Vec<PolyVert> points;
-    std::vector<VertItr> itr;
-  };
 
   // A circularly-linked list representing the polygon(s) that still need to be
   // triangulated. This gets smaller as ears are clipped until it degenerates to
@@ -538,6 +541,23 @@ class EarClip {
   // from it, but it is still linked to them.
   static bool Clipped(VertItr v) { return v->right->left != v; }
 
+  void Reset(double epsilon) {
+    // Clear iterator-owning containers before invalidating polygon_.
+    earsQueue_.clear();
+    holes_.clear();
+    hole2BBox_.clear();
+    starts_.clear();
+    outers_.clear();
+    simples_.clear();
+    collider_.itr.clear();
+    collider_.points.clear(false);
+    polygon_.clear();
+
+    result_ = {};
+    bBox_ = {};
+    epsilon_ = epsilon;
+  }
+
   // Apply func to each un-clipped vert in a polygon and return an un-clipped
   // vert.
   template <typename F>
@@ -602,8 +622,8 @@ class EarClip {
   }
 
   // Build the circular list polygon structures.
-  std::vector<VertItr> Initialize(const PolygonsIdx& polys) {
-    std::vector<VertItr> starts;
+  void Initialize(const PolygonsIdx& polys) {
+    starts_.reserve(polys.size());
     const auto invalidItr = polygon_.begin();
     for (const SimplePolygonIdx& poly : polys) {
       auto vert = poly.begin();
@@ -620,7 +640,7 @@ class EarClip {
       VertItr last = first;
       // This is not the real rightmost start, but just an arbitrary vert for
       // now to identify each polygon.
-      starts.push_back(first);
+      starts_.push_back(first);
 
       for (++vert; vert != poly.end(); ++vert) {
         bBox_.Union(vert->pos);
@@ -644,8 +664,7 @@ class EarClip {
 
     result_.AddContours(polys);
     // Slightly more than enough, since each hole can cause two extra triangles.
-    result_.ReserveTriangles(polygon_.size() + 2 * starts.size());
-    return starts;
+    result_.ReserveTriangles(polygon_.size() + 2 * starts_.size());
   }
 
   // Find the actual rightmost starts after degenerate removal. Also calculate
@@ -818,17 +837,18 @@ class EarClip {
   // Create a collider of all vertices in this polygon, each expanded by
   // epsilon_. Each ear uses this BVH to quickly find a subset of vertices to
   // check for cost.
-  IdxCollider VertCollider(VertItr start) const {
+  IdxCollider& VertCollider(VertItr start) {
     ZoneScoped;
-    std::vector<VertItr> itr;
-    Vec<PolyVert> points;
-    Loop(start, [&itr, &points](VertItr v) {
-      points.push_back({v->pos, static_cast<int>(itr.size())});
-      itr.push_back(v);
+    collider_.points.clear(false);
+    collider_.itr.clear();
+    Loop(start, [this](VertItr v) {
+      collider_.points.push_back(
+          {v->pos, static_cast<int>(collider_.itr.size())});
+      collider_.itr.push_back(v);
     });
 
-    BuildTwoDTree(points);
-    return {std::move(points), std::move(itr)};
+    BuildTwoDTree(collider_.points);
+    return collider_;
   }
 
   // The main ear-clipping loop. This is called once for each simple polygon -
@@ -836,7 +856,7 @@ class EarClip {
   void TriangulatePoly(VertItr start) {
     ZoneScoped;
 
-    IdxCollider vertCollider = VertCollider(start);
+    IdxCollider& vertCollider = VertCollider(start);
 
     if (vertCollider.itr.empty()) {
       PRINT("Empty poly");
@@ -939,8 +959,8 @@ HalfedgeTriangulation TriangulateIdxHalfedges(const PolygonsIdx& polys,
     if (allowConvex && IsConvex(polys, epsilon)) {  // fast path
       result = TriangulateConvex(polys);
     } else {
-      EarClip triangulator(polys, epsilon);
-      result = triangulator.Triangulate();
+      thread_local static EarClip triangulator;
+      result = triangulator.Triangulate(polys, epsilon);
       updatedEpsilon = triangulator.GetPrecision();
     }
     result.epsilon = updatedEpsilon;

--- a/src/polygon_internal.h
+++ b/src/polygon_internal.h
@@ -15,11 +15,16 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <unordered_map>
 #include <vector>
 
 #include "manifold/polygon.h"
 #include "shared.h"
+
+#if MANIFOLD_PAR == 1
+#include <tbb/combinable.h>
+#endif
 
 namespace manifold {
 
@@ -111,8 +116,49 @@ struct HalfedgeTriangulation {
   }
 };
 
+// Reuses ear-clipping scratch allocations across sequential calls.
+class PolygonTriangulator {
+ public:
+  PolygonTriangulator();
+  ~PolygonTriangulator();
+
+  PolygonTriangulator(const PolygonTriangulator&) = delete;
+  PolygonTriangulator& operator=(const PolygonTriangulator&) = delete;
+
+  HalfedgeTriangulation Triangulate(const PolygonsIdx& polys, double epsilon);
+  double GetPrecision() const;
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+// Supplies one reusable triangulator per worker in parallel builds and one per
+// operation in sequential builds.
+class PolygonTriangulatorStore {
+ public:
+  PolygonTriangulator& local() {
+#if MANIFOLD_PAR == 1
+    return store_.local();
+#else
+    return store_;
+#endif
+  }
+
+ private:
+#if MANIFOLD_PAR == 1
+  tbb::combinable<PolygonTriangulator> store_;
+#else
+  PolygonTriangulator store_;
+#endif
+};
+
 HalfedgeTriangulation TriangulateIdxHalfedges(const PolygonsIdx& polys,
                                               double epsilon = -1,
                                               bool allowConvex = true);
+
+HalfedgeTriangulation TriangulateIdxHalfedges(
+    const PolygonsIdx& polys, double epsilon, bool allowConvex,
+    PolygonTriangulator& triangulator);
 
 }  // namespace manifold

--- a/test/polygon_test.cpp
+++ b/test/polygon_test.cpp
@@ -15,10 +15,14 @@
 #include "manifold/polygon.h"
 
 #include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
 #ifndef MANIFOLD_NO_IOSTREAM
 #include <fstream>
 #endif
 #include <limits>
+#include <thread>
 
 #include "polygon_corpus.h"
 #include "test.h"
@@ -54,6 +58,17 @@ Polygons Duplicate(Polygons polys) {
       vert.x += shift;
     }
     polys.push_back(poly);
+  }
+  return polys;
+}
+
+Polygons StarPolygon(int numVert) {
+  Polygons polys(1);
+  polys[0].reserve(numVert);
+  for (int i = 0; i < numVert; ++i) {
+    const double angle = kTwoPi * i / numVert;
+    const double radius = i % 2 == 0 ? 2.0 : 1.0;
+    polys[0].push_back({radius * std::cos(angle), radius * std::sin(angle)});
   }
   return polys;
 }
@@ -99,6 +114,44 @@ void RegisterPolygonTestsFile(const std::string& filename) {
 }
 #endif
 }  // namespace
+
+TEST(TriangulatorReuse, ClearsState) {
+  const Polygons large = StarPolygon(64);
+  const Polygons withHole = SquareHole();
+
+  const auto largeTriangles = Triangulate(large, -1, false);
+  const auto holeTriangles = Triangulate(withHole, -1, false);
+
+  EXPECT_EQ(largeTriangles.size(), 62);
+  EXPECT_EQ(holeTriangles.size(), 8);
+  EXPECT_EQ(Triangulate(large, -1, false), largeTriangles);
+}
+
+#ifndef __EMSCRIPTEN__
+TEST(TriangulatorReuse, IsThreadLocal) {
+  const Polygons large = StarPolygon(64);
+  const Polygons withHole = SquareHole();
+  const auto largeTriangles = Triangulate(large, -1, false);
+  const auto holeTriangles = Triangulate(withHole, -1, false);
+
+  std::atomic<bool> success = true;
+  std::array<std::thread, 8> threads;
+  for (std::thread& thread : threads) {
+    thread = std::thread([&] {
+      for (int i = 0; i < 10; ++i) {
+        if (Triangulate(large, -1, false) != largeTriangles ||
+            Triangulate(withHole, -1, false) != holeTriangles) {
+          success = false;
+          return;
+        }
+      }
+    });
+  }
+  for (std::thread& thread : threads) thread.join();
+
+  EXPECT_TRUE(success);
+}
+#endif
 
 #ifndef MANIFOLD_NO_IOSTREAM
 void RegisterPolygonTests() {

--- a/test/polygon_test.cpp
+++ b/test/polygon_test.cpp
@@ -23,7 +23,9 @@
 #endif
 #include <limits>
 #include <thread>
+#include <utility>
 
+#include "../src/polygon_internal.h"
 #include "polygon_corpus.h"
 #include "test.h"
 
@@ -73,6 +75,18 @@ Polygons StarPolygon(int numVert) {
   return polys;
 }
 
+PolygonsIdx IndexPolygons(const Polygons& polys) {
+  PolygonsIdx indexed;
+  int idx = 0;
+  for (const SimplePolygon& poly : polys) {
+    SimplePolygonIdx simple;
+    simple.reserve(poly.size());
+    for (const vec2& pos : poly) simple.push_back({pos, idx++});
+    indexed.push_back(std::move(simple));
+  }
+  return indexed;
+}
+
 void TestPoly(const Polygons& polys, int expectedNumTri,
               double epsilon = -1.0) {
   std::vector<ivec3> triangles;
@@ -118,29 +132,49 @@ void RegisterPolygonTestsFile(const std::string& filename) {
 TEST(TriangulatorReuse, ClearsState) {
   const Polygons large = StarPolygon(64);
   const Polygons withHole = SquareHole();
+  const PolygonsIdx largeIndexed = IndexPolygons(large);
+  const PolygonsIdx holeIndexed = IndexPolygons(withHole);
+  PolygonTriangulatorStore triangulators;
 
   const auto largeTriangles = Triangulate(large, -1, false);
   const auto holeTriangles = Triangulate(withHole, -1, false);
 
   EXPECT_EQ(largeTriangles.size(), 62);
   EXPECT_EQ(holeTriangles.size(), 8);
-  EXPECT_EQ(Triangulate(large, -1, false), largeTriangles);
+  EXPECT_EQ(
+      TriangulateIdxHalfedges(largeIndexed, -1, false, triangulators.local())
+          .Triangles(),
+      largeTriangles);
+  EXPECT_EQ(
+      TriangulateIdxHalfedges(holeIndexed, -1, false, triangulators.local())
+          .Triangles(),
+      holeTriangles);
+  EXPECT_EQ(
+      TriangulateIdxHalfedges(largeIndexed, -1, false, triangulators.local())
+          .Triangles(),
+      largeTriangles);
 }
 
-#ifndef __EMSCRIPTEN__
+#if MANIFOLD_PAR == 1 && !defined(__EMSCRIPTEN__)
 TEST(TriangulatorReuse, IsThreadLocal) {
   const Polygons large = StarPolygon(64);
   const Polygons withHole = SquareHole();
+  const PolygonsIdx largeIndexed = IndexPolygons(large);
+  const PolygonsIdx holeIndexed = IndexPolygons(withHole);
   const auto largeTriangles = Triangulate(large, -1, false);
   const auto holeTriangles = Triangulate(withHole, -1, false);
+  PolygonTriangulatorStore triangulators;
 
   std::atomic<bool> success = true;
   std::array<std::thread, 8> threads;
   for (std::thread& thread : threads) {
     thread = std::thread([&] {
+      PolygonTriangulator& triangulator = triangulators.local();
       for (int i = 0; i < 10; ++i) {
-        if (Triangulate(large, -1, false) != largeTriangles ||
-            Triangulate(withHole, -1, false) != holeTriangles) {
+        if (TriangulateIdxHalfedges(largeIndexed, -1, false, triangulator)
+                    .Triangles() != largeTriangles ||
+            TriangulateIdxHalfedges(holeIndexed, -1, false, triangulator)
+                    .Triangles() != holeTriangles) {
           success = false;
           return;
         }


### PR DESCRIPTION
## Summary

- reuse ear-clipping scratch buffers across face triangulations
- scope storage to one `Face2Tri` operation: `tbb::combinable` supplies one triangulator per worker in parallel builds, while non-TBB builds reuse one operation-local instance
- reset iterator-bearing state in a safe order while retaining vector and collider capacity
- add sequential and concurrent regressions for alternating polygon shapes

## Why

The ear-clipping path rebuilt its polygon and collider scratch buffers for every face. Reusing them removes repeated allocations without sharing mutable state between workers. Native `thread_local` storage is deliberately avoided, and public triangulation calls remain call-local.

## Results

Matched Linux/GCC 13 Release builds, one pinned core, seven interleaved runs after warm-up, forced ear clipping:

| Vertices | Base | This PR | Change |
|---:|---:|---:|---:|
| 8 | 2.252 us/call | 2.016 us/call | 10.5% faster |
| 16 | 7.116 us/call | 5.814 us/call | 18.3% faster |
| 64 | 34.791 us/call | 30.961 us/call | 11.0% faster |
| 256 | 201.023 us/call | 200.029 us/call | within noise (0.5% faster) |
| mixed 16/64/256 | 85.492 us/call | 84.882 us/call | within noise (0.7% faster) |

Steady-state global `new`/`new[]` instrumentation over 1,000 calls:

| Vertices | Allocations/call (base -> PR) | Allocated bytes/call (base -> PR) |
|---:|---:|---:|
| 8 | 58 -> 48 | 3,708 -> 2,276 |
| 16 | 119 -> 108 | 7,972 -> 5,180 |
| 64 | 457 -> 444 | 33,588 -> 22,700 |
| 256 | 1,803 -> 1,788 | 140,644 -> 97,340 |

Outputs matched in every benchmark run.

## Validation

- Linux/GCC 13, TBB ON, strict `-Werror`: 525/525 tests
- Windows/MSVC, TBB OFF, Release `/WX`: 507/507 tests
- Linux ASan+UBSan mixed-size reusable-path stress
- Linux TBB-TSAN reusable-path and representative Boolean-path tests
- clang-format 20 and `git diff --check`

Fixes #1149.