### PR TITLE
Confine the atomic reinterpret_cast to one shim, use std::atomic_ref at C++20

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -91,24 +91,41 @@ jobs:
         name: meshes-windows
         path: meshes-windows/
   build:
-    name: GCC ${{matrix.gcc}} (TBB:${{matrix.parallelization}}${{matrix.std == 20 && ', C++20' || ''}})
+    name: ${{matrix.name}}
     timeout-minutes: 45
     strategy:
-      fail-fast: false
       matrix:
-        parallelization: [OFF, ON]
-        os: [ubuntu-24.04]
-        gcc: [13, 14]
-        std: [17]
         include:
-          - parallelization: ON
-            os: ubuntu-22.04
+          - name: GCC 11 (TBB:ON)
             gcc: 11
+            parallelization: ON
+            os: ubuntu-22.04
+            std: 17
+          - name: GCC 13 (TBB:OFF)
+            gcc: 13
+            parallelization: OFF
+            os: ubuntu-24.04
+            std: 17
+          - name: GCC 13 (TBB:ON)
+            gcc: 13
+            parallelization: ON
+            os: ubuntu-24.04
+            std: 17
+          - name: GCC 14 (TBB:OFF)
+            gcc: 14
+            parallelization: OFF
+            os: ubuntu-24.04
+            std: 17
+          - name: GCC 14 (TBB:ON)
+            gcc: 14
+            parallelization: ON
+            os: ubuntu-24.04
             std: 17
           # One strict lane at C++20, to catch what it deprecates or redefines.
-          - parallelization: ON
-            os: ubuntu-24.04
+          - name: GCC 14 (TBB:ON, C++20)
             gcc: 14
+            parallelization: ON
+            os: ubuntu-24.04
             std: 20
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -91,17 +91,27 @@ jobs:
         name: meshes-windows
         path: meshes-windows/
   build:
-    name: GCC ${{matrix.gcc}} (TBB:${{matrix.parallelization}})
+    name: GCC ${{matrix.gcc}} (TBB:${{matrix.parallelization}}${{matrix.std == 20 && ', C++20' || ''}})
     timeout-minutes: 45
     strategy:
+      fail-fast: false
       matrix:
         parallelization: [OFF, ON]
         os: [ubuntu-24.04]
         gcc: [13, 14]
+        std: [17]
         include:
           - parallelization: ON
             os: ubuntu-22.04
             gcc: 11
+            std: 17
+          # One strict lane at C++20. Deprecations are silenced for now: the
+          # shared_ptr atomic free functions in manifold.cpp are deprecated
+          # there and removed in C++26. Drop the flag once those are replaced.
+          - parallelization: ON
+            os: ubuntu-24.04
+            gcc: 14
+            std: 20
     runs-on: ${{ matrix.os }}
     env:
       CC: gcc-${{ matrix.gcc }}
@@ -124,6 +134,8 @@ jobs:
       run: |
         cmake \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DCMAKE_CXX_STANDARD=${{matrix.std}} \
+          -DMANIFOLD_FLAGS=${{matrix.std == 20 && '-Wno-deprecated-declarations' || ''}} \
           -DBUILD_SHARED_LIBS=ON \
           -DMANIFOLD_STRICT=ON \
           -DMANIFOLD_PYBIND=ON \

--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -105,9 +105,7 @@ jobs:
             os: ubuntu-22.04
             gcc: 11
             std: 17
-          # One strict lane at C++20. Deprecations are silenced for now: the
-          # shared_ptr atomic free functions in manifold.cpp are deprecated
-          # there and removed in C++26. Drop the flag once those are replaced.
+          # One strict lane at C++20, to catch what it deprecates or redefines.
           - parallelization: ON
             os: ubuntu-24.04
             gcc: 14
@@ -135,7 +133,6 @@ jobs:
         cmake \
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DCMAKE_CXX_STANDARD=${{matrix.std}} \
-          -DMANIFOLD_FLAGS=${{matrix.std == 20 && '-Wno-deprecated-declarations' || ''}} \
           -DBUILD_SHARED_LIBS=ON \
           -DMANIFOLD_STRICT=ON \
           -DMANIFOLD_PYBIND=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,11 @@
 cmake_minimum_required(VERSION 3.18)
 project(manifold LANGUAGES CXX)
 
