### PR TITLE
Fix degree sine reduction on Windows ARM64

### DIFF
--- a/include/manifold/common.h
+++ b/include/manifold/common.h
@@ -109,8 +109,14 @@ constexpr double smoothstep(double edge0, double edge1, double a) {
 inline double sind(double x) {
   if (!la::isfinite(x)) return NAN;
   if (x < 0.0) return -sind(-x);
+#if defined(_WIN32) && defined(_M_ARM64)
+  x = std::fmod(x, 360.0);
+  const int quo = static_cast<int>(std::floor(x / 90.0 + 0.5));
+  x -= quo * 90.0;
+#else
   int quo;
   x = std::remquo(std::fabs(x), 90.0, &quo);
+#endif
   const double xr = radians(x);
   switch (quo % 4) {
     case 0:

--- a/test/manifold_test.cpp
+++ b/test/manifold_test.cpp
@@ -777,6 +777,13 @@ TEST(Manifold, Extrude) {
   EXPECT_FLOAT_EQ(donut.SurfaceArea(), 48.0);
 }
 
+TEST(Manifold, ExtrudeSquare) {
+  const Polygons square = {{{0, 0}, {1, 0}, {1, 1}, {0, 1}}};
+  const Manifold prism = Manifold::Extrude(square, 10.0);
+  EXPECT_NEAR(prism.Volume(), 10.0, 0.001);
+  EXPECT_NEAR(prism.SurfaceArea(), 42.0, 0.001);
+}
+
 TEST(Manifold, ExtrudeCone) {
   Polygons polys = SquareHole();
   Manifold donut = Manifold::Extrude(polys, 1.0, 0, 0, vec2(0.0));


### PR DESCRIPTION
## Summary

Use explicit angle reduction in `sind()` only on Windows ARM64, where the existing `std::remquo` path produces incorrect extrusion geometry.

Other platforms retain the existing `std::remquo` implementation.

Add a regression test for extruding a unit square to verify the expected volume and surface area.

## Validation

Tested natively on Windows ARM64:

- built and installed a CPython 3.13 `win_arm64` wheel
- ran `bindings/python/examples/run_all.py`: all 12 examples passed
- ran the new `Manifold.ExtrudeSquare` regression test
- ran the complete native C++ test suite: all 544 tests passed

Before this fix, the extrusion test produced a volume of `11.666666666666668` instead of the expected `10.0`.