### PR TITLE
versioned documentation deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,6 @@
 name: Deploy documentation
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types:
-      - completed
-    branches: [master]
   release:
     types: [published]
   workflow_dispatch:
@@ -20,15 +15,11 @@ on:
 jobs:
   deploy_github_pages:
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'release' ||
-      github.event.workflow_run.conclusion == 'success'
 
     steps:
     - uses: actions/checkout@v6
       with:
-        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event_name == 'release' && github.ref || github.event.workflow_run.head_sha }}
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
 
     - name: Doxygen Action
       uses: mattnotmitt/doxygen-action@edge
@@ -45,20 +36,19 @@ jobs:
       uses: dawidd6/action-download-artifact@v6
       with:
         workflow: manifold.yml
-        workflow_conclusion: completed
-        run_id: ${{ github.event.workflow_run.id }}
-        commit: ${{ github.event_name == 'release' && github.sha || '' }}
+        workflow_conclusion: success
+        commit: ${{ github.sha }}
         check_artifacts: true
         name: wasmpublic
         path: ./public
 
-    - name: Deploy to versioned subdirectory
+    - name: Deploy to vX.Y.Z/
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
         publish_dir: ./public
-        destination_dir: ${{ github.event_name == 'workflow_dispatch' && inputs.destination_dir || github.event_name == 'release' && github.ref_name || 'master' }}
+        destination_dir: ${{ github.event_name == 'release' && github.ref_name || inputs.destination_dir }}
         keep_files: true
 
     - name: Deploy to latest/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy documentation 
+name: Deploy documentation
 
 on:
   workflow_run:
@@ -6,13 +6,20 @@ on:
     types:
       - completed
     branches: [master]
+  release:
+    types: [published]
 
 jobs:
   deploy_github_pages:
     runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'release' ||
+      github.event.workflow_run.conclusion == 'success'
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event_name == 'release' && github.ref || github.event.workflow_run.head_sha }}
 
     - name: Doxygen Action
       uses: mattnotmitt/doxygen-action@edge
@@ -22,7 +29,6 @@ jobs:
         mkdir public
         mv ./samples ./public
         mv ./docs ./public
-        # weekly benchmark dashboard, served at /dashboard
         mv ./dashboard ./public
 
     - name: Download manifoldCAD editor, examples and documentation
@@ -30,18 +36,41 @@ jobs:
       with:
         workflow: manifold.yml
         workflow_conclusion: completed
-        # specific to the triggering workflow
-        run_id: ${{github.event.workflow_run.id}}
-        # do not download from old run
-        check_artifacts: true 
+        run_id: ${{ github.event.workflow_run.id }}
+        commit: ${{ github.event_name == 'release' && github.sha || '' }}
+        check_artifacts: true
         name: wasmpublic
         path: ./public
 
-    - name: Deploy to Github Pages
+    - name: Deploy to versioned subdirectory
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
-        force_orphan: true
-        cname: manifoldcad.org
         publish_dir: ./public
+        destination_dir: ${{ github.event_name == 'release' && github.ref_name || 'master' }}
+        keep_files: true
+
+    - name: Deploy to latest/
+      if: github.event_name == 'release'
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_branch: gh-pages
+        publish_dir: ./public
+        destination_dir: latest
+        keep_files: true
+
+    - name: Write CNAME to gh-pages root
+      if: github.event_name == 'release'
+      run: mkdir cname_only
+      # peaceiris writes cname into publish_dir then deploys it to root;
+      # an empty dir ensures nothing else is touched at the root level.
+    - uses: peaceiris/actions-gh-pages@v3
+      if: github.event_name == 'release'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_branch: gh-pages
+        publish_dir: ./cname_only
+        keep_files: true
+        cname: manifoldcad.org

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,18 +8,27 @@ on:
     branches: [master]
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to build docs from (e.g. v3.4.0)'
+        required: true
+      destination_dir:
+        description: 'Subdirectory to deploy to on gh-pages (e.g. v3.4.0)'
+        required: true
 
 jobs:
   deploy_github_pages:
     runs-on: ubuntu-latest
     if: >
+      github.event_name == 'workflow_dispatch' ||
       github.event_name == 'release' ||
       github.event.workflow_run.conclusion == 'success'
 
     steps:
     - uses: actions/checkout@v6
       with:
-        ref: ${{ github.event_name == 'release' && github.ref || github.event.workflow_run.head_sha }}
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event_name == 'release' && github.ref || github.event.workflow_run.head_sha }}
 
     - name: Doxygen Action
       uses: mattnotmitt/doxygen-action@edge
@@ -32,6 +41,7 @@ jobs:
         mv ./dashboard ./public
 
     - name: Download manifoldCAD editor, examples and documentation
+      continue-on-error: ${{ github.event_name == 'workflow_dispatch' }}
       uses: dawidd6/action-download-artifact@v6
       with:
         workflow: manifold.yml
@@ -48,7 +58,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
         publish_dir: ./public
-        destination_dir: ${{ github.event_name == 'release' && github.ref_name || 'master' }}
+        destination_dir: ${{ github.event_name == 'workflow_dispatch' && inputs.destination_dir || github.event_name == 'release' && github.ref_name || 'master' }}
         keep_files: true
 
     - name: Deploy to latest/
@@ -64,8 +74,7 @@ jobs:
     - name: Write CNAME to gh-pages root
       if: github.event_name == 'release'
       run: mkdir cname_only
-      # peaceiris writes cname into publish_dir then deploys it to root;
-      # an empty dir ensures nothing else is touched at the root level.
+
     - uses: peaceiris/actions-gh-pages@v3
       if: github.event_name == 'release'
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+        ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.ref) || github.ref }}
 
     - name: Doxygen Action
       uses: mattnotmitt/doxygen-action@edge
@@ -48,7 +48,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
         publish_dir: ./public
-        destination_dir: ${{ github.event_name == 'release' && github.ref_name || inputs.destination_dir }}
+        destination_dir: ${{ (github.event_name == 'release' && github.ref_name) || inputs.destination_dir }}
         keep_files: true
 
     - name: Deploy to latest/


### PR DESCRIPTION
Closes #1731

Replaces `force_orphan: true` with subdirectory deploys so doc versions accumulate in gh-pages instead of being wiped on every push.

- master push → `master/`
- release published → `vX.Y.Z/` + `latest/`
- CNAME stays at gh-pages root
