### PR TITLE
Smooth quads

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
       "program": "${workspaceFolder}/build/test/manifold_test",
       "args": [
         "--gtest_catch_exceptions=0",
-        "--gtest_filter=Boolean.Perturb3"
+        "--gtest_filter=Smooth.MissingNormalsCone"
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/build/test",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
       "program": "${workspaceFolder}/build/test/manifold_test",
       "args": [
         "--gtest_catch_exceptions=0",
-        "--gtest_filter=Smooth.MissingNormalsCone"
+        "--gtest_filter=Smooth.Fillet"
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/build/test",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
       "program": "${workspaceFolder}/build/test/manifold_test",
       "args": [
         "--gtest_catch_exceptions=0",
-        "--gtest_filter=Smooth.Fillet"
+        "--gtest_filter=Smooth.Csaszar"
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/build/test",

--- a/include/manifold/manifold.h
+++ b/include/manifold/manifold.h
@@ -320,6 +320,7 @@ class Manifold {
    */
   ///@{
   bool MatchesTriNormals() const;
+  bool HasSimpleProps() const;
   size_t NumDegenerateTris() const;
   double GetEpsilon() const;
   ///@}

--- a/src/edge_op.cpp
+++ b/src/edge_op.cpp
@@ -442,7 +442,7 @@ void Manifold::Impl::SimplifyTopology2() {
     //           << ", swapped: " << numSwapped
     //           << ", edges left: " << (end - edges.begin()) << ", "
     //           << itr - edges.begin() << std::endl;
-    totalCollapsed += numCollapsed;
+    // totalCollapsed += numCollapsed;
     if (numCollapsed == 0 && numSwapped == 0) break;
 
     for_each_n(autoPolicy(NumTri(), 1e4), countAt(0), NumTri(), [&](int tri) {

--- a/src/edge_op.cpp
+++ b/src/edge_op.cpp
@@ -876,20 +876,20 @@ bool Manifold::Impl::CollapseEdge(const int edge, Vec<int>& edges, double tol,
   vertPos_[startVert] = vec3(NAN);
   CollapseTri(tri1edge);
 
+  const int startProp0 = halfedge_.Prop(tri0edge[0]);
+  const int endProp0 = halfedge_.Prop(tri0edge[1]);
+  const int startProp1 = halfedge_.Prop(tri1edge[1]);
+  const int endProp1 = halfedge_.Prop(tri1edge[0]);
   // Orbit startVert
-  const int tri0 = edge / 3;
-  const int tri1 = pair / 3;
   current = start;
   while (current != tri0edge[2]) {
     current = NextHalfedge(current);
 
     if (NumProp() > 0) {
-      // Update the shifted triangles to the vertBary of endVert
-      const int tri = current / 3;
-      if (triRef[tri].SameFace(triRef[tri0])) {
-        halfedge_.SetProp(current, halfedge_.Prop(NextHalfedge(edge)));
-      } else if (triRef[tri].SameFace(triRef[tri1])) {
-        halfedge_.SetProp(current, halfedge_.Prop(pair));
+      if (halfedge_.Prop(current) == startProp0) {
+        halfedge_.SetProp(current, endProp0);
+      } else if (halfedge_.Prop(current) == startProp1) {
+        halfedge_.SetProp(current, endProp1);
       }
     }
 
@@ -1065,62 +1065,14 @@ void Manifold::Impl::RecursiveEdgeSwap(const int edge, int& tag,
     v[i] = projection * vertPos_[halfedge_.Start(tri0edge[i])];
   v[3] = projection * vertPos_[halfedge_.Start(tri1edge[2])];
 
-  auto SwapEdge = [&]() {
-    // The 0-verts are swapped to the opposite 2-verts.
-    const int v0 = halfedge_.Start(tri0edge[2]);
-    const int v1 = halfedge_.Start(tri1edge[2]);
-    halfedge_.SetStart(tri0edge[0], v1);
-    halfedge_.SetEnd(tri0edge[2], v1);
-    halfedge_.SetStart(tri1edge[0], v0);
-    halfedge_.SetEnd(tri1edge[2], v0);
-    PairUp(tri0edge[0], halfedge_.Pair(tri1edge[2]));
-    PairUp(tri1edge[0], halfedge_.Pair(tri0edge[2]));
-    PairUp(tri0edge[2], tri1edge[2]);
-    // Both triangles are now subsets of the neighboring triangle.
-    const int tri0 = tri0edge[0] / 3;
-    const int tri1 = tri1edge[0] / 3;
-    faceNormal_[tri0] = faceNormal_[tri1];
-    triRef[tri0] = triRef[tri1];
-    const double l01 = la::length(v[1] - v[0]);
-    const double l02 = la::length(v[2] - v[0]);
-    const double a = std::max(0.0, std::min(1.0, l02 / l01));
-    // Update properties if applicable
-    if (properties_.size() > 0) {
-      Vec<double>& prop = properties_;
-      halfedge_.SetProp(tri0edge[1], halfedge_.Prop(tri1edge[0]));
-      halfedge_.SetProp(tri0edge[0], halfedge_.Prop(tri1edge[2]));
-      halfedge_.SetProp(tri0edge[2], halfedge_.Prop(tri1edge[2]));
-      const int numProp = NumProp();
-      const int newProp = prop.size() / numProp;
-      const int propIdx0 = halfedge_.Prop(tri1edge[0]);
-      const int propIdx1 = halfedge_.Prop(tri1edge[1]);
-      for (int p = 0; p < numProp; ++p) {
-        prop.push_back(a * prop[numProp * propIdx0 + p] +
-                       (1 - a) * prop[numProp * propIdx1 + p]);
-      }
-      halfedge_.SetProp(tri1edge[0], newProp);
-      halfedge_.SetProp(tri0edge[2], newProp);
-    }
-
-    // if the new edge already exists, duplicate the verts and split the mesh.
-    int current = halfedge_.Pair(tri1edge[0]);
-    const int endVert = halfedge_.End(tri1edge[1]);
-    while (current != tri0edge[1]) {
-      current = NextHalfedge(current);
-      if (halfedge_.End(current) == endVert) {
-        FormLoop(tri0edge[2], current);
-        RemoveIfFolded(tri0edge[2]);
-        return;
-      }
-      current = halfedge_.Pair(current);
-    }
-  };
-
+  const double l01 = la::length(v[1] - v[0]);
+  const double l02 = la::length(v[2] - v[0]);
+  const double a = std::max(0.0, std::min(1.0, l02 / l01));
   // Only operate if the other triangles are not degenerate.
   if (CCW(v[1], v[0], v[3], tolerance_) <= 0) {
     if (!Is01Longest(v[1], v[0], v[3])) return;
     // Two facing, long-edge degenerates can swap.
-    SwapEdge();
+    SwapEdge(edge, a);
     const vec2 e23 = v[3] - v[2];
     if (la::dot(e23, e23) < tolerance_ * tolerance_) {
       tag++;
@@ -1138,7 +1090,7 @@ void Manifold::Impl::RecursiveEdgeSwap(const int edge, int& tag,
     return;
   }
   // Normal path
-  SwapEdge();
+  SwapEdge(edge, a);
   visited[edge] = tag;
   visited[pair] = tag;
   for (auto edge : {halfedge_.Pair(tri1edge[0]), halfedge_.Pair(tri0edge[1])})

--- a/src/edge_op.cpp
+++ b/src/edge_op.cpp
@@ -442,7 +442,7 @@ void Manifold::Impl::SimplifyTopology2() {
     //           << ", swapped: " << numSwapped
     //           << ", edges left: " << (end - edges.begin()) << ", "
     //           << itr - edges.begin() << std::endl;
-    // totalCollapsed += numCollapsed;
+    totalCollapsed += numCollapsed;
     if (numCollapsed == 0 && numSwapped == 0) break;
 
     for_each_n(autoPolicy(NumTri(), 1e4), countAt(0), NumTri(), [&](int tri) {

--- a/src/impl.h
+++ b/src/impl.h
@@ -244,7 +244,7 @@ struct Manifold::Impl {
                              bool = false);
 
   // smoothing.cpp
-  bool IsInsideQuad(int halfedge) const;
+  void MarkQuads();
   bool IsMarkedInsideQuad(int halfedge) const;
   vec3 GetNormal(int halfedge, int normalIdx) const;
   vec4 TangentFromNormal(const vec3& normal, int halfedge) const;

--- a/src/impl.h
+++ b/src/impl.h
@@ -244,7 +244,7 @@ struct Manifold::Impl {
                              bool = false);
 
   // smoothing.cpp
-  void MarkQuads();
+  void MarkQuads(const Vec<bool>& fixedHalfedge);
   bool IsMarkedInsideQuad(int halfedge) const;
   vec3 GetNormal(int halfedge, int normalIdx) const;
   vec4 TangentFromNormal(const vec3& normal, int halfedge) const;

--- a/src/impl.h
+++ b/src/impl.h
@@ -259,7 +259,7 @@ struct Manifold::Impl {
   void SharpenTangent(int halfedge, double smoothness);
   void SetNormals(int normalIdx, double minSharpAngle);
   void LinearizeFlatTangents();
-  void DistributeTangents(const Vec<bool>& fixedHalfedges);
+  void DistributeTangents(Vec<bool>& fixedHalfedges);
   void CreateTangents(int normalIdx);
   void CreateTangents(std::vector<Smoothness>,
                       ExecutionContext::Impl* ctx = nullptr);

--- a/src/manifold.cpp
+++ b/src/manifold.cpp
@@ -477,6 +477,18 @@ bool Manifold::MatchesTriNormals() const {
 }
 
 /**
+ * Returns true if properties are shared everywhere except across mesh
+ * boundaries. This is not true in general, but only because an input mesh may
+ * have property discontinuities. For simple input meshes where properties are
+ * 1:1 with verts, this HasSimpleProps condition should still be true after any
+ * combination of boolean operations and simplifications. CalculateNormals()
+ * will cause this to be false anytime the mesh contains a sharp edge.
+ */
+bool Manifold::HasSimpleProps() const {
+  return GetCsgLeafNode().GetImpl()->HasSimpleProps();
+}
+
+/**
  * The number of triangles that are colinear within Precision(). This library
  * attempts to remove all of these, but it cannot always remove all of them
  * without changing the mesh by too much.

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -247,7 +247,8 @@ int Manifold::Impl::NumDegenerateTris() const {
  * boundaries. This is not true in general, but only because an input mesh may
  * have property discontinuities. For simple input meshes where properties are
  * 1:1 with verts, this HasSimpleProps condition should still be true after any
- * combination of boolean operations and simplifications.
+ * combination of boolean operations and simplifications. CalculateNormals()
+ * will cause this to be false anytime the mesh contains a sharp edge.
  */
 bool Manifold::Impl::HasSimpleProps() const {
   if (halfedge_.size() == 0 || NumProp() == 0) return true;

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -854,7 +854,10 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
             e,
             [normalIdx, this](int halfedge) {
               const vec3 normal = GetNormal(halfedge, normalIdx);
-              return FlatNormal({normal == faceNormal_[halfedge / 3], normal});
+              return FlatNormal(
+                  {la::maxelem(la::abs(normal - faceNormal_[halfedge / 3])) <
+                       std::numeric_limits<double>::epsilon(),
+                   normal});
             },
             [&](int halfedge, const FlatNormal& here, const FlatNormal& next) {
               // Tangents not known at first are used as temporary storage for

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -721,12 +721,12 @@ void Manifold::Impl::LinearizeFlatTangents() {
  * operated on. If there is only one, then that halfedge is not treated as
  * fixed, but the whole circle is turned to an average orientation.
  */
-void Manifold::Impl::DistributeTangents(const Vec<bool>& fixedHalfedges) {
+void Manifold::Impl::DistributeTangents(Vec<bool>& fixedHalfedges) {
   const int numHalfedge = fixedHalfedges.size();
   for_each_n(
       autoPolicy(numHalfedge, 1e4), countAt(0), numHalfedge,
       [this, &fixedHalfedges](int halfedge) {
-        if (!fixedHalfedges[halfedge] || IsMarkedInsideQuad(halfedge)) return;
+        if (!fixedHalfedges[halfedge]) return;
 
         vec3 normal(0.0);
         Vec<double> currentAngle;
@@ -742,7 +742,6 @@ void Manifold::Impl::DistributeTangents(const Vec<bool>& fixedHalfedges) {
         int current = halfedge;
         do {
           current = NextHalfedge(halfedge_.Pair(current));
-          if (IsMarkedInsideQuad(current)) continue;
           const vec3 thisEdgeVec =
               SafeNormalize(vertPos_[halfedge_.End(current)] - center);
           const vec3 thisTangent =
@@ -769,11 +768,13 @@ void Manifold::Impl::DistributeTangents(const Vec<bool>& fixedHalfedges) {
 
         const double scale = currentAngle.back() / desiredAngle.back();
         double offset = 0;
+        bool unmarkFixed = false;
         if (current == halfedge) {  // only one - find average offset
           for (size_t i = 0; i < currentAngle.size(); ++i) {
             offset += Wrap(currentAngle[i] - scale * desiredAngle[i]);
           }
           offset /= currentAngle.size();
+          unmarkFixed = true;
         }
 
         current = halfedge;
@@ -781,7 +782,6 @@ void Manifold::Impl::DistributeTangents(const Vec<bool>& fixedHalfedges) {
         do {
           current = NextHalfedge(halfedge_.Pair(current));
           if (current != halfedge && fixedHalfedges[current]) break;
-          if (IsMarkedInsideQuad(current)) continue;
           desiredAngle[i] *= scale;
           const double lastAngle = i > 0 ? desiredAngle[i - 1] : 0;
           // shrink obtuse angles
@@ -800,6 +800,7 @@ void Manifold::Impl::DistributeTangents(const Vec<bool>& fixedHalfedges) {
           }
           ++i;
         } while (!fixedHalfedges[current]);
+        if (unmarkFixed) fixedHalfedges[halfedge] = false;
       });
 }
 
@@ -916,6 +917,10 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
                 halfedgeTangent_[current] =
                     TangentFromNormal(prevNormal, current);
               } else {
+                // tangents at the intersection of two normals are fixed.
+                fixedHalfedge[current] = true;
+                // Override the flat face logic if more than one normal.
+                faceEdges[0] = -2;
                 const vec3 dir = la::cross(prevNormal, nextNormal);
                 const vec3 edgeVec = vertPos_[halfedge_.End(current)] -
                                      vertPos_[halfedge_.Start(current)];

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -372,7 +372,8 @@ void Manifold::Impl::MarkQuads(const Vec<bool>& fixedHalfedge) {
  * halfedge tangent having negative weight.
  */
 bool Manifold::Impl::IsMarkedInsideQuad(int halfedge) const {
-  return halfedgeTangent_.size() > 0 && halfedgeTangent_[halfedge].w < 0;
+  return halfedgeTangent_.size() > 0 &&
+         halfedgeTangent_[halfedge].w == kInsideQuad;
 }
 
 // sharpenedEdges are referenced to the input Mesh, but the triangles have
@@ -1058,7 +1059,7 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges,
             if (current == second) {
               smoothness =
                   (vert[1].second.smoothness + vert[0].first.smoothness) / 2;
-            } else if (current != first && !IsMarkedInsideQuad(current)) {
+            } else if (current != first) {
               SharpenTangent(current, smoothness);
             }
           });

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -719,7 +719,8 @@ void Manifold::Impl::LinearizeFlatTangents() {
  * edges. This avoids folding the output shape and gives smoother results. There
  * must be at least one fixed halfedge on a vertex for that vertex to be
  * operated on. If there is only one, then that halfedge is not treated as
- * fixed, but the whole circle is turned to an average orientation.
+ * fixed, but the whole circle is turned to an average orientation, and this
+ * halfedge is unmarked as fixed so it doesn't affect MarkQuads().
  */
 void Manifold::Impl::DistributeTangents(Vec<bool>& fixedHalfedges) {
   const int numHalfedge = fixedHalfedges.size();
@@ -833,6 +834,25 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
         int startHalfedge = -1;
         vec3 lastNormal(0.0);
 
+        auto calculateTangent = [&](int halfedge, vec3 prevNormal,
+                                    vec3 nextNormal) {
+          if (EqualNormals(nextNormal, prevNormal)) {
+            halfedgeTangent_[halfedge] =
+                TangentFromNormal(prevNormal, halfedge);
+          } else {
+            // tangents at the intersection of two normals are fixed.
+            fixedHalfedge[halfedge] = true;
+            // Override the flat face logic if more than one normal.
+            faceEdges[0] = -2;
+
+            const vec3 edgeVec = vertPos_[halfedge_.End(halfedge)] -
+                                 vertPos_[halfedge_.Start(halfedge)];
+            const vec3 dir = la::cross(prevNormal, nextNormal);
+            halfedgeTangent_[halfedge] = CircularTangent(
+                (la::dot(dir, edgeVec) < 0 ? -1.0 : 1.0) * dir, edgeVec);
+          }
+        };
+
         ForVert<FlatNormal>(
             e,
             [normalIdx, this](int halfedge) {
@@ -871,22 +891,7 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
                 return;
               }
 
-              // calculate tangents
-              if (EqualNormals(next.normal, here.normal)) {
-                halfedgeTangent_[halfedge] =
-                    TangentFromNormal(here.normal, halfedge);
-              } else {
-                // tangents at the intersection of two normals are fixed.
-                fixedHalfedge[halfedge] = true;
-                // Override the flat face logic if more than one normal.
-                faceEdges[0] = -2;
-
-                const vec3 edgeVec = vertPos_[halfedge_.End(halfedge)] -
-                                     vertPos_[halfedge_.Start(halfedge)];
-                const vec3 dir = la::cross(here.normal, next.normal);
-                halfedgeTangent_[halfedge] = CircularTangent(
-                    (la::dot(dir, edgeVec) < 0 ? -1.0 : 1.0) * dir, edgeVec);
-              }
+              calculateTangent(halfedge, here.normal, next.normal);
             });
 
         if (startHalfedge != -1 && lastNormal == vec3(0.)) {
@@ -913,20 +918,7 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
                 nextNormal = lastNormal;
               }
 
-              if (EqualNormals(prevNormal, nextNormal)) {
-                halfedgeTangent_[current] =
-                    TangentFromNormal(prevNormal, current);
-              } else {
-                // tangents at the intersection of two normals are fixed.
-                fixedHalfedge[current] = true;
-                // Override the flat face logic if more than one normal.
-                faceEdges[0] = -2;
-                const vec3 dir = la::cross(prevNormal, nextNormal);
-                const vec3 edgeVec = vertPos_[halfedge_.End(current)] -
-                                     vertPos_[halfedge_.Start(current)];
-                halfedgeTangent_[current] = CircularTangent(
-                    (la::dot(dir, edgeVec) < 0 ? -1.0 : 1.0) * dir, edgeVec);
-              }
+              calculateTangent(current, prevNormal, nextNormal);
             }
             vec3 currentNormal = GetNormal(current, normalIdx);
             if (currentNormal != vec3(0.)) {

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -42,6 +42,9 @@ double Wrap(double radians) {
 // Floating point noise in the dihedral angle computation can reach ~1e-6
 // degrees for nearly-parallel face normals; this threshold must exceed that.
 constexpr double kMinSharpAngle = 1e-4;
+// special flags for tangent.w
+constexpr double kInsideQuad = -1;
+constexpr double kMissingNormal = -3;
 
 // Get the angle between two unit-vectors.
 double AngleBetween(vec3 a, vec3 b) {
@@ -302,34 +305,59 @@ vec4 Manifold::Impl::TangentFromNormal(const vec3& normal, int halfedge) const {
 }
 
 /**
- * Returns true if this halfedge should be marked as the interior of a quad, as
- * defined by its two triangles referring to the same face, and those triangles
- * having no further face neighbors beyond.
- */
-bool Manifold::Impl::IsInsideQuad(int halfedge) const {
-  if (halfedgeTangent_.size() > 0) {
-    return halfedgeTangent_[halfedge].w < 0;
-  }
-  const int tri = halfedge / 3;
-  const TriRef ref = meshRelation_.triRef[tri];
-  const int pair = halfedge_.Pair(halfedge);
-  const int pairTri = pair / 3;
-  const TriRef pairRef = meshRelation_.triRef[pairTri];
-  if (!ref.SameFace(pairRef)) return false;
+Greedily marks pairs of triangles as quads, using a cost based on the four
+corner angles. A rectangle has zero cost, as does a symmetric trapezoid, while a
+parallelogram has positive cost. Two equilateral triangles have cost == 2.0,
+so we only allow a quad when cost < 1.0.
+*/
+void Manifold::Impl::MarkQuads() {
+  ZoneScoped;
+  halfedgeTangent_.resize(halfedge_.size(), vec4(0.));
+  Vec<vec3> edgeDir(halfedge_.size());
+  for_each_n(autoPolicy(edgeDir.size(), 1e5), countAt(0), edgeDir.size(),
+             [this, &edgeDir](int edge) {
+               if (!halfedge_.IsForward(edge)) return;
+               edgeDir[edge] = SafeNormalize(vertPos_[halfedge_.End(edge)] -
+                                             vertPos_[halfedge_.Start(edge)]);
+               edgeDir[halfedge_.Pair(edge)] = -edgeDir[edge];
+             });
 
-  auto SameFace = [this](int halfedge, const TriRef& ref) {
-    return ref.SameFace(meshRelation_.triRef[halfedge_.Pair(halfedge) / 3]);
+  struct EdgeInfo {
+    int halfedge;
+    double cost;
   };
+  Vec<EdgeInfo> edgeInfo(halfedge_.size(),
+                         {-1, std::numeric_limits<double>::infinity()});
+  for_each_n(autoPolicy(edgeInfo.size(), 1e5), countAt(0), edgeInfo.size(),
+             [this, &edgeInfo, &edgeDir](int edge) {
+               if (!halfedge_.IsForward(edge)) return;
+               const int pair = halfedge_.Pair(edge);
+               const ivec4 quad = {NextHalfedge(edge), PrevHalfedge(edge),
+                                   NextHalfedge(pair), PrevHalfedge(pair)};
+               const double cost =
+                   std::abs(la::dot(edgeDir[quad[0]], edgeDir[quad[1]]) +
+                            la::dot(edgeDir[quad[2]], edgeDir[quad[3]])) +
+                   std::abs(la::dot(edgeDir[quad[0]], edgeDir[quad[3]]) +
+                            la::dot(edgeDir[quad[2]], edgeDir[quad[1]]));
+               if (cost < 1) edgeInfo[edge] = {edge, cost};
+             });
 
-  int neighbor = NextHalfedge(halfedge);
-  if (SameFace(neighbor, ref)) return false;
-  neighbor = NextHalfedge(neighbor);
-  if (SameFace(neighbor, ref)) return false;
-  neighbor = NextHalfedge(pair);
-  if (SameFace(neighbor, pairRef)) return false;
-  neighbor = NextHalfedge(neighbor);
-  if (SameFace(neighbor, pairRef)) return false;
-  return true;
+  stable_sort(
+      edgeInfo.begin(), edgeInfo.end(),
+      [](const EdgeInfo& a, const EdgeInfo& b) { return a.cost < b.cost; });
+
+  for (const EdgeInfo& info : edgeInfo) {
+    if (info.halfedge < 0) break;
+    const int edge = info.halfedge;
+    const int pair = halfedge_.Pair(edge);
+    if (IsMarkedInsideQuad(NextHalfedge(edge)) ||
+        IsMarkedInsideQuad(PrevHalfedge(edge)) ||
+        IsMarkedInsideQuad(NextHalfedge(pair)) ||
+        IsMarkedInsideQuad(PrevHalfedge(pair)))
+      continue;
+    halfedgeTangent_[edge] = {0, 0, 0, kInsideQuad};
+    halfedgeTangent_[pair] = {0, 0, 0, kInsideQuad};
+  }
 }
 
 /**
@@ -782,13 +810,8 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
   ZoneScoped;
   const int numVert = NumVert();
   const int numHalfedge = halfedge_.size();
-  halfedgeTangent_.clear();
-  Vec<vec4> tangent(numHalfedge);
   Vec<bool> fixedHalfedge(numHalfedge, false);
-
-  // special flags for tangent.w
-  constexpr double kInsideQuad = -1;
-  constexpr double kMissingNormal = -3;
+  MarkQuads();
 
   Vec<int> vertHalfedge = VertHalfedge();
   for_each_n(
@@ -813,8 +836,6 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
               // Tangents not known at first are used as temporary storage for
               // normals and w is set to a negative flag value. This starts with
               // the flag clear.
-              tangent[halfedge].w = 1;
-
               if (here.isFlatFace != next.isFlatFace) {
                 // Record the two halfedges that border a single flat face.
                 if (faceEdges[0] == -1) {
@@ -834,17 +855,20 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
                 } else {  // both missing
                   if (startHalfedge < 0) startHalfedge = -2;
                 }
-                tangent[halfedge] = {lastNormal, kMissingNormal};
+                if (halfedgeTangent_[halfedge].w != kInsideQuad)
+                  halfedgeTangent_[halfedge].w = kMissingNormal;
               }
 
-              if (IsInsideQuad(halfedge))
-                tangent[halfedge] = {lastNormal, kInsideQuad};
-
-              if (tangent[halfedge].w < 0) return;
+              if (halfedgeTangent_[halfedge].w < 0) {
+                for (const int i : {0, 1, 2})
+                  halfedgeTangent_[halfedge][i] = lastNormal[i];
+                return;
+              }
 
               // calculate tangents
               if (EqualNormals(next.normal, here.normal)) {
-                tangent[halfedge] = TangentFromNormal(here.normal, halfedge);
+                halfedgeTangent_[halfedge] =
+                    TangentFromNormal(here.normal, halfedge);
               } else {
                 // tangents at the intersection of two normals are fixed.
                 fixedHalfedge[halfedge] = true;
@@ -854,7 +878,7 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
                 const vec3 edgeVec = vertPos_[halfedge_.End(halfedge)] -
                                      vertPos_[halfedge_.Start(halfedge)];
                 const vec3 dir = la::cross(here.normal, next.normal);
-                tangent[halfedge] = CircularTangent(
+                halfedgeTangent_[halfedge] = CircularTangent(
                     (la::dot(dir, edgeVec) < 0 ? -1.0 : 1.0) * dir, edgeVec);
               }
             });
@@ -863,8 +887,8 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
           // Use vert pseudo normal if no normals are present at all.
           const vec3 normal = vertNormal_[halfedge_.Start(e)];
           ForVert(e, [&](int halfedge) {
-            if (tangent[halfedge].w != kInsideQuad)
-              tangent[halfedge] = TangentFromNormal(normal, halfedge);
+            if (halfedgeTangent_[halfedge].w != kInsideQuad)
+              halfedgeTangent_[halfedge] = TangentFromNormal(normal, halfedge);
           });
           return;
         }
@@ -878,19 +902,20 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
           do {
             DEBUG_ASSERT(prevNormal != vec3(0.), logicErr,
                          "missing prevNormal");
-            if (tangent[current].w == kMissingNormal) {
-              vec3 nextNormal = tangent[current].xyz();
+            if (halfedgeTangent_[current].w == kMissingNormal) {
+              vec3 nextNormal = halfedgeTangent_[current].xyz();
               if (nextNormal == vec3(0.)) {
                 nextNormal = lastNormal;
               }
 
               if (EqualNormals(prevNormal, nextNormal)) {
-                tangent[current] = TangentFromNormal(prevNormal, current);
+                halfedgeTangent_[current] =
+                    TangentFromNormal(prevNormal, current);
               } else {
                 const vec3 dir = la::cross(prevNormal, nextNormal);
                 const vec3 edgeVec = vertPos_[halfedge_.End(current)] -
                                      vertPos_[halfedge_.Start(current)];
-                tangent[current] = CircularTangent(
+                halfedgeTangent_[current] = CircularTangent(
                     (la::dot(dir, edgeVec) < 0 ? -1.0 : 1.0) * dir, edgeVec);
               }
             }
@@ -912,15 +937,14 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
           const vec3 edge1 = vertPos_[halfedge_.End(faceEdges[1])] -
                              vertPos_[halfedge_.Start(faceEdges[1])];
           const vec3 newTangent = la::normalize(edge0) - la::normalize(edge1);
-          tangent[faceEdges[0]] = CircularTangent(newTangent, edge0);
-          tangent[faceEdges[1]] = CircularTangent(-newTangent, edge1);
+          halfedgeTangent_[faceEdges[0]] = CircularTangent(newTangent, edge0);
+          halfedgeTangent_[faceEdges[1]] = CircularTangent(-newTangent, edge1);
           // Fix these tangents to keep them even to the edges.
           fixedHalfedge[faceEdges[0]] = true;
           fixedHalfedge[faceEdges[1]] = true;
         }
       });
 
-  halfedgeTangent_ = std::move(tangent);
   DistributeTangents(fixedHalfedge);
 }
 
@@ -937,8 +961,6 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges,
                                     ExecutionContext::Impl* ctx) {
   ZoneScoped;
   const int numHalfedge = halfedge_.size();
-  halfedgeTangent_.clear();
-  Vec<vec4> tangent(numHalfedge);
   Vec<bool> fixedHalfedge(numHalfedge, false);
 
   Vec<int> vertHalfedge = VertHalfedge();
@@ -952,16 +974,15 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges,
   }
   ADVANCE_PHASE_OR_RETURN(ctx);
 
+  MarkQuads();
+
   for_each_n(autoPolicy(numHalfedge, 1e4), countAt(0), numHalfedge, ctx,
-             [&tangent, &vertNormal, this](const int edgeIdx) {
-               tangent[edgeIdx] =
-                   IsInsideQuad(edgeIdx)
-                       ? vec4(0, 0, 0, -1)
-                       : TangentFromNormal(vertNormal[halfedge_.Start(edgeIdx)],
-                                           edgeIdx);
+             [&vertNormal, this](const int edgeIdx) {
+               if (!IsMarkedInsideQuad(edgeIdx))
+                 halfedgeTangent_[edgeIdx] = TangentFromNormal(
+                     vertNormal[halfedge_.Start(edgeIdx)], edgeIdx);
              });
 
-  halfedgeTangent_ = std::move(tangent);
   ADVANCE_PHASE_OR_RETURN(ctx);
 
   // Add sharpened edges around faces, just on the face side.

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -822,14 +822,19 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
   Vec<int> vertHalfedge = VertHalfedge();
   for_each_n(
       autoPolicy(numVert, 1e4), vertHalfedge.begin(), numVert, [&](int e) {
-        struct FlatNormal {
-          bool isFlatFace;
-          vec3 normal;
-        };
-
         ivec2 faceEdges(-1, -1);
         int startHalfedge = -1;
         vec3 lastNormal(0.0);
+
+        auto markToAlign = [&](int halfedge) {
+          if (faceEdges[0] == -1) {
+            faceEdges[0] = halfedge;
+          } else if (faceEdges[1] == -1) {
+            faceEdges[1] = halfedge;
+          } else {
+            faceEdges[0] = -2;
+          }
+        };
 
         auto calculateTangent = [&](int halfedge, vec3 prevNormal,
                                     vec3 nextNormal) {
@@ -850,48 +855,32 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
           }
         };
 
-        ForVert<FlatNormal>(
+        ForVert<vec3>(
             e,
             [normalIdx, this](int halfedge) {
-              const vec3 normal = GetNormal(halfedge, normalIdx);
-              return FlatNormal(
-                  {la::maxelem(la::abs(normal - faceNormal_[halfedge / 3])) <
-                       std::numeric_limits<double>::epsilon(),
-                   normal});
+              return GetNormal(halfedge, normalIdx);
             },
-            [&](int halfedge, const FlatNormal& here, const FlatNormal& next) {
+            [&](int halfedge, const vec3& here, const vec3& next) {
               // Tangents not known at first are used as temporary storage for
               // normals and w is set to a negative flag value. This starts with
               // the flag clear.
-              if (here.isFlatFace != next.isFlatFace) {
-                // Record the two halfedges that border a single flat face.
-                if (faceEdges[0] == -1) {
-                  faceEdges[0] = halfedge;
-                } else if (faceEdges[1] == -1) {
-                  faceEdges[1] = halfedge;
-                } else {
-                  faceEdges[0] = -2;
-                }
-              }
-
-              if (next.normal == vec3(0.) || here.normal == vec3(0.)) {
-                if (here.normal != vec3(0.)) {  // next missing
-                  lastNormal = here.normal;
-                } else if (next.normal != vec3(0.)) {  // here missing
+              if (next == vec3(0.) || here == vec3(0.)) {
+                if (here != vec3(0.)) {  // next missing
+                  markToAlign(halfedge);
+                  lastNormal = here;
+                } else if (next != vec3(0.)) {  // here missing
+                  markToAlign(halfedge);
                   if (startHalfedge < 0) startHalfedge = halfedge;
                 } else {  // both missing
                   if (startHalfedge < 0) startHalfedge = -2;
                 }
                 halfedgeTangent_[halfedge].w = kMissingNormal;
-              }
-
-              if (halfedgeTangent_[halfedge].w < 0) {
                 for (const int i : {0, 1, 2})
                   halfedgeTangent_[halfedge][i] = lastNormal[i];
                 return;
               }
 
-              calculateTangent(halfedge, here.normal, next.normal);
+              calculateTangent(halfedge, here, next);
             });
 
         if (startHalfedge != -1 && lastNormal == vec3(0.)) {

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -338,7 +338,8 @@ void Manifold::Impl::MarkQuads(const Vec<bool>& fixedHalfedge) {
                    la::dot(edgeDir[quad[2]], edgeDir[halfedge_.Pair(quad[1])])};
                const double cost = std::abs(points[0] + points[1]) +
                                    std::abs(points[2] + points[3]);
-               if (cost < 1 && la::maxelem(la::abs(points)) < sqrt(3) / 2) {
+               if (cost < std::sqrt(3) &&
+                   la::maxelem(la::abs(points)) < std::sqrt(3) / 2) {
                  edgeInfo[edge] = {edge, cost};
                }
              });
@@ -861,8 +862,7 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
                 } else {  // both missing
                   if (startHalfedge < 0) startHalfedge = -2;
                 }
-                if (halfedgeTangent_[halfedge].w != kInsideQuad)
-                  halfedgeTangent_[halfedge].w = kMissingNormal;
+                halfedgeTangent_[halfedge].w = kMissingNormal;
               }
 
               if (halfedgeTangent_[halfedge].w < 0) {
@@ -893,8 +893,7 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
           // Use vert pseudo normal if no normals are present at all.
           const vec3 normal = vertNormal_[halfedge_.Start(e)];
           ForVert(e, [&](int halfedge) {
-            if (halfedgeTangent_[halfedge].w != kInsideQuad)
-              halfedgeTangent_[halfedge] = TangentFromNormal(normal, halfedge);
+            halfedgeTangent_[halfedge] = TangentFromNormal(normal, halfedge);
           });
           return;
         }

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -310,16 +310,12 @@ corner angles. A rectangle has zero cost, as does a symmetric trapezoid, while a
 parallelogram has positive cost. Two equilateral triangles have cost == 2.0,
 so we only allow a quad when cost < 1.0.
 */
-void Manifold::Impl::MarkQuads() {
+void Manifold::Impl::MarkQuads(const Vec<bool>& fixedHalfedge) {
   ZoneScoped;
-  halfedgeTangent_.resize(halfedge_.size(), vec4(0.));
   Vec<vec3> edgeDir(halfedge_.size());
   for_each_n(autoPolicy(edgeDir.size(), 1e5), countAt(0), edgeDir.size(),
              [this, &edgeDir](int edge) {
-               if (!halfedge_.IsForward(edge)) return;
-               edgeDir[edge] = SafeNormalize(vertPos_[halfedge_.End(edge)] -
-                                             vertPos_[halfedge_.Start(edge)]);
-               edgeDir[halfedge_.Pair(edge)] = -edgeDir[edge];
+               edgeDir[edge] = SafeNormalize(halfedgeTangent_[edge].xyz());
              });
 
   struct EdgeInfo {
@@ -329,19 +325,29 @@ void Manifold::Impl::MarkQuads() {
   Vec<EdgeInfo> edgeInfo(halfedge_.size(),
                          {-1, std::numeric_limits<double>::infinity()});
   for_each_n(autoPolicy(edgeInfo.size(), 1e5), countAt(0), edgeInfo.size(),
-             [this, &edgeInfo, &edgeDir](int edge) {
+             [this, &edgeInfo, &edgeDir, &fixedHalfedge](int edge) {
                if (!halfedge_.IsForward(edge)) return;
                const int pair = halfedge_.Pair(edge);
+               if (fixedHalfedge[edge] || fixedHalfedge[pair]) return;
                const ivec4 quad = {NextHalfedge(edge), PrevHalfedge(edge),
                                    NextHalfedge(pair), PrevHalfedge(pair)};
-               const double cost =
-                   std::abs(la::dot(edgeDir[quad[0]], edgeDir[quad[1]]) +
-                            la::dot(edgeDir[quad[2]], edgeDir[quad[3]])) +
-                   std::abs(la::dot(edgeDir[quad[0]], edgeDir[quad[3]]) +
-                            la::dot(edgeDir[quad[2]], edgeDir[quad[1]]));
-               if (cost < 1) edgeInfo[edge] = {edge, cost};
+               const vec4 points = {
+                   la::dot(edgeDir[halfedge_.Pair(quad[0])], edgeDir[quad[1]]),
+                   la::dot(edgeDir[halfedge_.Pair(quad[2])], edgeDir[quad[3]]),
+                   la::dot(edgeDir[quad[0]], edgeDir[halfedge_.Pair(quad[3])]),
+                   la::dot(edgeDir[quad[2]], edgeDir[halfedge_.Pair(quad[1])])};
+               const double cost = std::abs(points[0] + points[1]) +
+                                   std::abs(points[2] + points[3]);
+               if (cost < 1 && la::maxelem(la::abs(points)) < sqrt(3) / 2) {
+                 edgeInfo[edge] = {edge, cost};
+               }
              });
 
+  edgeInfo.resize(
+      remove_if(autoPolicy(edgeInfo.size(), 1e5), edgeInfo.begin(),
+                edgeInfo.end(),
+                [](const EdgeInfo& info) { return info.halfedge < 0; }) -
+      edgeInfo.begin());
   stable_sort(
       edgeInfo.begin(), edgeInfo.end(),
       [](const EdgeInfo& a, const EdgeInfo& b) { return a.cost < b.cost; });
@@ -811,7 +817,7 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
   const int numVert = NumVert();
   const int numHalfedge = halfedge_.size();
   Vec<bool> fixedHalfedge(numHalfedge, false);
-  MarkQuads();
+  halfedgeTangent_.resize(numHalfedge, vec4(0.));
 
   Vec<int> vertHalfedge = VertHalfedge();
   for_each_n(
@@ -946,6 +952,7 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
       });
 
   DistributeTangents(fixedHalfedge);
+  MarkQuads(fixedHalfedge);
 }
 
 /**
@@ -961,6 +968,7 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges,
                                     ExecutionContext::Impl* ctx) {
   ZoneScoped;
   const int numHalfedge = halfedge_.size();
+  halfedgeTangent_.resize(numHalfedge, vec4(0.));
   Vec<bool> fixedHalfedge(numHalfedge, false);
 
   Vec<int> vertHalfedge = VertHalfedge();
@@ -974,13 +982,10 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges,
   }
   ADVANCE_PHASE_OR_RETURN(ctx);
 
-  MarkQuads();
-
   for_each_n(autoPolicy(numHalfedge, 1e4), countAt(0), numHalfedge, ctx,
              [&vertNormal, this](const int edgeIdx) {
-               if (!IsMarkedInsideQuad(edgeIdx))
-                 halfedgeTangent_[edgeIdx] = TangentFromNormal(
-                     vertNormal[halfedge_.Start(edgeIdx)], edgeIdx);
+               halfedgeTangent_[edgeIdx] = TangentFromNormal(
+                   vertNormal[halfedge_.Start(edgeIdx)], edgeIdx);
              });
 
   ADVANCE_PHASE_OR_RETURN(ctx);
@@ -1075,13 +1080,11 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges,
 
           ForVert(vert[0].first.halfedge,
                   [this, &triIsFlatFace, smoothness](int current) {
-                    if (!IsMarkedInsideQuad(current)) {
-                      const int pair = halfedge_.Pair(current);
-                      SharpenTangent(current, triIsFlatFace[current / 3] ||
-                                                      triIsFlatFace[pair / 3]
-                                                  ? 0
-                                                  : smoothness);
-                    }
+                    const int pair = halfedge_.Pair(current);
+                    SharpenTangent(current, triIsFlatFace[current / 3] ||
+                                                    triIsFlatFace[pair / 3]
+                                                ? 0
+                                                : smoothness);
                   });
         }
       });
@@ -1092,6 +1095,8 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges,
 
   DistributeTangents(fixedHalfedge);
   ADVANCE_PHASE_OR_RETURN(ctx);
+
+  MarkQuads(fixedHalfedge);
 }
 
 bool Manifold::Impl::ValidTangents() const {

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -52,10 +52,6 @@ double AngleBetween(vec3 a, vec3 b) {
   return dot >= 1 ? 0 : (dot <= -1 ? kPi : math::acos(dot));
 }
 
-bool EqualNormals(vec3 a, vec3 b) {
-  return la::dot(SafeNormalize(a), SafeNormalize(b)) > 0.9999;
-}
-
 // Calculate a tangent vector in the form of a weighted cubic Bezier taking as
 // input the desired tangent direction (length doesn't matter) and the edge
 // vector to the neighboring vertex. In a symmetric situation where the tangents
@@ -837,7 +833,7 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
 
         auto calculateTangent = [&](int halfedge, vec3 prevNormal,
                                     vec3 nextNormal) {
-          if (EqualNormals(nextNormal, prevNormal)) {
+          if (nextNormal == prevNormal) {
             halfedgeTangent_[halfedge] =
                 TangentFromNormal(prevNormal, halfedge);
           } else {

--- a/src/smoothing.cpp
+++ b/src/smoothing.cpp
@@ -836,8 +836,7 @@ void Manifold::Impl::CreateTangents(int normalIdx) {
             e,
             [normalIdx, this](int halfedge) {
               const vec3 normal = GetNormal(halfedge, normalIdx);
-              return FlatNormal(
-                  {EqualNormals(normal, faceNormal_[halfedge / 3]), normal});
+              return FlatNormal({normal == faceNormal_[halfedge / 3], normal});
             },
             [&](int halfedge, const FlatNormal& here, const FlatNormal& next) {
               // Tangents not known at first are used as temporary storage for
@@ -1093,9 +1092,8 @@ void Manifold::Impl::CreateTangents(std::vector<Smoothness> sharpenedEdges,
   ADVANCE_PHASE_OR_RETURN(ctx);
 
   DistributeTangents(fixedHalfedge);
-  ADVANCE_PHASE_OR_RETURN(ctx);
-
   MarkQuads(fixedHalfedge);
+  ADVANCE_PHASE_OR_RETURN(ctx);
 }
 
 bool Manifold::Impl::ValidTangents() const {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,8 +33,8 @@ set(
   hull_test.cpp
   samples_test.cpp
   boolean_complex_test.cpp
-  boolean2_test.cpp
   cross_section_test.cpp
+  cross_section_complex_test.cpp
   cross_section_offset_corpus_test.cpp
   $<$<BOOL:${MANIFOLD_CBIND}>:manifoldc_test.cpp>
 )

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -349,6 +349,18 @@ TEST(Boolean, CreatePropertiesSlow) {
   EXPECT_EQ(result.NumProp(), 3);
 }
 
+TEST(Boolean, SimpleProperties) {
+  Manifold cube = Manifold::Cube(vec3(2), true).CalculateNormals(0, 180);
+  EXPECT_TRUE(cube.HasSimpleProps());
+  Manifold flange = Manifold::Extrude(cube.Slice(), 1, 0, 0, vec2(2));
+  EXPECT_TRUE(flange.HasSimpleProps());
+  Manifold result = cube + flange;
+  EXPECT_EQ(result.NumProp(), 3);
+  EXPECT_NEAR(result.Volume(), 13.3333, 0.0001);
+  EXPECT_EQ(result.NumVert(), 16);
+  EXPECT_TRUE(result.HasSimpleProps());
+}
+
 /**
  * These tests check Boolean operations on coplanar faces.
  */

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -352,11 +352,11 @@ TEST(Boolean, CreatePropertiesSlow) {
 TEST(Boolean, SimpleProperties) {
   Manifold cube = Manifold::Cube(vec3(2), true).CalculateNormals(0, 180);
   EXPECT_TRUE(cube.HasSimpleProps());
-  Manifold flange = Manifold::Extrude(cube.Slice(), 1, 0, 0, vec2(2));
+  Manifold flange = Manifold::Extrude(cube.Slice(), 2, 0, 0, vec2(2));
   EXPECT_TRUE(flange.HasSimpleProps());
   Manifold result = cube + flange;
   EXPECT_EQ(result.NumProp(), 3);
-  EXPECT_NEAR(result.Volume(), 13.3333, 0.0001);
+  EXPECT_NEAR(result.Volume(), 22.6666, 0.0001);
   EXPECT_EQ(result.NumVert(), 16);
   EXPECT_TRUE(result.HasSimpleProps());
 }

--- a/test/context_test.cpp
+++ b/test/context_test.cpp
@@ -32,7 +32,7 @@
 using namespace manifold;
 
 // A CSG tree with N leaves reduces to 1 result in N-1 combinations.
-TEST(Manifold, ExecutionContextProgress) {
+TEST(Context, ExecutionContextProgress) {
   // Build a tree with 5 leaves: a union of 5 cubes.
   std::vector<Manifold> items;
   for (int i = 0; i < 5; i++) {
@@ -49,7 +49,7 @@ TEST(Manifold, ExecutionContextProgress) {
 
 // Forcing evaluation first, then observing with a fresh context, should
 // report no pending work: the Manifold is already a leaf.
-TEST(Manifold, ExecutionContextAlreadyEvaluated) {
+TEST(Context, ExecutionContextAlreadyEvaluated) {
   Manifold u = Manifold::Cube(vec3(1), true) + Manifold::Cube(vec3(1), true);
   // Force evaluation.
   EXPECT_EQ(u.Status(), Manifold::Error::NoError);
@@ -62,7 +62,7 @@ TEST(Manifold, ExecutionContextAlreadyEvaluated) {
 
 // Setting cancel before calling Status(ctx) should return Cancelled
 // without doing any work.
-TEST(Manifold, ExecutionContextCancelBeforeEval) {
+TEST(Context, ExecutionContextCancelBeforeEval) {
   std::vector<Manifold> items;
   for (int i = 0; i < 10; i++) {
     items.push_back(Manifold::Sphere(1.0, 32).Translate(vec3(i * 0.5, 0, 0)));
@@ -83,7 +83,7 @@ TEST(Manifold, ExecutionContextCancelBeforeEval) {
 // — cancellation mid-evaluation isn't meaningful there anyway since the
 // eval is synchronous.
 #if MANIFOLD_PAR == 1
-TEST(Manifold, ExecutionContextCancelConcurrent) {
+TEST(Context, ExecutionContextCancelConcurrent) {
   // Build a large enough tree that evaluation takes measurable time.
   std::vector<Manifold> items;
   for (int i = 0; i < 50; i++) {
@@ -121,7 +121,7 @@ TEST(Manifold, ExecutionContextCancelConcurrent) {
 // single boolean would run to completion. With phase-boundary checks, cancel
 // requested mid-way is honored.
 #if MANIFOLD_PAR == 1
-TEST(Manifold, ExecutionContextCancelMidBoolean) {
+TEST(Context, ExecutionContextCancelMidBoolean) {
   // One big boolean — N-1 = 1 op, so outer-loop cancel only has a single
   // checkpoint. The work itself (two large spheres overlapping) takes long
   // enough that cancel fires reliably while Boolean3 is running.
@@ -147,7 +147,7 @@ TEST(Manifold, ExecutionContextCancelMidBoolean) {
 #endif  // MANIFOLD_PAR == 1
 
 // Status() and Status(ctx) should return identical results when no cancel.
-TEST(Manifold, ExecutionContextMatchesPlainStatus) {
+TEST(Context, ExecutionContextMatchesPlainStatus) {
   Manifold u = (Manifold::Cube(vec3(1), true) + Manifold::Sphere(1.0, 32)) -
                Manifold::Tetrahedron();
 
@@ -166,7 +166,7 @@ TEST(Manifold, ExecutionContextMatchesPlainStatus) {
 }
 
 // N-1 invariant holds for Subtract trees too.
-TEST(Manifold, ExecutionContextProgressSubtract) {
+TEST(Context, ExecutionContextProgressSubtract) {
   // Tree shape: (cube + sphere) - tet - octahedron
   Manifold u = (Manifold::Cube(vec3(1), true) + Manifold::Sphere(1.0, 16)) -
                Manifold::Tetrahedron() - Manifold::Cube(vec3(0.5), true);
@@ -179,7 +179,7 @@ TEST(Manifold, ExecutionContextProgressSubtract) {
 
 // Reusing the same context for two sequential evaluations should reset
 // doneBooleans so Progress is always in [0, 1].
-TEST(Manifold, ExecutionContextReuse) {
+TEST(Context, ExecutionContextReuse) {
   auto makeTree = [](int n) {
     std::vector<Manifold> items;
     for (int i = 0; i < n; i++) {
@@ -204,7 +204,7 @@ TEST(Manifold, ExecutionContextReuse) {
 
 // Cancel is permanent: once fired, Status on that Manifold stays Cancelled
 // even when called without a context.
-TEST(Manifold, ExecutionContextCancelPermanent) {
+TEST(Context, ExecutionContextCancelPermanent) {
   std::vector<Manifold> items;
   for (int i = 0; i < 30; i++) {
     items.push_back(Manifold::Sphere(1.0, 48).Translate(vec3(i * 0.3, 0, 0)));
@@ -225,7 +225,7 @@ TEST(Manifold, ExecutionContextCancelPermanent) {
 
 // Once a context is cancelled it stays cancelled for any future evaluation
 // through it — not just the Manifold in flight at the time of Cancel().
-TEST(Manifold, ExecutionContextCancelStickyAcrossManifolds) {
+TEST(Context, ExecutionContextCancelStickyAcrossManifolds) {
   ExecutionContext ctx;
   ctx.Cancel();
 
@@ -242,7 +242,7 @@ TEST(Manifold, ExecutionContextCancelStickyAcrossManifolds) {
 
 // A cancelled ctx does NOT contaminate a fresh context: constructing a new
 // ExecutionContext gives an evaluation that can complete normally.
-TEST(Manifold, ExecutionContextFreshContextEscapesCancel) {
+TEST(Context, ExecutionContextFreshContextEscapesCancel) {
   ExecutionContext cancelledCtx;
   cancelledCtx.Cancel();
   Manifold dead = Manifold::Cube() + Manifold::Sphere(0.5);
@@ -259,7 +259,7 @@ TEST(Manifold, ExecutionContextFreshContextEscapesCancel) {
 // evaluation needed) returns the Manifold's real status — cancel only
 // applies when there is actual evaluation work to short-circuit. This
 // matches the docstring phrasing "every subsequent evaluation".
-TEST(Manifold, ExecutionContextCancelSkippedOnLeaf) {
+TEST(Context, ExecutionContextCancelSkippedOnLeaf) {
   Manifold cube = Manifold::Cube();  // CsgLeafNode from the start
   ExecutionContext ctx;
   ctx.Cancel();
@@ -269,7 +269,7 @@ TEST(Manifold, ExecutionContextCancelSkippedOnLeaf) {
 // Progress is observable from another thread while evaluation runs.
 // MANIFOLD_PAR guard: see note on ExecutionContextCancelConcurrent above.
 #if MANIFOLD_PAR == 1
-TEST(Manifold, ExecutionContextConcurrentProgress) {
+TEST(Context, ExecutionContextConcurrentProgress) {
   std::vector<Manifold> items;
   for (int i = 0; i < 30; i++) {
     items.push_back(Manifold::Sphere(1.0, 48).Translate(vec3(i * 0.5, 0, 0)));
@@ -305,7 +305,7 @@ TEST(Manifold, ExecutionContextConcurrentProgress) {
 // Boolean3::Result before any phase() site executes. The PhaseBalance scope
 // guard must still credit a full kPhasesPerBoolean phases on those returns
 // so Progress() reaches 1.0 after a sequence of no-op evaluations.
-TEST(Manifold, ExecutionContextProgressReachesOneOnTrivialBooleans) {
+TEST(Context, ExecutionContextProgressReachesOneOnTrivialBooleans) {
   ExecutionContext ctx;
   // Boolean of empty + cube: Boolean3::Result takes the IsEmpty fast-path.
   Manifold result = Manifold() + Manifold::Cube();
@@ -320,7 +320,7 @@ TEST(Manifold, ExecutionContextProgressReachesOneOnTrivialBooleans) {
 // Sub-Boolean granularity: within a single Boolean3 op, Progress() should
 // observably advance through phases (donePhases > 0 while doneBooleans == 0).
 // MANIFOLD_PAR guard: same as above, polling thread requires std::thread.
-TEST(Manifold, ExecutionContextSubBooleanProgress) {
+TEST(Context, ExecutionContextSubBooleanProgress) {
   // A single nontrivial Boolean with a real intersection: NumLeaves == 2 ->
   // totalBooleans == 1, so doneBooleans only flips from 0 to 1 at the very
   // end. Any observed Progress() > 0 mid-eval comes from sub-Boolean phase
@@ -358,7 +358,7 @@ TEST(Manifold, ExecutionContextSubBooleanProgress) {
 
 // Calling Status(ctx) on an already-evaluated Manifold should reset counters,
 // not leave stale values from a previous evaluation on a different Manifold.
-TEST(Manifold, ExecutionContextNoStaleState) {
+TEST(Context, ExecutionContextNoStaleState) {
   Manifold complex = Manifold::BatchBoolean(
       {Manifold::Cube(vec3(1), true),
        Manifold::Cube(vec3(1), true).Translate(vec3(2, 0, 0)),
@@ -379,7 +379,7 @@ TEST(Manifold, ExecutionContextNoStaleState) {
 
 // ExecutionContext copies share state (pimpl semantics): one thread
 // evaluates, another thread holds a copy and observes the same progress.
-TEST(Manifold, ExecutionContextCopyShareState) {
+TEST(Context, ExecutionContextCopyShareState) {
   ExecutionContext ctx1;
   ExecutionContext ctx2 = ctx1;  // copy shares impl
 
@@ -396,7 +396,7 @@ TEST(Manifold, ExecutionContextCopyShareState) {
 }
 
 // Move construction and move assignment preserve shared state.
-TEST(Manifold, ExecutionContextMoveSemantics) {
+TEST(Context, ExecutionContextMoveSemantics) {
   ExecutionContext ctx1;
   ctx1.Cancel();
   ExecutionContext ctx2 = std::move(ctx1);  // move-construct
@@ -409,7 +409,7 @@ TEST(Manifold, ExecutionContextMoveSemantics) {
 }
 
 // A Manifold that's already a leaf (no CSG tree) should report no work.
-TEST(Manifold, ExecutionContextNoWorkNeeded) {
+TEST(Context, ExecutionContextNoWorkNeeded) {
   Manifold cube = Manifold::Cube(vec3(1), true);
   ExecutionContext ctx;
   EXPECT_EQ(cube.WithContext(ctx).Status(), Manifold::Error::NoError);
@@ -421,7 +421,7 @@ TEST(Manifold, ExecutionContextNoWorkNeeded) {
 
 // doneBooleans reaches totalBooleans exactly for many tree shapes — the N-1
 // invariant shouldn't depend on op type or tree shape.
-TEST(Manifold, ExecutionContextProgressInvariant) {
+TEST(Context, ExecutionContextProgressInvariant) {
   // Intersect
   {
     std::vector<Manifold> items{
@@ -469,7 +469,7 @@ TEST(Manifold, ExecutionContextProgressInvariant) {
 // must skip the entire range; cancel-unset must run every element. This
 // is the mechanism test; the integration test that cancel works
 // end-to-end on a real boolean is ExecutionContextCancelMidBoolean.
-TEST(Manifold, ForEachCtxSkipsWhenCancelled) {
+TEST(Context, ForEachCtxSkipsWhenCancelled) {
   ExecutionContext ctx;
   ctx.Cancel();
   std::atomic<int> calls{0};
@@ -481,7 +481,7 @@ TEST(Manifold, ForEachCtxSkipsWhenCancelled) {
 }
 
 // Nullptr ctx: must not crash and must invoke the functor for every element.
-TEST(Manifold, ForEachCtxNullCtxPassesThrough) {
+TEST(Context, ForEachCtxNullCtxPassesThrough) {
   std::atomic<int> calls{0};
   Vec<int> range(10);
   sequence(range.begin(), range.end());
@@ -494,7 +494,7 @@ TEST(Manifold, ForEachCtxNullCtxPassesThrough) {
 // Cancel set mid-iteration must be observed within bounded latency
 // (kSeqCancelChunk = 1024 in parallel.h). Functor cancels after 100
 // calls; total calls must be < N + 1024 (= 100 + at most one full chunk).
-TEST(Manifold, ForEachCtxCancelMidSeqLoop) {
+TEST(Context, ForEachCtxCancelMidSeqLoop) {
   ExecutionContext ctx;
   std::atomic<int> calls{0};
   constexpr int N = 10000;
@@ -514,7 +514,7 @@ TEST(Manifold, ForEachCtxCancelMidSeqLoop) {
 // are sequential and unique; keys are scrambled by a multiplicative hash
 // so the input isn't already sorted by key. std::stable_sort is the
 // oracle.
-TEST(Manifold, ParallelStableSortStability) {
+TEST(Context, ParallelStableSortStability) {
   constexpr size_t kN = 50000;  // > kSeqThreshold to hit parallel
   constexpr size_t kBucketSizes[] = {kN, kN / 2, kN / 4, kN / 8, 1000, 100};
   for (size_t bucket : kBucketSizes) {
@@ -553,7 +553,7 @@ TEST(Manifold, ParallelStableSortStability) {
 
 // Raw copy preserves the attachment: ctx-attached on the source means
 // Status on the copy observes the same ctx.
-TEST(Manifold, ManifoldContextRawCopyPreservesAttachment) {
+TEST(Context, ManifoldContextRawCopyPreservesAttachment) {
   ExecutionContext ctx;
   Manifold u = Manifold::Cube(vec3(1), true) +
                Manifold::Cube(vec3(1), true).Translate(vec3(2, 0, 0));
@@ -566,7 +566,7 @@ TEST(Manifold, ManifoldContextRawCopyPreservesAttachment) {
 }
 
 // Assignment also preserves the attachment.
-TEST(Manifold, ManifoldContextAssignmentPreservesAttachment) {
+TEST(Context, ManifoldContextAssignmentPreservesAttachment) {
   ExecutionContext ctx;
   Manifold u = Manifold::Cube(vec3(1), true) +
                Manifold::Cube(vec3(1), true).Translate(vec3(2, 0, 0));
@@ -583,7 +583,7 @@ TEST(Manifold, ManifoldContextAssignmentPreservesAttachment) {
 // result. Verified behaviorally: a pre-cancelled ctx attached to the input
 // does not cancel the result's Status (the deferred op's result has no
 // ctx, so Status routes around it).
-TEST(Manifold, ManifoldContextDeferredOpsDropAttachment) {
+TEST(Context, ManifoldContextDeferredOpsDropAttachment) {
   ExecutionContext ctx;
   ctx.Cancel();
   Manifold a = Manifold::Cube(vec3(1), true).WithContext(ctx);
@@ -600,7 +600,7 @@ TEST(Manifold, ManifoldContextDeferredOpsDropAttachment) {
 
 // Static factories (BatchBoolean, vector-of-Manifold Hull) are deferred and
 // drop any ctx attached to their inputs.
-TEST(Manifold, ManifoldContextStaticFactoriesDropAttachment) {
+TEST(Context, ManifoldContextStaticFactoriesDropAttachment) {
   ExecutionContext ctx;
   ctx.Cancel();
   std::vector<Manifold> items = {
@@ -616,7 +616,7 @@ TEST(Manifold, ManifoldContextStaticFactoriesDropAttachment) {
 
 // no-arg Status() on a ctx-attached Manifold observes the attached ctx:
 // counters update exactly as if Status had been passed an explicit ctx.
-TEST(Manifold, ManifoldContextStatusObservesAttached) {
+TEST(Context, ManifoldContextStatusObservesAttached) {
   std::vector<Manifold> items;
   for (int i = 0; i < 4; i++) {
     items.push_back(Manifold::Cube(vec3(1), true).Translate(vec3(i * 2, 0, 0)));
@@ -633,7 +633,7 @@ TEST(Manifold, ManifoldContextStatusObservesAttached) {
 
 // Idiom for observing a deferred CSG tree: build the tree, attach ctx to
 // the root, call Status. Cancel via the same ctx aborts mid-evaluation.
-TEST(Manifold, ManifoldContextDeferredTreeRootObserves) {
+TEST(Context, ManifoldContextDeferredTreeRootObserves) {
   std::vector<Manifold> items;
   for (int i = 0; i < 8; i++) {
     items.push_back(Manifold::Cube(vec3(1), true).Translate(vec3(i * 2, 0, 0)));
@@ -648,7 +648,7 @@ TEST(Manifold, ManifoldContextDeferredTreeRootObserves) {
 // Eager ops (Refine family) read this->ctx_ during the in-call work. A
 // pre-cancelled attached ctx aborts Refine via the cancel check between
 // Subdivide and the post-pass; the result is a Cancelled-status leaf.
-TEST(Manifold, ManifoldContextCancelMidRefine) {
+TEST(Context, ManifoldContextCancelMidRefine) {
   ExecutionContext ctx;
   ctx.Cancel();
   Manifold cube = Manifold::Cube(vec3(1), true).WithContext(ctx);
@@ -660,7 +660,7 @@ TEST(Manifold, ManifoldContextCancelMidRefine) {
 // attached. Verified behaviorally: a fresh ctx pre-loaded with a sentinel
 // counter value is left untouched by Status() on the Refine result, because
 // no ctx is attached to dispatch through.
-TEST(Manifold, ManifoldContextRefineDropsAttachmentFromResult) {
+TEST(Context, ManifoldContextRefineDropsAttachmentFromResult) {
   ExecutionContext ctx;
   Manifold cube = Manifold::Cube(vec3(1), true).WithContext(ctx);
   Manifold refined = cube.Refine(2);
@@ -678,7 +678,7 @@ TEST(Manifold, ManifoldContextRefineDropsAttachmentFromResult) {
 // Eager Hull observes attached ctx -- a pre-cancelled ctx aborts the
 // post-pass that runs after QuickHull's buildMesh, returning a Cancelled
 // result rather than a finished hull.
-TEST(Manifold, ManifoldContextCancelMidHull) {
+TEST(Context, ManifoldContextCancelMidHull) {
   ExecutionContext ctx;
   ctx.Cancel();
   // Non-trivial input so the post-buildMesh path is reached.
@@ -690,7 +690,7 @@ TEST(Manifold, ManifoldContextCancelMidHull) {
 // Eager Minkowski observes attached ctx -- a pre-cancelled ctx aborts
 // between the hull/Boolean phases. Cancel granularity is "one batch" of
 // per-face hulls.
-TEST(Manifold, ManifoldContextCancelMidMinkowski) {
+TEST(Context, ManifoldContextCancelMidMinkowski) {
   ExecutionContext ctx;
   ctx.Cancel();
   // Two convex inputs hit the fast path; that's enough to exercise the
@@ -709,7 +709,7 @@ TEST(Manifold, ManifoldContextCancelMidMinkowski) {
 // MANIFOLD_PAR guard: same as the other concurrent tests -- requires
 // std::thread.
 #if MANIFOLD_PAR == 1
-TEST(Manifold, ManifoldContextCancelConcurrentHull) {
+TEST(Context, ManifoldContextCancelConcurrentHull) {
   // High-resolution sphere so QuickHull + SortGeometry have measurable
   // work to do.
   Manifold sphere = Manifold::Sphere(1.0, 256);
@@ -739,7 +739,7 @@ TEST(Manifold, ManifoldContextCancelConcurrentHull) {
 // MANIFOLD_PAR guard: same as the other concurrent tests -- requires
 // std::thread.
 #if MANIFOLD_PAR == 1
-TEST(Manifold, ManifoldContextCancelConcurrentMinkowski) {
+TEST(Context, ManifoldContextCancelConcurrentMinkowski) {
   // Two non-convex inputs to force the slow path. The tet-difference here
   // produces near-degenerate geometry that fails the MANIFOLD_DEBUG
   // triangulation CCW check on macOS without processOverlaps -- matches
@@ -769,7 +769,7 @@ TEST(Manifold, ManifoldContextCancelConcurrentMinkowski) {
 
 // Cancellation requested on the attached ctx after Status() begins (or
 // before, in the deferred-tree-root idiom) aborts evaluation.
-TEST(Manifold, ManifoldContextCancelMidEval) {
+TEST(Context, ManifoldContextCancelMidEval) {
   std::vector<Manifold> items;
   for (int i = 0; i < 8; i++) {
     items.push_back(Manifold::Cube(vec3(1), true).Translate(vec3(i * 2, 0, 0)));
@@ -783,7 +783,7 @@ TEST(Manifold, ManifoldContextCancelMidEval) {
 }
 
 // FromMeshGL: ctx-aware analog of the `Manifold(MeshGL)` ctor.
-TEST(ExecutionContextFromMeshGL, HappyPath) {
+TEST(Context, MeshGLHappyPath) {
   ExecutionContext ctx;
   Manifold tet = ctx.FromMeshGL(TetGL());
   EXPECT_FALSE(tet.IsEmpty());
@@ -794,7 +794,7 @@ TEST(ExecutionContextFromMeshGL, HappyPath) {
 }
 
 // Equivalent geometry to the plain ctor.
-TEST(ExecutionContextFromMeshGL, MatchesCtor) {
+TEST(Context, MeshGLMatchesCtor) {
   MeshGL mesh = Manifold::Sphere(1.0, 32).GetMeshGL();
   ExecutionContext ctx;
   Manifold viaCtx = ctx.FromMeshGL(mesh);
@@ -805,7 +805,7 @@ TEST(ExecutionContextFromMeshGL, MatchesCtor) {
 }
 
 // Pre-cancel beats the heavy path on well-formed input.
-TEST(ExecutionContextFromMeshGL, CancelBeforeIngest) {
+TEST(Context, MeshGLCancelBeforeIngest) {
   ExecutionContext ctx;
   ctx.Cancel();
   Manifold m = ctx.FromMeshGL(TetGL());
@@ -813,7 +813,7 @@ TEST(ExecutionContextFromMeshGL, CancelBeforeIngest) {
 }
 
 // Pre-cancel beats the empty-input fast path (would otherwise be NoError).
-TEST(ExecutionContextFromMeshGL, CancelBeforeEmptyInputWinsOverNoError) {
+TEST(Context, MeshGLCancelBeforeEmptyInputWinsOverNoError) {
   ExecutionContext ctx;
   ctx.Cancel();
   Manifold m = ctx.FromMeshGL(MeshGL{});
@@ -833,7 +833,7 @@ static MeshGL MalformedMissingPositionProperties() {
 }
 
 // Pre-cancel beats validation errors.
-TEST(ExecutionContextFromMeshGL, CancelBeforeMalformedWinsOverValidation) {
+TEST(Context, MeshGLCancelBeforeMalformedWinsOverValidation) {
   ExecutionContext ctx;
   ctx.Cancel();
   Manifold m = ctx.FromMeshGL(MalformedMissingPositionProperties());
@@ -842,7 +842,7 @@ TEST(ExecutionContextFromMeshGL, CancelBeforeMalformedWinsOverValidation) {
 
 // Validation errors surface unchanged when no cancel is in flight;
 // counters stay at 0/kPhasesPerFromMesh since no phase ran.
-TEST(ExecutionContextFromMeshGL, ValidationErrorWithoutCancel) {
+TEST(Context, MeshGLValidationErrorWithoutCancel) {
   ExecutionContext ctx;
   Manifold m = ctx.FromMeshGL(MalformedMissingPositionProperties());
   EXPECT_EQ(m.Status(), Manifold::Error::MissingPositionProperties);
@@ -854,7 +854,7 @@ TEST(ExecutionContextFromMeshGL, ValidationErrorWithoutCancel) {
 // at least one Cancelled outcome (otherwise the cancel path is dead);
 // each Cancelled hit also pins donePhases < totalPhases.
 #if MANIFOLD_PAR == 1
-TEST(ExecutionContextFromMeshGL, CancelConcurrent) {
+TEST(Context, MeshGLCancelConcurrent) {
   MeshGL mesh = Manifold::Sphere(1.0, 512).GetMeshGL();  // ~524k tris
   int cancelledHits = 0;
   auto sleep = std::chrono::microseconds(100);
@@ -880,7 +880,7 @@ TEST(ExecutionContextFromMeshGL, CancelConcurrent) {
 #endif  // MANIFOLD_PAR == 1
 
 // FromMeshGL then a Boolean on the same ctx: counters reset between.
-TEST(ExecutionContextFromMeshGL, ReuseForBoolean) {
+TEST(Context, MeshGLReuseForBoolean) {
   ExecutionContext ctx;
   Manifold tet = ctx.FromMeshGL(TetGL());
   ASSERT_EQ(tet.Status(), Manifold::Error::NoError);
@@ -894,7 +894,7 @@ TEST(ExecutionContextFromMeshGL, ReuseForBoolean) {
 }
 
 // Two FromMeshGL calls on the same ctx: counters reset between.
-TEST(ExecutionContextFromMeshGL, ReuseForSecondFromMeshGL) {
+TEST(Context, MeshGLReuseForSecondFromMeshGL) {
   ExecutionContext ctx;
   ASSERT_EQ(ctx.FromMeshGL(TetGL()).Status(), Manifold::Error::NoError);
   ASSERT_EQ(ctx.impl_->donePhases.load(), kPhasesPerFromMesh);
@@ -906,7 +906,7 @@ TEST(ExecutionContextFromMeshGL, ReuseForSecondFromMeshGL) {
 }
 
 // Sticky cancel survives across FromMeshGL calls.
-TEST(ExecutionContextFromMeshGL, StickyCancelAcrossCalls) {
+TEST(Context, MeshGLStickyCancelAcrossCalls) {
   ExecutionContext ctx;
   ctx.Cancel();
   EXPECT_EQ(ctx.FromMeshGL(TetGL()).Status(), Manifold::Error::Cancelled);
@@ -919,7 +919,7 @@ TEST(ExecutionContextFromMeshGL, StickyCancelAcrossCalls) {
 // path, parity with the plain factory, the entry-time cancel gate in
 // MakeSmoothImpl (distinct from the shared Impl-ctor gate), concurrent cancel
 // through the extra tangent-creation phases, and the sharpenedEdges argument.
-TEST(ExecutionContextSmooth, HappyPath) {
+TEST(Context, SmoothHappyPath) {
   ExecutionContext ctx;
   Manifold tet = ctx.Smooth(TetGL());
   EXPECT_FALSE(tet.IsEmpty());
@@ -930,7 +930,7 @@ TEST(ExecutionContextSmooth, HappyPath) {
 }
 
 // Equivalent geometry to the plain factory.
-TEST(ExecutionContextSmooth, MatchesFactory) {
+TEST(Context, SmoothMatchesFactory) {
   MeshGL mesh = Manifold::Sphere(1.0, 32).GetMeshGL();
   ExecutionContext ctx;
   Manifold viaCtx = ctx.Smooth(mesh);
@@ -942,7 +942,7 @@ TEST(ExecutionContextSmooth, MatchesFactory) {
 
 // Pre-cancel hits Smooth's own entry gate in MakeSmoothImpl and returns
 // before ingest - distinct from the shared Impl-ctor gate FromMeshGL covers.
-TEST(ExecutionContextSmooth, CancelBeforeIngest) {
+TEST(Context, SmoothCancelBeforeIngest) {
   ExecutionContext ctx;
   ctx.Cancel();
   Manifold m = ctx.Smooth(TetGL());
@@ -953,7 +953,7 @@ TEST(ExecutionContextSmooth, CancelBeforeIngest) {
 // at least one Cancelled outcome; each Cancelled hit pins donePhases <
 // totalPhases.
 #if MANIFOLD_PAR == 1
-TEST(ExecutionContextSmooth, CancelConcurrent) {
+TEST(Context, SmoothCancelConcurrent) {
   MeshGL mesh = Manifold::Sphere(1.0, 512).GetMeshGL();  // ~524k tris
   int cancelledHits = 0;
   auto sleep = std::chrono::microseconds(100);
@@ -982,7 +982,7 @@ TEST(ExecutionContextSmooth, CancelConcurrent) {
 // faceID-restoration loop in MakeSmoothImpl is a natural no-op after
 // MakeEmpty.
 #if MANIFOLD_PAR == 1
-TEST(ExecutionContextSmooth, CancelWithSharpenedEdges) {
+TEST(Context, SmoothCancelWithSharpenedEdges) {
   MeshGL mesh = Manifold::Sphere(1.0, 512).GetMeshGL();
   std::vector<Smoothness> sharpenedEdges = {{0, 0.0}, {3, 0.5}, {6, 0.0}};
   int cancelledHits = 0;
@@ -1015,7 +1015,7 @@ TEST(ExecutionContextSmooth, CancelWithSharpenedEdges) {
 // happy path, parity with the plain factory, the entry-time cancel gate in
 // CreateLevelSet, and concurrent cancel through the dominant voxel-sampling
 // phase.
-TEST(ExecutionContextLevelSet, HappyPath) {
+TEST(Context, LevelSetHappyPath) {
   // Sphere SDF: positive inside, negative outside.
   auto sphere = [](vec3 p) { return 1.0 - la::length(p); };
   ExecutionContext ctx;
@@ -1029,7 +1029,7 @@ TEST(ExecutionContextLevelSet, HappyPath) {
 
 // Equivalent geometry to the plain factory. (Named MatchesFactory, not
 // MatchesCtor - LevelSet has no constructor form.)
-TEST(ExecutionContextLevelSet, MatchesFactory) {
+TEST(Context, LevelSetMatchesFactory) {
   auto sphere = [](vec3 p) { return 1.0 - la::length(p); };
   const Box bounds = {vec3(-1.1), vec3(1.1)};
   const double edgeLength = 0.1;
@@ -1043,7 +1043,7 @@ TEST(ExecutionContextLevelSet, MatchesFactory) {
 
 // Pre-cancel hits CreateLevelSet's entry gate and returns before allocating or
 // sampling the voxel grid - LevelSet's analog of Smooth's CancelBeforeIngest.
-TEST(ExecutionContextLevelSet, CancelBeforeSampling) {
+TEST(Context, LevelSetCancelBeforeSampling) {
   auto sphere = [](vec3 p) { return 1.0 - la::length(p); };
   ExecutionContext ctx;
   ctx.Cancel();
@@ -1057,7 +1057,7 @@ TEST(ExecutionContextLevelSet, CancelBeforeSampling) {
 // backoff guarantees at least one Cancelled outcome; each pins donePhases <
 // totalPhases.
 #if MANIFOLD_PAR == 1
-TEST(ExecutionContextLevelSet, CancelConcurrent) {
+TEST(Context, LevelSetCancelConcurrent) {
   auto slowSphere = [](vec3 p) {
     std::this_thread::sleep_for(std::chrono::microseconds(5));
     return 1.0 - la::length(p);

--- a/test/cross_section_complex_test.cpp
+++ b/test/cross_section_complex_test.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../src/boolean2.h"
-
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -29,6 +27,7 @@
 #include <utility>
 #include <vector>
 
+#include "../src/boolean2.h"
 #include "manifold/common.h"
 #include "manifold/cross_section.h"
 #include "manifold/manifold.h"
@@ -369,7 +368,7 @@ std::pair<std::vector<vec2>, std::vector<EdgeM>> CombinedInput(
 // Constructed verts may sit closer than eps only around a genuinely sub-eps
 // crossing tangle. Inputs whose features are all far above eps must not
 // silently acquire sub-eps output verts.
-TEST(Boolean2, CleanInputsKeepEpsSeparatedVerts) {
+TEST(CrossSectionComplex, CleanInputsKeepEpsSeparatedVerts) {
   const Polygons a = {{{0., 0.}, {4., 0.}, {4., 4.}, {0., 4.}}};
   const Polygons b = {{{2., 2.}, {6., 2.}, {6., 6.}, {2., 6.}}};
   const double eps = InferEps(a, b);
@@ -394,7 +393,7 @@ TEST(Boolean2, CleanInputsKeepEpsSeparatedVerts) {
 // RemoveOverlaps2D does so through a boolean Add on a hard mixed-scale input
 // (1e-6 alongside 1024). Replicated inline (CheckRetainedGraphValidity isn't
 // public).
-TEST(Boolean2, RemoveOverlaps2DTopologyMixedScale) {
+TEST(CrossSectionComplex, RemoveOverlaps2DTopologyMixedScale) {
   // Inputs A and B exactly as the BooleanRobustness fuzz target
   // constructs them from the counterexample raw polygons. The
   // topology check is on the OUTPUT of the boolean Add, not the
@@ -450,7 +449,7 @@ TEST(Boolean2, RemoveOverlaps2DTopologyMixedScale) {
   }
 }
 
-TEST(Boolean2, MergeVertsTransitiveChainCanDriftPastEps) {
+TEST(CrossSectionComplex, MergeVertsTransitiveChainCanDriftPastEps) {
   const double eps = 1.0;
   const std::vector<vec2> verts = {{0.0, 0.0},  {0.99, 0.0}, {1.98, 0.0},
                                    {2.97, 0.0}, {3.96, 0.0}, {10.0, 0.0},
@@ -471,7 +470,7 @@ TEST(Boolean2, MergeVertsTransitiveChainCanDriftPastEps) {
   EXPECT_GT(std::hypot(endpointDrift.x, endpointDrift.y), eps);
 }
 
-TEST(Boolean2, VertexMergeIdempotenceTightCluster) {
+TEST(CrossSectionComplex, VertexMergeIdempotenceTightCluster) {
   const std::vector<vec2> verts = {{-564.24299726366871, -1.},
                                    {-564.25684749526681, -1.},
                                    {-564.25684749526681, -1.},
@@ -514,7 +513,7 @@ TEST(Boolean2, VertexMergeIdempotenceTightCluster) {
       << ", eps=" << eps << ")";
 }
 
-TEST(Boolean2, ValidatorRejectsRetainedVertsWithinEps) {
+TEST(CrossSectionComplex, ValidatorRejectsRetainedVertsWithinEps) {
   const std::vector<vec2> verts = {{0.0, 0.0}, {10.0, 0.0}, {0.0, 10.0},
                                    {0.5, 0.5}, {20.0, 0.0}, {20.0, 10.0}};
   const std::vector<EdgeM> edges = {{0, 1, 1}, {1, 2, 1}, {2, 0, 1},
@@ -525,7 +524,7 @@ TEST(Boolean2, ValidatorRejectsRetainedVertsWithinEps) {
       result, edges, result.inputVert2Merged, result.numMergedVerts, 1.0));
 }
 
-TEST(Boolean2, ValidatorRejectsNearEndpointTJunction) {
+TEST(CrossSectionComplex, ValidatorRejectsNearEndpointTJunction) {
   const std::vector<vec2> verts = {{0.0, 0.0},   {10.0, 0.0}, {0.5, 0.9},
                                    {10.0, 10.0}, {20.0, 5.0}, {20.0, 15.0}};
   const std::vector<EdgeM> edges = {{0, 1, 1}, {1, 3, 1}, {3, 0, 1},
@@ -536,7 +535,7 @@ TEST(Boolean2, ValidatorRejectsNearEndpointTJunction) {
       result, edges, result.inputVert2Merged, result.numMergedVerts, 1.0));
 }
 
-TEST(Boolean2, ValidatorRejectsRetainedStrictCrossing) {
+TEST(CrossSectionComplex, ValidatorRejectsRetainedStrictCrossing) {
   const std::vector<vec2> verts = {{0.0, 0.0},  {10.0, 10.0}, {0.0, 10.0},
                                    {10.0, 0.0}, {-10.0, 5.0}, {20.0, 5.0}};
   const std::vector<EdgeM> edges = {{0, 1, 1}, {1, 4, 1}, {4, 0, 1},
@@ -547,7 +546,7 @@ TEST(Boolean2, ValidatorRejectsRetainedStrictCrossing) {
       result, edges, result.inputVert2Merged, result.numMergedVerts, 0.01));
 }
 
-TEST(Boolean2, CleanupPassMatchesValidAddSinglePass) {
+TEST(CrossSectionComplex, CleanupPassMatchesValidAddSinglePass) {
   Polygons polys{RandomTopologicalRing(8, 15)};
   const double eps = InferEps(polys, {});
   const auto [verts, edges] = PolygonsToInput(polys);
@@ -581,7 +580,7 @@ TEST(Boolean2, CleanupPassMatchesValidAddSinglePass) {
 // read in SweepMode::Winding and nowhere in the arrangement. So on the same
 // self-intersecting input it must produce a graph the independent oracle still
 // accepts, over the same vertex merge Add gets.
-TEST(Boolean2, EvenOddRetainedGraphMatchesAddArrangement) {
+TEST(CrossSectionComplex, EvenOddRetainedGraphMatchesAddArrangement) {
   Polygons polys{RandomTopologicalRing(8, 15)};
   const double eps = InferEps(polys, {});
   const auto [verts, edges] = PolygonsToInput(polys);
@@ -598,7 +597,7 @@ TEST(Boolean2, EvenOddRetainedGraphMatchesAddArrangement) {
   EXPECT_FALSE(OutEdgesToPolygons(evenOdd.verts, evenOdd.edges).empty());
 }
 
-TEST(Boolean2, OffsetRoundUsesRequestedSegments) {
+TEST(CrossSectionComplex, OffsetRoundUsesRequestedSegments) {
   SimplePolygon square = {{0, 0}, {20, 0}, {20, 20}, {0, 20}};
   const int segments = 20;
   const double delta = 5.0;
@@ -609,7 +608,7 @@ TEST(Boolean2, OffsetRoundUsesRequestedSegments) {
   EXPECT_EQ(rounded[0].size(), segments + 4);
 }
 
-TEST(Boolean2, OffsetRoundClampsHugeSegmentCount) {
+TEST(CrossSectionComplex, OffsetRoundClampsHugeSegmentCount) {
   // An absurd requested count is clamped so the vertex count cannot blow up;
   // the clamp is kMaxRoundJoinSegments == 1 << 15 (file-local in offset.cpp).
   SimplePolygon square = {{0, 0}, {20, 0}, {20, 20}, {0, 20}};
@@ -618,14 +617,14 @@ TEST(Boolean2, OffsetRoundClampsHugeSegmentCount) {
   EXPECT_EQ(rounded[0].size(), (1 << 15) + 4);
 }
 
-TEST(Boolean2, OffsetZeroDeltaRejectsNonFiniteInput) {
+TEST(CrossSectionComplex, OffsetZeroDeltaRejectsNonFiniteInput) {
   const double nan = std::numeric_limits<double>::quiet_NaN();
   SimplePolygon bad = {{0.0, 0.0}, {1.0, 0.0}, {nan, 1.0}, {0.0, 1.0}};
 
   EXPECT_TRUE(Offset({bad}, 0.0, JoinType::Miter).empty());
 }
 
-TEST(Boolean2, OffsetExtremeFiniteEdgesStayFinite) {
+TEST(CrossSectionComplex, OffsetExtremeFiniteEdgesStayFinite) {
   // Large-but-finite coordinates must not yield inf/nan. Collinearity uses the
   // canonical CCW predicate, whose area products saturate above ~1e77, so the
   // exercised scale stays under that (still far beyond any real input).
@@ -643,7 +642,7 @@ TEST(Boolean2, OffsetExtremeFiniteEdgesStayFinite) {
   }
 }
 
-TEST(Boolean2, OffsetSquareJoinKeepsCapOnSharpSpike) {
+TEST(CrossSectionComplex, OffsetSquareJoinKeepsCapOnSharpSpike) {
   // A near-degenerate spike (base 100, height 1e-9) survives regularization but
   // drives the square-join half-angle to ~90 degrees, where cosHalf can round
   // below 0. The caps must still be emitted (area ~204, two ~unit caps) rather
@@ -659,7 +658,7 @@ TEST(Boolean2, OffsetSquareJoinKeepsCapOnSharpSpike) {
   EXPECT_LT(area, 206.0);
 }
 
-TEST(Boolean2, DecomposeContainmentBboxUsesTolerance) {
+TEST(CrossSectionComplex, DecomposeContainmentBboxUsesTolerance) {
   const double eps = EpsilonFromScale(0.5);
   const double d = 0.25 * eps;
   SimplePolygon outer = {{0, 0}, {1, 0}, {1, 1}, {0, 1}};
@@ -672,7 +671,7 @@ TEST(Boolean2, DecomposeContainmentBboxUsesTolerance) {
   ASSERT_EQ(components[0].size(), 2);
 }
 
-TEST(Boolean2, DecomposeContainmentDropsDegenerateRings) {
+TEST(CrossSectionComplex, DecomposeContainmentDropsDegenerateRings) {
   SimplePolygon outer = {{0, 0}, {1, 0}, {1, 1}, {0, 1}};
   SimplePolygon line = {{0.25, 0.25}, {0.75, 0.75}};
 
@@ -683,7 +682,7 @@ TEST(Boolean2, DecomposeContainmentDropsDegenerateRings) {
   EXPECT_EQ(components[0][0].size(), outer.size());
 }
 
-TEST(Boolean2, OffsetSquareInsetCapStaysOnSolidSide) {
+TEST(CrossSectionComplex, OffsetSquareInsetCapStaysOnSolidSide) {
   // L-shape: 2x2 square minus the top-right [1,2]x[1,2] quadrant (CCW). The
   // reflex corner at (1,1) routes through the square join when inset.
   SimplePolygon L = {{0, 0}, {2, 0}, {2, 1}, {1, 1}, {1, 2}, {0, 2}};
@@ -709,7 +708,7 @@ TEST(Boolean2, OffsetSquareInsetCapStaysOnSolidSide) {
   EXPECT_GT(std::fabs(TotalSignedArea(grown)), 3.0);
 }
 
-TEST(Boolean2, OffsetLargeMiterLimitStaysBounded) {
+TEST(CrossSectionComplex, OffsetLargeMiterLimitStaysBounded) {
   // Thin spike: apex (0,1e6) with near-antiparallel edge normals (1+dotN ~ 1
   // ULP), so the apex miter is near-unbounded. A huge miter_limit must not let
   // MiterPoint escape; the square fallback must engage.
@@ -739,7 +738,7 @@ TEST(Boolean2, OffsetLargeMiterLimitStaysBounded) {
   EXPECT_TRUE(rightCap);
 }
 
-TEST(Boolean2, OffsetReversalSpikeKeepsFarCap) {
+TEST(CrossSectionComplex, OffsetReversalSpikeKeepsFarCap) {
   // A near-zero-width spike whose tip edges are antiparallel triggers the
   // collinear-reversal branch; the offset must still cap the far side rather
   // than collapse the tip to a single point.
@@ -756,7 +755,7 @@ TEST(Boolean2, OffsetReversalSpikeKeepsFarCap) {
   EXPECT_TRUE(farCap) << "far side of the reversal spike was dropped";
 }
 
-TEST(Boolean2, DecomposeContainmentDropsZeroAreaRing) {
+TEST(CrossSectionComplex, DecomposeContainmentDropsZeroAreaRing) {
   SimplePolygon outer = {{0, 0}, {10, 0}, {10, 10}, {0, 10}};
   SimplePolygon collinear = {{1, 1}, {2, 1}, {3, 1}};  // zero area, size 3
   auto comps = DecomposeByContainment({outer, collinear});
@@ -764,7 +763,7 @@ TEST(Boolean2, DecomposeContainmentDropsZeroAreaRing) {
   EXPECT_EQ(comps[0].size(), 1);  // sliver dropped, not leaked as a hole
 }
 
-TEST(Boolean2, DecomposeContainmentKeepsFiniteThinHole) {
+TEST(CrossSectionComplex, DecomposeContainmentKeepsFiniteThinHole) {
   SimplePolygon outer = {{0, 0}, {10, 0}, {10, 10}, {0, 10}};
   SimplePolygon thinHole = {{1, 1}, {1, 1.000001}, {9, 1.000001}, {9, 1}};
 
@@ -775,7 +774,7 @@ TEST(Boolean2, DecomposeContainmentKeepsFiniteThinHole) {
   EXPECT_NEAR(TotalSignedArea(comps[0]), 100.0 - 8e-6, 1e-12);
 }
 
-TEST(Boolean2, DecomposeContainmentKeepsNestedPositiveRing) {
+TEST(CrossSectionComplex, DecomposeContainmentKeepsNestedPositiveRing) {
   SimplePolygon A = {{0, 0}, {10, 0}, {10, 10}, {0, 10}};  // +100
   SimplePolygon B = {{3, 3}, {7, 3}, {7, 7}, {3, 7}};      // +16, inside A
   SimplePolygon H = {{4, 4}, {4, 6}, {6, 6}, {6, 4}};      // -4, inside B
@@ -786,7 +785,7 @@ TEST(Boolean2, DecomposeContainmentKeepsNestedPositiveRing) {
   EXPECT_NEAR(retained, 112.0, 1e-9);
 }
 
-TEST(Boolean2, DecomposeContainmentToleranceIsSizeScaledOffOrigin) {
+TEST(CrossSectionComplex, DecomposeContainmentToleranceIsSizeScaledOffOrigin) {
   // Off-origin rings: the containment epsilon must scale with the bbox SIZE,
   // not the coordinate magnitude. A hole sticking out by 1e-10 (above the
   // size-scaled eps, below a position-scaled one) is not contained, so it is
@@ -805,7 +804,7 @@ TEST(Boolean2, DecomposeContainmentToleranceIsSizeScaledOffOrigin) {
 
 // Output topology balance check fails after Add on raw
 // multi-contour, near-duplicate-heavy polygons.
-TEST(Boolean2, BooleanRobustnessMergeTopologyBalance) {
+TEST(CrossSectionComplex, BooleanRobustnessMergeTopologyBalance) {
   const Polygons a = {{{1024., 1024.},
                        {1., 1.},
                        {9.9999999999999995e-07, -9.9999999999999995e-07}}};
@@ -839,7 +838,7 @@ TEST(Boolean2, BooleanRobustnessMergeTopologyBalance) {
 
 // Direct-cast disconnected-component winding fallback emitted an
 // open spur after Add.
-TEST(Boolean2, BooleanRobustnessDirectCastKeepsExpectedArea) {
+TEST(CrossSectionComplex, BooleanRobustnessDirectCastKeepsExpectedArea) {
   const Polygons a = {{{-9.9999999999999995e-07, 9.9999999999999995e-07},
                        {-9.9999999999999995e-07, -9.9999999999999995e-07},
                        {-0., 0.},
@@ -886,7 +885,7 @@ TEST(Boolean2, BooleanRobustnessDirectCastKeepsExpectedArea) {
 // OutEdgesToPolygons. Earlier closure logic detected closure by trying to
 // re-select the start edge as `next`, which is skipped by the visited guard;
 // the natural walk terminates with destV == startV instead.
-TEST(Boolean2, OutEdgesToPolygonsClosesSimpleRing) {
+TEST(CrossSectionComplex, OutEdgesToPolygonsClosesSimpleRing) {
   const std::vector<vec2> verts = {{0, 0}, {1, 0}, {1, 1}, {0, 1}};
   const std::vector<OutEdge> edges = {{0, 1}, {1, 2}, {2, 3}, {3, 0}};
   const auto polys = OutEdgesToPolygons(verts, edges);
@@ -894,7 +893,7 @@ TEST(Boolean2, OutEdgesToPolygonsClosesSimpleRing) {
   EXPECT_EQ(polys[0].size(), 4u);
 }
 
-TEST(Boolean2, OutEdgesToPolygonsSplitsExactRepeatedVertex) {
+TEST(CrossSectionComplex, OutEdgesToPolygonsSplitsExactRepeatedVertex) {
   const std::vector<vec2> verts = {{0, 0}, {1, 0}, {1, -1}, {2, -1}, {1, 1}};
   const std::vector<OutEdge> edges = {{0, 1}, {1, 2}, {2, 3},
                                       {3, 1}, {1, 4}, {4, 0}};
@@ -905,7 +904,7 @@ TEST(Boolean2, OutEdgesToPolygonsSplitsExactRepeatedVertex) {
   EXPECT_NEAR(TotalSignedArea(polys), 1.0, 1e-12);
 }
 
-TEST(Boolean2, OutEdgesToPolygonsKeepsNearDistinctVertex) {
+TEST(CrossSectionComplex, OutEdgesToPolygonsKeepsNearDistinctVertex) {
   constexpr double kDelta = 1e-12;
   const std::vector<vec2> verts = {{0, 0},  {1, 0}, {1, -1},
                                    {2, -1}, {1, 1}, {1 + kDelta, 0}};
@@ -924,7 +923,7 @@ TEST(Boolean2, OutEdgesToPolygonsKeepsNearDistinctVertex) {
   EXPECT_NEAR(solid.Volume(), reconsumed.Area(), 1e-9);
 }
 
-TEST(Boolean2, KeepsNearDistinctPresentationVertex) {
+TEST(CrossSectionComplex, KeepsNearDistinctPresentationVertex) {
   constexpr double kDelta = 1e-12;
   const Polygons input = {
       {{0, 0}, {1, 0}, {1, -1}, {2, -1}, {1 + kDelta, 0}, {1, 1}}};
@@ -940,7 +939,7 @@ TEST(Boolean2, KeepsNearDistinctPresentationVertex) {
 // When the edge passes through the corner, the incidence pre-split makes the
 // corner a shared vertex and the crossing resolves to it, so the two coincide.
 // Mere proximity within the broad-phase band does not merge them.
-TEST(Boolean2, NearCornerCrossingDistinctUnlessIncident) {
+TEST(CrossSectionComplex, NearCornerCrossingDistinctUnlessIncident) {
   constexpr double eps = 1e-6;
   const Polygons a = {{{0, 0}, {10, 0}, {10, 1}, {0, 1}}};
   auto countNear = [](const std::vector<vec2>& points, vec2 target, double r) {
@@ -983,7 +982,7 @@ TEST(Boolean2, NearCornerCrossingDistinctUnlessIncident) {
   }
 }
 
-TEST(Boolean2, RemoveOverlapsMergesExactDuplicateCoordinates) {
+TEST(CrossSectionComplex, RemoveOverlapsMergesExactDuplicateCoordinates) {
   const Polygons polys = {{{0, 0}, {1, 0}, {0, 1}}, {{0, 0}, {-1, 0}, {0, -1}}};
   const auto [verts, edges] = PolygonsToInput(polys);
   ASSERT_EQ(verts.size(), 6u);
@@ -998,7 +997,7 @@ TEST(Boolean2, RemoveOverlapsMergesExactDuplicateCoordinates) {
   EXPECT_EQ(overlap.inputVert2Merged[0], overlap.inputVert2Merged[3]);
 }
 
-TEST(Boolean2, NonFiniteInputReturnsEmpty) {
+TEST(CrossSectionComplex, NonFiniteInputReturnsEmpty) {
   const double inf = std::numeric_limits<double>::infinity();
   Polygons bad = {{{0.0, 0.0}, {1.0, 0.0}, {inf, 1.0}, {0.0, 1.0}}};
   Polygons finite = {{{0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}}};
@@ -1010,7 +1009,7 @@ TEST(Boolean2, NonFiniteInputReturnsEmpty) {
 // A near-origin degenerate Subtract whose regularized graph must stay valid; a
 // missed split would leave a retained vertex inside another edge's interior
 // band.
-TEST(Boolean2, NearOriginSubtractStaysValid) {
+TEST(CrossSectionComplex, NearOriginSubtractStaysValid) {
   const Polygons a = {{{0, 0},
                        {0, -1.3875065265425851e-15},
                        {0.00013875065265428477, -7.4683028744398387e-16},
@@ -1034,7 +1033,7 @@ TEST(Boolean2, NearOriginSubtractStaysValid) {
 // that overlap its left and right sides; their inner edges cross the short
 // bottom edge 0.4 eps apart. The eps-scale merge fuses those near-coincident
 // crossings, cancelling the subtraction cleanly back to the rectangle.
-TEST(Boolean2, ShortEdgeFusion) {
+TEST(CrossSectionComplex, ShortEdgeFusion) {
   const double eps = 1e-6;
   const double d = 2.6 * eps, h = 1.0 / eps, x0 = 1.1 * eps, x1 = 1.5 * eps;
   const SimplePolygon rect = {{0, 0}, {d, 0}, {d, h}, {0, h}};
@@ -1058,7 +1057,7 @@ TEST(Boolean2, ShortEdgeFusion) {
 // union n (left u right) = left u right = 9.99. Those are the true areas; the
 // engine fuses a sub-eps gap and lands within a loose eps*length band of them
 // (see the body) - a below-resolution floor, not a regression.
-TEST(Boolean2, ShortEdgeFusionAddIntersect) {
+TEST(CrossSectionComplex, ShortEdgeFusionAddIntersect) {
   const double eps = 1e-6;
   const double d = 2.6 * eps, h = 1.0 / eps, x0 = 1.1 * eps, x1 = 1.5 * eps;
   const SimplePolygon rect = {{0, 0}, {d, 0}, {d, h}, {0, h}};
@@ -1096,7 +1095,7 @@ TEST(Boolean2, ShortEdgeFusionAddIntersect) {
 // explicit op-eps (production InferEps would not reach the cluster). Same class
 // as the disabled near-coincident-corner case; re-enable once insertion keeps
 // the dropped crossing (reaches general position).
-TEST(Boolean2, VisibleMissedCrossingLargeEps) {
+TEST(CrossSectionComplex, VisibleMissedCrossingLargeEps) {
   const double eps = 1.75;
   const std::vector<vec2> verts = {
       {100, 0},    {93.99241891, -2.888671352},  {99.58902672, -0.3730219929},

--- a/test/cross_section_test.cpp
+++ b/test/cross_section_test.cpp
@@ -1399,7 +1399,7 @@ TEST(CrossSection, SubtractInvariantsSeeds) {
   for (const auto& c : kSubtractInvariantsSeeds) {
     SCOPED_TRACE(c.name);
     // Flush the seed name so a hard crash is still attributable.
-    std::cerr << "[seed] " << c.name << std::endl;
+    // std::cerr << "[seed] " << c.name << std::endl;
     const CrossSection a = MakeShape(c.a), b = MakeShape(c.b);
     const auto aIb = a ^ b;
     const auto aUb = a + b;
@@ -1534,7 +1534,7 @@ TEST(CrossSection, BooleanCommutativitySeeds) {
   for (const auto& c : kBooleanCommutativitySeeds) {
     SCOPED_TRACE(c.name);
     // Flush the seed name so a hard crash is still attributable.
-    std::cerr << "[seed] " << c.name << std::endl;
+    // std::cerr << "[seed] " << c.name << std::endl;
     const CrossSection a = MakeShape(c.a), b = MakeShape(c.b);
     const auto aPlusB = a + b;
     const auto bPlusA = b + a;
@@ -1586,7 +1586,7 @@ TEST(CrossSection, PrismSeeds) {
   };
   for (const auto& c : kPrismSeeds) {
     SCOPED_TRACE(c.name);
-    std::cerr << "[seed] " << c.name << std::endl;
+    // std::cerr << "[seed] " << c.name << std::endl;
     const CrossSection a(regular(3, c.radiusA));
     const CrossSection b(regular(3, c.radiusB));
     const auto expected = a + b;
@@ -1635,7 +1635,7 @@ TEST(CrossSection, BooleanAssociativitySeeds) {
   for (const auto& c : kBooleanAssociativitySeeds) {
     SCOPED_TRACE(c.name);
     // Flush the seed name so a hard crash is still attributable.
-    std::cerr << "[seed] " << c.name << std::endl;
+    // std::cerr << "[seed] " << c.name << std::endl;
     const CrossSection a = MakeShape(c.a), b = MakeShape(c.b),
                        cc = MakeShape(c.c);
     const auto ab_c = (a + b) + cc;
@@ -2173,7 +2173,7 @@ TEST(CrossSection, BooleanDistributivitySeeds) {
     // Print the seed name unconditionally: SCOPED_TRACE is not flushed on a
     // raw abort/segfault, so this line is what attributes a hard crash to a
     // specific seed.
-    std::cerr << "[seed] " << c.name << std::endl;
+    // std::cerr << "[seed] " << c.name << std::endl;
     const CrossSection a = MakeShape(c.a), b = MakeShape(c.b),
                        cc = MakeShape(c.c);
     if (c.kind == DistribKind::AreaOnly) {

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -1105,7 +1105,7 @@ TEST(Manifold, MeshRelationRefinePrecision) {
   Manifold csaszar = Manifold::Smooth(inGL);
 
   csaszar = csaszar.RefineToTolerance(0.05);
-  ExpectMeshes(csaszar, {{2343, 4686, 3}});
+  ExpectMeshes(csaszar, {{2135, 4270, 3}});
   std::vector<uint32_t> runOriginalID = csaszar.GetMeshGL().runOriginalID;
   EXPECT_EQ(runOriginalID.size(), 1);
   EXPECT_EQ(runOriginalID[0], id);

--- a/test/measurement_test.cpp
+++ b/test/measurement_test.cpp
@@ -25,7 +25,7 @@
 
 using namespace manifold;
 
-TEST(Manifold, RayCastHitCube) {
+TEST(Measurement, RayCastHitCube) {
   // Ray through center along Z — also tests watertight shared edge at (0,0)
   Manifold cube = Manifold::Cube(vec3(1), true);
 
@@ -39,12 +39,12 @@ TEST(Manifold, RayCastHitCube) {
   EXPECT_FLOAT_EQ(hits[1].normal.z, 1.0);
 }
 
-TEST(Manifold, RayCastMiss) {
+TEST(Measurement, RayCastMiss) {
   Manifold cube = Manifold::Cube(vec3(1), true);
   EXPECT_EQ(cube.RayCast(vec3(10, 10, -5), vec3(10, 10, 5)).size(), 0);
 }
 
-TEST(Manifold, RayCastDiagonal) {
+TEST(Measurement, RayCastDiagonal) {
   // Diagonal ray — not axis-aligned
   Manifold cube = Manifold::Cube(vec3(1), true);
 
@@ -53,12 +53,12 @@ TEST(Manifold, RayCastDiagonal) {
   EXPECT_FLOAT_EQ(hits[0].position.z, -0.5);
 }
 
-TEST(Manifold, RayCastBehindOrigin) {
+TEST(Measurement, RayCastBehindOrigin) {
   Manifold cube = Manifold::Cube(vec3(1), true);
   EXPECT_EQ(cube.RayCast(vec3(0, 0, 5), vec3(0, 0, 10)).size(), 0);
 }
 
-TEST(Manifold, RayCastSphere) {
+TEST(Measurement, RayCastSphere) {
   Manifold sphere = Manifold::Sphere(1.0, 128);
 
   auto hits = sphere.RayCast(vec3(0, 0, -5), vec3(0, 0, 5));
@@ -68,7 +68,7 @@ TEST(Manifold, RayCastSphere) {
   EXPECT_EQ(sphere.RayCast(vec3(2, 2, -5), vec3(2, 2, 5)).size(), 0);
 }
 
-TEST(Manifold, RayCastTwoCubes) {
+TEST(Measurement, RayCastTwoCubes) {
   Manifold c1 = Manifold::Cube(vec3(1), true);
   Manifold c2 = Manifold::Cube(vec3(1), true).Translate(vec3(0, 0, 5));
   Manifold both = c1 + c2;
@@ -81,12 +81,12 @@ TEST(Manifold, RayCastTwoCubes) {
   EXPECT_FLOAT_EQ(hits[3].position.z, 5.5);
 }
 
-TEST(Manifold, RayCastEmpty) {
+TEST(Measurement, RayCastEmpty) {
   Manifold empty;
   EXPECT_EQ(empty.RayCast(vec3(0, 0, -5), vec3(0, 0, 5)).size(), 0);
 }
 
-TEST(Manifold, RayCastAlongX) {
+TEST(Measurement, RayCastAlongX) {
   Manifold cube = Manifold::Cube(vec3(1), true);
 
   auto hits = cube.RayCast(vec3(-5, 0, 0), vec3(5, 0, 0));
@@ -94,7 +94,7 @@ TEST(Manifold, RayCastAlongX) {
   EXPECT_FLOAT_EQ(hits[0].position.x, -0.5);
 }
 
-TEST(Manifold, RayCastAlongY) {
+TEST(Measurement, RayCastAlongY) {
   Manifold cube = Manifold::Cube(vec3(1), true);
 
   auto hits = cube.RayCast(vec3(0, -5, 0), vec3(0, 5, 0));
@@ -102,12 +102,12 @@ TEST(Manifold, RayCastAlongY) {
   EXPECT_FLOAT_EQ(hits[0].position.y, -0.5);
 }
 
-TEST(Manifold, RayCastZeroLength) {
+TEST(Measurement, RayCastZeroLength) {
   Manifold cube = Manifold::Cube(vec3(1), true);
   EXPECT_EQ(cube.RayCast(vec3(0, 0, 0), vec3(0, 0, 0)).size(), 0);
 }
 
-TEST(Manifold, RayCastWatertightVertex) {
+TEST(Measurement, RayCastWatertightVertex) {
   // Ray exactly through a vertex. Symbolic perturbation should assign
   // the hit to exactly one triangle per face.
   Manifold cube = Manifold::Cube(vec3(1), true);
@@ -117,7 +117,7 @@ TEST(Manifold, RayCastWatertightVertex) {
   EXPECT_FLOAT_EQ(hits[0].position.z, -0.5);
 }
 
-TEST(Manifold, RayCastSilhouetteEdge) {
+TEST(Measurement, RayCastSilhouetteEdge) {
   // Ray at the silhouette edge should return 0 or 2 hits, never 1.
   Manifold cube = Manifold::Cube(vec3(1), true);
 
@@ -125,7 +125,7 @@ TEST(Manifold, RayCastSilhouetteEdge) {
   EXPECT_TRUE(hits.size() == 0 || hits.size() == 2);
 }
 
-TEST(Properties, MinGapCubeCube) {
+TEST(Measurement, MinGapCubeCube) {
   auto a = Manifold::Cube();
   auto b = Manifold::Cube().Translate({2, 2, 0});
 
@@ -134,7 +134,7 @@ TEST(Properties, MinGapCubeCube) {
   EXPECT_FLOAT_EQ(distance, sqrt(2));
 }
 
-TEST(Properties, MinGapCubeCube2) {
+TEST(Measurement, MinGapCubeCube2) {
   auto a = Manifold::Cube();
   auto b = Manifold::Cube().Translate({3, 3, 0});
 
@@ -143,7 +143,7 @@ TEST(Properties, MinGapCubeCube2) {
   EXPECT_FLOAT_EQ(distance, sqrt(2) * 2);
 }
 
-TEST(Properties, MinGapCubeSphereOverlapping) {
+TEST(Measurement, MinGapCubeSphereOverlapping) {
   auto a = Manifold::Cube();
   auto b = Manifold::Sphere(1);
 
@@ -152,7 +152,7 @@ TEST(Properties, MinGapCubeSphereOverlapping) {
   EXPECT_FLOAT_EQ(distance, 0);
 }
 
-TEST(Properties, MinGapSphereSphere) {
+TEST(Measurement, MinGapSphereSphere) {
   auto a = Manifold::Sphere(1);
   auto b = Manifold::Sphere(1).Translate({2, 2, 0});
 
@@ -161,7 +161,7 @@ TEST(Properties, MinGapSphereSphere) {
   EXPECT_FLOAT_EQ(distance, 2 * sqrt(2) - 2);
 }
 
-TEST(Properties, MinGapSphereSphereOutOfBounds) {
+TEST(Measurement, MinGapSphereSphereOutOfBounds) {
   auto a = Manifold::Sphere(1);
   auto b = Manifold::Sphere(1).Translate({2, 2, 0});
 
@@ -170,7 +170,7 @@ TEST(Properties, MinGapSphereSphereOutOfBounds) {
   EXPECT_FLOAT_EQ(distance, 0.8);
 }
 
-TEST(Properties, MinGapClosestPointOnEdge) {
+TEST(Measurement, MinGapClosestPointOnEdge) {
   auto a = Manifold::Cube({1, 1, 1}, true).Rotate(0, 0, 45);
   auto b =
       Manifold::Cube({1, 1, 1}, true).Rotate(0, 45, 0).Translate({2, 0, 0});
@@ -180,7 +180,7 @@ TEST(Properties, MinGapClosestPointOnEdge) {
   EXPECT_FLOAT_EQ(distance, 2 - sqrt(2));
 }
 
-TEST(Properties, MinGapClosestPointOnTriangleFace) {
+TEST(Measurement, MinGapClosestPointOnTriangleFace) {
   auto a = Manifold::Cube();
   auto b = Manifold::Cube().Scale({10, 10, 10}).Translate({2, -5, -1});
 
@@ -189,7 +189,7 @@ TEST(Properties, MinGapClosestPointOnTriangleFace) {
   EXPECT_FLOAT_EQ(distance, 1);
 }
 
-TEST(Properties, MingapAfterTransformations) {
+TEST(Measurement, MingapAfterTransformations) {
   auto a = Manifold::Sphere(1, 512).Rotate(30, 30, 30);
   auto b =
       Manifold::Sphere(1, 512).Scale({3, 1, 1}).Rotate(0, 90, 45).Translate(
@@ -200,7 +200,7 @@ TEST(Properties, MingapAfterTransformations) {
   ASSERT_NEAR(distance, 1, 0.001);
 }
 
-TEST(Properties, MingapStretchyBracelet) {
+TEST(Measurement, MingapStretchyBracelet) {
   auto a = StretchyBracelet();
   auto b = StretchyBracelet().Translate({0, 0, 20});
 
@@ -209,7 +209,7 @@ TEST(Properties, MingapStretchyBracelet) {
   ASSERT_NEAR(distance, 5, 0.001);
 }
 
-TEST(Properties, MinGapAfterTransformationsOutOfBounds) {
+TEST(Measurement, MinGapAfterTransformationsOutOfBounds) {
   auto a = Manifold::Sphere(1, 512).Rotate(30, 30, 30);
   auto b =
       Manifold::Sphere(1, 512).Scale({3, 1, 1}).Rotate(0, 90, 45).Translate(
@@ -220,7 +220,7 @@ TEST(Properties, MinGapAfterTransformationsOutOfBounds) {
   ASSERT_NEAR(distance, 0.95, 0.001);
 }
 
-TEST(Properties, TriangleDistanceClosestPointsOnVertices) {
+TEST(Measurement, TriangleDistanceClosestPointsOnVertices) {
   std::array<vec3, 3> p = {vec3{-1, 0, 0}, vec3{1, 0, 0}, vec3{0, 1, 0}};
 
   std::array<vec3, 3> q = {vec3{2, 0, 0}, vec3{4, 0, 0}, vec3{3, 1, 0}};
@@ -230,7 +230,7 @@ TEST(Properties, TriangleDistanceClosestPointsOnVertices) {
   EXPECT_FLOAT_EQ(distance, 1);
 }
 
-TEST(Properties, TriangleDistanceClosestPointOnEdge) {
+TEST(Measurement, TriangleDistanceClosestPointOnEdge) {
   std::array<vec3, 3> p = {vec3{-1, 0, 0}, vec3{1, 0, 0}, vec3{0, 1, 0}};
 
   std::array<vec3, 3> q = {vec3{-1, 2, 0}, vec3{1, 2, 0}, vec3{0, 3, 0}};
@@ -240,7 +240,7 @@ TEST(Properties, TriangleDistanceClosestPointOnEdge) {
   EXPECT_FLOAT_EQ(distance, 1);
 }
 
-TEST(Properties, TriangleDistanceClosestPointOnEdge2) {
+TEST(Measurement, TriangleDistanceClosestPointOnEdge2) {
   std::array<vec3, 3> p = {vec3{-1, 0, 0}, vec3{1, 0, 0}, vec3{0, 1, 0}};
 
   std::array<vec3, 3> q = {vec3{1, 1, 0}, vec3{3, 1, 0}, vec3{2, 2, 0}};
@@ -250,7 +250,7 @@ TEST(Properties, TriangleDistanceClosestPointOnEdge2) {
   EXPECT_FLOAT_EQ(distance, 0.5);
 }
 
-TEST(Properties, TriangleDistanceClosestPointOnFace) {
+TEST(Measurement, TriangleDistanceClosestPointOnFace) {
   std::array<vec3, 3> p = {vec3{-1, 0, 0}, vec3{1, 0, 0}, vec3{0, 1, 0}};
 
   std::array<vec3, 3> q = {vec3{-1, 2, -0.5}, vec3{1, 2, -0.5},
@@ -261,7 +261,7 @@ TEST(Properties, TriangleDistanceClosestPointOnFace) {
   EXPECT_FLOAT_EQ(distance, 1);
 }
 
-TEST(Properties, TriangleDistanceOverlapping) {
+TEST(Measurement, TriangleDistanceOverlapping) {
   std::array<vec3, 3> p = {vec3{-1, 0, 0}, vec3{1, 0, 0}, vec3{0, 1, 0}};
 
   std::array<vec3, 3> q = {vec3{-1, 0, 0}, vec3{1, 0.5, 0}, vec3{0, 1, 0}};
@@ -274,7 +274,7 @@ TEST(Properties, TriangleDistanceOverlapping) {
 // A tall box where the query point is far below the top face. The +Z ray from
 // the point must reach the top face even though it's well outside the point's
 // 3D bounding-box in Z. This exercises the XY-projected collider query.
-TEST(Manifold, WindingTallBox) {
+TEST(Measurement, WindingTallBox) {
   Manifold box = Manifold::Cube(vec3(1, 1, 10), true);  // z in [-5, 5]
   const auto w =
       box.WindingNumber({{0, 0, -4}, {0, 0, 0}, {0, 0, 6}, {0, 0, -6}});
@@ -284,7 +284,7 @@ TEST(Manifold, WindingTallBox) {
   EXPECT_EQ(w[3], 0);  // below
 }
 
-TEST(Manifold, WindingEmpty) {
+TEST(Measurement, WindingEmpty) {
   const auto w = Manifold{}.WindingNumber({{0, 0, 0}});
   ASSERT_EQ(w.size(), 1u);
   EXPECT_EQ(w[0], 0);
@@ -292,7 +292,7 @@ TEST(Manifold, WindingEmpty) {
 
 // Watertight winding across shared cube edges and vertices - must be exactly
 // 0 or 1, never 2 from double-counting.
-TEST(Manifold, WindingWatertight) {
+TEST(Measurement, WindingWatertight) {
   Manifold cube = Manifold::Cube(vec3(1), true);
   const auto w =
       cube.WindingNumber({{0.4999, 0.4999, 0}, {0.5, 0, 0}, {0, 0, 0}});
@@ -303,7 +303,7 @@ TEST(Manifold, WindingWatertight) {
 
 // Hollow shell (sphere - sphere): cavity center must return winding 0, wall
 // point 1, outside 0. Proves real winding number, not just ray parity.
-TEST(Manifold, WindingHollowShell) {
+TEST(Measurement, WindingHollowShell) {
   Manifold shell = Manifold::Sphere(2, 32) - Manifold::Sphere(1, 32);
   const auto w = shell.WindingNumber({{0, 0, 0}, {0, 0, 1.5}, {0, 0, 3}});
   EXPECT_EQ(w[0], 0);  // cavity
@@ -312,7 +312,7 @@ TEST(Manifold, WindingHollowShell) {
 }
 
 // Cross-check: winding != 0 agrees with RayCast hit-count parity.
-TEST(Manifold, WindingMatchesRayCastParity) {
+TEST(Measurement, WindingMatchesRayCastParity) {
   Manifold cube = Manifold::Cube(vec3(1), true);
   const std::vector<vec3> pts = {{0, 0, 0}, {0.3, 0.2, 0.1}, {0.5, 0.5, 0.5},
                                  {0, 0, 1}, {0, 0, 2},       {-1, 0, 0}};

--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -45,7 +45,7 @@ TEST(Smooth, RefineQuads) {
   Manifold cylinder = WithPositionColors(Manifold::Cylinder(2, 1, -1, 12))
                           .SmoothOut()
                           .RefineToLength(0.05);
-  EXPECT_EQ(cylinder.NumTri(), 17044);
+  EXPECT_EQ(cylinder.NumTri(), 16924);
   EXPECT_NEAR(cylinder.Volume(), 2 * kPi, 0.003);
   EXPECT_NEAR(cylinder.SurfaceArea(), 6 * kPi, 0.004);
   const MeshGL out = cylinder.GetMeshGL();
@@ -85,6 +85,7 @@ TEST(Smooth, ToLength) {
       CrossSection::Circle(10, 10).Translate({10, 0}).ToPolygons(), 2, 0, 0,
       {0, 0});
   cone += cone.Scale({1, 1, -5});
+  EXPECT_EQ(cone.NumVert(), 12);
   Manifold smooth =
       cone.AsOriginal().Simplify().SmoothOut(180).RefineToLength(0.1);
   ExpectMeshes(smooth, {{85250, 170496}});
@@ -241,8 +242,8 @@ TEST(Smooth, Fillet) {
   EXPECT_EQ(chamfered.NumTri(), 56);
   Manifold fillet = chamfered.SmoothByNormals(0).RefineToTolerance(0.01);
   EXPECT_EQ(fillet.Status(), Manifold::Error::NoError);
-  EXPECT_NEAR(fillet.Volume(), 7745, 1);
-  EXPECT_NEAR(fillet.SurfaceArea(), 2622, 1);
+  EXPECT_NEAR(fillet.Volume(), 12797, 1);
+  EXPECT_NEAR(fillet.SurfaceArea(), 3453, 1);
   if (options.exportModels) WriteTestOBJ("fillet.obj", fillet);
 }
 
@@ -303,8 +304,8 @@ TEST(Smooth, Csaszar) {
   Manifold csaszar = Manifold::Smooth(Csaszar());
   csaszar = csaszar.Refine(100);
   ExpectMeshes(csaszar, {{70000, 140000}});
-  EXPECT_NEAR(csaszar.Volume(), 78760, 10);
-  EXPECT_NEAR(csaszar.SurfaceArea(), 11935, 10);
+  EXPECT_NEAR(csaszar.Volume(), 81294, 10);
+  EXPECT_NEAR(csaszar.SurfaceArea(), 11748, 10);
 
   if (options.exportModels) WriteTestOBJ("smoothCsaszar.obj", csaszar);
 }

--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -211,11 +211,11 @@ TEST(Smooth, MissingNormals) {
 }
 
 TEST(Smooth, MissingNormalsCone) {
-  Manifold cone = Manifold::Cylinder(10, 10, 0, 5).CalculateNormals(0, 60);
-  Manifold diff = cone - Manifold::Cube(vec3(10), true).Translate({0, 0, 10});
+  Manifold cone = Manifold::Cylinder(10, 10, 4, 6).CalculateNormals(0, 60);
+  Manifold diff = cone - Manifold::Cube(vec3(20), true).Translate({0, 0, 15});
   Manifold out = diff.SmoothByNormals(0).Refine(20);
-  EXPECT_NEAR(out.Volume(), 1009, 1);
-  EXPECT_NEAR(out.SurfaceArea(), 736, 1);
+  EXPECT_NEAR(out.Volume(), 1467, 1);
+  EXPECT_NEAR(out.SurfaceArea(), 825, 1);
   if (options.exportModels) WriteTestOBJ("missingNormalsCone.obj", out);
 }
 

--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -221,16 +221,20 @@ TEST(Smooth, MissingNormalsCone) {
 TEST(Smooth, Fillet) {
   float depth = 3;
   float radius = 10;
-  Manifold cylinder =
-      Manifold::Cylinder(10, radius, radius, 6, false).CalculateNormals(0, 80);
-  Manifold chamfer = Manifold::Extrude(cylinder.Slice(0), depth, 0, 0,
-                                       vec2(radius + depth) / radius)
-                         .Simplify()
-                         .Mirror({0, 0, 1});
+  float filletScale = 1 + depth / radius;
+  Manifold cylinder = Manifold::Cylinder(20, radius, radius, 6, true)
+                          .CalculateNormals(0, 80)
+                          .Rotate(20);
+  CrossSection section = cylinder.Slice(0);
+  Manifold chamfer =
+      Manifold::Extrude(section.Simplify().ToPolygons(), depth, 0, 0,
+                        vec2(filletScale, 1.1 * filletScale))
+          .Mirror({0, 0, 1});
   EXPECT_EQ(chamfer.NumDegenerateTris(), 0);
   EXPECT_EQ(chamfer.NumTri(), 20);
-  Manifold base = Manifold::Cylinder(5, 15, 15, 6)
-                      .Translate({0, 0, -5 - depth})
+  Manifold base = Manifold::Cylinder(10, 15, 15, 6)
+                      .Translate({0, 0, -10 - depth})
+                      .Scale({1, 1.2, 1})
                       .CalculateNormals(0, 80);
   Manifold chamfered = cylinder + chamfer + base;
   EXPECT_EQ(chamfered.NumDegenerateTris(), 0);

--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -304,8 +304,8 @@ TEST(Smooth, Csaszar) {
   Manifold csaszar = Manifold::Smooth(Csaszar());
   csaszar = csaszar.Refine(100);
   ExpectMeshes(csaszar, {{70000, 140000}});
-  EXPECT_NEAR(csaszar.Volume(), 81294, 10);
-  EXPECT_NEAR(csaszar.SurfaceArea(), 11748, 10);
+  EXPECT_NEAR(csaszar.Volume(), 74757, 10);
+  EXPECT_NEAR(csaszar.SurfaceArea(), 11313, 10);
 
   if (options.exportModels) WriteTestOBJ("smoothCsaszar.obj", csaszar);
 }

--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -247,6 +247,33 @@ TEST(Smooth, Fillet) {
   if (options.exportModels) WriteTestOBJ("fillet.obj", fillet);
 }
 
+TEST(Smooth, Fillet2) {
+  float depth = 3;
+  float radius = 10;
+  float filletScale = 1 + depth / radius;
+  Manifold cylinder = Manifold::Cylinder(40, radius, radius, 6, true)
+                          .Rotate(0, 30)
+                          .CalculateNormals(0, 80);
+  CrossSection section = cylinder.Slice(0);
+
+  Manifold chamfer = Manifold::Extrude(section.Simplify().ToPolygons(), depth,
+                                       0, 0, vec2(1.3, 1.2))
+                         .Mirror({0, 0, 1});
+  EXPECT_EQ(chamfer.NumDegenerateTris(), 0);
+  EXPECT_EQ(chamfer.NumTri(), 20);
+  Manifold base = Manifold::Cube(vec3(40), true)
+                      .Translate({0, 0, -20 - depth})
+                      .CalculateNormals();
+  Manifold chamfered = cylinder + chamfer + base;
+  EXPECT_EQ(chamfered.NumDegenerateTris(), 0);
+  EXPECT_EQ(chamfered.NumTri(), 48);
+  Manifold fillet = chamfered.SmoothByNormals(0).RefineToTolerance(0.01);
+  EXPECT_EQ(fillet.Status(), Manifold::Error::NoError);
+  EXPECT_NEAR(fillet.Volume(), 71369, 1);
+  EXPECT_NEAR(fillet.SurfaceArea(), 10928, 1);
+  if (options.exportModels) WriteTestOBJ("fillet2.obj", fillet);
+}
+
 TEST(Smooth, Manual) {
   // Unit Octahedron
   const auto oct = Manifold::Sphere(1, 4).GetMeshGL();

--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -211,11 +211,12 @@ TEST(Smooth, MissingNormals) {
 }
 
 TEST(Smooth, MissingNormalsCone) {
-  Manifold cone = Manifold::Cylinder(10, 10, 4, 6).CalculateNormals(0, 60);
-  Manifold diff = cone - Manifold::Cube(vec3(20), true).Translate({0, 0, 15});
-  Manifold out = diff.SmoothByNormals(0).Refine(20);
-  EXPECT_NEAR(out.Volume(), 1467, 1);
-  EXPECT_NEAR(out.SurfaceArea(), 825, 1);
+  Manifold cone = Manifold::Cylinder(5, 10, 7, 6).CalculateNormals(0, 60);
+  Manifold peak = Manifold::Cylinder(4, 7, 0, 6);
+  Manifold biCone = cone + peak.Translate({0, 0, 5});
+  Manifold out = biCone.SmoothByNormals(0).RefineToTolerance(0.01);
+  EXPECT_NEAR(out.Volume(), 1480, 1);
+  EXPECT_NEAR(out.SurfaceArea(), 828, 1);
   if (options.exportModels) WriteTestOBJ("missingNormalsCone.obj", out);
 }
 
@@ -242,8 +243,8 @@ TEST(Smooth, Fillet) {
   EXPECT_EQ(chamfered.NumTri(), 56);
   Manifold fillet = chamfered.SmoothByNormals(0).RefineToTolerance(0.01);
   EXPECT_EQ(fillet.Status(), Manifold::Error::NoError);
-  EXPECT_NEAR(fillet.Volume(), 12797, 1);
-  EXPECT_NEAR(fillet.SurfaceArea(), 3453, 1);
+  EXPECT_NEAR(fillet.Volume(), 12805, 1);
+  EXPECT_NEAR(fillet.SurfaceArea(), 3452, 1);
   if (options.exportModels) WriteTestOBJ("fillet.obj", fillet);
 }
 
@@ -269,8 +270,8 @@ TEST(Smooth, Fillet2) {
   EXPECT_EQ(chamfered.NumTri(), 48);
   Manifold fillet = chamfered.SmoothByNormals(0).RefineToTolerance(0.01);
   EXPECT_EQ(fillet.Status(), Manifold::Error::NoError);
-  EXPECT_NEAR(fillet.Volume(), 71369, 1);
-  EXPECT_NEAR(fillet.SurfaceArea(), 10928, 1);
+  EXPECT_NEAR(fillet.Volume(), 71507, 1);
+  EXPECT_NEAR(fillet.SurfaceArea(), 10936, 1);
   if (options.exportModels) WriteTestOBJ("fillet2.obj", fillet);
 }
 

--- a/test/smooth_test.cpp
+++ b/test/smooth_test.cpp
@@ -45,7 +45,7 @@ TEST(Smooth, RefineQuads) {
   Manifold cylinder = WithPositionColors(Manifold::Cylinder(2, 1, -1, 12))
                           .SmoothOut()
                           .RefineToLength(0.05);
-  EXPECT_EQ(cylinder.NumTri(), 16924);
+  EXPECT_EQ(cylinder.NumTri(), 16644);
   EXPECT_NEAR(cylinder.Volume(), 2 * kPi, 0.003);
   EXPECT_NEAR(cylinder.SurfaceArea(), 6 * kPi, 0.004);
   const MeshGL out = cylinder.GetMeshGL();
@@ -106,7 +106,7 @@ TEST(Smooth, ToLength) {
 TEST(Smooth, Sphere) {
   int n[5] = {4, 8, 16, 32, 64};
   // Tests vertex precision of interpolation
-  double precision[5] = {0.04, 0.003, 0.003, 0.0005, 0.00006};
+  double precision[5] = {0.04, 0.015, 0.003, 0.0005, 0.00006};
   for (int i = 0; i < 5; ++i) {
     Manifold sphere = Manifold::Sphere(1, n[i]);
     // Refine(3*x) makes a center point, which is the worst case.
@@ -430,7 +430,7 @@ TEST(Smooth, SDF) {
           .SetProperties(1, error);
 
   MeshGL out = smoothed.GetMeshGL();
-  EXPECT_NEAR(GetMaxProperty(out, 3), 0, 0.028);
+  EXPECT_NEAR(GetMaxProperty(out, 3), 0, 0.035);
   EXPECT_NEAR(GetMaxProperty(interpolated.GetMeshGL(), 3), 0, 0.083);
 
   if (options.exportModels) WriteTestOBJ("smoothGyroid.obj", smoothed);


### PR DESCRIPTION
Before, smoothing would only identify pairs of coplanar triangles as quads. However, quad smoothing tends to work much better than triangle smoothing most of the time, so now I aggressively pair up triangles into quads based on a simple cost function. I'm pleased with the results, and this, along with smoothing over missing normals, makes it possible to form arbitrary fillets pretty nicely. I also found and fixed a few other small bugs in the smoothing.

I also renamed some tests to match their files. I did some clean up of edge collapsing and exposed a new testing hook called `HasSimpleProps()` which I used to catch a bug where prop verts were being duplicated unnecessarily. I also made the tangents align better and made everything less sensitive to rounding error.

Here's an [example](https://manifoldcad.org/#fillet%3Ccode%3Eimport%20%7B%20Manifold%20%7D%20from%20'manifold-3d%2FmanifoldCAD'%3B%0A%0Aconst%20depth%20%3D%203%0Aconst%20cylinder%20%3D%20Manifold.cylinder(40%2C%2010%2C%2010%2C%206%2C%20true).rotate(0%2C%2030).calculateNormals(0%2C%2080)%3B%0Aconst%20section%20%3D%20cylinder.slice(0).simplify()%3B%0Aconst%20chamfer%20%3D%20section.extrude(depth%2C%200%2C%200%2C%20%5B1.3%2C%201.2%5D).mirror(%5B0%2C%200%2C%201%5D)%3B%0Aconst%20base%20%3D%20Manifold.cube(40%2C%20true).translate(%5B0%2C%200%2C%20-20%20-%20depth%5D).calculateNormals(0)%3B%0Aconst%20chamfered%20%3D%20cylinder.add(chamfer).add(base)%3B%0A%0Aconst%20test%20%3D%20chamfered.smoothByNormals(0).refineToTolerance(0.01)%3B%0A%0Aexport%20default%20test.translate(%5B0%2C%200%2C%20depth%5D)%3B%0A) of making a complex fillet with a low-res cylinder and a simple no-normals boolean op. 
Before smoothing:
<img width="676" height="556" alt="image" src="https://github.com/user-attachments/assets/766db6a4-1d93-4f6c-ac37-0a53b6156848" />

After smoothing:
<img width="676" height="556" alt="image" src="https://github.com/user-attachments/assets/c30ff086-18dc-4a62-9bb8-4dc238d831ae" />
