### PR TITLE
Build native Windows ARM64 wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -20,11 +20,6 @@ jobs:
           git config --global core.longpaths true
       - if: matrix.os == 'macos-15'
         run: echo "CIBW_ARCHS=arm64 universal2" >> "$GITHUB_ENV"
-      - if: matrix.os == 'windows-11-arm'
-        shell: pwsh
-        run: |
-          "CIBW_ARCHS=ARM64" >> $env:GITHUB_ENV
-          "CIBW_BUILD=cp311-* cp312-* cp313-* cp314-*" >> $env:GITHUB_ENV
       - uses: actions/checkout@v6
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.0

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -21,7 +21,7 @@ jobs:
       - if: matrix.os == 'macos-15'
         run: echo "CIBW_ARCHS=arm64 universal2" >> "$GITHUB_ENV"
       - if: matrix.os == 'windows-11-arm'
-        run: echo "CIBW_BUILD=cp311-* cp312-* cp313-* cp314-*" >> "$GITHUB_ENV"
+        run: echo "CIBW_BUILD=cp311-* cp312-* cp313-* cp314-*" >> $env:GITHUB_ENV
       - uses: actions/checkout@v6
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.0

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -20,6 +20,8 @@ jobs:
           git config --global core.longpaths true
       - if: matrix.os == 'macos-15'
         run: echo "CIBW_ARCHS=arm64 universal2" >> "$GITHUB_ENV"
+      - if: matrix.os == 'windows-11-arm'
+        run: echo "CIBW_BUILD=cp311-* cp312-* cp313-* cp314-*" >> "$GITHUB_ENV"
       - uses: actions/checkout@v6
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.0

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,6 +1,7 @@
 name: build_wheels
 
 on:
+  pull_request:
   release:
     types: [published]
   workflow_dispatch:
@@ -13,13 +14,18 @@ jobs:
       matrix:
         # macos-15-intel: x86-64
         # macos-15: arm64
-        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2025, macos-15-intel, macos-15]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2025, windows-11-arm, macos-15-intel, macos-15]
     steps:
       - run: |
           git config --global submodule.fetchJobs 8
           git config --global core.longpaths true
       - if: matrix.os == 'macos-15'
         run: echo "CIBW_ARCHS=arm64 universal2" >> "$GITHUB_ENV"
+      - if: matrix.os == 'windows-11-arm'
+        shell: pwsh
+        run: |
+          "CIBW_ARCHS=ARM64" >> $env:GITHUB_ENV
+          "CIBW_BUILD=cp311-* cp312-* cp313-* cp314-*" >> $env:GITHUB_ENV
       - uses: actions/checkout@v6
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.0

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,7 +1,6 @@
 name: build_wheels
 
 on:
-  pull_request:
   release:
     types: [published]
   workflow_dispatch:

--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -109,9 +109,8 @@ constexpr double smoothstep(double edge0, double edge1, double a) {
 inline double sind(double x) {
   if (!la::isfinite(x)) return NAN;
   if (x < 0.0) return -sind(-x);
-  x = std::fmod(x, 360.0);
-  const int quo = static_cast<int>(std::floor(x / 90.0 + 0.5));
-  x -= quo * 90.0;
+  int quo;
+  x = std::remquo(std::fabs(x), 90.0, &quo);
   const double xr = radians(x);
   switch (quo % 4) {
     case 0:

--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -109,8 +109,9 @@ constexpr double smoothstep(double edge0, double edge1, double a) {
 inline double sind(double x) {
   if (!la::isfinite(x)) return NAN;
   if (x < 0.0) return -sind(-x);
-  int quo;
-  x = std::remquo(std::fabs(x), 90.0, &quo);
+  x = std::fmod(x, 360.0);
+  const int quo = static_cast<int>(std::floor(x / 90.0 + 0.5));
+  x -= quo * 90.0;
   const double xr = radians(x);
   switch (quo % 4) {
     case 0:


### PR DESCRIPTION
## Summary

- add `windows-11-arm` to the existing cibuildwheel runner matrix
- rely on cibuildwheel's native architecture detection to build `win_arm64` wheels
- make no source or runtime behavior changes

## Validation

- verified cibuildwheel 3.4.0 selects `cp39`, `cp310`, `cp311`, `cp312`, `cp313`, `cp314`, and `cp314t` `win_arm64` builds on a native ARM64 host
- locally built and clean-installed a CPython 3.13 `win_arm64` wheel
- verified the extension PE machine is `AA64`
- the existing `run_all.py` extrusion test still fails on native ARM64; that runtime issue is intentionally out of scope for this one-line CI change
- hosted `build_wheels` execution is pending manual dispatch or a release event