### PR TITLE
fix the five high-severity zizmor findings

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -459,7 +459,8 @@ jobs:
       matrix:
         parallelization: [OFF, ON]
     runs-on: ubuntu-latest
-    container: openscad/mxe-x86_64-gui:latest
+    # Resolved from openscad/mxe-x86_64-gui:latest on 2026-09-07.
+    container: openscad/mxe-x86_64-gui@sha256:2df7d1c09a50192a523b4f9ea1f6155228a90e405545149d5bb3b41907f61b55
     steps:
     - uses: actions/checkout@v6
     - name: Build

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -29,7 +29,9 @@ jobs:
     # The lockfiles are edited in place rather than regenerated with npm
     # install, which keeps this fast and limits the commit to the version.
     - name: Set the version
-      run: python3 scripts/set_version.py "${{ inputs.version }}"
+      run: python3 scripts/set_version.py "$VERSION"
+      env:
+        VERSION: ${{ inputs.version }}
 
     # gh rather than a third-party action; release_file.yml already uses it.
     - name: Commit and open a pull request

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -27,15 +27,14 @@ jobs:
       with:
         node-version: 25
         registry-url: 'https://registry.npmjs.org/'
+        # No shared cache on the publish path.
+        package-manager-cache: false
 
     - name: Update npm # Ensure npm 11.5.1 or later for trusted publishing
       run: npm install -g npm@latest
 
-    - name: Install apt packages
-      uses: awalsh128/cache-apt-pkgs-action@v1.6.0
-      with:
-        packages: cmake
-        version: 1
+    - name: Install cmake
+      run: sudo apt-get update && sudo apt-get install -y cmake
 
     - name: Setup EMSDK
       uses: mymindstorm/setup-emsdk@v14

--- a/.github/workflows/release_file.yml
+++ b/.github/workflows/release_file.yml
@@ -10,22 +10,25 @@ jobs:
     name: Upload archive
     runs-on: ubuntu-latest
     steps:
+      # env, not interpolation: the tag reaches the shell as a variable.
       - run: |
-          ref=${{ github.ref_name }}
-          echo "release_name=manifold-${ref#v}" >> $GITHUB_ENV
+          echo "release_name=manifold-${REF#v}" >> $GITHUB_ENV
+        env:
+          REF: ${{ github.ref_name }}
       - uses: actions/checkout@v6
         with:
           path: ${{ env.release_name }}
           submodules: recursive
       - name: Build archive
         run: >
-          tar --exclude=".git*" -cz ${{ env.release_name }} -f ${{ env.release_name }}.tar.gz
+          tar --exclude=".git*" -cz "$release_name" -f "$release_name.tar.gz"
       - name: Log checksum
         run: >
-          sha256sum ${{ env.release_name }}.tar.gz
+          sha256sum "$release_name.tar.gz"
       - name: Add file to release
         run: |
-          cd ${{ env.release_name }} || exit 1
-          gh release upload ${{ github.ref_name }} ../${{ env.release_name }}.tar.gz
+          cd "$release_name" || exit 1
+          gh release upload "$REF" "../$release_name.tar.gz"
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          REF: ${{ github.ref_name }}

--- a/.github/workflows/weekly_benchmark.yml
+++ b/.github/workflows/weekly_benchmark.yml
@@ -8,7 +8,7 @@ on:
     - cron: "0 2 * * 0"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: weekly-benchmark
@@ -27,6 +27,9 @@ jobs:
     if: ${{ !cancelled() }}
     timeout-minutes: 60
     runs-on: macos-15
+    # Pushes results to the benchmark-data branch.
+    permissions:
+      contents: write
     env:
       WEEKLY_BENCHMARK_REPEATS: 5
       WEEKLY_BENCHMARK_THREADS: 1


### PR DESCRIPTION
Fixes #1799. Verified with `uvx zizmor --no-online-audits .github/workflows/` — template-injection, cache-poisoning and unpinned-images are all at zero.

- **`release_file.yml`** — the tag goes through `env:` and later steps read `$release_name`, clearing all seven template-injection findings since six were the derived value.
- **`publish_npm.yml`** — `package-manager-cache: false` on setup-node. Also swapped `cache-apt-pkgs-action` for a plain `apt-get`, since it "always restores from cache" and this job publishes to npm. Slightly slower, negligible against the emscripten build.
- **`weekly_benchmark.yml`** — `contents: read` at workflow level, `write` only on the job pushing to `benchmark-data`. The `sanitizer` job only uploads artifacts.
- **`manifold.yml`** — MXE container pinned by digest, resolved from `:latest` on 2026-09-07.
- **`prepare_release.yml`** — `inputs.version` through `env:`.

Two of these weren't in the issue: the apt caching action and the `prepare_release` injection. Both only surfaced once the others were fixed, and both came in with #1810.

Worth knowing: updating the container digest is manual. `.github/dependabot.yml` only covers `pip`, so nothing bumps it automatically. Adding the `github-actions` ecosystem there would also make SHA-pinning the 69 `unpinned-uses` findings much less painful, if that's ever worth revisiting.