### PR TITLE
use node 24 lts

### DIFF
--- a/.github/workflows/manifold.yml
+++ b/.github/workflows/manifold.yml
@@ -317,7 +317,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
-        node-version: 25
+        node-version: 24
         cache: 'npm'
         cache-dependency-path: bindings/**/package-lock.json
     - name: Install apt packages

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v6
       with:
-        node-version: 25
+        node-version: 24
         registry-url: 'https://registry.npmjs.org/'
 
     - name: Update npm # Ensure npm 11.5.1 or later for trusted publishing


### PR DESCRIPTION
`npm@latest` is now npm 12, which dropped Node 25 — it's odd-numbered so not LTS. Required is `^22.22.2 || ^24.15.0 || >=26.0.0`, which is why the v3.5.3 publish failed at `Update npm`.

Same change on the 3.5.x branch in #1821.