### PR TITLE
cmake: Drop -std=c++17 from pkg-config bindings.

### DIFF
--- a/cmake/manifold.pc.in
+++ b/cmake/manifold.pc.in
@@ -9,4 +9,4 @@ Version: @MANIFOLD_VERSION@
 URL: https://github.com/elalish/manifold
 Requires-private: @TEMPLATE_OPTIONAL_TBB@
 Libs: -L${libdir} -lmanifold@PCFILE_LIB_SUFFIX@
-Cflags: -I${includedir} -std=c++17
+Cflags: -I${includedir}


### PR DESCRIPTION
-std=c++17 is a GCC specific flag that emits warnings due to being unrecognized by MSVC. Moreover, pkg-config generally does not carry the "standard version" to use, as this breaks as soon as 2 people do this. One would expect manifold to work when combined with something else that wants C++20 but this in the `.pc` would potentially force that back to 17 depending on which order the `.pc`s got visited. There is nothing like CMake's resolution process which selects the lowest standard value consistent with greater-than constraints from targets.

This was discovered by GPT 5.6 Sol while reviewing https://github.com/microsoft/vcpkg/pull/53831