### PR TITLE
Optimize MergeMeshGL open-edge discovery

### DIFF
--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <atomic>
-#include <set>
+#include <cstdint>
 
 #include "disjoint_sets.h"
 #include "impl.h"
@@ -31,6 +31,23 @@ uint32_t MortonCode(vec3 position, Box bBox) {
   if (std::isnan(position.x)) return kNoCode;
 
   return Collider::MortonCode(position, bBox);
+}
+
+uint64_t EncodeOpenEdge(int first, int second) {
+  const uint32_t low = static_cast<uint32_t>(std::min(first, second));
+  const uint32_t high = static_cast<uint32_t>(std::max(first, second));
+  const uint64_t direction = first > second ? 1 : 0;
+  // Vertex indices are non-negative ints, so 31 bits each leaves one bit for
+  // direction. Keeping direction in the low bit groups opposing edges together
+  // when the encoded values are sorted.
+  return (static_cast<uint64_t>(low) << 32) |
+         (static_cast<uint64_t>(high) << 1) | direction;
+}
+
+int OpenEdgeFirst(uint64_t edge) {
+  const int low = static_cast<int>(edge >> 32);
+  const int high = static_cast<int>((edge >> 1) & 0x7FFFFFFFu);
+  return (edge & 1) == 0 ? low : high;
 }
 
 struct ReindexFace {
@@ -61,7 +78,6 @@ struct ReindexFace {
 template <typename Precision, typename I>
 bool MergeMeshGLP(MeshGLP<Precision, I>& mesh) {
   ZoneScoped;
-  std::multiset<std::pair<int, int>> openEdges;
 
   std::vector<int> merge(mesh.NumVert());
   std::iota(merge.begin(), merge.end(), 0);
@@ -71,31 +87,61 @@ bool MergeMeshGLP(MeshGLP<Precision, I>& mesh) {
 
   const auto numVert = mesh.NumVert();
   const auto numTri = mesh.NumTri();
+  Vec<uint64_t> edges(3 * numTri);
   const int next[3] = {1, 2, 0};
-  for (size_t tri = 0; tri < numTri; ++tri) {
-    for (int i : {0, 1, 2}) {
-      auto edge = std::make_pair(merge[mesh.triVerts[3 * tri + next[i]]],
-                                 merge[mesh.triVerts[3 * tri + i]]);
-      auto it = openEdges.find(edge);
-      if (it == openEdges.end()) {
-        std::swap(edge.first, edge.second);
-        openEdges.insert(edge);
-      } else {
-        openEdges.erase(it);
+  for_each_n(autoPolicy(numTri, 1e5), countAt(0_uz), numTri,
+             [&edges, &merge, &mesh, &next](size_t tri) {
+               for (int i : {0, 1, 2}) {
+                 const int first = merge[mesh.triVerts[3 * tri + i]];
+                 const int second = merge[mesh.triVerts[3 * tri + next[i]]];
+                 edges[3 * tri + i] = EncodeOpenEdge(first, second);
+               }
+             });
+  stable_sort(edges.begin(), edges.end());
+
+  Vec<int> openVerts;
+  openVerts.reserve(edges.size());
+  // Opposing directed edges cancel in pairs. Repeated edges in the same
+  // direction remain, matching the previous multiset behavior. Collapsed
+  // self-edges likewise remain only when their count is odd.
+  for (size_t begin = 0; begin < edges.size();) {
+    const uint64_t key = edges[begin] >> 1;
+    size_t end = begin + 1;
+    while (end < edges.size() && edges[end] >> 1 == key) {
+      ++end;
+    }
+
+    const int low = static_cast<int>(edges[begin] >> 32);
+    const int high = static_cast<int>((edges[begin] >> 1) & 0x7FFFFFFFu);
+    if (low == high) {
+      if ((end - begin) % 2 == 1) {
+        openVerts.push_back(low);
+      }
+    } else {
+      size_t split = begin;
+      while (split < end && (edges[split] & 1) == 0) {
+        ++split;
+      }
+      const size_t numForward = split - begin;
+      const size_t numReverse = end - split;
+      const size_t numOpen =
+          std::max(numForward, numReverse) - std::min(numForward, numReverse);
+      const uint64_t edge =
+          numForward >= numReverse ? edges[begin] : edges[end - 1];
+      for (size_t i = 0; i < numOpen; ++i) {
+        openVerts.push_back(OpenEdgeFirst(edge));
       }
     }
+    begin = end;
   }
-  if (openEdges.empty()) {
+  if (openVerts.empty()) {
     return false;
   }
+  // The multiset yielded first vertices in ascending order. Preserve that
+  // ordering so equal Morton codes keep the same deterministic merge roots.
+  stable_sort(openVerts.begin(), openVerts.end());
 
-  const auto numOpenVert = openEdges.size();
-  Vec<int> openVerts(numOpenVert);
-  int i = 0;
-  for (const auto& edge : openEdges) {
-    const int vert = edge.first;
-    openVerts[i++] = vert;
-  }
+  const auto numOpenVert = openVerts.size();
 
   Vec<Precision> vertPropD(mesh.vertProperties);
   Box bBox;

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -1160,6 +1160,29 @@ TEST(Manifold, Merge) {
   CheckCube(cubeSTL);
 }
 
+TEST(Manifold, MergeCollapsedEdgeParity) {
+  MeshGL mesh;
+  mesh.vertProperties = {0, 0, 0,  //
+                         0, 0, 0,  //
+                         1, 0, 0,  //
+                         3, 0, 0,  //
+                         3, 0, 0,  //
+                         4, 0, 0};
+  mesh.mergeFromVert = {1, 4};
+  mesh.mergeToVert = {0, 3};
+
+  // These triangles collapse to (0, 0, 2) and (3, 3, 5). Their opposing
+  // non-degenerate edges cancel, leaving one self-edge per triangle. Two
+  // copies of each triangle cancel those self-edges as well.
+  mesh.triVerts = {0, 1, 2, 0, 1, 2, 3, 4, 5, 3, 4, 5};
+  EXPECT_FALSE(mesh.Merge());
+
+  mesh.triVerts = {0, 1, 2, 3, 4, 5};
+  EXPECT_TRUE(mesh.Merge());
+  EXPECT_EQ(mesh.mergeFromVert, (std::vector<uint32_t>{1, 4}));
+  EXPECT_EQ(mesh.mergeToVert, (std::vector<uint32_t>{0, 3}));
+}
+
 TEST(Manifold, MergeEmpty) {
   MeshGL shape;
   shape.numProp = 7;


### PR DESCRIPTION
## Summary

- replace per-edge `std::multiset` updates with a compact encoded edge array
- populate the array in parallel and use Manifold's integral sort path
- cancel opposing edge counts in a linear scan while preserving duplicate, collapsed self-edge, and deterministic merge-root behavior
- add a regression for collapsed self-edge parity

## Performance

For a shuffled mesh of 1,000,000 disjoint triangles, measuring the complete `MeshGL::Merge()` call in matched Linux/GCC 13 Release builds with TBB, `MANIFOLD_DEBUG`, and `MANIFOLD_ASSERT` enabled:

- upstream: 2.394-2.408 seconds
- this branch: 0.575-0.623 seconds

Both versions returned `changed = true` with zero merge entries. This is a 74-76% reduction in elapsed time for this open-edge-heavy case.

## Validation

- exact output comparison against pristine upstream for 2,000 deterministic randomized meshes, including repeated, collapsed, and pre-merged edges
- Linux/GCC 13, TBB enabled, `MANIFOLD_DEBUG`, `MANIFOLD_ASSERT`, and `-Werror`: all 524 tests
- Windows/MSVC Release: all 507 tests
- ASan+UBSan randomized differential test
- clang-format and `git diff --check`

Addresses item 5 in #1474.