-# Use C++17
+# C++17 by default, guarded so -DCMAKE_CXX_STANDARD and parent projects work.
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD 17)
+if(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD LESS 17)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -345,16 +345,16 @@ class Manifold {
   // Propagates through copy ctor / op= (raw copy preserves the attachment).
   // Manifold-returning ops do *not* propagate it: derived Manifolds get a
   // null ctx_. Eager ops (Status, Refine family) snapshot ctx_ to observe
-  // their in-call work; the snapshot uses std::atomic_load, which pins the
+  // their in-call work; the snapshot uses an atomic load, which pins the
   // Impl across long-running evaluations even if a concurrent op= reseats
   // ctx_ mid-eval.
   //
-  // Accessed only via std::atomic_load / std::atomic_store: no const method
-  // mutates ctx_, but op= and the copy ctor write it on a Manifold that
+  // Accessed only atomically (AtomicLoadShared/AtomicStoreShared): no const
+  // method mutates ctx_, but op= and the copy ctor write it on a Manifold that
   // may be concurrently observed by const methods on other threads. The
   // atomic-shared-ptr free functions give a torn-read-free snapshot
   // without taking a lock. (pNode_ uses a mutex instead because lazy CSG
-  // eval mutates it through const methods, which atomic_load can't model.)
+  // eval mutates it through const methods, which an atomic load can't model.)
   std::shared_ptr<ExecutionContext::Impl> ctx_;
 
   std::shared_ptr<CsgNode> LoadPNode() const;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,9 +42,9 @@ set(
 
 set(
   MANIFOLD_PRIVATE_HDRS
+  atomic_compat.h
   boolean2.h
   boolean2_diagnostics.h
-  atomic_compat.h
   boolean3.h
   collider.h
   csg_tree.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ set(
   MANIFOLD_PRIVATE_HDRS
   boolean2.h
   boolean2_diagnostics.h
+  atomic_compat.h
   boolean3.h
   collider.h
   csg_tree.h

--- a/src/atomic_compat.h
+++ b/src/atomic_compat.h
@@ -33,10 +33,16 @@
 #include <memory>
 #include <type_traits>
 
-// Only the 64-bit MSVC backend below needs these, and <intrin.h> is heavy, so
-// keep them out of every other configuration's include graph. They must stay
-// at file scope: an #include inside a namespace nests whatever it declares.
+// One definition of "this build uses the hand-written MSVC atomic backend", so
+// the include guard, the backend selection and the test cannot drift apart.
 #if defined(_MSC_VER) && !defined(__clang__) && !defined(__cpp_lib_atomic_ref)
+#define MANIFOLD_MSVC_ATOMIC_INTRINSICS 1
+#endif
+
+// <intrin.h> is heavy, so keep it off every other configuration's include
+// graph. These must stay at file scope: an #include inside a namespace nests
+// whatever it declares.
+#ifdef MANIFOLD_MSVC_ATOMIC_INTRINSICS
 #include <intrin.h>
 
 #include <cstring>
@@ -55,7 +61,7 @@ using AtomicRef = std::atomic_ref<T>;
 
 namespace details {
 
-#if defined(_MSC_VER) && !defined(__clang__)  // MSVC backend
+#ifdef MANIFOLD_MSVC_ATOMIC_INTRINSICS  // MSVC backend
 
 // The intrinsics below need a 64-bit target: _InterlockedExchange64 and
 // _InterlockedExchangeAdd64 are documented for ARM/x64/ARM64 only, and

--- a/src/atomic_compat.h
+++ b/src/atomic_compat.h
@@ -29,13 +29,8 @@
 #pragma once
 #include <atomic>
 #include <cstdint>
-#include <cstring>
 #include <memory>
 #include <type_traits>
-
-#if defined(_MSC_VER) && !defined(__clang__)
-#include <intrin.h>
-#endif
 
 #include "manifold/optional_assert.h"
 
@@ -52,6 +47,47 @@ namespace details {
 
 #if defined(_MSC_VER) && !defined(__clang__)  // MSVC backend
 
+// 32-bit MSVC keeps the pre-#1153 behavior. The intrinsics below are not all
+// available there (_InterlockedExchange64 and _InterlockedExchangeAdd64 are
+// documented for ARM/x64/ARM64 only), and __iso_volatile_load64/store64 are
+// not atomic on a 32-bit target - the compiler may split them into two 32-bit
+// accesses. Writing the CAS-loop workarounds MSVC STL uses would mean carrying
+// code no CI lane can compile, so instead this target falls back to exactly
+// what the tree did before: the reinterpret_cast to std::atomic. That is still
+// the undefined behavior #1153 is about, but it is the status quo rather than
+// a regression, and refusing to build would take away a working configuration.
+#if defined(_M_IX86) || defined(_M_ARM)
+#pragma message( \
+    "manifold: 32-bit MSVC keeps the pre-#1153 reinterpret_cast for atomics; build x64/ARM64 or /std:c++20 for the checked path")
+
+template <typename T>
+struct AtomicBackend {
+  static std::atomic<T>& Ref(T* p) {
+    return reinterpret_cast<std::atomic<T>&>(*p);
+  }
+  static T Load(T* p, std::memory_order order) { return Ref(p).load(order); }
+  static void Store(T* p, T desired, std::memory_order order) {
+    Ref(p).store(desired, order);
+  }
+  static T Exchange(T* p, T desired, std::memory_order order) {
+    return Ref(p).exchange(desired, order);
+  }
+  static bool CompareExchange(T* p, T& expected, T desired,
+                              std::memory_order order, bool weak) {
+    return weak ? Ref(p).compare_exchange_weak(expected, desired, order)
+                : Ref(p).compare_exchange_strong(expected, desired, order);
+  }
+  static T FetchAdd(T* p, T arg, std::memory_order order) {
+    return Ref(p).fetch_add(arg, order);
+  }
+};
+
+#else  // 64-bit MSVC: real intrinsics
+
+#include <intrin.h>
+
+#include <cstring>
+
 // One integer width per object size, reached through memcpy so the same code
 // serves `double` as well as the integer types. The read-modify-write
 // intrinsics are all full barriers, so a weaker requested order is satisfied
@@ -62,9 +98,10 @@ struct MsvcAtomic;
 // On ARM this is a fence-based mapping (ldr + dmb) where MSVC's std::atomic
 // uses ldar/stlr. The two interoperate because MSVC's seq_cst store ends in a
 // full dmb, but nothing here relies on that: no AtomicRef operation needs to
-// share the seq_cst total order with a std::atomic one. The only std::atomic
-// beside AtomicRef data is HashTableD::used_, relaxed on every concurrent
-// path. Ordering the two would need checking against that mapping first.
+// share the seq_cst total order with a std::atomic one. HashTableD is the only
+// structure that mixes the two - its used_ counter sits beside AtomicRef-
+// accessed keys - and it reads used_ relaxed on every concurrent path.
+// Ordering the two would need checking against that mapping first.
 //
 // MSVC's own _Compiler_or_memory_barrier: on x86/x64 the hardware already
 // orders loads, so acquire and seq_cst need only a compiler barrier, and
@@ -170,6 +207,8 @@ struct AtomicBackend {
     return FromInt(MsvcAtomic<sizeof(T)>::Add(AsInt(p), ToInt(arg)));
   }
 };
+
+#endif  // 32-bit MSVC fallback
 
 #else  // GCC/Clang backend
 
@@ -278,8 +317,11 @@ struct AtomicBackend {
  * to it every access must go through one.
  *
  * Memory orders are honored exactly on GCC/Clang, matching what the C++20
- * alias does. MSVC's read-modify-write intrinsics are all full barriers, so
- * there a weaker request is satisfied by being stronger, never weaker.
+ * alias does. On MSVC the read-modify-write intrinsics are all full barriers,
+ * so a weaker request is satisfied by being stronger. `Load` is the exception:
+ * a plain load plus a trailing fence, exact on x86/x64, and on ARM64 an
+ * acquire load that serves as seq_cst only because the store side goes through
+ * the full-barrier _InterlockedExchange.
  */
 template <typename T>
 class AtomicRef {

--- a/src/atomic_compat.h
+++ b/src/atomic_compat.h
@@ -19,9 +19,8 @@
 //   - `AtomicRef<T>` is `std::atomic_ref` (P0019R8). It replaces a
 //     reinterpret_cast of a plain `T&` to `std::atomic<T>&`, which was
 //     undefined behavior that happened to work on every ABI we ship
-//     (elalish/manifold#1153). At C++20 it becomes a plain alias. 32-bit MSVC
-//     is the exception: it keeps the cast, since the intrinsics needed to
-//     avoid it are not all available there.
+//     (elalish/manifold#1153). At C++20 it becomes a plain alias. 32-bit
+//     MSVC has no C++17 path here and is rejected outright.
 //   - `AtomicLoadShared` / `AtomicStoreShared` wrap the `std::atomic_load` and
 //     `std::atomic_store` shared_ptr overloads, which C++20 deprecates and
 //     C++26 removes (P2869). Their replacement is a member of type
@@ -37,8 +36,7 @@
 // Only the 64-bit MSVC backend below needs these, and <intrin.h> is heavy, so
 // keep them out of every other configuration's include graph. They must stay
 // at file scope: an #include inside a namespace nests whatever it declares.
-#if defined(_MSC_VER) && !defined(__clang__) && !defined(_M_IX86) && \
-    !defined(_M_ARM) && !defined(__cpp_lib_atomic_ref)
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__cpp_lib_atomic_ref)
 #include <intrin.h>
 
 #include <cstring>
@@ -59,45 +57,16 @@ namespace details {
 
 #if defined(_MSC_VER) && !defined(__clang__)  // MSVC backend
 
-// 32-bit MSVC keeps the pre-#1153 behavior. The intrinsics below are not all
-// available there (_InterlockedExchange64 and _InterlockedExchangeAdd64 are
-// documented for ARM/x64/ARM64 only), and __iso_volatile_load64/store64 are
-// not atomic on a 32-bit target - the compiler may split them into two 32-bit
-// accesses. Writing the CAS-loop workarounds MSVC STL uses would mean carrying
-// code no CI lane can compile, so instead this target falls back to exactly
-// what the tree did before: the reinterpret_cast to std::atomic. That is still
-// the undefined behavior #1153 is about, but it is the status quo rather than
-// a regression, and refusing to build would take away a working configuration.
+// The intrinsics below need a 64-bit target: _InterlockedExchange64 and
+// _InterlockedExchangeAdd64 are documented for ARM/x64/ARM64 only, and
+// __iso_volatile_load64/store64 are not atomic on a 32-bit target, where the
+// compiler may split them into two 32-bit accesses. Rather than carry the
+// CAS-loop workarounds MSVC STL uses for code no CI lane can compile, say so.
+// This is 32-bit x86 and ARMv7; ARM64 and ARM64EC are 64-bit and unaffected.
 #if defined(_M_IX86) || defined(_M_ARM)
-#pragma message( \
-    "manifold: 32-bit MSVC keeps the pre-#1153 reinterpret_cast for atomics; build x64/ARM64 or /std:c++20 for the checked path")
-
-template <typename T>
-struct AtomicBackend {
-  static std::atomic<T>& Ref(T* p) {
-    return reinterpret_cast<std::atomic<T>&>(*p);
-  }
-  static T Load(T* p, std::memory_order order) { return Ref(p).load(order); }
-  static void Store(T* p, T desired, std::memory_order order) {
-    Ref(p).store(desired, order);
-  }
-  static T Exchange(T* p, T desired, std::memory_order order) {
-    return Ref(p).exchange(desired, order);
-  }
-  static bool CompareExchange(T* p, T& expected, T desired,
-                              std::memory_order order, bool weak) {
-    return weak ? Ref(p).compare_exchange_weak(expected, desired, order)
-                : Ref(p).compare_exchange_strong(expected, desired, order);
-  }
-  // std::atomic<double>::fetch_add does not exist in C++17. This compiles
-  // only because AtomicRef::fetch_add is SFINAE-gated on is_integral, so this
-  // body is never instantiated for a floating-point T. Keep that gate.
-  static T FetchAdd(T* p, T arg, std::memory_order order) {
-    return Ref(p).fetch_add(arg, order);
-  }
-};
-
-#else  // 64-bit MSVC: real intrinsics
+#error \
+    "manifold does not support 32-bit MSVC: the 64-bit atomics it needs are unavailable there. Build for x64/ARM64, or with /std:c++20."
+#endif
 
 // One integer width per object size, reached through memcpy so the same code
 // serves `double` as well as the integer types. The read-modify-write
@@ -119,7 +88,7 @@ struct MsvcAtomic;
 // std::atomic_thread_fence would instead emit a locked _InterlockedIncrement.
 // ARM is weakly ordered and needs the real dmb.
 inline void PostLoadBarrier(std::memory_order order) {
-#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
   std::atomic_thread_fence(order);
 #else
   std::atomic_signal_fence(order);
@@ -157,6 +126,9 @@ inline void PostLoadBarrier(std::memory_order order) {
     static Int Cas(volatile Int* p, Int expected, Int desired) {            \
       return _InterlockedCompareExchange##Suffix(p, desired, expected);     \
     }                                                                       \
+    /* Integral only. A floating-point T would compile here and silently    \
+       integer-add the memcpy'd bit pattern; AtomicRef::fetch_add is        \
+       enable_if'd to integral for exactly that reason. Keep that gate. */  \
     static Int Add(volatile Int* p, Int v) {                                \
       return _InterlockedExchangeAdd##Suffix(p, v);                         \
     }                                                                       \
@@ -218,8 +190,6 @@ struct AtomicBackend {
     return FromInt(MsvcAtomic<sizeof(T)>::Add(AsInt(p), ToInt(arg)));
   }
 };
-
-#endif  // 32-bit MSVC fallback
 
 #else  // GCC/Clang backend
 
@@ -332,8 +302,7 @@ struct AtomicBackend {
  * so a weaker request is satisfied by being stronger. `Load` is the exception:
  * a plain load plus a trailing fence, exact on x86/x64, and on ARM64 an
  * acquire load that serves as seq_cst only because the store side goes through
- * the full-barrier _InterlockedExchange. That describes the 64-bit MSVC
- * backend; the 32-bit fallback defers to std::atomic and is exact throughout.
+ * the full-barrier _InterlockedExchange.
  */
 template <typename T>
 class AtomicRef {
@@ -400,9 +369,10 @@ class AtomicRef {
                                     /*weak=*/false);
   }
 
-  // Integral only: __atomic_fetch_add and _InterlockedExchangeAdd are both
-  // defined for integers and pointers. Floating-point accumulation goes
-  // through the compare_exchange_weak loop in AtomicAdd.
+  // Integral only. GCC rejects a floating-point __atomic_fetch_add outright,
+  // but Clang accepts it and the MSVC backend would silently integer-add the
+  // bit pattern, so this gate is what keeps `double` on AtomicAdd's
+  // compare_exchange_weak loop instead. Keep it.
   template <typename U = T>
   std::enable_if_t<std::is_integral<U>::value, T> fetch_add(
       T arg, std::memory_order order = std::memory_order_seq_cst) {

--- a/src/atomic_compat.h
+++ b/src/atomic_compat.h
@@ -19,7 +19,9 @@
 //   - `AtomicRef<T>` is `std::atomic_ref` (P0019R8). It replaces a
 //     reinterpret_cast of a plain `T&` to `std::atomic<T>&`, which was
 //     undefined behavior that happened to work on every ABI we ship
-//     (elalish/manifold#1153). At C++20 it becomes a plain alias.
+//     (elalish/manifold#1153). At C++20 it becomes a plain alias. 32-bit MSVC
+//     is the exception: it keeps the cast, since the intrinsics needed to
+//     avoid it are not all available there.
 //   - `AtomicLoadShared` / `AtomicStoreShared` wrap the `std::atomic_load` and
 //     `std::atomic_store` shared_ptr overloads, which C++20 deprecates and
 //     C++26 removes (P2869). Their replacement is a member of type
@@ -31,6 +33,16 @@
 #include <cstdint>
 #include <memory>
 #include <type_traits>
+
+// Only the 64-bit MSVC backend below needs these, and <intrin.h> is heavy, so
+// keep them out of every other configuration's include graph. They must stay
+// at file scope: an #include inside a namespace nests whatever it declares.
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(_M_IX86) && \
+    !defined(_M_ARM) && !defined(__cpp_lib_atomic_ref)
+#include <intrin.h>
+
+#include <cstring>
+#endif
 
 #include "manifold/optional_assert.h"
 
@@ -77,16 +89,15 @@ struct AtomicBackend {
     return weak ? Ref(p).compare_exchange_weak(expected, desired, order)
                 : Ref(p).compare_exchange_strong(expected, desired, order);
   }
+  // std::atomic<double>::fetch_add does not exist in C++17. This compiles
+  // only because AtomicRef::fetch_add is SFINAE-gated on is_integral, so this
+  // body is never instantiated for a floating-point T. Keep that gate.
   static T FetchAdd(T* p, T arg, std::memory_order order) {
     return Ref(p).fetch_add(arg, order);
   }
 };
 
 #else  // 64-bit MSVC: real intrinsics
-
-#include <intrin.h>
-
-#include <cstring>
 
 // One integer width per object size, reached through memcpy so the same code
 // serves `double` as well as the integer types. The read-modify-write
@@ -321,7 +332,8 @@ struct AtomicBackend {
  * so a weaker request is satisfied by being stronger. `Load` is the exception:
  * a plain load plus a trailing fence, exact on x86/x64, and on ARM64 an
  * acquire load that serves as seq_cst only because the store side goes through
- * the full-barrier _InterlockedExchange.
+ * the full-barrier _InterlockedExchange. That describes the 64-bit MSVC
+ * backend; the 32-bit fallback defers to std::atomic and is exact throughout.
  */
 template <typename T>
 class AtomicRef {

--- a/src/atomic_compat.h
+++ b/src/atomic_compat.h
@@ -13,19 +13,19 @@
 // limitations under the License.
 //
 // C++17 stand-ins for atomic facilities the library would otherwise get from
-// C++20. Everything here is scaffolding for that gap, collected in one file so
-// it can be removed in one go once the baseline moves:
+// C++20. The two halves have different lifetimes:
 //
-//   - `AtomicRef<T>` is `std::atomic_ref` (P0019R8). It replaces a
-//     reinterpret_cast of a plain `T&` to `std::atomic<T>&`, which was
-//     undefined behavior that happened to work on every ABI we ship
-//     (elalish/manifold#1153). At C++20 it becomes a plain alias. 32-bit
-//     MSVC has no C++17 path here and is rejected outright.
+//   - `AtomicRef<T>` is `std::atomic_ref` (P0019R8), replacing a
+//     reinterpret_cast of `T&` to `std::atomic<T>&` that was undefined
+//     behavior. At C++20 it becomes a plain alias and goes away. 32-bit MSVC
+//     has no C++17 path and is rejected outright.
 //   - `AtomicLoadShared` / `AtomicStoreShared` wrap the `std::atomic_load` and
 //     `std::atomic_store` shared_ptr overloads, which C++20 deprecates and
-//     C++26 removes (P2869). Their replacement is a member of type
-//     `std::atomic<std::shared_ptr<T>>`, which is C++20-only and would delete
-//     `Manifold`'s defaulted move operations, so it is a separate change.
+//     C++26 removes (P2869). These do not go away at C++20: the replacement
+//     changes the member's type to `std::atomic<std::shared_ptr<T>>` rather
+//     than how it is accessed, and libc++ still leaves
+//     `__cpp_lib_atomic_shared_ptr` undefined. Revisit when the baseline moves
+//     and libc++ ships it.
 
 #pragma once
 #include <atomic>

--- a/src/atomic_compat.h
+++ b/src/atomic_compat.h
@@ -12,19 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Atomic operations on an object that was not itself declared `std::atomic`.
+// C++17 stand-ins for atomic facilities the library would otherwise get from
+// C++20. Everything here is scaffolding for that gap, collected in one file so
+// it can be removed in one go once the baseline moves:
 //
-// This is `std::atomic_ref` (P0019R8), which manifold cannot use while it
-// targets C++17. The code it replaces reinterpret_cast a plain `T&` to
-// `std::atomic<T>&` - undefined behavior that happens to work on every ABI we
-// ship (elalish/manifold#1153). Everything here is scaffolding for that gap:
-// once the baseline moves to C++20 the whole file collapses to the alias at
-// the top, and every call site stays as it is.
+//   - `AtomicRef<T>` is `std::atomic_ref` (P0019R8). It replaces a
+//     reinterpret_cast of a plain `T&` to `std::atomic<T>&`, which was
+//     undefined behavior that happened to work on every ABI we ship
+//     (elalish/manifold#1153). At C++20 it becomes a plain alias.
+//   - `AtomicLoadShared` / `AtomicStoreShared` wrap the `std::atomic_load` and
+//     `std::atomic_store` shared_ptr overloads, which C++20 deprecates and
+//     C++26 removes (P2869). Their replacement is a member of type
+//     `std::atomic<std::shared_ptr<T>>`, which is C++20-only and would delete
+//     `Manifold`'s defaulted move operations, so it is a separate change.
 
 #pragma once
 #include <atomic>
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <type_traits>
 
 #if defined(_MSC_VER) && !defined(__clang__)
@@ -354,5 +360,36 @@ class AtomicRef {
 };
 
 #endif  // std::atomic_ref vs the C++17 stand-in
+
+// Suppresses every deprecation inside its region, so keep the regions to a
+// single expression. Neither GCC nor Clang offers per-symbol suppression.
+#if defined(_MSC_VER) && !defined(__clang__)
+#define MANIFOLD_IGNORE_DEPRECATED_BEGIN \
+  __pragma(warning(push)) __pragma(warning(disable : 4996))
+#define MANIFOLD_IGNORE_DEPRECATED_END __pragma(warning(pop))
+#else
+#define MANIFOLD_IGNORE_DEPRECATED_BEGIN \
+  _Pragma("GCC diagnostic push")         \
+      _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define MANIFOLD_IGNORE_DEPRECATED_END _Pragma("GCC diagnostic pop")
+#endif
+
+// Atomic access to a plain `shared_ptr`, which C++17 can only express through
+// these overloads. There is no atomic_ref equivalent: atomic_ref requires a
+// trivially copyable type, so the C++20 replacement changes the member's type
+// rather than how it is accessed.
+template <typename T>
+std::shared_ptr<T> AtomicLoadShared(const std::shared_ptr<T>* ptr) {
+  MANIFOLD_IGNORE_DEPRECATED_BEGIN
+  return std::atomic_load(ptr);
+  MANIFOLD_IGNORE_DEPRECATED_END
+}
+
+template <typename T>
+void AtomicStoreShared(std::shared_ptr<T>* ptr, std::shared_ptr<T> value) {
+  MANIFOLD_IGNORE_DEPRECATED_BEGIN
+  std::atomic_store(ptr, std::move(value));
+  MANIFOLD_IGNORE_DEPRECATED_END
+}
 
 }  // namespace manifold

--- a/src/atomic_compat.h
+++ b/src/atomic_compat.h
@@ -15,10 +15,11 @@
 // C++17 stand-ins for atomic facilities the library would otherwise get from
 // C++20. The two halves have different lifetimes:
 //
-//   - `AtomicRef<T>` is `std::atomic_ref` (P0019R8), replacing a
-//     reinterpret_cast of `T&` to `std::atomic<T>&` that was undefined
-//     behavior. At C++20 it becomes a plain alias and goes away. 32-bit MSVC
-//     has no C++17 path and is rejected outright.
+//   - `AtomicRef<T>` is `std::atomic_ref` (P0019R8) at C++20, and at C++17 a
+//     thin wrapper over the reinterpret_cast it replaces. The cast is still
+//     undefined behavior, but it is now in one place instead of scattered
+//     across the call sites, its preconditions are static_asserts rather than
+//     assumptions, and the C++20 lane builds the defined version.
 //   - `AtomicLoadShared` / `AtomicStoreShared` wrap the `std::atomic_load` and
 //     `std::atomic_store` shared_ptr overloads, which C++20 deprecates and
 //     C++26 removes (P2869). These do not go away at C++20: the replacement
@@ -33,21 +34,6 @@
 #include <memory>
 #include <type_traits>
 
-// One definition of "this build uses the hand-written MSVC atomic backend", so
-// the include guard, the backend selection and the test cannot drift apart.
-#if defined(_MSC_VER) && !defined(__clang__) && !defined(__cpp_lib_atomic_ref)
-#define MANIFOLD_MSVC_ATOMIC_INTRINSICS 1
-#endif
-
-// <intrin.h> is heavy, so keep it off every other configuration's include
-// graph. These must stay at file scope: an #include inside a namespace nests
-// whatever it declares.
-#ifdef MANIFOLD_MSVC_ATOMIC_INTRINSICS
-#include <intrin.h>
-
-#include <cstring>
-#endif
-
 #include "manifold/optional_assert.h"
 
 namespace manifold {
@@ -57,296 +43,68 @@ namespace manifold {
 template <typename T>
 using AtomicRef = std::atomic_ref<T>;
 
-#else  // C++17: everything below stands in for it
-
-namespace details {
-
-#ifdef MANIFOLD_MSVC_ATOMIC_INTRINSICS  // MSVC backend
-
-// The intrinsics below need a 64-bit target: _InterlockedExchange64 and
-// _InterlockedExchangeAdd64 are documented for ARM/x64/ARM64 only, and
-// __iso_volatile_load64/store64 are not atomic on a 32-bit target, where the
-// compiler may split them into two 32-bit accesses. Rather than carry the
-// CAS-loop workarounds MSVC STL uses for code no CI lane can compile, say so.
-// This is 32-bit x86 and ARMv7; ARM64 and ARM64EC are 64-bit and unaffected.
-#if defined(_M_IX86) || defined(_M_ARM)
-#error \
-    "manifold does not support 32-bit MSVC: the 64-bit atomics it needs are unavailable there. Build for x64/ARM64, or with /std:c++20."
-#endif
-
-// One integer width per object size, reached through memcpy so the same code
-// serves `double` as well as the integer types. The read-modify-write
-// intrinsics are all full barriers, so a weaker requested order is satisfied
-// by being stronger than asked; `Load` alone honors the order exactly.
-template <size_t N>
-struct MsvcAtomic;
-
-// On ARM this is a fence-based mapping (ldr + dmb) where MSVC's std::atomic
-// uses ldar/stlr. The two interoperate because MSVC's seq_cst store ends in a
-// full dmb, but nothing here relies on that: no AtomicRef operation needs to
-// share the seq_cst total order with a std::atomic one. HashTableD is the only
-// structure that mixes the two - its used_ counter sits beside AtomicRef-
-// accessed keys - and it reads used_ relaxed on every concurrent path.
-// Ordering the two would need checking against that mapping first.
-//
-// MSVC's own _Compiler_or_memory_barrier: on x86/x64 the hardware already
-// orders loads, so acquire and seq_cst need only a compiler barrier, and
-// std::atomic_thread_fence would instead emit a locked _InterlockedIncrement.
-// ARM is weakly ordered and needs the real dmb.
-inline void PostLoadBarrier(std::memory_order order) {
-#if defined(_M_ARM64) || defined(_M_ARM64EC)
-  std::atomic_thread_fence(order);
-#else
-  std::atomic_signal_fence(order);
-#endif
-}
-
-// `Load` must stay a plain load: the _Interlocked* family is read-modify-write,
-// which would both write through a const reference and turn HashTableD's probe
-// loop into locked traffic. This mirrors what MSVC's own <atomic> does - a
-// single __iso_volatile_load plus a barrier - except the barrier is
-// std::atomic_thread_fence, which costs nothing on x86/x64, emits dmb on ARM64,
-// and avoids the deprecated _ReadWriteBarrier that /WX would reject.
-#define MANIFOLD_MSVC_ATOMIC(N, Int, IsoInt, Suffix, Bits)                  \
-  template <>                                                               \
-  struct MsvcAtomic<N> {                                                    \
-    using Int_t = Int;                                                      \
-    static Int Load(const volatile Int* p, std::memory_order order) {       \
-      const Int value = static_cast<Int>(__iso_volatile_load##Bits(         \
-          reinterpret_cast<const volatile IsoInt*>(p)));                    \
-      if (order != std::memory_order_relaxed) PostLoadBarrier(order);       \
-      return value;                                                         \
-    }                                                                       \
-    static void Store(volatile Int* p, Int v, std::memory_order order) {    \
-      if (order != std::memory_order_relaxed &&                             \
-          order != std::memory_order_release) {                             \
-        _InterlockedExchange##Suffix(p, v);                                 \
-        return;                                                             \
-      }                                                                     \
-      PostLoadBarrier(order);                                               \
-      __iso_volatile_store##Bits(reinterpret_cast<volatile IsoInt*>(p), v); \
-    }                                                                       \
-    static Int Exchange(volatile Int* p, Int v) {                           \
-      return _InterlockedExchange##Suffix(p, v);                            \
-    }                                                                       \
-    static Int Cas(volatile Int* p, Int expected, Int desired) {            \
-      return _InterlockedCompareExchange##Suffix(p, desired, expected);     \
-    }                                                                       \
-    /* Integral only. A floating-point T would compile here and silently    \
-       integer-add the memcpy'd bit pattern; AtomicRef::fetch_add is        \
-       enable_if'd to integral for exactly that reason. Keep that gate. */  \
-    static Int Add(volatile Int* p, Int v) {                                \
-      return _InterlockedExchangeAdd##Suffix(p, v);                         \
-    }                                                                       \
-  }
-
-MANIFOLD_MSVC_ATOMIC(1, char, __int8, 8, 8);
-MANIFOLD_MSVC_ATOMIC(2, short, __int16, 16, 16);
-MANIFOLD_MSVC_ATOMIC(4, long, __int32, , 32);
-MANIFOLD_MSVC_ATOMIC(8, __int64, __int64, 64, 64);
-#undef MANIFOLD_MSVC_ATOMIC
-
-// The MSVC backend: every operation goes through the integer of matching
-// width, with the value memcpy'd in and out.
-template <typename T>
-struct AtomicBackend {
-  using Int_t = typename MsvcAtomic<sizeof(T)>::Int_t;
-
-  static Int_t ToInt(T value) {
-    Int_t bits;
-    std::memcpy(&bits, &value, sizeof(T));
-    return bits;
-  }
-  static T FromInt(Int_t bits) {
-    T value;
-    std::memcpy(&value, &bits, sizeof(T));
-    return value;
-  }
-  // Unavoidable, and narrower than it looks: MSVC's intrinsics are declared
-  // per integer width, so this is how you call them at all - even `int` needs
-  // it, since _InterlockedExchange takes long*. MSVC's own <atomic> does the
-  // same thing (_Atomic_address_as), and MSVC does no type-based alias
-  // analysis. Unlike the cast this file removes, it reinterprets an address
-  // for a builtin that works on raw memory rather than asserting that T is
-  // laid out like something else.
-  static volatile Int_t* AsInt(T* p) {
-    return reinterpret_cast<volatile Int_t*>(p);
-  }
-
-  static T Load(T* p, std::memory_order order) {
-    return FromInt(MsvcAtomic<sizeof(T)>::Load(AsInt(p), order));
-  }
-  static void Store(T* p, T desired, std::memory_order order) {
-    MsvcAtomic<sizeof(T)>::Store(AsInt(p), ToInt(desired), order);
-  }
-  static T Exchange(T* p, T desired, std::memory_order) {
-    return FromInt(MsvcAtomic<sizeof(T)>::Exchange(AsInt(p), ToInt(desired)));
-  }
-  // _InterlockedCompareExchange never fails spuriously, so it serves both the
-  // weak and the strong form.
-  static bool CompareExchange(T* p, T& expected, T desired, std::memory_order,
-                              bool) {
-    const T previous = FromInt(
-        MsvcAtomic<sizeof(T)>::Cas(AsInt(p), ToInt(expected), ToInt(desired)));
-    if (std::memcmp(&previous, &expected, sizeof(T)) == 0) return true;
-    expected = previous;
-    return false;
-  }
-  static T FetchAdd(T* p, T arg, std::memory_order) {
-    return FromInt(MsvcAtomic<sizeof(T)>::Add(AsInt(p), ToInt(arg)));
-  }
-};
-
-#else  // GCC/Clang backend
-
-// The GCC/Clang backend: the `__atomic` builtins, which are documented to
-// operate on ordinary objects and are what `std::atomic_ref` itself lowers to.
-// Orders are switched onto literals rather than passed through as an int:
-// libstdc++ can rely on its own enum matching __ATOMIC_*, but this header
-// compiles against libstdc++ and libc++ both, so it does not assume that.
-template <typename T>
-struct AtomicBackend {
-  static T Load(T* p, std::memory_order order) {
-    T value;
-    switch (order) {
-      case std::memory_order_relaxed:
-        __atomic_load(p, &value, __ATOMIC_RELAXED);
-        break;
-      case std::memory_order_consume:
-      case std::memory_order_acquire:
-        __atomic_load(p, &value, __ATOMIC_ACQUIRE);
-        break;
-      default:
-        __atomic_load(p, &value, __ATOMIC_SEQ_CST);
-        break;
-    }
-    return value;
-  }
-  static void Store(T* p, T desired, std::memory_order order) {
-    switch (order) {
-      case std::memory_order_relaxed:
-        __atomic_store(p, &desired, __ATOMIC_RELAXED);
-        break;
-      case std::memory_order_release:
-        __atomic_store(p, &desired, __ATOMIC_RELEASE);
-        break;
-      default:
-        __atomic_store(p, &desired, __ATOMIC_SEQ_CST);
-        break;
-    }
-  }
-  static T Exchange(T* p, T desired, std::memory_order order) {
-    T previous;
-    switch (order) {
-      case std::memory_order_relaxed:
-        __atomic_exchange(p, &desired, &previous, __ATOMIC_RELAXED);
-        break;
-      case std::memory_order_acquire:
-        __atomic_exchange(p, &desired, &previous, __ATOMIC_ACQUIRE);
-        break;
-      case std::memory_order_release:
-        __atomic_exchange(p, &desired, &previous, __ATOMIC_RELEASE);
-        break;
-      case std::memory_order_acq_rel:
-        __atomic_exchange(p, &desired, &previous, __ATOMIC_ACQ_REL);
-        break;
-      default:
-        __atomic_exchange(p, &desired, &previous, __ATOMIC_SEQ_CST);
-        break;
-    }
-    return previous;
-  }
-  // The failure order must not be stronger than success, and must not be a
-  // release order, so it is derived rather than passed through.
-  static bool CompareExchange(T* p, T& expected, T desired,
-                              std::memory_order order, bool weak) {
-    switch (order) {
-      case std::memory_order_relaxed:
-        return __atomic_compare_exchange(p, &expected, &desired, weak,
-                                         __ATOMIC_RELAXED, __ATOMIC_RELAXED);
-      case std::memory_order_acquire:
-        return __atomic_compare_exchange(p, &expected, &desired, weak,
-                                         __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE);
-      case std::memory_order_release:
-        return __atomic_compare_exchange(p, &expected, &desired, weak,
-                                         __ATOMIC_RELEASE, __ATOMIC_RELAXED);
-      case std::memory_order_acq_rel:
-        return __atomic_compare_exchange(p, &expected, &desired, weak,
-                                         __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
-      default:
-        return __atomic_compare_exchange(p, &expected, &desired, weak,
-                                         __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
-    }
-  }
-  static T FetchAdd(T* p, T arg, std::memory_order order) {
-    switch (order) {
-      case std::memory_order_relaxed:
-        return __atomic_fetch_add(p, arg, __ATOMIC_RELAXED);
-      case std::memory_order_acquire:
-        return __atomic_fetch_add(p, arg, __ATOMIC_ACQUIRE);
-      case std::memory_order_release:
-        return __atomic_fetch_add(p, arg, __ATOMIC_RELEASE);
-      case std::memory_order_acq_rel:
-        return __atomic_fetch_add(p, arg, __ATOMIC_ACQ_REL);
-      default:
-        return __atomic_fetch_add(p, arg, __ATOMIC_SEQ_CST);
-    }
-  }
-};
-
-#endif  // MSVC vs GCC/Clang backend
-
-}  // namespace details
+#else  // C++17: the cast, confined
 
 /**
- * A C++17 stand-in for std::atomic_ref, over one of the backends above. The
- * referenced object must outlive the AtomicRef, and while any AtomicRef refers
- * to it every access must go through one.
+ * A C++17 stand-in for std::atomic_ref. Reinterprets the referenced object as
+ * `std::atomic<T>` and forwards to it, which is what the call sites did before
+ * this type existed.
  *
- * Memory orders are honored exactly on GCC/Clang, matching what the C++20
- * alias does. On MSVC the read-modify-write intrinsics are all full barriers,
- * so a weaker request is satisfied by being stronger. `Load` is the exception:
- * a plain load plus a trailing fence, exact on x86/x64, and on ARM64 an
- * acquire load that serves as seq_cst only because the store side goes through
- * the full-barrier _InterlockedExchange.
+ * That cast is undefined behavior: the object is not an atomic object, and
+ * nothing in the standard says the two are layout-compatible. It works on
+ * every ABI we ship, and the static_asserts below check the parts a compiler
+ * can check, but they cannot make it defined. The point of the type is that
+ * there is now exactly one cast to audit, and that at C++20 it is replaced
+ * wholesale by the alias above rather than being repaired.
+ *
+ * The referenced object must outlive the AtomicRef, and while any AtomicRef
+ * refers to it every access must go through one.
+ *
+ * Deliberately a subset of std::atomic_ref: only what the call sites use, so
+ * the C++20 alias is a superset and anything written against this compiles
+ * either way. Missing on purpose are `operator=`, `operator T`, the other
+ * fetch_* operations, the compound assignments, and wait/notify. Adding one
+ * here is fine; relying on one that only the alias has builds on the C++20
+ * lane and fails everywhere else.
  */
 template <typename T>
 class AtomicRef {
-  // Scalars only, deliberately narrower than std::atomic_ref's trivially-
-  // copyable. A padded type would need its padding cleared before every
-  // compare_exchange (libstdc++ calls __clear_padding for exactly this), or
-  // stale padding bytes make the exchange fail forever. Every use here is a
-  // scalar, so the simpler contract is the honest one.
+  // Every use here is a scalar. Narrower than std::atomic_ref's trivially-
+  // copyable contract, and it keeps padded types - whose padding bytes would
+  // have to be cleared before each compare_exchange - out of the cast.
   static_assert(std::is_scalar<T>::value, "AtomicRef requires a scalar type");
-  static_assert(sizeof(T) <= 8, "AtomicRef supports up to 8-byte scalars");
-  // The same test libc++ and MSVC STL use to decide whether padding needs
-  // clearing; scalars that pass it need none.
-  static_assert(std::has_unique_object_representations_v<T> ||
-                    std::is_floating_point_v<T>,
-                "AtomicRef requires a type with no padding bits");
-
-  using Backend = details::AtomicBackend<T>;
+  // What makes the cast work in practice. A lock-based std::atomic<T> carries
+  // a lock alongside the value, so these would catch it.
+  static_assert(sizeof(std::atomic<T>) == sizeof(T),
+                "std::atomic<T> must be the same size as T");
+  static_assert(alignof(std::atomic<T>) == alignof(T),
+                "std::atomic<T> must be aligned like T");
+  static_assert(std::atomic<T>::is_always_lock_free,
+                "AtomicRef requires a lock-free std::atomic<T>");
 
  public:
-  explicit AtomicRef(T& obj) : ptr_(&obj) {
-    // The atomic ops need the object naturally aligned, which alignof(T) does
-    // not promise: 32-bit x86 gives alignof(double) == 4. So check the address,
-    // as libstdc++ and Boost both do in their constructors. Compiles away
-    // entirely without MANIFOLD_DEBUG.
-    DEBUG_ASSERT(reinterpret_cast<uintptr_t>(ptr_) % sizeof(T) == 0, logicErr,
+  explicit AtomicRef(T& obj) : ref_(reinterpret_cast<std::atomic<T>&>(obj)) {
+    // Natural alignment is not implied by alignof(T): 32-bit x86 gives
+    // alignof(double) == 4. Compiles away without MANIFOLD_DEBUG. The C++20
+    // alias has no equivalent check - std::atomic_ref states the requirement
+    // as required_alignment and leaves violations undefined - so this catches
+    // a misaligned caller only on the C++17 side.
+    DEBUG_ASSERT(reinterpret_cast<uintptr_t>(&obj) % sizeof(T) == 0, logicErr,
                  "AtomicRef requires an object aligned to its own size");
   }
 
   T load(std::memory_order order = std::memory_order_seq_cst) const {
-    return Backend::Load(ptr_, order);
+    return ref_.load(order);
   }
 
-  void store(T desired, std::memory_order order = std::memory_order_seq_cst) {
-    Backend::Store(ptr_, desired, order);
+  void store(T desired,
+             std::memory_order order = std::memory_order_seq_cst) const {
+    ref_.store(desired, order);
   }
 
-  T exchange(T desired, std::memory_order order = std::memory_order_seq_cst) {
-    return Backend::Exchange(ptr_, desired, order);
+  T exchange(T desired,
+             std::memory_order order = std::memory_order_seq_cst) const {
+    return ref_.exchange(desired, order);
   }
 
   // As in std::atomic_ref, `expected` is updated with the current value when
@@ -355,41 +113,35 @@ class AtomicRef {
   // one.
   bool compare_exchange_weak(
       T& expected, T desired,
-      std::memory_order order = std::memory_order_seq_cst) {
-    return Backend::CompareExchange(ptr_, expected, desired, order,
-                                    /*weak=*/true);
+      std::memory_order order = std::memory_order_seq_cst) const {
+    return ref_.compare_exchange_weak(expected, desired, order);
   }
 
   bool compare_exchange_weak(T& expected, T desired, std::memory_order success,
-                             std::memory_order) {
-    // The failure order is derived from `success` in the backend, matching
-    // libstdc++'s __cmpexch_failure_order2, so it is accepted and ignored.
-    return Backend::CompareExchange(ptr_, expected, desired, success,
-                                    /*weak=*/true);
+                             std::memory_order failure) const {
+    return ref_.compare_exchange_weak(expected, desired, success, failure);
   }
 
   bool compare_exchange_strong(
       T& expected, T desired,
-      std::memory_order order = std::memory_order_seq_cst) {
-    return Backend::CompareExchange(ptr_, expected, desired, order,
-                                    /*weak=*/false);
+      std::memory_order order = std::memory_order_seq_cst) const {
+    return ref_.compare_exchange_strong(expected, desired, order);
   }
 
-  // Integral only. GCC rejects a floating-point __atomic_fetch_add outright,
-  // but Clang accepts it and the MSVC backend would silently integer-add the
-  // bit pattern, so this gate is what keeps `double` on AtomicAdd's
-  // compare_exchange_weak loop instead. Keep it.
+  // Integral only: C++17's std::atomic has no floating-point fetch_add, so
+  // this gate is what keeps `double` on AtomicAdd's compare_exchange_weak
+  // loop. Keep it.
   template <typename U = T>
   std::enable_if_t<std::is_integral<U>::value, T> fetch_add(
-      T arg, std::memory_order order = std::memory_order_seq_cst) {
-    return Backend::FetchAdd(ptr_, arg, order);
+      T arg, std::memory_order order = std::memory_order_seq_cst) const {
+    return ref_.fetch_add(arg, order);
   }
 
  private:
-  T* ptr_;
+  std::atomic<T>& ref_;
 };
 
-#endif  // std::atomic_ref vs the C++17 stand-in
+#endif  // std::atomic_ref vs the C++17 cast
 
 // Suppresses every deprecation inside its region, so keep the regions to a
 // single expression. Neither GCC nor Clang offers per-symbol suppression.

--- a/src/atomic_ref.h
+++ b/src/atomic_ref.h
@@ -1,0 +1,358 @@
+// Copyright 2026 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Atomic operations on an object that was not itself declared `std::atomic`.
+//
+// This is `std::atomic_ref` (P0019R8), which manifold cannot use while it
+// targets C++17. The code it replaces reinterpret_cast a plain `T&` to
+// `std::atomic<T>&` - undefined behavior that happens to work on every ABI we
+// ship (elalish/manifold#1153). Everything here is scaffolding for that gap:
+// once the baseline moves to C++20 the whole file collapses to the alias at
+// the top, and every call site stays as it is.
+
+#pragma once
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#include <intrin.h>
+#endif
+
+#include "manifold/optional_assert.h"
+
+namespace manifold {
+
+#if defined(__cpp_lib_atomic_ref)  // C++20: the real thing
+
+template <typename T>
+using AtomicRef = std::atomic_ref<T>;
+
+#else  // C++17: everything below stands in for it
+
+namespace details {
+
+#if defined(_MSC_VER) && !defined(__clang__)  // MSVC backend
+
+// One integer width per object size, reached through memcpy so the same code
+// serves `double` as well as the integer types. The read-modify-write
+// intrinsics are all full barriers, so a weaker requested order is satisfied
+// by being stronger than asked; `Load` alone honors the order exactly.
+template <size_t N>
+struct MsvcAtomic;
+
+// On ARM this is a fence-based mapping (ldr + dmb) where MSVC's std::atomic
+// uses ldar/stlr. The two interoperate because MSVC's seq_cst store ends in a
+// full dmb, but nothing here relies on that: no AtomicRef operation needs to
+// share the seq_cst total order with a std::atomic one. The only std::atomic
+// beside AtomicRef data is HashTableD::used_, relaxed on every concurrent
+// path. Ordering the two would need checking against that mapping first.
+//
+// MSVC's own _Compiler_or_memory_barrier: on x86/x64 the hardware already
+// orders loads, so acquire and seq_cst need only a compiler barrier, and
+// std::atomic_thread_fence would instead emit a locked _InterlockedIncrement.
+// ARM is weakly ordered and needs the real dmb.
+inline void PostLoadBarrier(std::memory_order order) {
+#if defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC)
+  std::atomic_thread_fence(order);
+#else
+  std::atomic_signal_fence(order);
+#endif
+}
+
+// `Load` must stay a plain load: the _Interlocked* family is read-modify-write,
+// which would both write through a const reference and turn HashTableD's probe
+// loop into locked traffic. This mirrors what MSVC's own <atomic> does - a
+// single __iso_volatile_load plus a barrier - except the barrier is
+// std::atomic_thread_fence, which costs nothing on x86/x64, emits dmb on ARM64,
+// and avoids the deprecated _ReadWriteBarrier that /WX would reject.
+#define MANIFOLD_MSVC_ATOMIC(N, Int, IsoInt, Suffix, Bits)                  \
+  template <>                                                               \
+  struct MsvcAtomic<N> {                                                    \
+    using Int_t = Int;                                                      \
+    static Int Load(const volatile Int* p, std::memory_order order) {       \
+      const Int value = static_cast<Int>(__iso_volatile_load##Bits(         \
+          reinterpret_cast<const volatile IsoInt*>(p)));                    \
+      if (order != std::memory_order_relaxed) PostLoadBarrier(order);       \
+      return value;                                                         \
+    }                                                                       \
+    static void Store(volatile Int* p, Int v, std::memory_order order) {    \
+      if (order != std::memory_order_relaxed &&                             \
+          order != std::memory_order_release) {                             \
+        _InterlockedExchange##Suffix(p, v);                                 \
+        return;                                                             \
+      }                                                                     \
+      PostLoadBarrier(order);                                               \
+      __iso_volatile_store##Bits(reinterpret_cast<volatile IsoInt*>(p), v); \
+    }                                                                       \
+    static Int Exchange(volatile Int* p, Int v) {                           \
+      return _InterlockedExchange##Suffix(p, v);                            \
+    }                                                                       \
+    static Int Cas(volatile Int* p, Int expected, Int desired) {            \
+      return _InterlockedCompareExchange##Suffix(p, desired, expected);     \
+    }                                                                       \
+    static Int Add(volatile Int* p, Int v) {                                \
+      return _InterlockedExchangeAdd##Suffix(p, v);                         \
+    }                                                                       \
+  }
+
+MANIFOLD_MSVC_ATOMIC(1, char, __int8, 8, 8);
+MANIFOLD_MSVC_ATOMIC(2, short, __int16, 16, 16);
+MANIFOLD_MSVC_ATOMIC(4, long, __int32, , 32);
+MANIFOLD_MSVC_ATOMIC(8, __int64, __int64, 64, 64);
+#undef MANIFOLD_MSVC_ATOMIC
+
+// The MSVC backend: every operation goes through the integer of matching
+// width, with the value memcpy'd in and out.
+template <typename T>
+struct AtomicBackend {
+  using Int_t = typename MsvcAtomic<sizeof(T)>::Int_t;
+
+  static Int_t ToInt(T value) {
+    Int_t bits;
+    std::memcpy(&bits, &value, sizeof(T));
+    return bits;
+  }
+  static T FromInt(Int_t bits) {
+    T value;
+    std::memcpy(&value, &bits, sizeof(T));
+    return value;
+  }
+  // Unavoidable, and narrower than it looks: MSVC's intrinsics are declared
+  // per integer width, so this is how you call them at all - even `int` needs
+  // it, since _InterlockedExchange takes long*. MSVC's own <atomic> does the
+  // same thing (_Atomic_address_as), and MSVC does no type-based alias
+  // analysis. Unlike the cast this file removes, it reinterprets an address
+  // for a builtin that works on raw memory rather than asserting that T is
+  // laid out like something else.
+  static volatile Int_t* AsInt(T* p) {
+    return reinterpret_cast<volatile Int_t*>(p);
+  }
+
+  static T Load(T* p, std::memory_order order) {
+    return FromInt(MsvcAtomic<sizeof(T)>::Load(AsInt(p), order));
+  }
+  static void Store(T* p, T desired, std::memory_order order) {
+    MsvcAtomic<sizeof(T)>::Store(AsInt(p), ToInt(desired), order);
+  }
+  static T Exchange(T* p, T desired, std::memory_order) {
+    return FromInt(MsvcAtomic<sizeof(T)>::Exchange(AsInt(p), ToInt(desired)));
+  }
+  // _InterlockedCompareExchange never fails spuriously, so it serves both the
+  // weak and the strong form.
+  static bool CompareExchange(T* p, T& expected, T desired, std::memory_order,
+                              bool) {
+    const T previous = FromInt(
+        MsvcAtomic<sizeof(T)>::Cas(AsInt(p), ToInt(expected), ToInt(desired)));
+    if (std::memcmp(&previous, &expected, sizeof(T)) == 0) return true;
+    expected = previous;
+    return false;
+  }
+  static T FetchAdd(T* p, T arg, std::memory_order) {
+    return FromInt(MsvcAtomic<sizeof(T)>::Add(AsInt(p), ToInt(arg)));
+  }
+};
+
+#else  // GCC/Clang backend
+
+// The GCC/Clang backend: the `__atomic` builtins, which are documented to
+// operate on ordinary objects and are what `std::atomic_ref` itself lowers to.
+// Orders are switched onto literals rather than passed through as an int:
+// libstdc++ can rely on its own enum matching __ATOMIC_*, but this header
+// compiles against libstdc++ and libc++ both, so it does not assume that.
+template <typename T>
+struct AtomicBackend {
+  static T Load(T* p, std::memory_order order) {
+    T value;
+    switch (order) {
+      case std::memory_order_relaxed:
+        __atomic_load(p, &value, __ATOMIC_RELAXED);
+        break;
+      case std::memory_order_consume:
+      case std::memory_order_acquire:
+        __atomic_load(p, &value, __ATOMIC_ACQUIRE);
+        break;
+      default:
+        __atomic_load(p, &value, __ATOMIC_SEQ_CST);
+        break;
+    }
+    return value;
+  }
+  static void Store(T* p, T desired, std::memory_order order) {
+    switch (order) {
+      case std::memory_order_relaxed:
+        __atomic_store(p, &desired, __ATOMIC_RELAXED);
+        break;
+      case std::memory_order_release:
+        __atomic_store(p, &desired, __ATOMIC_RELEASE);
+        break;
+      default:
+        __atomic_store(p, &desired, __ATOMIC_SEQ_CST);
+        break;
+    }
+  }
+  static T Exchange(T* p, T desired, std::memory_order order) {
+    T previous;
+    switch (order) {
+      case std::memory_order_relaxed:
+        __atomic_exchange(p, &desired, &previous, __ATOMIC_RELAXED);
+        break;
+      case std::memory_order_acquire:
+        __atomic_exchange(p, &desired, &previous, __ATOMIC_ACQUIRE);
+        break;
+      case std::memory_order_release:
+        __atomic_exchange(p, &desired, &previous, __ATOMIC_RELEASE);
+        break;
+      case std::memory_order_acq_rel:
+        __atomic_exchange(p, &desired, &previous, __ATOMIC_ACQ_REL);
+        break;
+      default:
+        __atomic_exchange(p, &desired, &previous, __ATOMIC_SEQ_CST);
+        break;
+    }
+    return previous;
+  }
+  // The failure order must not be stronger than success, and must not be a
+  // release order, so it is derived rather than passed through.
+  static bool CompareExchange(T* p, T& expected, T desired,
+                              std::memory_order order, bool weak) {
+    switch (order) {
+      case std::memory_order_relaxed:
+        return __atomic_compare_exchange(p, &expected, &desired, weak,
+                                         __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+      case std::memory_order_acquire:
+        return __atomic_compare_exchange(p, &expected, &desired, weak,
+                                         __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE);
+      case std::memory_order_release:
+        return __atomic_compare_exchange(p, &expected, &desired, weak,
+                                         __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+      case std::memory_order_acq_rel:
+        return __atomic_compare_exchange(p, &expected, &desired, weak,
+                                         __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+      default:
+        return __atomic_compare_exchange(p, &expected, &desired, weak,
+                                         __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    }
+  }
+  static T FetchAdd(T* p, T arg, std::memory_order order) {
+    switch (order) {
+      case std::memory_order_relaxed:
+        return __atomic_fetch_add(p, arg, __ATOMIC_RELAXED);
+      case std::memory_order_acquire:
+        return __atomic_fetch_add(p, arg, __ATOMIC_ACQUIRE);
+      case std::memory_order_release:
+        return __atomic_fetch_add(p, arg, __ATOMIC_RELEASE);
+      case std::memory_order_acq_rel:
+        return __atomic_fetch_add(p, arg, __ATOMIC_ACQ_REL);
+      default:
+        return __atomic_fetch_add(p, arg, __ATOMIC_SEQ_CST);
+    }
+  }
+};
+
+#endif  // MSVC vs GCC/Clang backend
+
+}  // namespace details
+
+/**
+ * A C++17 stand-in for std::atomic_ref, over one of the backends above. The
+ * referenced object must outlive the AtomicRef, and while any AtomicRef refers
+ * to it every access must go through one.
+ *
+ * Memory orders are honored exactly on GCC/Clang, matching what the C++20
+ * alias does. MSVC's read-modify-write intrinsics are all full barriers, so
+ * there a weaker request is satisfied by being stronger, never weaker.
+ */
+template <typename T>
+class AtomicRef {
+  // Scalars only, deliberately narrower than std::atomic_ref's trivially-
+  // copyable. A padded type would need its padding cleared before every
+  // compare_exchange (libstdc++ calls __clear_padding for exactly this), or
+  // stale padding bytes make the exchange fail forever. Every use here is a
+  // scalar, so the simpler contract is the honest one.
+  static_assert(std::is_scalar<T>::value, "AtomicRef requires a scalar type");
+  static_assert(sizeof(T) <= 8, "AtomicRef supports up to 8-byte scalars");
+  // The same test libc++ and MSVC STL use to decide whether padding needs
+  // clearing; scalars that pass it need none.
+  static_assert(std::has_unique_object_representations_v<T> ||
+                    std::is_floating_point_v<T>,
+                "AtomicRef requires a type with no padding bits");
+
+  using Backend = details::AtomicBackend<T>;
+
+ public:
+  explicit AtomicRef(T& obj) : ptr_(&obj) {
+    // The atomic ops need the object naturally aligned, which alignof(T) does
+    // not promise: 32-bit x86 gives alignof(double) == 4. So check the address,
+    // as libstdc++ and Boost both do in their constructors. Compiles away
+    // entirely without MANIFOLD_DEBUG.
+    DEBUG_ASSERT(reinterpret_cast<uintptr_t>(ptr_) % sizeof(T) == 0, logicErr,
+                 "AtomicRef requires an object aligned to its own size");
+  }
+
+  T load(std::memory_order order = std::memory_order_seq_cst) const {
+    return Backend::Load(ptr_, order);
+  }
+
+  void store(T desired, std::memory_order order = std::memory_order_seq_cst) {
+    Backend::Store(ptr_, desired, order);
+  }
+
+  T exchange(T desired, std::memory_order order = std::memory_order_seq_cst) {
+    return Backend::Exchange(ptr_, desired, order);
+  }
+
+  // As in std::atomic_ref, `expected` is updated with the current value when
+  // the exchange fails. Only the weak form may fail spuriously, so a caller
+  // that treats failure as evidence about the stored value needs the strong
+  // one.
+  bool compare_exchange_weak(
+      T& expected, T desired,
+      std::memory_order order = std::memory_order_seq_cst) {
+    return Backend::CompareExchange(ptr_, expected, desired, order,
+                                    /*weak=*/true);
+  }
+
+  bool compare_exchange_weak(T& expected, T desired, std::memory_order success,
+                             std::memory_order) {
+    // The failure order is derived from `success` in the backend, matching
+    // libstdc++'s __cmpexch_failure_order2, so it is accepted and ignored.
+    return Backend::CompareExchange(ptr_, expected, desired, success,
+                                    /*weak=*/true);
+  }
+
+  bool compare_exchange_strong(
+      T& expected, T desired,
+      std::memory_order order = std::memory_order_seq_cst) {
+    return Backend::CompareExchange(ptr_, expected, desired, order,
+                                    /*weak=*/false);
+  }
+
+  // Integral only: __atomic_fetch_add and _InterlockedExchangeAdd are both
+  // defined for integers and pointers. Floating-point accumulation goes
+  // through the compare_exchange_weak loop in AtomicAdd.
+  template <typename U = T>
+  std::enable_if_t<std::is_integral<U>::value, T> fetch_add(
+      T arg, std::memory_order order = std::memory_order_seq_cst) {
+    return Backend::FetchAdd(ptr_, arg, order);
+  }
+
+ private:
+  T* ptr_;
+};
+
+#endif  // std::atomic_ref vs the C++17 stand-in
+
+}  // namespace manifold

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -20,7 +20,7 @@
 #include <intrin.h>
 #endif
 
-#include "atomic_ref.h"
+#include "atomic_compat.h"
 #include "utils.h"
 #include "vec.h"
 

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -20,6 +20,7 @@
 #include <intrin.h>
 #endif
 
+#include "atomic_ref.h"
 #include "utils.h"
 #include "vec.h"
 
@@ -62,23 +63,21 @@ inline uint32_t CeilLog2(size_t value) {
 
 template <typename T>
 T AtomicCAS(T& target, T compare, T val) {
-  std::atomic<T>& tar = reinterpret_cast<std::atomic<T>&>(target);
+  // Must be the strong form: Insert treats a returned `kOpen` as proof it
+  // claimed the slot, and a spurious weak failure would report exactly that
+  // without having written the key.
+  manifold::AtomicRef<T> tar(target);
   tar.compare_exchange_strong(compare, val, std::memory_order_acq_rel);
   return compare;
 }
 
 template <typename T>
-void AtomicStore(T& target, T val) {
-  std::atomic<T>& tar = reinterpret_cast<std::atomic<T>&>(target);
-  // release is good enough, although not really something general
-  tar.store(val, std::memory_order_release);
-}
-
-template <typename T>
 T AtomicLoad(const T& target) {
-  const std::atomic<T>& tar = reinterpret_cast<const std::atomic<T>&>(target);
-  // acquire is good enough, although not general
-  return tar.load(std::memory_order_acquire);
+  // acquire is good enough, although not general. The const_cast is the
+  // caller's business rather than AtomicRef's, so the C++20 path can be a
+  // plain alias for std::atomic_ref, which takes only a mutable reference.
+  return manifold::AtomicRef<T>(const_cast<T&>(target))
+      .load(std::memory_order_acquire);
 }
 
 }  // namespace

--- a/src/impl.cpp
+++ b/src/impl.cpp
@@ -148,8 +148,7 @@ void Manifold::Impl::RemoveUnreferencedVerts() {
   for_each_n(policy, countAt(0), halfedge_.size(), [&keep, this](int edge) {
     const int startVert = halfedge_.Start(edge);
     if (startVert >= 0) {
-      reinterpret_cast<std::atomic<int>*>(&keep[startVert])
-          ->store(1, std::memory_order_relaxed);
+      AtomicRef<int>(keep[startVert]).store(1, std::memory_order_relaxed);
     }
   });
 

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 
+#include "atomic_compat.h"
 #include "boolean3.h"
 #include "csg_tree.h"
 #include "execution_impl.h"

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -24,38 +24,6 @@
 namespace {
 using namespace manifold;
 
-// `ctx_` is a plain shared_ptr accessed atomically, which C++17 can only do
-// through std::atomic_load/atomic_store. Those are deprecated in C++20 and
-// removed in C++26 (P2869); the sanctioned replacement, a member of type
-// std::atomic<std::shared_ptr<T>>, is C++20-only and would also delete
-// Manifold's defaulted move operations, so it is a separate change. Until
-// then, funnel every use through these two so the suppression is here and
-// nowhere else - any other deprecation still fails the C++20 build.
-#if defined(_MSC_VER) && !defined(__clang__)
-#define MANIFOLD_IGNORE_DEPRECATED_BEGIN \
-  __pragma(warning(push)) __pragma(warning(disable : 4996))
-#define MANIFOLD_IGNORE_DEPRECATED_END __pragma(warning(pop))
-#else
-#define MANIFOLD_IGNORE_DEPRECATED_BEGIN \
-  _Pragma("GCC diagnostic push")         \
-      _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#define MANIFOLD_IGNORE_DEPRECATED_END _Pragma("GCC diagnostic pop")
-#endif
-
-template <typename T>
-std::shared_ptr<T> AtomicLoadShared(const std::shared_ptr<T>* ptr) {
-  MANIFOLD_IGNORE_DEPRECATED_BEGIN
-  return std::atomic_load(ptr);
-  MANIFOLD_IGNORE_DEPRECATED_END
-}
-
-template <typename T>
-void AtomicStoreShared(std::shared_ptr<T>* ptr, std::shared_ptr<T> value) {
-  MANIFOLD_IGNORE_DEPRECATED_BEGIN
-  std::atomic_store(ptr, std::move(value));
-  MANIFOLD_IGNORE_DEPRECATED_END
-}
-
 ExecutionParams manifoldParams;
 
 Manifold Halfspace(Box bBox, vec3 normal, double originOffset) {

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -24,6 +24,38 @@
 namespace {
 using namespace manifold;
 
+// `ctx_` is a plain shared_ptr accessed atomically, which C++17 can only do
+// through std::atomic_load/atomic_store. Those are deprecated in C++20 and
+// removed in C++26 (P2869); the sanctioned replacement, a member of type
+// std::atomic<std::shared_ptr<T>>, is C++20-only and would also delete
+// Manifold's defaulted move operations, so it is a separate change. Until
+// then, funnel every use through these two so the suppression is here and
+// nowhere else - any other deprecation still fails the C++20 build.
+#if defined(_MSC_VER) && !defined(__clang__)
+#define MANIFOLD_IGNORE_DEPRECATED_BEGIN \
+  __pragma(warning(push)) __pragma(warning(disable : 4996))
+#define MANIFOLD_IGNORE_DEPRECATED_END __pragma(warning(pop))
+#else
+#define MANIFOLD_IGNORE_DEPRECATED_BEGIN \
+  _Pragma("GCC diagnostic push")         \
+      _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define MANIFOLD_IGNORE_DEPRECATED_END _Pragma("GCC diagnostic pop")
+#endif
+
+template <typename T>
+std::shared_ptr<T> AtomicLoadShared(const std::shared_ptr<T>* ptr) {
+  MANIFOLD_IGNORE_DEPRECATED_BEGIN
+  return std::atomic_load(ptr);
+  MANIFOLD_IGNORE_DEPRECATED_END
+}
+
+template <typename T>
+void AtomicStoreShared(std::shared_ptr<T>* ptr, std::shared_ptr<T> value) {
+  MANIFOLD_IGNORE_DEPRECATED_BEGIN
+  std::atomic_store(ptr, std::move(value));
+  MANIFOLD_IGNORE_DEPRECATED_END
+}
+
 ExecutionParams manifoldParams;
 
 Manifold Halfspace(Box bBox, vec3 normal, double originOffset) {
@@ -128,7 +160,7 @@ Manifold& Manifold::operator=(Manifold&&) noexcept = default;
 Manifold::Manifold(const Manifold& other) {
   std::lock_guard<std::mutex> lock(*other.pNodeMutex_);
   pNode_ = other.pNode_;
-  std::atomic_store(&ctx_, std::atomic_load(&other.ctx_));
+  AtomicStoreShared(&ctx_, AtomicLoadShared(&other.ctx_));
 }
 
 Manifold::Manifold(std::shared_ptr<CsgNode> pNode) : pNode_(pNode) {}
@@ -156,7 +188,7 @@ Manifold& Manifold::operator=(const Manifold& other) {
   if (this != &other) {
     std::scoped_lock lock(*pNodeMutex_, *other.pNodeMutex_);
     pNode_ = other.pNode_;
-    std::atomic_store(&ctx_, std::atomic_load(&other.ctx_));
+    AtomicStoreShared(&ctx_, AtomicLoadShared(&other.ctx_));
   }
   return *this;
 }
@@ -170,7 +202,7 @@ Manifold& Manifold::operator=(const Manifold& other) {
  */
 Manifold Manifold::WithContext(const ExecutionContext& ctx) const {
   Manifold result = *this;
-  std::atomic_store(&result.ctx_, ctx.impl_);
+  AtomicStoreShared(&result.ctx_, ctx.impl_);
   return result;
 }
 
@@ -305,7 +337,7 @@ Manifold::Error Manifold::Status() const {
   // expression -- through the lazy eval inside GetCsgLeafNode -- so a
   // concurrent op= reseating ctx_ on this Manifold can't free the Impl out
   // from under us.
-  return GetCsgLeafNode(std::atomic_load(&ctx_).get()).GetImpl()->status_;
+  return GetCsgLeafNode(AtomicLoadShared(&ctx_).get()).GetImpl()->status_;
 }
 /**
  * The number of vertices in the Manifold.
@@ -788,7 +820,7 @@ Manifold Manifold::SmoothOut(double minSharpAngle, double minSmoothness) const {
  * @param n The number of pieces to split every edge into. Must be > 1.
  */
 Manifold Manifold::Refine(int n) const {
-  auto ctx = std::atomic_load(&ctx_);
+  auto ctx = AtomicLoadShared(&ctx_);
   auto leafImpl = GetCsgLeafNode(ctx.get()).GetImpl();
   if (leafImpl->status_ != Error::NoError)
     return PropagateStatus(leafImpl->status_);
@@ -813,7 +845,7 @@ Manifold Manifold::Refine(int n) const {
  */
 Manifold Manifold::RefineToLength(double length) const {
   length = std::abs(length);
-  auto ctx = std::atomic_load(&ctx_);
+  auto ctx = AtomicLoadShared(&ctx_);
   auto leafImpl = GetCsgLeafNode(ctx.get()).GetImpl();
   if (leafImpl->status_ != Error::NoError)
     return PropagateStatus(leafImpl->status_);
@@ -842,7 +874,7 @@ Manifold Manifold::RefineToLength(double length) const {
  */
 Manifold Manifold::RefineToTolerance(double tolerance) const {
   tolerance = std::abs(tolerance);
-  auto ctx = std::atomic_load(&ctx_);
+  auto ctx = AtomicLoadShared(&ctx_);
   auto leafImpl = GetCsgLeafNode(ctx.get()).GetImpl();
   if (leafImpl->status_ != Error::NoError)
     return PropagateStatus(leafImpl->status_);
@@ -1011,7 +1043,7 @@ Manifold Manifold::TrimByPlane(vec3 normal, double originOffset) const {
  * @param other The other manifold to minkowski sum to this one.
  */
 Manifold Manifold::MinkowskiSum(const Manifold& other) const {
-  auto ctx = std::atomic_load(&ctx_);
+  auto ctx = AtomicLoadShared(&ctx_);
   auto aImpl = GetCsgLeafNode(ctx.get()).GetImpl();
   if (aImpl->status_ != Error::NoError) return PropagateStatus(aImpl->status_);
   auto bImpl = other.GetCsgLeafNode(ctx.get()).GetImpl();
@@ -1029,7 +1061,7 @@ Manifold Manifold::MinkowskiSum(const Manifold& other) const {
  * @param other The other manifold to minkowski subtract from this one.
  */
 Manifold Manifold::MinkowskiDifference(const Manifold& other) const {
-  auto ctx = std::atomic_load(&ctx_);
+  auto ctx = AtomicLoadShared(&ctx_);
   auto aImpl = GetCsgLeafNode(ctx.get()).GetImpl();
   if (aImpl->status_ != Error::NoError) return PropagateStatus(aImpl->status_);
   auto bImpl = other.GetCsgLeafNode(ctx.get()).GetImpl();
@@ -1076,7 +1108,7 @@ Manifold Manifold::Hull(const std::vector<vec3>& pts) {
  * Compute the convex hull of this manifold.
  */
 Manifold Manifold::Hull() const {
-  auto ctx = std::atomic_load(&ctx_);
+  auto ctx = AtomicLoadShared(&ctx_);
   auto srcImpl = GetCsgLeafNode(ctx.get()).GetImpl();
   if (srcImpl->status_ != Error::NoError)
     return PropagateStatus(srcImpl->status_);

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -326,9 +326,8 @@ void Manifold::Impl::CalculateCurvature(int gaussianIdx, int meanIdx) {
       const int vert = halfedge_.Start(edge);
       const int propVert = halfedge_.Prop(edge);
 
-      auto old = std::atomic_exchange(
-          reinterpret_cast<std::atomic<uint8_t>*>(&counters[propVert]),
-          static_cast<uint8_t>(1));
+      auto old = AtomicRef<uint8_t>(counters[propVert])
+                     .exchange(static_cast<uint8_t>(1));
       if (old == 1) continue;
 
       for (int p = 0; p < oldNumProp; ++p) {

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -412,9 +412,8 @@ Vec<int> Manifold::Impl::VertHalfedge() const {
   for_each_n(autoPolicy(halfedge_.size(), 1e5), countAt(0), halfedge_.size(),
              [&vertHalfedge, &counters, this](const int idx) {
                const int start = halfedge_.Start(idx);
-               auto old = std::atomic_exchange(
-                   reinterpret_cast<std::atomic<uint8_t>*>(&counters[start]),
-                   static_cast<uint8_t>(1));
+               auto old = AtomicRef<uint8_t>(counters[start])
+                              .exchange(static_cast<uint8_t>(1));
                if (old == 1) return;
                // arbitrary, last one wins.
                vertHalfedge[start] = idx;

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -390,8 +390,8 @@ void Manifold::Impl::CompactProps(ExecutionContext::Impl* ctx) {
   auto policy = autoPolicy(numVerts, 1e5);
 
   for_each_n(policy, countAt(0), halfedge_.size(), ctx, [this, &keep](int idx) {
-    reinterpret_cast<std::atomic<int>*>(&keep[halfedge_.Prop(idx)])
-        ->store(1, std::memory_order_relaxed);
+    AtomicRef<int>(keep[halfedge_.Prop(idx)])
+        .store(1, std::memory_order_relaxed);
   });
   if (IsCancelled(ctx)) return;
   Vec<int> propOld2New(numVerts + 1, 0);

--- a/src/utils.h
+++ b/src/utils.h
@@ -66,8 +66,7 @@ void Permute(std::vector<T>& inOut, const Vec<T1>& new2Old) {
 // Floating-point accumulation, since fetch_add takes integers only. The
 // relaxed seed and relaxed failure order are what libstdc++'s __fetch_add_flt
 // and libc++'s floating-point fetch_add both use: only the successful exchange
-// needs to synchronize. The C++20 alias honors the failure order; the C++17
-// backend derives one from the success order instead, which is never weaker.
+// needs to synchronize.
 template <typename T>
 T AtomicAdd(T& target, T add) {
   AtomicRef<T> tar(target);

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,7 +18,7 @@
 #include <memory>
 #include <mutex>
 
-#include "atomic_ref.h"
+#include "atomic_compat.h"
 #include "manifold/common.h"
 #include "vec.h"
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <mutex>
 
+#include "atomic_ref.h"
 #include "manifold/common.h"
 #include "vec.h"
 
@@ -62,21 +63,24 @@ void Permute(std::vector<T>& inOut, const Vec<T1>& new2Old) {
   gather(new2Old.begin(), new2Old.end(), tmp.begin(), inOut.begin());
 }
 
+// Floating-point accumulation, since fetch_add takes integers only. The
+// relaxed seed and relaxed failure order are what libstdc++'s __fetch_add_flt
+// and libc++'s floating-point fetch_add both use: only the successful exchange
+// needs to synchronize.
 template <typename T>
 T AtomicAdd(T& target, T add) {
-  std::atomic<T>& tar = reinterpret_cast<std::atomic<T>&>(target);
-  T old_val = tar.load();
+  AtomicRef<T> tar(target);
+  T old_val = tar.load(std::memory_order_relaxed);
   while (!tar.compare_exchange_weak(old_val, old_val + add,
-                                    std::memory_order_seq_cst)) {
+                                    std::memory_order_seq_cst,
+                                    std::memory_order_relaxed)) {
   }
   return old_val;
 }
 
 template <>
 inline int AtomicAdd(int& target, int add) {
-  std::atomic<int>& tar = reinterpret_cast<std::atomic<int>&>(target);
-  int old_val = tar.fetch_add(add, std::memory_order_seq_cst);
-  return old_val;
+  return AtomicRef<int>(target).fetch_add(add);
 }
 
 template <typename T>

--- a/src/utils.h
+++ b/src/utils.h
@@ -66,7 +66,8 @@ void Permute(std::vector<T>& inOut, const Vec<T1>& new2Old) {
 // Floating-point accumulation, since fetch_add takes integers only. The
 // relaxed seed and relaxed failure order are what libstdc++'s __fetch_add_flt
 // and libc++'s floating-point fetch_add both use: only the successful exchange
-// needs to synchronize.
+// needs to synchronize. The C++20 alias honors the failure order; the C++17
+// backend derives one from the success order instead, which is never weaker.
 template <typename T>
 T AtomicAdd(T& target, T add) {
   AtomicRef<T> tar(target);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ enable_testing()
 set(
   SOURCE_FILES
   test_main.cpp
+  utils_test.cpp
   polygon_test.cpp
   properties_test.cpp
   manifold_test.cpp

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -51,6 +51,9 @@ void RunConcurrently(F body) {
 TEST(Utils, AtomicRefBackend) {
 #if defined(__cpp_lib_atomic_ref)
   const char* backend = "std::atomic_ref";
+#elif defined(_MSC_VER) && !defined(__clang__) && \
+    (defined(_M_IX86) || defined(_M_ARM))
+  const char* backend = "std::atomic reinterpret_cast (32-bit MSVC)";
 #elif defined(_MSC_VER) && !defined(__clang__)
   const char* backend = "_Interlocked* intrinsics";
 #else

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -51,7 +51,7 @@ void RunConcurrently(F body) {
 TEST(Utils, AtomicRefBackend) {
 #if defined(__cpp_lib_atomic_ref)
   const char* backend = "std::atomic_ref";
-#elif defined(_MSC_VER) && !defined(__clang__)
+#elif defined(MANIFOLD_MSVC_ATOMIC_INTRINSICS)
   const char* backend = "_Interlocked* intrinsics";
 #else
   const char* backend = "__atomic builtins";

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -51,10 +51,8 @@ void RunConcurrently(F body) {
 TEST(Utils, AtomicRefBackend) {
 #if defined(__cpp_lib_atomic_ref)
   const char* backend = "std::atomic_ref";
-#elif defined(MANIFOLD_MSVC_ATOMIC_INTRINSICS)
-  const char* backend = "_Interlocked* intrinsics";
 #else
-  const char* backend = "__atomic builtins";
+  const char* backend = "C++17 cast";
 #endif
   RecordProperty("backend", backend);
   std::cout << "AtomicRef backend: " << backend << std::endl;
@@ -72,8 +70,8 @@ TEST(Utils, AtomicRefFetchAddLosesNothing) {
 }
 
 // AtomicAdd's generic overload accumulates through a compare_exchange_weak
-// loop, because neither __atomic_fetch_add nor _InterlockedExchangeAdd take
-// floating point. Sum 1.0 so the result is exactly representable.
+// loop, because C++17's std::atomic has no floating-point fetch_add. Sum 1.0
+// so the result is exactly representable.
 TEST(Utils, AtomicAddAccumulatesDoubles) {
   double total = 0.0;
   RunConcurrently([&total](int) {
@@ -134,9 +132,8 @@ TEST(Utils, AtomicRefCompareExchangeReportsCurrentValue) {
   EXPECT_EQ(value, 9);
 }
 
-// The MSVC backend is specialized per object width with a different intrinsic
-// family each time, and those lanes are the only place it compiles, so
-// exercise every width plus a non-integer type.
+// std::atomic's layout and lock-freedom are asserted per width, and the cast
+// relies on both, so exercise every width plus a non-integer type.
 template <typename T>
 void ExpectRoundTrip(T a, T b) {
   SCOPED_TRACE(testing::Message() << "sizeof(T) = " << sizeof(T));
@@ -168,8 +165,7 @@ TEST(Utils, AtomicRefRoundTripsEveryWidth) {
   ExpectRoundTrip<double>(-2.5, 1e300);
 }
 
-// fetch_add across the integer widths, which on MSVC is a fourth intrinsic
-// family again.
+// fetch_add across the integer widths.
 TEST(Utils, AtomicRefFetchAddEveryWidth) {
   uint8_t u8 = 250;
   EXPECT_EQ(AtomicRef<uint8_t>(u8).fetch_add(3), 250);
@@ -210,4 +206,19 @@ TEST(Utils, AtomicRefLoadStoreRoundTrip) {
   EXPECT_EQ(AtomicRef<int>(const_cast<int&>(constValue))
                 .load(std::memory_order_acquire),
             3);
+}
+
+// std::atomic_ref's mutators are const - it is a handle, so constness of the
+// handle says nothing about the referent. The C++17 stand-in has to match, or
+// code written against one standard fails to build on the other.
+TEST(Utils, AtomicRefMutatorsAreConst) {
+  int value = 0;
+  const AtomicRef<int> ref(value);
+  ref.store(4);
+  EXPECT_EQ(ref.load(), 4);
+  EXPECT_EQ(ref.exchange(5), 4);
+  int expected = 5;
+  EXPECT_TRUE(ref.compare_exchange_strong(expected, 6));
+  EXPECT_EQ(ref.fetch_add(1), 6);
+  EXPECT_EQ(value, 7);
 }

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -17,34 +17,11 @@
 #include <atomic>
 #include <cstdint>
 #include <iostream>
-#include <thread>
-#include <vector>
 
 #include "../src/atomic_compat.h"
 #include "gtest/gtest.h"
 
 using namespace manifold;
-
-namespace {
-#ifndef __EMSCRIPTEN__
-// Enough contention to catch a lost update, without making the suite slow.
-constexpr int kThreads = 8;
-constexpr int kPerThread = 20000;
-// HashTableD's empty-slot marker.
-constexpr uint64_t kOpen = ~uint64_t{0};
-
-// Run `body(t)` on kThreads threads and join them all. Native-only: the WASM
-// build is single-threaded, so std::thread construction throws and aborts
-// under -fno-exceptions, as in cross_section_test's concurrency tests.
-template <typename F>
-void RunConcurrently(F body) {
-  std::vector<std::thread> threads;
-  threads.reserve(kThreads);
-  for (int t = 0; t < kThreads; ++t) threads.emplace_back(body, t);
-  for (auto& thread : threads) thread.join();
-}
-#endif  // __EMSCRIPTEN__
-}  // namespace
 
 // Which backend this build selected is not otherwise visible. Report it so a
 // CI log says whether the lane covered the std::atomic_ref path or a fallback.
@@ -57,67 +34,6 @@ TEST(Utils, AtomicRefBackend) {
   RecordProperty("backend", backend);
   std::cout << "AtomicRef backend: " << backend << std::endl;
 }
-
-#ifndef __EMSCRIPTEN__
-// The whole point of the class: the target is a plain int, not a std::atomic,
-// and concurrent increments must still not lose an update.
-TEST(Utils, AtomicRefFetchAddLosesNothing) {
-  int counter = 0;
-  RunConcurrently([&counter](int) {
-    for (int i = 0; i < kPerThread; ++i) AtomicRef<int>(counter).fetch_add(1);
-  });
-  EXPECT_EQ(counter, kThreads * kPerThread);
-}
-
-// AtomicAdd's generic overload accumulates through a compare_exchange_weak
-// loop, because C++17's std::atomic has no floating-point fetch_add. Sum 1.0
-// so the result is exactly representable.
-TEST(Utils, AtomicAddAccumulatesDoubles) {
-  double total = 0.0;
-  RunConcurrently([&total](int) {
-    for (int i = 0; i < kPerThread; ++i) AtomicAdd(total, 1.0);
-  });
-  EXPECT_EQ(total, static_cast<double>(kThreads * kPerThread));
-}
-
-// The pattern in AssignNormals and DedupePropVerts: whoever exchanges in the
-// 1 first is the single owner, and everyone else must observe it.
-TEST(Utils, AtomicRefExchangeHasExactlyOneWinner) {
-  uint8_t flag = 0;
-  std::atomic<int> winners{0};
-  RunConcurrently([&flag, &winners](int) {
-    if (AtomicRef<uint8_t>(flag).exchange(static_cast<uint8_t>(1)) == 0) {
-      winners.fetch_add(1);
-    }
-  });
-  EXPECT_EQ(winners.load(), 1);
-  EXPECT_EQ(flag, 1u);
-}
-
-// HashTableD::Insert treats a returned kOpen as proof that it claimed the
-// slot, so the CAS must be the strong form. A weak CAS may fail spuriously
-// and report the unchanged value, which would let two threads both believe
-// they own the same key. Note this cannot actually catch the weak form on
-// x86, where lock cmpxchg never fails spuriously - the guarantee is
-// architectural, and this pins the intent rather than policing it.
-TEST(Utils, AtomicRefCompareExchangeStrongHasExactlyOneWinner) {
-  uint64_t slot = kOpen;
-  std::atomic<int> claims{0};
-  RunConcurrently([&slot, &claims](int t) {
-    uint64_t expected = kOpen;
-    if (AtomicRef<uint64_t>(slot).compare_exchange_strong(
-            expected, static_cast<uint64_t>(t))) {
-      claims.fetch_add(1);
-    } else {
-      // On failure `expected` must carry the value that beat us, never kOpen.
-      EXPECT_NE(expected, kOpen);
-    }
-  });
-  EXPECT_EQ(claims.load(), 1);
-  EXPECT_NE(slot, kOpen);
-}
-
-#endif  // __EMSCRIPTEN__
 
 // A failed compare_exchange reports the current value through `expected`,
 // which is what the AtomicAdd retry loop relies on.

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -139,6 +139,7 @@ TEST(Utils, AtomicRefCompareExchangeReportsCurrentValue) {
 // exercise every width plus a non-integer type.
 template <typename T>
 void ExpectRoundTrip(T a, T b) {
+  SCOPED_TRACE(testing::Message() << "sizeof(T) = " << sizeof(T));
   T value = a;
   AtomicRef<T> ref(value);
   EXPECT_EQ(ref.load(), a);

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -51,9 +51,6 @@ void RunConcurrently(F body) {
 TEST(Utils, AtomicRefBackend) {
 #if defined(__cpp_lib_atomic_ref)
   const char* backend = "std::atomic_ref";
-#elif defined(_MSC_VER) && !defined(__clang__) && \
-    (defined(_M_IX86) || defined(_M_ARM))
-  const char* backend = "std::atomic reinterpret_cast (32-bit MSVC)";
 #elif defined(_MSC_VER) && !defined(__clang__)
   const char* backend = "_Interlocked* intrinsics";
 #else

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -20,7 +20,7 @@
 #include <thread>
 #include <vector>
 
-#include "../src/atomic_ref.h"
+#include "../src/atomic_compat.h"
 #include "gtest/gtest.h"
 
 using namespace manifold;

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -1,0 +1,212 @@
+// Copyright 2026 The Manifold Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/utils.h"
+
+#include <atomic>
+#include <cstdint>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include "../src/atomic_ref.h"
+#include "gtest/gtest.h"
+
+using namespace manifold;
+
+namespace {
+#ifndef __EMSCRIPTEN__
+// Enough contention to catch a lost update, without making the suite slow.
+constexpr int kThreads = 8;
+constexpr int kPerThread = 20000;
+// HashTableD's empty-slot marker.
+constexpr uint64_t kOpen = ~uint64_t{0};
+
+// Run `body(t)` on kThreads threads and join them all. Native-only: the WASM
+// build is single-threaded, so std::thread construction throws and aborts
+// under -fno-exceptions, as in cross_section_test's concurrency tests.
+template <typename F>
+void RunConcurrently(F body) {
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) threads.emplace_back(body, t);
+  for (auto& thread : threads) thread.join();
+}
+#endif  // __EMSCRIPTEN__
+}  // namespace
+
+// Which backend this build selected is not otherwise visible. Report it so a
+// CI log says whether the lane covered the std::atomic_ref path or a fallback.
+TEST(Utils, AtomicRefBackend) {
+#if defined(__cpp_lib_atomic_ref)
+  const char* backend = "std::atomic_ref";
+#elif defined(_MSC_VER) && !defined(__clang__)
+  const char* backend = "_Interlocked* intrinsics";
+#else
+  const char* backend = "__atomic builtins";
+#endif
+  RecordProperty("backend", backend);
+  std::cout << "AtomicRef backend: " << backend << std::endl;
+}
+
+#ifndef __EMSCRIPTEN__
+// The whole point of the class: the target is a plain int, not a std::atomic,
+// and concurrent increments must still not lose an update.
+TEST(Utils, AtomicRefFetchAddLosesNothing) {
+  int counter = 0;
+  RunConcurrently([&counter](int) {
+    for (int i = 0; i < kPerThread; ++i) AtomicRef<int>(counter).fetch_add(1);
+  });
+  EXPECT_EQ(counter, kThreads * kPerThread);
+}
+
+// AtomicAdd's generic overload accumulates through a compare_exchange_weak
+// loop, because neither __atomic_fetch_add nor _InterlockedExchangeAdd take
+// floating point. Sum 1.0 so the result is exactly representable.
+TEST(Utils, AtomicAddAccumulatesDoubles) {
+  double total = 0.0;
+  RunConcurrently([&total](int) {
+    for (int i = 0; i < kPerThread; ++i) AtomicAdd(total, 1.0);
+  });
+  EXPECT_EQ(total, static_cast<double>(kThreads * kPerThread));
+}
+
+// The pattern in AssignNormals and DedupePropVerts: whoever exchanges in the
+// 1 first is the single owner, and everyone else must observe it.
+TEST(Utils, AtomicRefExchangeHasExactlyOneWinner) {
+  uint8_t flag = 0;
+  std::atomic<int> winners{0};
+  RunConcurrently([&flag, &winners](int) {
+    if (AtomicRef<uint8_t>(flag).exchange(static_cast<uint8_t>(1)) == 0) {
+      winners.fetch_add(1);
+    }
+  });
+  EXPECT_EQ(winners.load(), 1);
+  EXPECT_EQ(flag, 1u);
+}
+
+// HashTableD::Insert treats a returned kOpen as proof that it claimed the
+// slot, so the CAS must be the strong form. A weak CAS may fail spuriously
+// and report the unchanged value, which would let two threads both believe
+// they own the same key. Note this cannot actually catch the weak form on
+// x86, where lock cmpxchg never fails spuriously - the guarantee is
+// architectural, and this pins the intent rather than policing it.
+TEST(Utils, AtomicRefCompareExchangeStrongHasExactlyOneWinner) {
+  uint64_t slot = kOpen;
+  std::atomic<int> claims{0};
+  RunConcurrently([&slot, &claims](int t) {
+    uint64_t expected = kOpen;
+    if (AtomicRef<uint64_t>(slot).compare_exchange_strong(
+            expected, static_cast<uint64_t>(t))) {
+      claims.fetch_add(1);
+    } else {
+      // On failure `expected` must carry the value that beat us, never kOpen.
+      EXPECT_NE(expected, kOpen);
+    }
+  });
+  EXPECT_EQ(claims.load(), 1);
+  EXPECT_NE(slot, kOpen);
+}
+
+#endif  // __EMSCRIPTEN__
+
+// A failed compare_exchange reports the current value through `expected`,
+// which is what the AtomicAdd retry loop relies on.
+TEST(Utils, AtomicRefCompareExchangeReportsCurrentValue) {
+  int value = 7;
+  int expected = 3;
+  EXPECT_FALSE(AtomicRef<int>(value).compare_exchange_strong(expected, 9));
+  EXPECT_EQ(expected, 7);
+  EXPECT_EQ(value, 7);
+
+  EXPECT_TRUE(AtomicRef<int>(value).compare_exchange_strong(expected, 9));
+  EXPECT_EQ(value, 9);
+}
+
+// The MSVC backend is specialized per object width with a different intrinsic
+// family each time, and those lanes are the only place it compiles, so
+// exercise every width plus a non-integer type.
+template <typename T>
+void ExpectRoundTrip(T a, T b) {
+  T value = a;
+  AtomicRef<T> ref(value);
+  EXPECT_EQ(ref.load(), a);
+
+  ref.store(b, std::memory_order_relaxed);
+  EXPECT_EQ(ref.load(std::memory_order_relaxed), b);
+  ref.store(a, std::memory_order_release);
+  EXPECT_EQ(ref.load(std::memory_order_acquire), a);
+
+  EXPECT_EQ(ref.exchange(b), a);
+  EXPECT_EQ(value, b);
+
+  T expected = a;  // wrong on purpose: the exchange must fail and report b
+  EXPECT_FALSE(ref.compare_exchange_strong(expected, a));
+  EXPECT_EQ(expected, b);
+  EXPECT_TRUE(ref.compare_exchange_strong(expected, a));
+  EXPECT_EQ(value, a);
+}
+
+TEST(Utils, AtomicRefRoundTripsEveryWidth) {
+  ExpectRoundTrip<uint8_t>(0x12, 0xf0);
+  ExpectRoundTrip<uint16_t>(0x1234, 0xf00d);
+  ExpectRoundTrip<uint32_t>(0x12345678u, 0xf00dbeefu);
+  ExpectRoundTrip<uint64_t>(0x1234567890abcdefull, 0xf00dbeefcafef00dull);
+  ExpectRoundTrip<int>(-7, 9);
+  ExpectRoundTrip<double>(-2.5, 1e300);
+}
+
+// fetch_add across the integer widths, which on MSVC is a fourth intrinsic
+// family again.
+TEST(Utils, AtomicRefFetchAddEveryWidth) {
+  uint8_t u8 = 250;
+  EXPECT_EQ(AtomicRef<uint8_t>(u8).fetch_add(3), 250);
+  EXPECT_EQ(u8, 253);
+
+  uint16_t u16 = 65000;
+  EXPECT_EQ(AtomicRef<uint16_t>(u16).fetch_add(500), 65000);
+  EXPECT_EQ(u16, 65500);
+
+  int32_t i32 = -5;
+  EXPECT_EQ(AtomicRef<int32_t>(i32).fetch_add(12), -5);
+  EXPECT_EQ(i32, 7);
+
+  uint64_t u64 = 1ull << 40;
+  EXPECT_EQ(AtomicRef<uint64_t>(u64).fetch_add(1), 1ull << 40);
+  EXPECT_EQ(u64, (1ull << 40) + 1);
+}
+
+// Every memory order the call sites use has to round-trip, including the
+// relaxed store in CalculateNormals/SortVerts and the acquire load in
+// HashTableD's probes.
+TEST(Utils, AtomicRefLoadStoreRoundTrip) {
+  int value = 0;
+  AtomicRef<int> ref(value);
+
+  ref.store(1, std::memory_order_relaxed);
+  EXPECT_EQ(ref.load(std::memory_order_relaxed), 1);
+
+  ref.store(2, std::memory_order_release);
+  EXPECT_EQ(ref.load(std::memory_order_acquire), 2);
+
+  ref.store(3);
+  EXPECT_EQ(ref.load(), 3);
+  EXPECT_EQ(value, 3);
+
+  // What HashTableD's const probes do: cast away const at the call site.
+  const int& constValue = value;
+  EXPECT_EQ(AtomicRef<int>(const_cast<int&>(constValue))
+                .load(std::memory_order_acquire),
+            3);
+}


### PR DESCRIPTION
`reinterpret_cast<std::atomic<T>&>` on a plain `T&` (#1153) is UB, and the sanctioned
`std::atomic_ref` is C++20 only. This doesn't remove the UB at C++17 - it moves the cast from nine
call sites (one of them dead) into one type whose preconditions (`sizeof`/`alignof` match,
`is_always_lock_free`) are static_asserts, and replaces it outright at C++20.

Also: `CMAKE_CXX_STANDARD` is now overridable (a plain `set()` shadowed both `-D` and parent
projects), and a new `GCC 14 (TBB:ON, C++20)` lane builds everything at C++20 under `-Werror`. It
immediately caught the deprecated shared_ptr `atomic_load`/`atomic_store` in `manifold.cpp`, now
behind a scoped pragma.

Suite green at C++17 and at C++20 under `-Werror`.
